### PR TITLE
feat(core): add spacing after typographic elements

### DIFF
--- a/packages/core/headings.scss
+++ b/packages/core/headings.scss
@@ -1,4 +1,5 @@
 @import "./variables/font-size";
+@import "./variables/spacing";
 
 %normal-font-weight {
     font-weight: normal;
@@ -8,22 +9,26 @@
     @extend %normal-font-weight;
     @include font-size("xxl");
     @include line-height("xxl");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-h2 {
     @extend %normal-font-weight;
     @include font-size("xl");
     @include line-height("xl");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-h3 {
     @extend %normal-font-weight;
     @include font-size("large");
     @include line-height("large");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-h4 {
     @extend %normal-font-weight;
     @include font-size("medium");
     line-height: $line-height-3; // exeption from scale
+    margin-bottom: $layout-spacing--small;
 }

--- a/packages/core/paragraphs.scss
+++ b/packages/core/paragraphs.scss
@@ -1,21 +1,26 @@
 @import "./variables/font-size";
+@import "./variables/spacing";
 
 .jkl-p {
     @include font-size("small");
     @include line-height("small");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-lead {
     @include font-size("medium");
     @include line-height("medium");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-small {
     @include font-size("xs");
     @include line-height("xs");
+    margin-bottom: $layout-spacing--small;
 }
 
 .jkl-tiny {
     @include font-size("xxs");
     @include line-height("xxs");
+    margin-bottom: $layout-spacing--small;
 }


### PR DESCRIPTION
## 📥 Proposed changes

Add spacing after typographic elements (headers and paragraphs), to restore some air to layouts.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/guides/Contribute.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

The exact spacing used should be looked at by the designers. As of now, there is no guidelines for this in the DS.