### PR TITLE
fix(radio-button): style fieldset and label correctly

### DIFF
--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -142,3 +142,17 @@ $radio-button-color: $svart;
         }
     }
 }
+
+.jkl-radio-button-choice {
+    border: 0;
+    padding: 0;
+    margin: 0;
+    line-height: 1;
+
+    & > legend {
+        font-size: $font-size-2;
+        line-height: $line-height-2;
+        color: $varm-fjellgrå;
+        padding-bottom: $component-spacing--small;
+    }
+}


### PR DESCRIPTION
## 📥 Proposed changes

Styles the fieldset of `jkl-radio-button.choice` to match other field labels in the design system

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

