### PR TITLE
feat(datepicker-react): use select from jkl-dropdown for month picker

### DIFF
--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -33,6 +33,9 @@
     },
     "dependencies": {
         "@fremtind/jkl-datepicker": "^0.6.1",
+        "@fremtind/jkl-dropdown": "^0.6.1",
+        "@fremtind/jkl-dropdown-react": "^0.5.2",
+        "@fremtind/jkl-text-input": "^0.6.1",
         "@fremtind/jkl-text-input-react": "^0.5.2",
         "@nrk/core-datepicker": "^3.0.5",
         "@nrk/core-toggle": "^3.0.4"

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -4,6 +4,7 @@ import CoreDatepicker from "@nrk/core-datepicker/jsx";
 // @ts-ignore
 import CoreToggle from "@nrk/core-toggle/jsx";
 import { TextField } from "@fremtind/jkl-text-input-react";
+import { Select } from "@fremtind/jkl-dropdown-react";
 
 interface ChangeDate {
     date: Date;
@@ -56,10 +57,8 @@ export function DatePicker({
                 >
                     <div className="jkl-datepicker__calendar-header">
                         <TextField label={yearLabel} type="year" className="jkl-datepicker__calendar-header--year" />
-                        <label className="jkl-datepicker__calendar-header--month">
-                            <span className="jkl-datepicker__month-label">{monthLabel}</span>
-                            <select />
-                        </label>
+
+                        <Select className="jkl-datepicker__calendar-header--month" label={monthLabel} items={[]} />
                     </div>
                     <table data-testid="jkl-datepicker-calendar" />
                 </CoreDatepicker>

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -1,7 +1,7 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
-@import "~@fremtind/jkl-core/paragraphs.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 @import "~@fremtind/jkl-text-input/text-input.scss";
+@import "~@fremtind/jkl-dropdown/dropdown.scss";
 
 $date-width: rem(46px);
 $calendar-padding: $component-spacing--xl;
@@ -35,33 +35,6 @@ $popup-top-position: $label-height + $input-height + $bottom-padding + rem(2px);
             position: relative;
             flex-grow: 2;
             padding-top: $label-height;
-
-            select {
-                appearance: none;
-                &::-ms-expand {
-                    display: none; // remove arrow in IE10 and IE11
-                }
-                border: 0;
-                border-radius: 0;
-                outline: none;
-
-                width: 100%;
-
-                display: block;
-                box-shadow: 0 rem(2px) 0 0 $svart;
-                transition: box-shadow 175ms ease-in;
-                background-color: $snøhvit;
-                text-transform: capitalize;
-
-                font-size: $input-font-size;
-                line-height: $input-height;
-                padding-bottom: $bottom-padding;
-
-                &:focus,
-                &:hover {
-                    box-shadow: 0 rem(4px) 0 0 $svart;
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## 📥 Proposed changes

Use the `Select` component from `jkl-dropdown` for the month dropdown, instead of a custom styled `select` element.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

This adds some weight to the component, since it must now depend on both `jkl-dropdown` and `jkl-dropdown-react`, but it keeps the style in sync.
