### PR TITLE
fix(accordion-react): use div to contain title text to avoid inline bug

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -71,12 +71,14 @@ $title-padding-bottom: $title-padding - $item-padding-top-bottom - $border-width
     &__title-text {
         @include font-size("small");
         @include line-height("small");
+        display: block;
         padding-right: 2rem;
     }
 
     &__title-icon {
         @include chevron($chevron-size, currentcolor, $weight: $chevron-weight);
         position: absolute;
+        display: block;
         top: $title-padding-top; // magic number to align chevron with base line
         right: $title-padding;
     }

--- a/packages/accordion/example/index.tsx
+++ b/packages/accordion/example/index.tsx
@@ -7,8 +7,10 @@ const App = () => (
         <div className="jkl-accordion" style={{ width: 700 }}>
             <div className="jkl-accordion-item jkl-accordion-item--expanded">
                 <button className="jkl-accordion-item__title">
-                    <div className="jkl-accordion-item__title-text">Tekst som står her</div>
-                    <div className="jkl-accordion-item__title-icon" />
+                    <span className="jkl-accordion-item__title-text">
+                        Tekst som står her og er så lang at vi får flere linjer som er avhengig av display block
+                    </span>
+                    <span className="jkl-accordion-item__title-icon"></span>
                 </button>
                 <div className="jkl-accordion-item__content">
                     Now let&lsquo;s use some more properties. Consider a list of 6 items, all with a fixed dimensions in
@@ -19,8 +21,8 @@ const App = () => (
             </div>
             <div className="jkl-accordion-item">
                 <button className="jkl-accordion-item__title">
-                    <div className="jkl-accordion-item__title-text">Second item</div>
-                    <div className="jkl-accordion-item__title-icon" />
+                    <span className="jkl-accordion-item__title-text">Second item</span>
+                    <span className="jkl-accordion-item__title-icon"></span>
                 </button>
                 <div className="jkl-accordion-item__content">
                     <p>This is a paragraph</p>
@@ -29,8 +31,8 @@ const App = () => (
             </div>
             <div className="jkl-accordion-item">
                 <button className="jkl-accordion-item__title">
-                    <div className="jkl-accordion-item__title-text">Third item</div>
-                    <div className="jkl-accordion-item__title-icon" />
+                    <span className="jkl-accordion-item__title-text">Third item</span>
+                    <span className="jkl-accordion-item__title-icon"></span>
                 </button>
                 <div className="jkl-accordion-item__content">
                     <p>This is a paragraph</p>


### PR DESCRIPTION
affects: @fremtind/jkl-accordion-react

ISSUES CLOSED: #397

## 📥 Proposed changes

Use div instead of span to ensure that padding works consistently (i.e. block level element).

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

Another alternative is to use CSS in the accordion package. 
