### PR TITLE
fix(ci): force build:docs before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 branches:
     only:
         - master
+before_deploy: yarn build:docs
 deploy:
     provider: pages
     local_dir: "./portal/public"


### PR DESCRIPTION
## 📥 Proposed changes

Make travis build docs before deploy

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Not 100% sure if this will work, but we'll see!
