### PR TITLE
fix(datepicker-react): stop datepicker from submitting forms when opened

### DIFF
--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -47,7 +47,7 @@ export function DatePicker({
 
     return (
         <div className="jkl-datepicker">
-            <button className="jkl-datepicker__toggler" data-testid="jkl-datepicker-toggler">
+            <button type="button" className="jkl-datepicker__toggler" data-testid="jkl-datepicker-toggler">
                 <TextField
                     label={label}
                     type="text"

--- a/portal/src/examples/DatepickerExample.tsx
+++ b/portal/src/examples/DatepickerExample.tsx
@@ -24,6 +24,7 @@ const example = `<>
                 "September",
                 "October",
                 "November",
+                "December"
             ]}
             days={[
                 "Mon",


### PR DESCRIPTION
## 📥 Proposed changes

Add `type="button"` to datepicker toggle to stop it from submitting any forms it is part of when toggled.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
