### PR TITLE
fix: remove all alerts from examples

### DIFF
--- a/packages/datepicker-react/example/index.tsx
+++ b/packages/datepicker-react/example/index.tsx
@@ -34,7 +34,7 @@ const App = () => (
             />
         </div>
         <div style={{ margin: "20px" }}>
-            <DatePicker onChange={(date) => alert(`Date selected is ${date}`)} helpLabel={"Choose visely"} />
+            <DatePicker onChange={(date) => console.log(`Date selected is ${date}`)} helpLabel={"Choose visely"} />
         </div>
         <div style={{ margin: "20px" }}>
             <DatePicker
@@ -43,7 +43,7 @@ const App = () => (
                 monthLabel="Try september"
                 onChange={(date) => {
                     if (date.toDateString() === "Mon Sep 26 1988") {
-                        alert("The greatest date is selected");
+                        console.log("The greatest date is selected");
                     }
                 }}
                 errorLabel={"Not the best date"}

--- a/packages/hamburger-react/example/index.tsx
+++ b/packages/hamburger-react/example/index.tsx
@@ -16,7 +16,7 @@ const App = () => {
                 <Hamburger
                     initialIsActive
                     negative
-                    onClick={(nextStatus) => alert(nextStatus ? "Is opening" : "Is closing")}
+                    onClick={(nextStatus) => console.log(nextStatus ? "Is opening" : "Is closing")}
                 />
             </div>
             <div style={{ padding: "100px", backgroundColor: "deeppink" }} ref={divRef}>

--- a/portal/src/examples/ButtonExample.tsx
+++ b/portal/src/examples/ButtonExample.tsx
@@ -6,7 +6,7 @@ import "@fremtind/jkl-button/button.min.css";
 import buttonType from "!raw-loader!@fremtind/jkl-button-react/build/Button.d.ts";
 
 const example = `<>
-    <PrimaryButton onClick={() => alert("hello!")}>Primærknapp</PrimaryButton>
+    <PrimaryButton onClick={() => console.log("hello!")}>Primærknapp</PrimaryButton>
     <SecondaryButton onClick={() => {}}>Sekundærknapp</SecondaryButton>
     <TertiaryButton onClick={() => {}}>Tertiærknapp</TertiaryButton>
 </>;`;

--- a/portal/src/examples/DropdownExample.tsx
+++ b/portal/src/examples/DropdownExample.tsx
@@ -24,7 +24,7 @@ const example = `<>
     defaultPrompt="Choose" // for screen readers
     items={["Apartment", "Duplex", "House", "Mansion"]}
     initialInputValue="House"
-    onChange={value => alert(value)}
+    onChange={value => console.log(value)}
     errorLabel="Select valid place to live"
   />
   <Select

--- a/portal/src/examples/HamburgerExample.tsx
+++ b/portal/src/examples/HamburgerExample.tsx
@@ -7,7 +7,7 @@ import hamburgerType from "!raw-loader!@fremtind/jkl-hamburger-react/build/Hambu
 
 const example = `<div style={{backgroundColor: "#696666", padding: "32px"}}>
     <Hamburger />
-    <Hamburger negative initialIsActive description="Burger" onClick={ (next) => alert(next ? "Is opening" : "Is closing")} />
+    <Hamburger negative initialIsActive description="Burger" onClick={ (next) => console.log(next ? "Is opening" : "Is closing")} />
 </div>`;
 
 const exampleImport = `import { Hamburger } from "@fremtind/jkl-hamburger-react";


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react, @fremtind/jkl-hamburger-react, @fremtind/portal

## 📥 Proposed changes

The alerts in many of the examples are so annoying! This replaces all of them with `console.log`s 🎉

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
