### PR TITLE
fix(portal): align github and figma links in menu

### DIFF
--- a/portal/src/components/Menu/Menu.scss
+++ b/portal/src/components/Menu/Menu.scss
@@ -82,15 +82,15 @@ $menu-width: rem(320px);
             &:first-of-type {
                 margin-top: $layout-spacing--large;
             }
-            margin-left: $layout-spacing--small;
+            padding-left: $component-spacing--large;
             background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 16 16' version='1.1' width='24' aria-hidden='true'%3E%3Cpath fill='%23fafafa' fill-rule='evenodd' d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'%3E%3C/path%3E%3C/svg%3E%0A");
-            background-position: right;
+            background-position: right $component-spacing--large center;
             background-repeat: no-repeat;
         }
         &--figma {
-            margin-left: $layout-spacing--small;
+            padding-left: $component-spacing--large;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' width='24' height='24' fill='%23fafafa' viewBox='0 0 200 300'%3E%3Cpath d='M50 300c27.6 0 50-22.4 50-50v-50H50c-27.6 0-50 22.4-50 50s22.4 50 50 50z' class='st0'/%3E%3Cpath d='M0 150c0-27.6 22.4-50 50-50h50v100H50c-27.6 0-50-22.4-50-50z' class='st1'/%3E%3Cpath d='M0 50C0 22.4 22.4 0 50 0h50v100H50C22.4 100 0 77.6 0 50z' class='st2'/%3E%3Cpath d='M100 0h50c27.6 0 50 22.4 50 50s-22.4 50-50 50h-50V0z' class='st3'/%3E%3Cpath d='M200 150c0 27.6-22.4 50-50 50s-50-22.4-50-50 22.4-50 50-50 50 22.4 50 50z' class='st4'/%3E%3C/svg%3E%0A");
-            background-position: right;
+            background-position: right $component-spacing--large center;
             background-repeat: no-repeat;
         }
     }


### PR DESCRIPTION
## 📥 Proposed changes

Align the GitHub and Figma links at the bottom of the menu with the top-level items.
## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

These items and their icons felt like they were too far to the right, especially when the last menu accordion was not open.
