### PR TITLE
fix(text-input): show underline in mobile Safari

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -59,6 +59,8 @@ $error-color: change-color($blomst, $lightness: 45%); // make $blomst WCAG compl
         transition: box-shadow $transition-timing;
 
         box-shadow: 0 rem(2px) 0 0 $border-color;
+        /* show border in mobile Safari */
+        -webkit-appearance: none;
 
         &:hover,
         &:focus {


### PR DESCRIPTION
## 📥 Proposed changes

Specify `-webkit-appearance: none` on text input fields to ensure bottom border is shown in mobile Safari 🤷‍♂️

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

