### PR TITLE
feat(portal): make markdown parser use our components

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -1,4 +1,27 @@
-# Button
+# Knapper
 
-I am the markdown documentation for Button
+Knapper starter en handling. De oppfordrer brukeren til å gjøre noe. Teksten på knappen forteller hva som vil skje når brukeren velger den.
 
+## Knappetyper
+
+-   Primærknapp – brukes når du vil oppfordre
+    til en hovedhandling på en side.
+-   Sekundærknapp – for handlinger som kommer i andre rekke på en side.
+-   Tertiærknapp - brukes for handlinger som har begrenset viktighet eller kan føre til uønskede konsekvenser
+
+For Fremtind designer vi knappene med animasjon etter prinsippet om [elevasjon](#). Det vil si at når brukerne beveger pekeren over eller velger en knapp, vil den bli midlertidig forstørret.
+
+## Eksempler
+
+Knapper brukes til handlinger som
+
+-   Lagre
+-   Slett
+-   Meld skade
+-   Fortsett (i et skjema)
+
+Hver side kan ha én eller to primærknapper. Hvis du ønsker at brukeren skal gjøre noe mer, bruk en sekundærknapp.
+
+## Generelle råd
+
+Ikke bruk knapper til å navigere. Hvis du vil at brukeren skal gå til en ny side, bruker du en lenke. Unntak: I skjemaer er det naturlig å hjelpe brukeren videre med en Fortsett-knapp.

--- a/portal/src/pages/components/button.tsx
+++ b/portal/src/pages/components/button.tsx
@@ -7,12 +7,13 @@ import ReactMarkdown from "react-markdown";
 import { ButtonExample } from "../../components/ButtonExample";
 import Layout from "../../components/layout";
 import { PrismHighlightedCode } from "../../components/PrismHighlightedCode";
+import { renderer } from "../../presentation/markdownRenderer";
 
 export default function Button() {
     return (
         <Layout>
             <div style={{ margin: "2rem 0" }}>
-                <ReactMarkdown source={ButtonMarkdown} />
+                <ReactMarkdown renderers={renderer} source={ButtonMarkdown} />
             </div>
             <div>
                 <ButtonExample />

--- a/portal/src/presentation/markdownRenderer.ts
+++ b/portal/src/presentation/markdownRenderer.ts
@@ -1,0 +1,17 @@
+import { createElement, ReactNode } from "react";
+
+interface Props {
+    children?: ReactNode;
+}
+
+interface HeadingProps extends Props {
+    level: number;
+}
+
+export const renderer = {
+    paragraph: ({ children }: Props) => createElement("p", { className: "jkl-p" }, children),
+    heading: ({ level, children }: HeadingProps) =>
+        createElement(`h${level}`, { className: `jkl-h${level}` }, children),
+    list: ({ children }: Props) => createElement("ul", { className: "jkl-bullet-list" }, children),
+    listItem: ({ children }: Props) => createElement("li", { className: "jkl-bullet-list__item" }, children),
+};


### PR DESCRIPTION
## 📥 Proposed changes

Add a renderer for `markdown-react` to use our styles for typographic elements when displaying the `readme.md` file for a component.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Currently handles paragraphs (not lead), headings and bullet lists (turns all lists into unordered lists)
