### PR TITLE
fix(bullet-list): remove import of paragraph styles and align spacing

### DIFF
--- a/packages/bullet-list-react/src/BulletList.tsx
+++ b/packages/bullet-list-react/src/BulletList.tsx
@@ -5,6 +5,6 @@ interface Props {
     className?: string;
 }
 
-export const BulletList = ({ children, className }: Props) => (
-    <ul className={`jkl-bullet-list ${className || ""}`}>{children}</ul>
+export const BulletList = ({ children, className = "jkl-p" }: Props) => (
+    <ul className={`jkl-bullet-list ${className}`}>{children}</ul>
 );

--- a/packages/bullet-list/bullet-list.scss
+++ b/packages/bullet-list/bullet-list.scss
@@ -1,31 +1,33 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
-@import "~@fremtind/jkl-core/paragraphs.scss";
 
+$list-indent: $component-spacing--xl;
 $bullet-size: rem(6px);
-$bullet-point-center-offset: rem(4px);
-$bullet-item-space-between: $component-spacing--xl;
-$bullet-item-indent: $component-spacing--large;
-$bullet-nested-item-indent: $component-spacing--xxl;
+$item-space-between: $component-spacing--large;
+$item-indent: $component-spacing--xxl;
 
 .jkl-bullet-list {
     list-style: none;
     padding: 0;
+    padding-left: $list-indent;
     margin: 0;
-    @extend .jkl-p; // paragraph font-size and line-height
+    margin-bottom: $layout-spacing--small;
 
     & > &__item {
-        margin: $bullet-item-space-between 0;
+        position: relative;
+        margin: $item-space-between 0;
+        padding-left: $item-indent;
 
         &::before {
             content: "";
+            position: absolute;
+            left: 0;
+            top: ($line-height-3 / 2) - rem(2px);
             display: inline-block;
             height: $bullet-size;
             width: $bullet-size;
             background-color: $svart;
-            transform: rotate(45deg);
-            margin-right: $bullet-item-indent;
-            margin-bottom: $bullet-point-center-offset;
+            transform: rotate(45deg) translateY(-50%);
         }
 
         &:first-of-type {
@@ -36,16 +38,15 @@ $bullet-nested-item-indent: $component-spacing--xxl;
         }
     }
     & & > &__item {
-        margin-left: $bullet-nested-item-indent;
         &::before {
             box-shadow: inset 0px 0px 0px rem(1px) $svart;
             background-color: transparent;
         }
         &:first-of-type {
-            margin-top: $bullet-item-space-between;
+            margin-top: $item-space-between;
         }
         &:last-of-type {
-            margin-bottom: $bullet-item-space-between;
+            margin-bottom: $item-space-between;
         }
     }
     & & & > &__item {

--- a/packages/bullet-list/example/index.html
+++ b/packages/bullet-list/example/index.html
@@ -9,7 +9,7 @@
     </head>
 
     <body>
-        <ul class="jkl-bullet-list">
+        <ul class="jkl-bullet-list jkl-p">
             <li class="jkl-bullet-list__item">Normal bullet list</li>
             <li class="jkl-bullet-list__item">Oh hi Mark</li>
             <li class="jkl-bullet-list__item">Oh hi Johnny</li>

--- a/portal/src/presentation/markdownRenderer.ts
+++ b/portal/src/presentation/markdownRenderer.ts
@@ -12,6 +12,6 @@ export const renderer = {
     paragraph: ({ children }: Props) => createElement("p", { className: "jkl-p" }, children),
     heading: ({ level, children }: HeadingProps) =>
         createElement(`h${level}`, { className: `jkl-h${level + 1}` }, children),
-    list: ({ children }: Props) => createElement("ul", { className: "jkl-bullet-list" }, children),
+    list: ({ children }: Props) => createElement("ul", { className: "jkl-bullet-list jkl-p" }, children),
     listItem: ({ children }: Props) => createElement("li", { className: "jkl-bullet-list__item" }, children),
 };


### PR DESCRIPTION
affects: @fremtind/jkl-bullet-list, @fremtind/portal

## 📥 Proposed changes

Remove unneeded import of `paragraph.css`. A class name for paragraph style (like `jkl-p` or `jkl-lead`) will now have to be applied to the list element along with `jkl-bullet-list`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/guides/Contribute.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

