### PR TITLE
fix(css): output prefixed css files, fix import from core

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 ## ☑️ Submission checklist
 
--   [ ] I have read the [CONTRIBUTING]("../guides/Contribute.md") doc
+-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/guides/Contribute.md) doc
 -   [ ] `yarn build` works locally with my changes
 -   [ ] I have added tests that prove my fix is effective or that my feature works
 -   [ ] I have added necessary documentation (if appropriate)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import { PrimaryButton } from "@fremtind/jkl-button-react";
 ### Stilark-pakker
 
 Hvis du ikke vil bruke React-komponentene, så kan du bruke stilarkene direkte. Da kan du enten laste inn css filene, eller du kan laste scss filene inn i din scss fil og få tilgang på Jøkuls variabler og mixins. Pass på at du uansett trenger en riktig loader for å ta det i bruk i ditt prosjekt.
-`yarn install @fremtind/jkl-button/build/css/button.css`
+`yarn install @fremtind/jkl-button/button.css`
 
 ```tsx
 import "@fremtind/jkl-button/button.css";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,13 +15,15 @@ function throwError(e) {
 }
 module.exports = {
     scss: function() {
-        return src("**/*.scss")
+        return src("**/*.scss", "!**/example/**")
             .pipe(sass({ importer }).on("error", throwError))
             .pipe(dest("./"));
     },
     css: function() {
         return src(["**/*.css", "!**/example/**", "!**/*.min.css"])
-            .pipe(postcss([autoprefixer(), cssnano()]))
+            .pipe(postcss([autoprefixer()]))
+            .pipe(dest("./"))
+            .pipe(postcss([cssnano()]))
             .pipe(rename({ suffix: ".min" }))
             .pipe(dest("./"));
     },

--- a/packages/checkbox-react/example/index.tsx
+++ b/packages/checkbox-react/example/index.tsx
@@ -1,5 +1,5 @@
 import "@fremtind/jkl-checkbox/checkbox.css";
-import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-core/core.css";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Checkbox } from "../src";

--- a/packages/checkbox/example/index.tsx
+++ b/packages/checkbox/example/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-core/core.css";
 import "../checkbox.scss";
 
 const App = () => (

--- a/packages/footer-react/example/index.tsx
+++ b/packages/footer-react/example/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Footer } from "../src";
 import "@fremtind/jkl-grid/grid.css";
-import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-core/core.css";
 import "@fremtind/jkl-footer/footer.css";
 
 const FooterDemo = () => <Footer />;

--- a/packages/footer/example/index.tsx
+++ b/packages/footer/example/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import { SmallParagraph } from "@fremtind/jkl-typography-react";
 import { Grid, GridElement } from "@fremtind/jkl-grid-react";
 import "@fremtind/jkl-grid/grid.css";
-import "@fremtind/jkl-core/build/css/core.css";
+import "@fremtind/jkl-core/core.css";
 import "../footer.scss";
 
 // eslint-disable-next-line


### PR DESCRIPTION
affects: @fremtind/jkl-checkbox-react, @fremtind/jkl-checkbox, @fremtind/jkl-footer-react,
@fremtind/jkl-footer

## 📥 Proposed changes

It used to just autoprefix the minified css files. Now it does it to both normal css and css.min files. Also excludes scss files in example to be compiled.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING]("../guides/Contribute.md") doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments
