### PR TITLE
fix: fix build order on initial setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
     "name": "@fremtind/jkl",
     "private": true,
     "scripts": {
-        "prebuild": "cd packages/utils && yarn build:before",
+        "prebuild": "run-s build:utils build:core",
         "build": "lerna exec --parallel yarn build",
+        "build:utils": "cd packages/utils && yarn build:before",
+        "build:core": "cd packages/core && yarn build:before",
         "build:portal": "cd packages/portal && yarn build:docs",
         "build:storybook": "cd packages/storybook && yarn build:docs",
         "build:docs": "run-p build:portal build:storybook",
@@ -15,10 +17,12 @@
         "test:e2e": "jest -c './jest/jest.e2e.js'",
         "prerelease": "yarn build",
         "release": "lerna publish",
+        "start": "run-p start:storybook start:portal",
         "start:storybook": "cd packages/storybook && yarn storybook",
         "start:portal": "cd packages/portal && yarn dev",
-        "start": "run-p start:storybook start:portal",
-        "dev": "parcel"
+        "dev": "parcel",
+        "setup": "run-s prebuild setup:build",
+        "setup:build": "lerna exec yarn build"
     },
     "dependencies": {
         "@types/react": "^16.8.17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
         "build"
     ],
     "scripts": {
-        "build": "echo 'noop'",
+        "build": "yarn build:styles",
         "build:before": "yarn build:styles",
         "build:css": "node-sass src -o build/css --importer='../../node_modules/node-sass-tilde-importer'",
         "prebuild:scss": "mkdirp -p build && mkdirp build/scss",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
         "build"
     ],
     "scripts": {
-        "build": "yarn build:styles",
+        "build": "echo 'noop'",
+        "build:before": "yarn build:styles",
         "build:css": "node-sass src -o build/css --importer='../../node_modules/node-sass-tilde-importer'",
         "prebuild:scss": "mkdirp -p build && mkdirp build/scss",
         "build:scss": "ncp src build/scss",

--- a/packages/portal/src/pages/Contribute/Contribute.tsx
+++ b/packages/portal/src/pages/Contribute/Contribute.tsx
@@ -80,6 +80,9 @@ const Contribute = () => {
                     <li>
                         Kjør <Code>yarn</Code> på rot i prosjektet
                     </li>
+                    <li>
+                        Kjør <Code>yarn setup</Code> på rot i prosjektet for å bygge pakkene
+                    </li>
                     <li>Løs feilen eller legg til ny funksjonalitet og legg til tester</li>
                     <li>
                         Pass på at alle tester går grønt med <Code>yarn test</Code>
@@ -123,20 +126,20 @@ const Contribute = () => {
                 <P>
                     I<Code>/packages</Code> er hver enkelt mappe en kjørbar npm-pakke. Alle som slutter på -react kan
                     starte et utviklingsview med<Code>yarn dev</Code> fra pakke-nivå. Den starter
-                    <Code>`pakkenavn`.html</Code> som brukes som til utviking og automatisk visuell regresjonstesting.
-                    <Code>yarn build</Code> bygger koden til ulike modulene vi støtter. Bygge komandoen kan kjøres fra
+                    <Code>example/`pakkenavn`.html</Code> som brukes som til utviking.
+                    <Code>yarn build</Code> bygger koden til ulike modulene vi støtter. Byggekomandoen kan kjøres fra
                     rot, da bygges alle pakkene, eller den kan kjøres enkeltvis. Tester kjøres med
                     <Code>yarn test</Code> fra rot i prosjektet. Hvis du ønsker å kjøre bare en test kan det spesfiseres
-                    etter komandoen,<Code>yarn test mintest</Code>, under utvikling kan
-                    <Code>yarn test --watch mintest</Code> være nyttig.
+                    etter komandoen,<Code>yarn test min-pakke</Code>, under utvikling kan
+                    <Code>yarn test --watch min-pakke</Code> være nyttig.
                 </P>
                 <H4>Legg til avhengighet</H4>
                 <P>
                     Hvis du skal legge til en avhengighet til en pakke fra det store internettet, er det som normalt. Gå
                     inn i pakken og kjør <Code>yarn add `somePackage`</Code>. Hvis du skal legge til en ny avhengighet
-                    på rot nivå, så er det <Code>yarn add -W `somePackage`</Code>, men tenk deg nøye om det er nødvendig
-                    å ha den i gloablt scope. Hvis en pakke skal depende på en annen pakke i monorepoet kjøer du{" "}
-                    <Code>lerna add @fremtind/jkl-en-pakke --scope=@fremtind/jkl-en-annen-pakke</Code>.
+                    på rot nivå, så er det <Code>yarn add -W `somePackage`</Code>, men tenk nøye over om det er
+                    nødvendig å ha den i globalt scope. Hvis en pakke skal depende på en annen pakke i monorepoet kjører
+                    du <Code>lerna add @fremtind/jkl-en-pakke --scope=@fremtind/jkl-en-annen-pakke</Code>.
                 </P>
                 <H4>Legg til ny pakke</H4>
                 <P>
@@ -169,12 +172,12 @@ const Contribute = () => {
             <GridContent>
                 <H3>Test</H3>
                 <P>
-                    Siden det er mange som er avhenige av Jøkul for å lage sine sider, er det viktig at komponent
-                    biblioteket er godt dokumentert og godt testet. Vi har ikke satt noen eksplistte prosentkrav til
-                    test, da dette kan ha negative sideeffekter. Det er opp til oss som utviklere å sørge for at vi
-                    tester det som trengs godt nok. Det forventes at all funksjonalitet vi skriver selv blir
-                    enhetstestet, pass på å teste som en bruker og ikke direkte på implementasjon. Det er også satt opp
-                    rammeverk for visuell regresjonstest og tilgjengelighet.
+                    Siden det er mange som er avhenige av Jøkul for å lage sine sider, er det viktig at
+                    komponentbiblioteket er godt dokumentert og godt testet. Vi har ikke satt noen eksplisitte
+                    prosentkrav til test, da dette kan ha negative sideeffekter. Det er opp til oss som utviklere å
+                    sørge for at vi tester det som trengs godt nok. Det forventes at all funksjonalitet vi skriver selv
+                    blir enhetstestet, pass på å teste som en bruker og ikke direkte på implementasjon. Det er også satt
+                    opp rammeverk for visuell regresjonstest og tilgjengelighet.
                 </P>
             </GridContent>
             <GridOffsetAfter />

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,10 +14,10 @@
         "build"
     ],
     "scripts": {
+        "build:before": "yarn build",
+        "build": "yarn run build:scripts && yarn run build:types",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build:before": "yarn run build:scripts && yarn run build:types",
-        "build": "echo 'noop'",
         "test": "echo \"Error: run tests from root\" && exit 1"
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,10 +18,6 @@
         "build:scripts": "rollup --config ../../rollup.config.js",
         "build:before": "yarn run build:scripts && yarn run build:types",
         "build": "echo 'noop'",
-        "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel typography.html"
-    },
-    "dependencies": {
-        "@fremtind/jkl-typography-react": "^0.0.1"
+        "test": "echo \"Error: run tests from root\" && exit 1"
     }
 }

--- a/packages/utils/src/internal/StoryTemplate.tsx
+++ b/packages/utils/src/internal/StoryTemplate.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import { P, LeadParagraph, H2 } from "@fremtind/jkl-typography-react";
 
 interface StoryTemplateProps {
     children: ReactNode;
@@ -10,9 +9,9 @@ interface StoryTemplateProps {
 
 export const StoryTemplate = ({ children, title, tldr, description }: StoryTemplateProps) => (
     <div style={{ margin: "30px" }}>
-        <H2>{title}</H2>
-        <LeadParagraph>{tldr}</LeadParagraph>
+        <h2 className="jkl-h2">{title}</h2>
+        <p className="jkl-lead">{tldr}</p>
         <div style={{ padding: "24px" }}>{children}</div>
-        <P>{description}</P>
+        <p className="jkl-p">{description}</p>
     </div>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5891,6 +5891,21 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -9411,7 +9426,7 @@ jest-dev-server@^4.2.0:
     tree-kill "^1.2.1"
     wait-on "^3.2.0"
 
-jest-diff@^24.8.0:
+jest-diff@^24.0.0, jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
   integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
@@ -9427,6 +9442,20 @@ jest-docblock@^24.3.0:
   integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.5.0.tgz#715908b545c0d66a0eba9d21fc59357fac024f43"
+  integrity sha512-xHnP3Qo/29oLAo2iixaZsoDrm3XKSVrMH5Wf2ZEiLychJQBTNzOeVMPxrCygCgJiyQMbnymXltme8bPzuiGOIA==
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^2.0.0"
 
 jest-each@^24.8.0:
   version "24.8.0"
@@ -9528,7 +9557,7 @@ jest-leak-detector@^24.8.0:
   dependencies:
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.8.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
   integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
@@ -12726,7 +12755,7 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
@@ -14639,7 +14668,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-button, @fremtind/jkl-core,
@fremtind/jkl-footer-react, @fremtind/jkl-footer, @fremtind/jkl-grid-react, @fremtind/jkl-grid,
@fremtind/jkl-header-react, @fremtind/jkl-header, @fremtind/jkl-logo-react,
@fremtind/parcel-consumer-example, @fremtind/jkl-portal, @fremtind/jkl-radio-button-react,
@fremtind/jkl-radio-button, @fremtind/jkl-storybook, @fremtind/jkl-text-field-react,
@fremtind/jkl-text-field, @fremtind/jkl-typography-react, @fremtind/jkl-utils,
@fremtind/webpack-consumer-example

## 📥 Proposed changes

Make changes to the build order so that it is possible to initially build the project. 

## 🎛 Types of changes

What types of changes does your code introduce to Jøkul?

-   [x] 🐞 Bugfix
-   [ ] ✨ New feature
-   [ ] ⚠️ Breaking change
-   [ ] 🤔 Other (Please specify):

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] Lint and unit tests pass locally with my changes
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further comments

initial build is now done with `yarn setup`. This is reflected in the updated docs.
