### PR TITLE
docs(pr-template): remove type section, as the commit enforces type selection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,16 +2,6 @@
 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
-## 🎛 Types of changes
-
-What types of changes does your code introduce to Jøkul?
-_Put an `x` in the boxes that apply_
-
--   [ ] 🐞 Bugfix
--   [ ] ✨ New feature
--   [ ] ⚠️ Breaking change
--   [ ] 🤔 Other (Please specify):
-
 ## ☑️ Submission checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._


### PR DESCRIPTION
## 📥 Proposed changes

Types is set in header. And github treats checkboxes as task to be done, so they way we used to did not make that much sense, as a pr will never be

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] Lint and unit tests pass locally with my changes
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further comments
