### PR TITLE
fix(dropdown): make dropdown use passed classname prop

### DIFF
--- a/packages/dropdown-react/example/index.scss
+++ b/packages/dropdown-react/example/index.scss
@@ -2,11 +2,15 @@ body {
     padding: 8rem;
 }
 
+button {
+    outline: none;
+}
+
 .jkl-dropdown {
     margin-bottom: 3rem;
     margin-right: 1rem;
-}
 
-button {
-    outline: none;
+    &.short {
+        width: 9rem;
+    }
 }

--- a/packages/dropdown-react/example/index.tsx
+++ b/packages/dropdown-react/example/index.tsx
@@ -45,7 +45,7 @@ const DropdownDemo = () => {
             </div>
 
             <div>
-                <Dropdown key={d} label="Fødselsår" items={years} />
+                <Dropdown className="short" key={d} label="Fødselsår" items={years} />
             </div>
         </>
     );

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -34,7 +34,7 @@ function focusSelected(listEl: HTMLElement, listId: string, selected: string | u
     focusedItem && focusedItem.focus();
 }
 
-export const Dropdown = ({ items, initialInputValue, label, onChange, defaultPrompt = "Velg" }: Props) => {
+export const Dropdown = ({ items, initialInputValue, label, onChange, className, defaultPrompt = "Velg" }: Props) => {
     const [selectedValue, setSelectedValue] = useState(initialInputValue);
     const [dropdownIsShown, setShown] = useState(false);
     const [listId] = useState(`dropdown${nanoid(16)}`);
@@ -57,17 +57,21 @@ export const Dropdown = ({ items, initialInputValue, label, onChange, defaultPro
         onChange && onChange(e.detail.textContent);
     }
 
-    let className = `jkl-dropdown`;
+    let appliedClassName = `jkl-dropdown`;
 
     if (dropdownIsShown) {
-        className = `${className} jkl-dropdown--open`;
+        appliedClassName = `${appliedClassName} jkl-dropdown--open`;
     }
 
     if (!hasSelectedValue) {
-        className = `${className} jkl-dropdown--no-value`;
+        appliedClassName = `${appliedClassName} jkl-dropdown--no-value`;
+    }
+
+    if (className) {
+        appliedClassName = `${appliedClassName} ${className}`;
     }
     return (
-        <div className={className}>
+        <div className={appliedClassName}>
             <span className={`jkl-dropdown__label ${hasSelectedValue ? "jkl-dropdown__label--has-value" : ""}`}>
                 {label}
             </span>

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -57,21 +57,11 @@ export const Dropdown = ({ items, initialInputValue, label, onChange, className,
         onChange && onChange(e.detail.textContent);
     }
 
-    let appliedClassName = `jkl-dropdown`;
-
-    if (dropdownIsShown) {
-        appliedClassName = `${appliedClassName} jkl-dropdown--open`;
-    }
-
-    if (!hasSelectedValue) {
-        appliedClassName = `${appliedClassName} jkl-dropdown--no-value`;
-    }
-
-    if (className) {
-        appliedClassName = `${appliedClassName} ${className}`;
-    }
+    const classModifiers = `${dropdownIsShown ? " jkl-dropdown--open" : ""}${
+        hasSelectedValue ? "" : " jkl-dropdown--no-value"
+    }`;
     return (
-        <div className={appliedClassName}>
+        <div className={`jkl-dropdown${classModifiers} ${className ? className : ""}`}>
             <span className={`jkl-dropdown__label ${hasSelectedValue ? "jkl-dropdown__label--has-value" : ""}`}>
                 {label}
             </span>

--- a/packages/dropdown/dropdown.scss
+++ b/packages/dropdown/dropdown.scss
@@ -30,7 +30,7 @@ $dropdown-total-height: $label-height + $value-height + $bottom-padding;
     background-color: $dropdown-bg-color;
     display: inline-block;
     height: $label-height + $value-height + $bottom-padding;
-    min-width: $dropdown-width;
+    width: $dropdown-width;
     padding-top: $label-height;
     position: relative;
     vertical-align: bottom;
@@ -72,11 +72,17 @@ $dropdown-total-height: $label-height + $value-height + $bottom-padding;
         line-height: $value-height;
         pointer-events: none; // Allow click to happen on the actual button
         position: absolute;
-        left: $side-padding;
+        left: 0;
         top: 0;
         transition: transform $transition-timing, color $transition-timing;
         transform-origin: top left;
         transform: translateY($label-height);
+
+        /* make sure label does not hit chevron */
+        max-width: calc(100% - #{$value-height + $side-padding});
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
 
         &--has-value {
             color: $varm-fjellgrå;
@@ -94,7 +100,7 @@ $dropdown-total-height: $label-height + $value-height + $bottom-padding;
         font-size: $value-font-size;
         height: $value-height + $bottom-padding;
         line-height: $value-height;
-        padding: 0 $side-padding $bottom-padding;
+        padding: 0 $side-padding $bottom-padding 0;
         padding-right: $value-height + $side-padding;
         text-align: left;
         transition: box-shadow $transition-timing, padding $transition-timing;
@@ -142,6 +148,7 @@ $dropdown-total-height: $label-height + $value-height + $bottom-padding;
         padding: 1rem 0.5rem 0;
         max-height: 60vh;
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
         z-index: $z-index--dropdown;
     }
 


### PR DESCRIPTION
## 📥 Proposed changes

Make dropdown actually use passed className prop. Align label and value far left as per new sketches.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
