### PR TITLE
chore: make clean script clean generated css files

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/bullet-list/package.json
+++ b/packages/bullet-list/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/bullet-list/package.json
+++ b/packages/bullet-list/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -20,7 +20,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -20,7 +20,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf build/ dist/ .cache node_modules/ **/*.css",
         "build": "run-s build:*",
         "build:style": "gulp build",
         "build:types": "tsc -p tsconfig-for-declarations.json",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/divider-line/package.json
+++ b/packages/divider-line/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/divider-line/package.json
+++ b/packages/divider-line/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "dev": "parcel example/index.html",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "dev": "parcel example/index.html",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -15,6 +15,7 @@
     ],
     "license": "MIT",
     "scripts": {
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "dev": "parcel example/index.html",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -15,7 +15,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "dev": "parcel example/index.html",

--- a/packages/hamburger/package.json
+++ b/packages/hamburger/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/hamburger/package.json
+++ b/packages/hamburger/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -19,7 +19,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -19,7 +19,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -21,7 +21,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -21,7 +21,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -19,7 +19,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf build/ dist/ .cache node_modules/",
+        "clean": "rimraf **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -19,7 +19,7 @@
         "*.css"
     ],
     "scripts": {
-        "clean": "rimraf **/*.css",
+        "clean": "rimraf node_modules/ dist/ **/*.css",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",


### PR DESCRIPTION
affects: @fremtind/jkl-accordion, @fremtind/jkl-bullet-list, @fremtind/jkl-button,
@fremtind/jkl-card, @fremtind/jkl-checkbox, @fremtind/jkl-core, @fremtind/jkl-datepicker,
@fremtind/jkl-divider-line, @fremtind/jkl-dropdown, @fremtind/jkl-field-group,
@fremtind/jkl-hamburger, @fremtind/jkl-loader, @fremtind/jkl-logo, @fremtind/jkl-message-box,
@fremtind/jkl-radio-button, @fremtind/jkl-text-input, @fremtind/jkl-toggle-switch

## 📥 Proposed changes

The `clean` script only removed build javascript files and types. Update the script in style packages to also remove generated css files.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
