### PR TITLE
fix(jkl-checkbox): give checkboxes correct vertical spacing when stacked

### DIFF
--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -13,10 +13,17 @@ $checkbox-focus-outline-color: $himmel;
     display: flex;
     font-size: $font-size-3;
     line-height: $line-height-3;
-    padding-right: $component-spacing--xl;
+
+    & + & {
+        margin-top: $component-spacing--large;
+    }
 
     &--inline {
         display: inline-flex;
+        & + & {
+            margin-top: unset;
+            margin-left: $component-spacing--xl;
+        }
     }
 
     &:hover > .jkl-checkbox__check-mark {

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -39,18 +39,16 @@ $radio-button-color: $svart;
 .jkl-radio-button {
     cursor: pointer;
     display: flex;
-    margin-bottom: $component-spacing--large;
 
-    &:last-of-type {
-        margin-bottom: 0;
+    & + & {
+        margin-top: $component-spacing--large;
     }
 
     &--inline {
         display: inline-flex;
-        margin-bottom: 0;
-        margin-right: $component-spacing--xl;
-        &:last-of-type {
-            margin-right: 0;
+        & + & {
+            margin-top: unset;
+            margin-left: $component-spacing--xl;
         }
     }
 


### PR DESCRIPTION
affects: @fremtind/jkl-checkbox

## 📥 Proposed changes

Checkboxes were spaced to close together when stacked vertically. This gives them the same spacing as radio buttons.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments
