### PR TITLE
fix(portal): make portal build correctly

### DIFF
--- a/portal/src/components/Menu/Menu.tsx
+++ b/portal/src/components/Menu/Menu.tsx
@@ -1,54 +1,79 @@
 import React from "react";
 import { Link } from "gatsby";
+import { LocationProvider } from "@reach/router";
 import { Accordion, AccordionItem } from "@fremtind/jkl-accordion-react";
 import { coreLinks, developerLinks, designerLinks, componentLinks, profileLinks } from "./links";
 
 import "./Menu.scss";
 
-const shouldBeOpen = (section = "string") => window && window.location && window.location.pathname.includes(section);
-const startOpen = () => window && window.location && window.location.pathname === "/";
-
 export function Menu() {
     return (
-        <nav className="portal-menu">
-            <Accordion>
-                <AccordionItem title="Grunnleggende" startExpanded={shouldBeOpen("core") || startOpen()}>
-                    {coreLinks.map((link) => (
-                        <Link key={link.title} className="portal-menu__link" to={`/${link.section}/${link.page}`}>
-                            {link.title}
-                        </Link>
-                    ))}
-                </AccordionItem>
+        <LocationProvider>
+            {({ location }) => (
+                <nav className="portal-menu">
+                    <Accordion>
+                        <AccordionItem
+                            title="Grunnleggende"
+                            startExpanded={location.pathname.includes("core") || location.pathname === "/"}
+                        >
+                            {coreLinks.map((link) => (
+                                <Link
+                                    key={link.title}
+                                    className="portal-menu__link"
+                                    to={`/${link.section}/${link.page}`}
+                                >
+                                    {link.title}
+                                </Link>
+                            ))}
+                        </AccordionItem>
 
-                <AccordionItem title="Profilelementer" startExpanded={shouldBeOpen("profile")}>
-                    {profileLinks.map((link) => (
-                        <Link key={link.title} className="portal-menu__link" to={`/${link.section}/${link.page}`}>
-                            {link.title}
-                        </Link>
-                    ))}
-                </AccordionItem>
-                <AccordionItem title="For designere" startExpanded={shouldBeOpen("designer")}>
-                    {designerLinks.map((link) => (
-                        <Link key={link.title} className="portal-menu__link" to={`/${link.section}/${link.page}`}>
-                            {link.title}
-                        </Link>
-                    ))}
-                </AccordionItem>
-                <AccordionItem title="For utviklere" startExpanded={shouldBeOpen("developer")}>
-                    {developerLinks.map((link) => (
-                        <Link key={link.title} className="portal-menu__link" to={`/${link.section}/${link.page}`}>
-                            {link.title}
-                        </Link>
-                    ))}
-                </AccordionItem>
-                <AccordionItem title="Komponenter" startExpanded={shouldBeOpen("components")}>
-                    {componentLinks.map((link) => (
-                        <Link key={link.title} className="portal-menu__link" to={`/${link.section}/${link.page}`}>
-                            {link.title}
-                        </Link>
-                    ))}
-                </AccordionItem>
-            </Accordion>
-        </nav>
+                        <AccordionItem title="Profilelementer" startExpanded={location.pathname.includes("profile")}>
+                            {profileLinks.map((link) => (
+                                <Link
+                                    key={link.title}
+                                    className="portal-menu__link"
+                                    to={`/${link.section}/${link.page}`}
+                                >
+                                    {link.title}
+                                </Link>
+                            ))}
+                        </AccordionItem>
+                        <AccordionItem title="For designere" startExpanded={location.pathname.includes("designer")}>
+                            {designerLinks.map((link) => (
+                                <Link
+                                    key={link.title}
+                                    className="portal-menu__link"
+                                    to={`/${link.section}/${link.page}`}
+                                >
+                                    {link.title}
+                                </Link>
+                            ))}
+                        </AccordionItem>
+                        <AccordionItem title="For utviklere" startExpanded={location.pathname.includes("developer")}>
+                            {developerLinks.map((link) => (
+                                <Link
+                                    key={link.title}
+                                    className="portal-menu__link"
+                                    to={`/${link.section}/${link.page}`}
+                                >
+                                    {link.title}
+                                </Link>
+                            ))}
+                        </AccordionItem>
+                        <AccordionItem title="Komponenter" startExpanded={location.pathname.includes("components")}>
+                            {componentLinks.map((link) => (
+                                <Link
+                                    key={link.title}
+                                    className="portal-menu__link"
+                                    to={`/${link.section}/${link.page}`}
+                                >
+                                    {link.title}
+                                </Link>
+                            ))}
+                        </AccordionItem>
+                    </Accordion>
+                </nav>
+            )}
+        </LocationProvider>
     );
 }


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

make `Menu` component use `Location` (from `@reach/router`) for getting url path instead of using the `window` object.


## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/guides/Contribute.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

The Menu component is a bit ugly now. We might consider refactoring sometime