### PR TITLE
feat(build): add watch job for css, refactor gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { src, dest } = require("gulp");
 const sass = require("gulp-sass");
 const importer = require("node-sass-tilde-importer");
 const postcss = require("gulp-postcss");
@@ -13,18 +12,20 @@ sass.compiler = require("node-sass");
 function throwError(e) {
     throw new Error("sass compilation failed", e);
 }
-module.exports = {
-    scss: function() {
-        return src("**/*.scss", "!**/example/**")
+
+module.exports = function(gulp) {
+    gulp.task("build", function() {
+        return gulp
+            .src("**/*.scss", "!**/example/**")
             .pipe(sass({ importer }).on("error", throwError))
-            .pipe(dest("./"));
-    },
-    css: function() {
-        return src(["**/*.css", "!**/example/**", "!**/*.min.css"])
             .pipe(postcss([autoprefixer()]))
-            .pipe(dest("./"))
+            .pipe(gulp.dest("./"))
             .pipe(postcss([cssnano()]))
             .pipe(rename({ suffix: ".min" }))
-            .pipe(dest("./"));
-    },
+            .pipe(gulp.dest("./"));
+    });
+    gulp.task("build:watch", function() {
+        return gulp.watch("**/*.scss", gulp.series("build"));
+    });
+    return gulp;
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,10 +13,12 @@ function throwError(e) {
     throw new Error("sass compilation failed", e);
 }
 
+const scssFiles = ["**/*.scss", "!example/*.scss"];
+
 module.exports = function(gulp) {
     gulp.task("build", function() {
         return gulp
-            .src("**/*.scss", "!**/example/**")
+            .src(scssFiles)
             .pipe(sass({ importer }).on("error", throwError))
             .pipe(postcss([autoprefixer()]))
             .pipe(gulp.dest("./"))
@@ -25,7 +27,7 @@ module.exports = function(gulp) {
             .pipe(gulp.dest("./"));
     });
     gulp.task("build:watch", function() {
-        return gulp.watch("**/*.scss", gulp.series("build"));
+        return gulp.watch(scssFiles, { ignoreInitial: false }, gulp.series("build"));
     });
     return gulp;
 };

--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Accordion for Jøkul",
+    "description": "Jøkul react accordion component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "accordion"
+        "accordion",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,13 +25,19 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-accordion yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-accordion": "^0.5.0",
         "@nrk/core-toggle": "^3.0.4"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -36,11 +45,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/accordion/gulpfile.js
+++ b/packages/accordion/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Accordion menu",
+    "description": "Jøkul style for accordion menu",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "accordion"
+        "accordion",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -22,11 +25,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/browserslist-config-jkl/package.json
+++ b/packages/browserslist-config-jkl/package.json
@@ -1,25 +1,27 @@
 {
     "name": "@fremtind/browserslist-config-jkl",
     "version": "0.3.0",
-    "description": "browserlist configuration for jøkul",
+    "description": "Browserlist configuration for jøkul",
     "keywords": [
-        "browserlist"
+        "browserlist",
+        "jøkul",
+        "fremtind"
     ],
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://github.com/fremtind/jokul#readme",
+    "homepage": "https://fremtind.github.io/jokul",
     "license": "MIT",
     "main": "index.js",
     "files": [
         "index.js"
     ],
+    "scripts": {
+        "test": "echo \"Error: run tests from root\" && exit 1"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
-    },
-    "scripts": {
-        "test": "echo \"Error: run tests from root\" && exit 1"
     },
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"

--- a/packages/bullet-list-react/example/index.tsx
+++ b/packages/bullet-list-react/example/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BulletList, BulletListItem } from "../src";
 import "@fremtind/jkl-bullet-list/bullet-list.scss";
-import "@fremtind/jkl-core/src/core.scss";
+import "@fremtind/jkl-core/core.scss";
 import "./index.scss";
 
 const UlExample = () => (

--- a/packages/bullet-list-react/package.json
+++ b/packages/bullet-list-react/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "bullet-list for Jøkul",
+    "description": "Jøkul react bullet list component",
     "keywords": [
-        "bullet-list"
+        "bullet-list",
+        "list",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,13 +25,19 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-bullet-list yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-bullet-list": "^0.5.0",
         "@nrk/core-toggle": "^3.0.4"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -36,11 +45,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/bullet-list/gulpfile.js
+++ b/packages/bullet-list/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/bullet-list/package.json
+++ b/packages/bullet-list/package.json
@@ -16,6 +16,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/bullet-list/package.json
+++ b/packages/bullet-list/package.json
@@ -4,10 +4,13 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Bullet list",
+    "description": "Jøkul style for bullet list",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "bullet list",
-        "list"
+        "list",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -23,11 +26,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/button-react/example/index.html
+++ b/packages/button-react/example/index.html
@@ -1,5 +1,4 @@
 <html>
-    <link rel="stylesheet" href="../index.scss" />
     <body>
         <div id="app"></div>
         <script src="index.tsx"></script>

--- a/packages/button-react/example/index.tsx
+++ b/packages/button-react/example/index.tsx
@@ -9,9 +9,15 @@ function onClick() {
 
 const Buttons = () => (
     <>
-        <PrimaryButton onClick={onClick}>Hello, Primary Button</PrimaryButton>
-        <SecondaryButton onClick={onClick}>Hello, Secondary Button</SecondaryButton>
-        <TertiaryButton onClick={onClick}>Tertiary</TertiaryButton>
+        <div style={{ margin: "20px" }}>
+            <PrimaryButton onClick={onClick}>Hello, Primary Button</PrimaryButton>
+        </div>
+        <div style={{ margin: "20px" }}>
+            <SecondaryButton onClick={onClick}>Hello, Secondary Button</SecondaryButton>
+        </div>
+        <div style={{ margin: "20px" }}>
+            <TertiaryButton onClick={onClick}>Tertiary</TertiaryButton>
+        </div>
     </>
 );
 

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -4,9 +4,15 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Buttons for Jøkul",
+    "description": "Jøkul react button components",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "button"
+        "button",
+        "primary button",
+        "secondary button",
+        "tertiary button",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,12 +28,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-button yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-button": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -35,11 +47,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/button/gulpfile.js
+++ b/packages/button/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -4,9 +4,15 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Buttons for Jøkul",
+    "description": "Jøkul style for buttons",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "button"
+        "button",
+        "primary button",
+        "secondary button",
+        "tertiary button",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -22,11 +28,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -4,7 +4,8 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Card component for Jøkul design system",
+    "description": "Jøkul react card component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "card"
     ],
@@ -22,18 +23,34 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-card yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-card": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.8.17",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/card/gulpfile.js
+++ b/packages/card/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -4,19 +4,18 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Style for card component in Jøkul design system",
+    "description": "Jøkul style for card",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "card"
+        "card",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
         "*.css"
     ],
     "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/fremtind/jokul.git"
-    },
     "scripts": {
         "build": "gulp build",
         "build:watch": "gulp build:watch",
@@ -26,11 +25,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -19,6 +19,7 @@
     },
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -4,9 +4,13 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React Checkboxes for Jøkul",
+    "description": "Jøkul react checkbox component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "checkbox"
+        "checkbox",
+        "form",
+        "jøkul",
+        "fremtind"
     ],
     "directories": {
         "lib": "build"
@@ -15,21 +19,41 @@
         "build"
     ],
     "license": "MIT",
+    "types": "./build/index.d.ts",
+    "main": "./build/cjs/index.js",
+    "module": "./build/esm/index.js",
+    "browser": "./build/browser/index.js",
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-checkbox yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.8.17",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/checkbox/gulpfile.js
+++ b/packages/checkbox/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -4,9 +4,13 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Checkboxes for Jøkul",
+    "description": "Jøkul style for checkbox",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "checkbox"
+        "checkbox",
+        "form",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -22,11 +26,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/core/example/index.tsx
+++ b/packages/core/example/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import "../src/core.scss";
+import "../core.scss";
 import "./style.scss";
 
 interface BoxProps {

--- a/packages/core/gulpfile.js
+++ b/packages/core/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,15 +31,18 @@
         "*.scss"
     ],
     "scripts": {
-        "build": "gulp build && yarn build:modules",
-        "build:modules": "yarn build:types && yarn build:scripts",
+        "build": "run-s build:*",
+        "build:style": "gulp build",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "gulp build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "repository": {
         "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,9 +4,15 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Kåre for Jøkul",
+    "description": "Jøkul score styles",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "core"
+        "core",
+        "typography",
+        "normalize",
+        "font",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -32,12 +38,18 @@
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },
-    "dependencies": {},
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "datepicker",
+    "description": "Jøkul react datepicker component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "datepicker"
+        "datepicker",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,16 +25,11 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/fremtind/jokul.git"
-    },
-    "bugs": {
-        "url": "https://github.com/fremtind/jokul/issues"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-datepicker yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-datepicker": "^0.5.0",
@@ -41,7 +39,21 @@
     },
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.3.0",
-        "@fremtind/jkl-core": "^0.5.0"
+        "@fremtind/jkl-core": "^0.5.0",
+        "npm-run-all": "^4.1.5"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.8.17",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
     },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"

--- a/packages/datepicker/gulpfile.js
+++ b/packages/datepicker/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "datepicker style",
+    "description": "Jøkul style for datepicker",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "datepicker"
+        "datepicker",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -23,6 +26,9 @@
         "@fremtind/jkl-core": "^0.5.0",
         "@fremtind/jkl-text-input": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -33,8 +39,5 @@
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/divider-line-react/package.json
+++ b/packages/divider-line-react/package.json
@@ -4,7 +4,15 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React wrapper for divider-line",
+    "description": "Jøkul react divider line component",
+    "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "divider",
+        "divider line",
+        "line",
+        "jøkul",
+        "fremtind"
+    ],
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",
@@ -19,22 +27,35 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
-    },
-    "bugs": {
-        "url": "https://github.com/fremtind/jokul/issues"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-divider-line yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-divider-line": "^0.5.0",
         "uuid": "^3.3.2"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.8.17",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/divider-line/divider-line.scss
+++ b/packages/divider-line/divider-line.scss
@@ -1,4 +1,4 @@
-@import "~@fremtind/jkl-core/variables/colors";
+@import "~@fremtind/jkl-core/variables/_colors.scss";
 
 $diamond-size: 1rem;
 $diamond-offset: $diamond-size/2;

--- a/packages/divider-line/gulpfile.js
+++ b/packages/divider-line/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/divider-line/package.json
+++ b/packages/divider-line/package.json
@@ -16,6 +16,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/divider-line/package.json
+++ b/packages/divider-line/package.json
@@ -4,10 +4,14 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Style for divider-line in Jøkul",
+    "description": "Jøkul style for divider line",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "divider",
-        "line"
+        "line",
+        "divider-line",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -23,14 +27,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/dropdown-react/package.json
+++ b/packages/dropdown-react/package.json
@@ -4,29 +4,42 @@
     "publishConfig": {
         "access": "public"
     },
+    "description": "Jøkul react dropdown component",
+    "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "dropdown",
+        "form",
+        "jøkul",
+        "fremtind"
+    ],
+    "license": "MIT",
+    "types": "./build/index.d.ts",
+    "main": "./build/cjs/index.js",
+    "module": "./build/esm/index.js",
+    "browser": "./build/browser/index.js",
     "directories": {
         "lib": "build"
     },
     "files": [
         "build"
     ],
-    "description": "react wrapper for dropdown",
-    "homepage": "https://fremtind.github.io/jokul",
-    "license": "MIT",
-    "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-dropdown yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-dropdown": "^0.5.0",
         "downshift": "^3.2.10"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "prop-types": "^15.7.2",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -40,10 +53,6 @@
     },
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
-    },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0",
-        "prop-types": "^15.7.2"
     },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"

--- a/packages/dropdown-react/package.json
+++ b/packages/dropdown-react/package.json
@@ -11,7 +11,7 @@
         "build"
     ],
     "description": "react wrapper for dropdown",
-    "homepage": "https://github.com/fremtind/jokul#readme",
+    "homepage": "https://fremtind.github.io/jokul",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/dropdown/dropdown.scss
+++ b/packages/dropdown/dropdown.scss
@@ -1,5 +1,5 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
-@import "~@fremtind/jkl-core/mixins/utils";
+@import "~@fremtind/jkl-core/mixins/_utils.scss";
 
 $dropdown-height: 3rem;
 $dropdown-width: 20rem;

--- a/packages/dropdown/gulpfile.js
+++ b/packages/dropdown/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Dropdowns for Jøkul",
+    "description": "Jøkul style for dropdown",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "dropdown"
+        "dropdown",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -21,11 +24,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1"
     },
     "dependencies": {

--- a/packages/footer-react/package.json
+++ b/packages/footer-react/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Fremtind footer",
+    "description": "Jøkul react fremtind footer component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "footer"
+        "footer",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,9 +25,11 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-footer yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0",
@@ -32,17 +37,25 @@
         "@fremtind/jkl-grid": "^0.5.0",
         "@fremtind/jkl-typography-react": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
+    },
     "peerDependencies": {
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/footer/gulpfile.js
+++ b/packages/footer/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Footer style for Jøkul",
+    "description": "Jøkul style for Fremtind footer",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "footer"
+        "footer",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "files": [
@@ -22,11 +25,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -15,6 +15,7 @@
     ],
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/grid-react/example/index.tsx
+++ b/packages/grid-react/example/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Grid, GridElement } from "../src";
-import "./style.scss";
+import "@fremtind/jkl-grid/grid.css";
 
 const Buttons = () => (
     <Grid>

--- a/packages/grid-react/example/style.scss
+++ b/packages/grid-react/example/style.scss
@@ -1,1 +1,0 @@
-@import "~@fremtind/jkl-grid/src/grid.scss";

--- a/packages/grid-react/package.json
+++ b/packages/grid-react/package.json
@@ -4,10 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React wrapper for grid components",
+    "description": "Jøkul react grid component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "grid",
-        "react"
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -23,12 +25,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-grid yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-grid": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -36,11 +44,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/grid/grid.scss
+++ b/packages/grid/grid.scss
@@ -1,4 +1,4 @@
-@import "~@fremtind/jkl-core/mixins/screens";
+@import "~@fremtind/jkl-core/mixins/_screens.scss";
 
 $number-of-columns--small: 4;
 $number-of-columns--medium: 8;

--- a/packages/grid/gulpfile.js
+++ b/packages/grid/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Grid for Jøkul",
+    "description": "Jøkul style for grid",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "core"
+        "grid",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "files": [
@@ -22,11 +25,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -15,6 +15,7 @@
     ],
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/header-react/package.json
+++ b/packages/header-react/package.json
@@ -4,7 +4,13 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Header component for Fremtind",
+    "description": "Jøkul react fremtind header component",
+    "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "header",
+        "jøkul",
+        "fremtind"
+    ],
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",
@@ -19,13 +25,19 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-header yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0",
         "@fremtind/jkl-header": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -33,11 +45,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/header/gulpfile.js
+++ b/packages/header/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/header/header.scss
+++ b/packages/header/header.scss
@@ -1,5 +1,5 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
-@import "~@fremtind/jkl-core/mixins/utils";
+@import "~@fremtind/jkl-core/mixins/_utils.scss";
 
 $jkl-header: (
     "background-color": $snøhvit,

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -16,6 +16,7 @@
     ],
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -4,10 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Header style for Jøkul",
+    "description": "Jøkul style for Fremtind header",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "header",
-        "style"
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "files": [
@@ -23,11 +25,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -1,11 +1,13 @@
 {
     "name": "@fremtind/jkl-loader-react",
     "version": "0.0.1",
-    "description": "react wrapper for jkl-loader",
-    "keywords": [
-        "loader"
-    ],
+    "description": "Jøkul react loader component",
     "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "loader",
+        "jøkul",
+        "fremtind"
+    ],
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",
@@ -20,12 +22,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-loader yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-loader": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -33,17 +41,14 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
     },
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
-    }
+    },
+    "browserslist": [
+        "extends @fremtind/browserslist-config-jkl"
+    ]
 }

--- a/packages/loader/gulpfile.js
+++ b/packages/loader/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/loader/loader.scss
+++ b/packages/loader/loader.scss
@@ -1,5 +1,5 @@
-@import "~@fremtind/jkl-core/variables/all";
-@import "~@fremtind/jkl-core/functions";
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
 
 @keyframes spin1 {
     0% {

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -16,6 +16,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -4,15 +4,17 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Loaders for Fremtind",
+    "description": "Jøkul style for loaders",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "loader"
+        "loader",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
         "*.css"
     ],
-    "homepage": "https://github.com/fremtind/jokul#readme",
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
@@ -22,6 +24,9 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
     },
     "repository": {
         "type": "git",
@@ -33,8 +38,5 @@
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -4,9 +4,12 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Logo components for Fremtind",
+    "description": "Jøkul react logo component",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "logo"
+        "logo",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,12 +25,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-logo yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-logo": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -35,11 +44,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/logo/gulpfile.js
+++ b/packages/logo/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/logo/logo.scss
+++ b/packages/logo/logo.scss
@@ -1,4 +1,4 @@
-@import "~@fremtind/jkl-core/variables/colors";
+@import "~@fremtind/jkl-core/variables/_colors.scss";
 
 $jkl-logo-color: $svart;
 $jkl-logo-color--negative: $snøhvit;

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -16,6 +16,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1"
     },
     "dependencies": {

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -8,11 +8,13 @@
         "!example",
         "*.css"
     ],
-    "description": "style for Fremtind logo",
+    "description": "Jøkul style for Fremtind logo",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "logo"
+        "logo",
+        "jøkul",
+        "fremtind"
     ],
-    "homepage": "https://github.com/fremtind/jokul#readme",
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
@@ -21,6 +23,9 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
     },
     "repository": {
         "type": "git",
@@ -32,8 +37,5 @@
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -4,9 +4,13 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React wrapper for message box",
+    "description": "Jøkul react message box components",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "messagebox"
+        "messagebox",
+        "message",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -22,16 +26,20 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-message-box yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-message-box": "^0.5.0",
         "@fremtind/jkl-typography-react": "^0.5.0"
     },
-    "devDependecies": {
-        "@fremtind/jkl-core": "^0.0.1"
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "@fremtind/jkl-core": "^0.5.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -49,8 +57,5 @@
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/message-box/gulpfile.js
+++ b/packages/message-box/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -1,6 +1,5 @@
-@import "~@fremtind/jkl-core/variables/colors";
-@import "~@fremtind/jkl-core/variables/spacing";
-@import "~@fremtind/jkl-core/mixins/utils";
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 
 .jkl-message-box {
     position: relative;

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -6,7 +6,9 @@
     },
     "description": "Jøkul message box style",
     "keywords": [
-        "message"
+        "message",
+        "jøkul",
+        "fremtind"
     ],
     "files": [
         "!example",
@@ -22,6 +24,9 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -32,8 +37,5 @@
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -15,6 +15,7 @@
     "license": "MIT",
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -4,11 +4,14 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React implementation of radio buttons in the Jøkul design system",
+    "description": "Jøkul react radio button components",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "interface",
-        "form-element",
-        "radio-button"
+        "radio",
+        "form",
+        "radio-button",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -24,9 +27,11 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-radio-button yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-radio-button": "^0.5.0",
@@ -34,7 +39,21 @@
     },
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5",
         "@types/uuid": "^3.4.4"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.8.17",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
     },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"

--- a/packages/radio-button/gulpfile.js
+++ b/packages/radio-button/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -4,12 +4,14 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Radio button fro the Jøkul design system",
+    "description": "Jøkul style for radio button",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
-        "interface",
         "radio",
+        "radio button",
         "form",
-        "form-field"
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "files": [
@@ -25,11 +27,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -18,6 +18,7 @@
     ],
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html --open"
     },

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -4,14 +4,16 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "React component for text input, text field and text area",
+    "description": "Jøkul react text input component",
     "keywords": [
-        "react",
         "text",
         "field",
-        "text",
+        "textfield",
+        "textarea",
         "input",
-        "form"
+        "form",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -27,12 +29,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-text-input yarn build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-text-input": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -40,11 +48,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/text-input/gulpfile.js
+++ b/packages/text-input/gulpfile.js
@@ -1,6 +1,3 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { series } = require("gulp");
-const build = require("../../gulpfile");
+require("../../gulpfile")(require("gulp"));
 /* eslint-enable @typescript-eslint/no-var-requires */
-
-exports.build = series(build.scss, build.css);

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -19,6 +19,7 @@
     ],
     "scripts": {
         "build": "gulp build",
+        "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -4,15 +4,18 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Style for text input components",
+    "description": "Jøkul style for text input fields",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "text",
-        "text",
-        "field",
-        "input"
+        "text field",
+        "text area",
+        "input",
+        "form",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
-    "typings": "build/*.d.ts",
     "files": [
         "!example",
         "*.css"
@@ -26,11 +29,18 @@
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
     },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/packages/typography-react/example/index.tsx
+++ b/packages/typography-react/example/index.tsx
@@ -1,5 +1,6 @@
-import "@fremtind/jkl-core/src/typography/typography.scss";
-import "@fremtind/jkl-core/src/normalize.scss";
+import "@fremtind/jkl-core/headings.min.css";
+import "@fremtind/jkl-core/paragraphs.min.css";
+import "@fremtind/jkl-core/normalize.min.css";
 import React from "react";
 import ReactDOM from "react-dom";
 import { H1, H2, H3, H4, LeadParagraph, P, SmallParagraph, TinyParagraph } from "../src";

--- a/packages/typography-react/package.json
+++ b/packages/typography-react/package.json
@@ -4,13 +4,16 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "Typography for Jøkul",
+    "description": "Jøkul react typography components",
+    "homepage": "https://fremtind.github.io/jokul",
     "keywords": [
         "typography",
         "heading",
         "paragraph",
         "small text",
-        "lead text"
+        "lead text",
+        "jøkul",
+        "fremtind"
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
@@ -26,12 +29,18 @@
     "scripts": {
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "rollup --config ../../rollup.config.js",
-        "build": "yarn run build:scripts && yarn run build:types",
+        "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
-        "dev": "parcel example/index.html"
+        "dev:style": "lerna exec --scope=@fremtind/jkl-core gulp build:watch",
+        "dev:js": "parcel example/index.html",
+        "dev": "run-p dev:*"
     },
     "dependencies": {
         "@fremtind/jkl-core": "^0.5.0"
+    },
+    "devDependencies": {
+        "@fremtind/browserslist-config-jkl": "^0.3.0",
+        "npm-run-all": "^4.1.5"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",
@@ -39,11 +48,15 @@
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
     "browserslist": [
         "extends @fremtind/browserslist-config-jkl"
     ],
-    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68",
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.3.0"
-    }
+    "gitHead": "44aec59eb546485ac7af7b875066408b2e696e68"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6220,7 +6220,7 @@ error-stack-parser@^2.0.0:
   dependencies:
     stackframe "^1.0.4"
 
-es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
+es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -7344,7 +7344,7 @@ fstream@^1.0.0, fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
@@ -10879,6 +10879,11 @@ memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
@@ -11634,6 +11639,21 @@ npm-pick-manifest@^2.2.3:
     figgy-pudding "^3.5.1"
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -12494,6 +12514,11 @@ picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+
+pidtree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
+  integrity sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -14519,7 +14544,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shell-quote@1.6.1:
+shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
@@ -15094,6 +15119,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string.prototype.padend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
+  integrity sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.4.3"
+    function-bind "^1.0.2"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
affects: @fremtind/jkl-accordion, @fremtind/jkl-bullet-list, @fremtind/jkl-button,
@fremtind/jkl-card, @fremtind/jkl-checkbox, @fremtind/jkl-core, @fremtind/jkl-datepicker,
@fremtind/jkl-divider-line, @fremtind/jkl-dropdown, @fremtind/jkl-footer, @fremtind/jkl-grid,
@fremtind/jkl-header, @fremtind/jkl-loader, @fremtind/jkl-logo, @fremtind/jkl-message-box,
@fremtind/jkl-radio-button, @fremtind/jkl-text-input

## 📥 Proposed changes

Gulp is a bit smoother now, only one build style job. Should be slightly faster. Added watch job. 

Normalized all package.json with homepage, repository and bugs. Added entrypoint to packages missing it. Fixed import issues in some examples. Start watch css job on `yarn dev`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/guides/Contribute.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

I'll look into creating a tool that starts the watch job on yarn dev in -react-package. And add it to yarn dev in style pkgs.

ISSUES CLOSED: #156