### PR TITLE
Dropdown value pairs

### DIFF
--- a/packages/dropdown-react/example/index.tsx
+++ b/packages/dropdown-react/example/index.tsx
@@ -10,9 +10,11 @@ import "./index.scss";
 initTabListener();
 const SelectDemo = () => {
     const items = ["The flower shop", "I have cancer", "Throwing the football", "ChirpChirpChirp"];
+    const valuePairs = [{ value: "firstvalue", label: "Value 1" }, { value: "secondvalue", label: "Value 2" }];
     const years = [...Array(120)].map((_, i) => (i + 1900).toString()); // 1900 - 2019
 
     const [favoriteScene, setFavoriteScene] = useState("");
+    const [valuePair, setValuePair] = useState<string>();
 
     return (
         <>
@@ -39,9 +41,10 @@ const SelectDemo = () => {
             <Select
                 className="jkl-spacing--top-5"
                 label="Native select"
-                items={items}
-                onChange={(e) => console.log(e.target.value)}
-                value="ChirpChirpChirp"
+                items={valuePairs}
+                onChange={(e) => setValuePair(e.target.value)}
+                value={valuePair}
+                helpLabel="This uses value/label pairs"
             />
             <Select
                 className="jkl-spacing--top-3"

--- a/packages/dropdown-react/example/index.tsx
+++ b/packages/dropdown-react/example/index.tsx
@@ -59,7 +59,13 @@ const SelectDemo = () => {
             />
 
             <Dropdown className="jkl-spacing--top-5" label="Favorite The Room scene" items={items} />
-            <Dropdown className="jkl-spacing--top-3" label="Fødselsår" items={years} />
+            <Dropdown
+                className="jkl-spacing--top-3"
+                label="Value pairs"
+                items={valuePairs}
+                onChange={(v) => console.log(v)}
+                helpLabel="This uses value/label pairs"
+            />
         </>
     );
 };

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -5,15 +5,11 @@ import nanoid from "nanoid";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
 import { labelVariant } from "@fremtind/jkl-core";
 import { useListNavigation } from "./useListNavigation";
-
-export type SelectValue = {
-    value: string;
-    label: string;
-};
+import { SelectValuePair, getSelectValuePairFrom } from "./SelectValuePair";
 
 interface Props {
     label: string;
-    items: Array<string | SelectValue>;
+    items: Array<string | SelectValuePair>;
     inline?: boolean;
     defaultPrompt?: string;
     className?: string;
@@ -43,10 +39,6 @@ function focusSelected(listEl: HTMLElement, listId: string, selected: string | u
         focusedItem = listEl.querySelector('[role="option"]');
     }
     focusedItem && focusedItem.focus();
-}
-
-export function makeSelectValueFrom(item: string | SelectValue) {
-    return typeof item === "string" ? { value: item, label: item } : item;
 }
 
 export function Dropdown({
@@ -119,7 +111,7 @@ export function Dropdown({
                         ref={listRef}
                     >
                         {items.map((item) => {
-                            item = makeSelectValueFrom(item);
+                            item = getSelectValuePairFrom(item);
                             return (
                                 <li key={item.value}>
                                     <button

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -86,7 +86,7 @@ export function Dropdown({
         e.target.button.focus();
         e.target.value = e.detail;
         setSelectedValue(e.detail.textContent);
-        onChange && onChange(e.detail.textContent);
+        onChange && onChange(selectedValue || "");
     }
 
     return (

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -5,9 +5,14 @@ import nanoid from "nanoid";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
 import { useListNavigation } from "./useListNavigation";
 
+export type SelectValue = {
+    value: string;
+    label: string;
+};
+
 interface Props {
     label: string;
-    items: string[];
+    items: Array<string | SelectValue>;
     inline?: boolean;
     defaultPrompt?: string;
     className?: string;
@@ -37,6 +42,10 @@ function focusSelected(listEl: HTMLElement, listId: string, selected: string | u
         focusedItem = listEl.querySelector('[role="option"]');
     }
     focusedItem && focusedItem.focus();
+}
+
+export function makeSelectValueFrom(item: string | SelectValue) {
+    return typeof item === "string" ? { value: item, label: item } : item;
 }
 
 export function Dropdown({
@@ -109,20 +118,23 @@ export function Dropdown({
                             tabIndex={-1}
                             ref={listRef}
                         >
-                            {items.map((item) => (
-                                <li key={item}>
-                                    <button
-                                        type="button"
-                                        id={`${listId}__${lower(item)}`}
-                                        className="jkl-dropdown__option"
-                                        data-testid="jkl-dropdown__option"
-                                        aria-selected={item === selectedValue}
-                                        role="option"
-                                    >
-                                        {item}
-                                    </button>
-                                </li>
-                            ))}
+                            {items.map((item) => {
+                                item = makeSelectValueFrom(item);
+                                return (
+                                    <li key={item.value}>
+                                        <button
+                                            type="button"
+                                            id={`${listId}__${lower(item.value)}`}
+                                            className="jkl-dropdown__option"
+                                            data-testid="jkl-dropdown__option"
+                                            aria-selected={item.value === selectedValue}
+                                            role="option"
+                                        >
+                                            {item.label}
+                                        </button>
+                                    </li>
+                                );
+                            })}
                         </ul>
                     </CoreToggle>
                     <span className="jkl-dropdown__chevron" />

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 
 interface CoreToggleSelectEvent {
-    detail: { textContent: string };
+    detail: { textContent: string; value: string };
     target: { hidden: boolean; button: HTMLButtonElement; value: { textContent: string } };
 }
 
@@ -54,6 +54,7 @@ export function Dropdown({
     variant,
 }: Props) {
     const [selectedValue, setSelectedValue] = useState(initialInputValue);
+    const [displayedValue, setDisplayedValue] = useState(initialInputValue);
     const [dropdownIsShown, setShown] = useState(false);
     const [listId] = useState(`dropdown${nanoid(16)}`);
     const hasSelectedValue = typeof selectedValue !== "undefined";
@@ -78,8 +79,10 @@ export function Dropdown({
         e.target.hidden = true;
         e.target.button.focus();
         e.target.value = e.detail;
-        setSelectedValue(e.detail.textContent);
-        onChange && onChange(selectedValue || "");
+        const nextValue = e.detail.value;
+        setDisplayedValue(e.detail.textContent);
+        setSelectedValue(nextValue);
+        onChange && onChange(nextValue || "");
     }
 
     return (
@@ -92,7 +95,7 @@ export function Dropdown({
                     data-testid="jkl-dropdown__value"
                     aria-haspopup="listbox"
                 >
-                    {hasSelectedValue ? selectedValue : defaultPrompt}
+                    {hasSelectedValue ? displayedValue : defaultPrompt}
                 </button>
                 <CoreToggle
                     id={listId}
@@ -121,6 +124,7 @@ export function Dropdown({
                                         data-testid="jkl-dropdown__option"
                                         aria-selected={item.value === selectedValue}
                                         role="option"
+                                        value={item.value}
                                     >
                                         {item.label}
                                     </button>

--- a/packages/dropdown-react/src/Select.test.tsx
+++ b/packages/dropdown-react/src/Select.test.tsx
@@ -6,7 +6,7 @@ describe("Select", () => {
     afterEach(cleanup);
 
     it("should render the correct label", () => {
-        const { getByText } = render(<Select label="testing" items={[]} />);
+        const { getByText } = render(<Select label="testing" items={["test"]} />);
 
         expect(getByText("testing")).toBeInTheDocument();
     });
@@ -15,5 +15,28 @@ describe("Select", () => {
         const { getAllByTestId } = render(<Select label="testing" items={["1", "2", "3"]} />);
 
         expect(getAllByTestId("jkl-dropdown__option")).toHaveLength(3);
+    });
+
+    it("should render correct label and value when given values as strings", () => {
+        const items = ["item 1", "item 2", "item 3"];
+        const { getAllByTestId } = render(<Select label="testing" items={items} />);
+
+        expect(getAllByTestId("jkl-dropdown__option")[0]).toHaveAttribute("value", "item 1");
+        expect(getAllByTestId("jkl-dropdown__option")[0]).toHaveTextContent("item 1");
+    });
+
+    it("should render correct label and value when given values as objects", () => {
+        const items = [{ value: "item1", label: "Item 1" }, { value: "item2", label: "Item 2" }];
+        const { getAllByTestId } = render(<Select label="testing" items={items} />);
+
+        expect(getAllByTestId("jkl-dropdown__option")[1]).toHaveAttribute("value", "item2");
+        expect(getAllByTestId("jkl-dropdown__option")[1]).toHaveTextContent("Item 2");
+    });
+
+    it("should render placeholder when given and field has no value", () => {
+        const items = ["item 1", "item 2", "item 3"];
+        const { getByText } = render(<Select label="testing" items={items} placeholder="Please choose" />);
+
+        expect(getByText("Please choose")).toBeInTheDocument();
     });
 });

--- a/packages/dropdown-react/src/Select.tsx
+++ b/packages/dropdown-react/src/Select.tsx
@@ -3,11 +3,11 @@
 import React from "react";
 import { labelVariant } from "@fremtind/jkl-core";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
-import { SelectValue, makeSelectValueFrom } from "./Dropdown";
+import { SelectValuePair, getSelectValuePairFrom } from "./SelectValuePair";
 
 interface Props {
     label: string;
-    items: Array<string | SelectValue>;
+    items: Array<string | SelectValuePair>;
     inline?: boolean;
     className?: string;
     onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -35,7 +35,7 @@ export function Select({
     // If no value is given, set it to first item, or to empty string if there is a placeholder
     if (!value) {
         if (!placeholder) {
-            value = makeSelectValueFrom(items[0]).value;
+            value = getSelectValuePairFrom(items[0]).value;
         } else {
             value = "";
         }

--- a/packages/dropdown-react/src/Select.tsx
+++ b/packages/dropdown-react/src/Select.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
+import { SelectValue, makeSelectValueFrom } from "./Dropdown";
 
 interface Props {
     label: string;
-    items: string[];
+    items: Array<string | SelectValue>;
     inline?: boolean;
     className?: string;
     onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -29,7 +30,7 @@ export function Select({
     ...rest
 }: Props) {
     // Set value to value given, or to first item if no value or placeholder is given:
-    value = value ? value : placeholder ? "" : items[0];
+    value = value ? value : placeholder ? "" : makeSelectValueFrom(items[0]).value;
     const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         onChange && onChange(event);
     };
@@ -54,11 +55,14 @@ export function Select({
                         {placeholder}
                     </option>
                 )}
-                {items.map((item) => (
-                    <option data-testid="jkl-dropdown__option" key={item} value={item}>
-                        {item}
-                    </option>
-                ))}
+                {items.map((item) => {
+                    item = typeof item === "string" ? { value: item, label: item } : item;
+                    return (
+                        <option data-testid="jkl-dropdown__option" key={item.value} value={item.value}>
+                            {item.label}
+                        </option>
+                    );
+                })}
             </select>
             <span className="jkl-dropdown__chevron" />
             <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} />

--- a/packages/dropdown-react/src/SelectValuePair.test.ts
+++ b/packages/dropdown-react/src/SelectValuePair.test.ts
@@ -1,0 +1,19 @@
+import { SelectValuePair, getSelectValuePairFrom } from "./SelectValuePair";
+
+describe("getSelectValuePairFrom", () => {
+    it("should convert a string to the correct SelectValuePair", () => {
+        const valuePair = getSelectValuePairFrom("hello");
+
+        expect(valuePair.label).toEqual("hello");
+        expect(valuePair.value).toEqual(valuePair.label);
+    });
+
+    it("should return a SelectValuePair unchanged", () => {
+        const valuePair: SelectValuePair = {
+            value: "hello",
+            label: "hello",
+        };
+
+        expect(getSelectValuePairFrom(valuePair)).toBe(valuePair);
+    });
+});

--- a/packages/dropdown-react/src/SelectValuePair.ts
+++ b/packages/dropdown-react/src/SelectValuePair.ts
@@ -1,0 +1,8 @@
+export interface SelectValuePair {
+    value: string;
+    label: string;
+}
+
+export function getSelectValuePairFrom(item: string | SelectValuePair) {
+    return typeof item === "string" ? { value: item, label: item } : item;
+}


### PR DESCRIPTION
## 📥 Proposed changes

Let `Dropdown` and `Select` accept value/label pairs in addition to `string`s as items. This matches native behaviour better, and closes #362 .

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

The form of the value/label pairs is defined as a type (`SelectValuePair`) in `SelectValuePair.ts` and can be imported from there. Both `Dropdown` and `Select` accepts an array of _either_ `string`s or `SelectValuePair`s as the `items` prop.

```ts
type SelectValuePair = {
    value: string;
    label: string;
};
```
```ts
interface Props {
    ...
    items: Array<string | SelectValuePair>;
}
```