### PR TITLE
feat(loader-react): make loader accept className as prop

### DIFF
--- a/packages/loader-react/src/Loader.test.tsx
+++ b/packages/loader-react/src/Loader.test.tsx
@@ -25,4 +25,9 @@ describe("Loader", () => {
 
         expect(getByTestId("jkl-loader")).toBeInTheDocument();
     });
+    it("should apply passed className prop", () => {
+        const { getByTestId } = render(<Loader className="testclass" />);
+
+        expect(getByTestId("jkl-loader")).toHaveClass("testclass");
+    });
 });

--- a/packages/loader-react/src/Loader.tsx
+++ b/packages/loader-react/src/Loader.tsx
@@ -7,7 +7,7 @@ interface Props {
 export const Loader = ({ negative = false, inline = false, className }: Props) => {
     const componentClassName = "jkl-loader"
         .concat(negative ? " jkl-loader--negative" : "")
-        .concat(inline ? "jkl-loader--inline" : "")
+        .concat(inline ? " jkl-loader--inline" : "")
         .concat(className ? ` ${className}` : "");
     return (
         <span data-testid="jkl-loader" className={componentClassName}>

--- a/packages/loader-react/src/Loader.tsx
+++ b/packages/loader-react/src/Loader.tsx
@@ -2,14 +2,18 @@ import React from "react";
 interface Props {
     negative?: boolean;
     inline?: boolean;
+    className?: string;
 }
-export const Loader = ({ negative = false, inline = false }: Props) => (
-    <span
-        data-testid="jkl-loader"
-        className={`jkl-loader ${negative ? "jkl-loader--negative" : ""} ${inline ? "jkl-loader--inline" : ""}`}
-    >
-        <span className="jkl-loader__1" />
-        <span className="jkl-loader__2" />
-        <span className="jkl-loader__3" />
-    </span>
-);
+export const Loader = ({ negative = false, inline = false, className }: Props) => {
+    const componentClassName = "jkl-loader"
+        .concat(negative ? " jkl-loader--negative" : "")
+        .concat(inline ? "jkl-loader--inline" : "")
+        .concat(className ? ` ${className}` : "");
+    return (
+        <span data-testid="jkl-loader" className={componentClassName}>
+            <span className="jkl-loader__1" />
+            <span className="jkl-loader__2" />
+            <span className="jkl-loader__3" />
+        </span>
+    );
+};


### PR DESCRIPTION
affects: @fremtind/jkl-loader-react

## 📥 Proposed changes

Add the possibility to pass a `className` prop to the `Loader` component. Can be useful for positioning with the `jkl-spacing` classes, for example.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments