### PR TITLE
fix(storybook): fix style import in storybook

### DIFF
--- a/packages/button-react/src/Button.stories.tsx
+++ b/packages/button-react/src/Button.stories.tsx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { StoryTemplate } from "@fremtind/jkl-utils";
 import { PrimaryButton, SecondaryButton } from ".";
+import "@fremtind/jkl-button/button.css";
 
 const stories = storiesOf("Atom/Knapper", module);
 stories.addDecorator(withKnobs);

--- a/packages/footer-react/src/Footer.stories.tsx
+++ b/packages/footer-react/src/Footer.stories.tsx
@@ -3,7 +3,9 @@ import { withInfo } from "@storybook/addon-info";
 import { storiesOf } from "@storybook/react";
 import { StoryTemplate } from "@fremtind/jkl-utils";
 import { Footer } from ".";
-import "../build/css/styles.css";
+import "@fremtind/jkl-footer/footer.css";
+import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-grid/grid.css";
 
 const stories = storiesOf("Molekyl/Footer", module);
 stories.addDecorator(withInfo);

--- a/packages/header-react/src/Header.stories.tsx
+++ b/packages/header-react/src/Header.stories.tsx
@@ -4,7 +4,7 @@ import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import { Header } from ".";
 import { StoryTemplate } from "@fremtind/jkl-utils";
-import "../build/css/styles.css";
+import "@fremtind/jkl-header/header.css";
 
 const stories = storiesOf("Molekyl/Header", module);
 stories.addDecorator(withKnobs);

--- a/packages/typography-react/src/Typography.stories.tsx
+++ b/packages/typography-react/src/Typography.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from "@storybook/react";
 import { H1, H2, H3, H4, LeadParagraph, P, SmallText } from ".";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 import { StoryTemplate } from "@fremtind/jkl-utils";
+import "@fremtind/jkl-core/build/css/core.css";
 
 const headerStories = storiesOf("Typografi/Overskrifter", module);
 


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-footer-react, @fremtind/jkl-header-react,
@fremtind/jkl-typography-react

## 📥 Proposed changes

After refactor style were removed from storybook, now its back

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] Lint and unit tests pass locally with my changes
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further comment
