### PR TITLE
feat(bullet-list): enable semantic nesting in bullet lists@

### DIFF
--- a/packages/bullet-list-react/example/index.tsx
+++ b/packages/bullet-list-react/example/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Ul, Li } from "../src";
 import "@fremtind/jkl-bullet-list/bullet-list.scss";
-import "@fremtind/jkl-core/src/core.scss"; // TODO: remove
+import "@fremtind/jkl-core/src/core.scss";
 
 const UlExample = () => (
     <>

--- a/packages/bullet-list-react/example/index.tsx
+++ b/packages/bullet-list-react/example/index.tsx
@@ -2,22 +2,36 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Ul, Li } from "../src";
 import "@fremtind/jkl-bullet-list/bullet-list.scss";
+import "@fremtind/jkl-core/src/core.scss"; // TODO: remove
 
 const UlExample = () => (
     <>
         <Ul>
             <Li>Ruth Sims</Li>
-            <Li>Hilda Robbins</Li>
-            <Li nested>Mattie Lawrence</Li>
-            <Li nested>Eric Huff</Li>
+            <Li>
+                Hilda Robbins
+                <Ul>
+                    <Li>Mattie Lawrence</Li>
+                    <Li>Eric Huff</Li>
+                </Ul>
+            </Li>
             <Li>Adam Norris</Li>
             <Li>Essie Diaz</Li>
         </Ul>
         <Ul lead>
             <Li>Ricky Wilkerson</Li>
-            <Li>Linnie Gill</Li>
-            <Li nested>Grace Cortez</Li>
-            <Li nested>Madge Hodges</Li>
+            <Li>
+                Linnie Gill
+                <Ul>
+                    <Li>Grace Cortez</Li>
+                    <Li>
+                        Madge Hodges
+                        <Ul>
+                            <Li>Somebody</Li>
+                        </Ul>
+                    </Li>
+                </Ul>
+            </Li>
             <Li>Cory Wagner</Li>
             <Li>Lora Carroll</Li>
         </Ul>

--- a/packages/bullet-list-react/src/Li.tsx
+++ b/packages/bullet-list-react/src/Li.tsx
@@ -2,9 +2,6 @@ import React, { ReactNode } from "react";
 
 interface Props {
     children: ReactNode;
-    nested?: boolean;
 }
 
-export const Li = ({ children, nested }: Props) => (
-    <li className={`jkl-bullet-list__item${nested ? "--nested" : ""}`}>{children}</li>
-);
+export const Li = ({ children }: Props) => <li className="jkl-bullet-list__item">{children}</li>;

--- a/packages/bullet-list-react/src/List.stories.tsx
+++ b/packages/bullet-list-react/src/List.stories.tsx
@@ -14,16 +14,24 @@ stories.add("BulletList", () => {
             <Ul>
                 <Li>Linnie Neal</Li>
                 <Li>Rena Taylor</Li>
-                <Li>Garrett Mack</Li>
-                <Li nested>Rebecca Robbins</Li>
+                <Li>
+                    Garrett Mack
+                    <Ul>
+                        <Li>Rebecca Robbins</Li>
+                    </Ul>
+                </Li>
             </Ul>
             <div style={{ margin: "20px" }} />
             <h2>With Lead styling</h2>
             <Ul lead>
                 <Li>Linnie Neal</Li>
                 <Li>Rena Taylor</Li>
-                <Li>Garrett Mack</Li>
-                <Li nested>Rebecca Robbins</Li>
+                <Li>
+                    Garrett Mack
+                    <Ul>
+                        <Li>Rebecca Robbins</Li>
+                    </Ul>
+                </Li>
             </Ul>
         </StoryTemplate>
     );

--- a/packages/bullet-list-react/src/List.test.tsx
+++ b/packages/bullet-list-react/src/List.test.tsx
@@ -10,8 +10,12 @@ describe("bullet list, Ul and Li", () => {
             <Ul>
                 <Li>Kibogiedo</Li>
                 <Li>Ovoopisow</Li>
-                <Li>Omocebig</Li>
-                <Li nested>Ramzoge</Li>
+                <Li>
+                    Omocebig
+                    <Ul>
+                        <Li>Ramzoge</Li>
+                    </Ul>
+                </Li>
             </Ul>,
         );
         expect(getByText("Kibogiedo")).toBeInTheDocument();
@@ -25,8 +29,12 @@ describe("bullet list, Ul and Li", () => {
             <Ul lead>
                 <Li>Kibogiedo</Li>
                 <Li>Ovoopisow</Li>
-                <Li>Omocebig</Li>
-                <Li nested>Ramzoge</Li>
+                <Li>
+                    Omocebig
+                    <Ul>
+                        <Li>Ramzoge</Li>
+                    </Ul>
+                </Li>
             </Ul>,
         );
         expect(getByText("Kibogiedo")).toBeInTheDocument();

--- a/packages/bullet-list/bullet-list.scss
+++ b/packages/bullet-list/bullet-list.scss
@@ -11,37 +11,55 @@ $bullet-item-indent: $component-spacing--large;
 $bullet-nested-item-indent: $component-spacing--xxl;
 
 .jkl-bullet-list {
+    list-style: none;
     padding: 0;
     margin: 0;
     @extend .jkl-p;
 
-    &__item {
-        display: flex;
-        align-items: center;
-        list-style-type: none;
-        margin-bottom: $bullet-item-space-between;
+    & > &__item {
+        //display: list-item;
+        //align-items: center;
+        //list-style-type: none;
+        margin: $bullet-item-space-between 0;
 
         &::before {
-            content: " ";
+            content: "";
+            display: inline-block;
             height: $bullet-size;
-            min-height: $bullet-size;
-            min-width: $bullet-size;
+            //min-height: $bullet-size;
+            //min-width: $bullet-size;
             width: $bullet-size;
             background-color: $svart;
             transform: rotate(45deg);
             margin-right: $bullet-item-indent;
             margin-bottom: $bullet-point-center-offset;
         }
+
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
+        }
     }
-    &__item:last-child {
-        margin-bottom: 0;
-    }
-    &__item--nested {
-        @extend .jkl-bullet-list__item;
+    & & > &__item {
         margin-left: $bullet-nested-item-indent;
         &::before {
             box-shadow: inset 0px 0px 0px rem(1px) $svart;
             background-color: transparent;
+        }
+        &:first-of-type {
+            margin-top: $bullet-item-space-between;
+        }
+        &:last-of-type {
+            margin-bottom: $bullet-item-space-between;
+        }
+    }
+    & & & > &__item {
+        &::before {
+            box-shadow: inset 0px 0px 0px rem(1px) $svart;
+            background-color: $svart;
+            transform: rotate(0deg);
         }
     }
 }

--- a/packages/bullet-list/bullet-list.scss
+++ b/packages/bullet-list/bullet-list.scss
@@ -17,17 +17,12 @@ $bullet-nested-item-indent: $component-spacing--xxl;
     @extend .jkl-p;
 
     & > &__item {
-        //display: list-item;
-        //align-items: center;
-        //list-style-type: none;
         margin: $bullet-item-space-between 0;
 
         &::before {
             content: "";
             display: inline-block;
             height: $bullet-size;
-            //min-height: $bullet-size;
-            //min-width: $bullet-size;
             width: $bullet-size;
             background-color: $svart;
             transform: rotate(45deg);


### PR DESCRIPTION
affects: @fremtind/jkl-bullet-list-react, @fremtind/jkl-bullet-list

## 📥 Proposed changes

Change implementation of bullet lists to use semantic nesting of elements, as used in plain HTML.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] Lint and unit tests pass locally with my changes
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further comments

This might be a bit more verbose, but is more accessible, and makes more sense when using only the style package.

Before:
```jsx
<Ul>
    <Li>Some element</Li>
    <Li nested>Some nested element</Li>
</Ul>
```

Now:
```jsx
<Ul>
    <Li>
        Some element
        <Ul>
            <Li>Some nested element</Li>
        </Ul>
    </Li>
</Ul>
```