### PR TITLE
feat(accordion): replace chevron svg with css

### DIFF
--- a/packages/accordion-react/src/Accordion.tsx
+++ b/packages/accordion-react/src/Accordion.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useState } from "react";
-import chevron from "@fremtind/jkl-accordion/chevron.svg";
 
 interface Props {
     children: ReactNode;
@@ -19,7 +18,7 @@ export const AccordionItem = ({ children, title }: ItemProps) => {
         <div className={`jkl-accordion__item ${openClassName}`} role="article" aria-expanded={isOpen}>
             <button className="jkl-accordion__item-title" onClick={() => setIsOpen(!isOpen)} tabIndex={0}>
                 <div className="jkl-accordion__item-title-text">{title}</div>
-                <img className="jkl-accordion__item-title-icon" src={chevron} alt={isOpen ? "Vis mindre" : "Vis mer"} />
+                <div className="jkl-accordion__item-title-icon" />
             </button>
             <div className="jkl-accordion__item-content">{children}</div>
         </div>

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -1,11 +1,16 @@
 @import "~@fremtind/jkl-core/build/scss/core.scss";
 
+$chevron-color: $svart;
+$chevron-size: 1.25rem;
+$chevron-weight: 0.125rem;
+$chevron-weight--hover: 0.1875rem;
+
 .jkl-accordion {
     &__item {
         margin-bottom: 2.5em;
         &--expanded {
             & .jkl-accordion__item-title-icon {
-                transform: rotateZ(180deg);
+                transform: rotate(135deg);
             }
             & .jkl-accordion__item-content {
                 height: auto;
@@ -13,8 +18,14 @@
         }
     }
     &__item-title {
-        @include font-size("medium");
+        /* Remove button styles */
         display: flex;
+        width: 100%;
+        border: none;
+        outline: none;
+
+        @include font-size("medium");
+
         justify-content: space-between;
         margin-bottom: 1.5em;
 
@@ -32,7 +43,14 @@
     }
 
     &__item-title-icon {
-        width: 2rem;
+        width: $chevron-size;
+        height: $chevron-size;
+
+        transform-origin: center;
+        transform: rotate(-45deg);
+
+        border-left: $chevron-weight solid $chevron-color;
+        border-bottom: $chevron-weight solid $chevron-color;
         transition: transform 400ms ease;
     }
 }

--- a/packages/accordion/example/index.tsx
+++ b/packages/accordion/example/index.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "../accordion.scss";
-import chevron from "../chevron.svg";
 
 const App = () => (
     <>
         <div className="jkl-accordion" style={{ width: 700 }}>
             <div className="jkl-accordion__item jkl-accordion__item--expanded">
-                <div className="jkl-accordion__item-title">
+                <button className="jkl-accordion__item-title">
                     <div className="jkl-accordion__item-title-text">Tekst som står her</div>
-                    <img className="jkl-accordion__item-title-icon" src={chevron} alt="Vis mindre" />
-                </div>
+                    <div className="jkl-accordion__item-title-icon" />
+                </button>
                 <div className="jkl-accordion__item-content">
                     Now let&lsquo;s use some more properties. Consider a list of 6 items, all with a fixed dimensions in
                     a matter of aesthetics but they could be auto-sized. We want them to be evenly and nicely
@@ -19,10 +18,10 @@ const App = () => (
                 </div>
             </div>
             <div className="jkl-accordion__item">
-                <div className="jkl-accordion__item-title">
+                <button className="jkl-accordion__item-title">
                     <div className="jkl-accordion__item-title-text">Second item</div>
-                    <img className="jkl-accordion__item-title-icon" src={chevron} alt="Vis mer" />
-                </div>
+                    <div className="jkl-accordion__item-title-icon" />
+                </button>
                 <div className="jkl-accordion__item-content">
                     <p>This is a paragraph</p>
                     <p>Another paragraph&hellip;</p>


### PR DESCRIPTION
affects: @fremtind/jkl-accordion-react, @fremtind/jkl-accordion

## 📥 Proposed changes

Replace the chevron svg in the accordion component with a styled DOM element

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] Lint and unit tests pass locally with my changes
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further comments

This fixes an issue with CI
