### PR TITLE
feat(core): implement font-face for better font handling

### DIFF
--- a/packages/core/src/typography/root.scss
+++ b/packages/core/src/typography/root.scss
@@ -1,5 +1,18 @@
+@font-face {
+    font-family: AkkuratPro;
+    font-style: normal;
+    font-weight: normal;
+    src: local("Akkurat Light Pro");
+}
+@font-face {
+    font-family: AkkuratPro;
+    font-style: normal;
+    font-weight: bold;
+    src: local("Akkurat Pro");
+}
+
 :root {
-    font-family: "Akkurat Light Pro";
+    font-family: AkkuratPro;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## 📥 Proposed changes

Implement the font using `@font-face`. 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

This enables us to use `font-weight: bold` to get Akkurat Pro instead of Akkurat Light Pro. Currently it looks for the locally installed fonts (which does not work in Safari), but it is trivial to use a url instead when we distribute the font later.

**Please note:** All styles specifying `font-family: "Akkurat Pro"` should be changed to use `font-weight: bold`.