### PR TITLE
fix(message-box): dont let it grow beoynd its size

### DIFF
--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -7,6 +7,7 @@
     min-height: $layout-spacing--xl;
     padding: $component-spacing--xl;
     background-color: $snøhvit;
+    box-sizing: border-box;
 
     &--full {
         width: 100%;


### PR DESCRIPTION
affects: @fremtind/jkl-message-box

## 📥 Proposed changes

Fix issue where messageboxes is bigger than container.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

