### PR TITLE
fix(tablistener): only listen to Tab key, not arrows

### DIFF
--- a/packages/core/src/utils/tabListener.ts
+++ b/packages/core/src/utils/tabListener.ts
@@ -1,4 +1,3 @@
-const navKeys = ["Tab", "ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"];
 let mousenavigation = false;
 
 function handleMouseDown() {
@@ -12,7 +11,7 @@ function handleMouseDown() {
 }
 
 function handleKeydown(event: KeyboardEvent) {
-    if (navKeys.indexOf(event.key) !== -1) {
+    if (event.key === "Tab") {
         if (mousenavigation) {
             mousenavigation = false;
             const htmlElement = document.querySelector("html");


### PR DESCRIPTION
## 📥 Proposed changes

Make tabListener listen only for the `Tab` key when deciding when to turn on keyboard navigation highlighting. Until now it has also listened to the arrow keys, which causes unwanted behavior e.g. when moving the cursor/selecting text in a text field.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments