### PR TITLE
fix(portal): use correct sass imports in portal components

### DIFF
--- a/portal/gatsby-browser.js
+++ b/portal/gatsby-browser.js
@@ -5,7 +5,7 @@
  */
 
 import "document-register-element";
-import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-core/core.min.css";
 import "prismjs/themes/prism.css";
 import "prismjs";
 import "prismjs/components/prism-jsx";

--- a/portal/src/components/Header.scss
+++ b/portal/src/components/Header.scss
@@ -1,4 +1,4 @@
-@import "~@fremtind/jkl-core/build/scss/variables/variables";
+@import "~@fremtind/jkl-core/variables/_all.scss";
 
 .portal-header {
     position: absolute;

--- a/portal/src/components/Layout.scss
+++ b/portal/src/components/Layout.scss
@@ -1,4 +1,4 @@
-@import "~@fremtind/jkl-core/build/scss/variables/variables";
+@import "~@fremtind/jkl-core/variables/_all.scss";
 
 /* This is the main container (@reach/router within gatsby wrapper) */
 #___gatsby > div[role="group"][tabindex] {

--- a/portal/src/components/Menu.scss
+++ b/portal/src/components/Menu.scss
@@ -1,5 +1,4 @@
-@import "~@fremtind/jkl-core/build/scss/variables/variables.scss";
-@import "~@fremtind/jkl-core/build/scss/typography/font-size.scss";
+@import "~@fremtind/jkl-core/variables/_all.scss";
 
 .portal-menu {
     box-sizing: border-box;


### PR DESCRIPTION
## 📥 Proposed changes

Use correct imports from `jkl-core`. Build on master now fails because of these imports in the Portal.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING]() doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
