### PR TITLE
Accordion item title

### DIFF
--- a/packages/accordion-react/src/AccordionItem.tsx
+++ b/packages/accordion-react/src/AccordionItem.tsx
@@ -6,7 +6,7 @@ import React, { ReactNode, useState } from "react";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 
 interface Props {
-    title: string;
+    title: string | ReactNode;
     children: ReactNode;
     startExpanded?: boolean;
 }

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -39,6 +39,7 @@ $title-padding-bottom: $title-padding - $item-padding-top-bottom - $border-width
         padding: $title-padding-top $title-padding $title-padding-bottom;
         text-align: left;
         width: 100%;
+        display: flex;
 
         /* Remove button styles */
         outline: none;
@@ -72,6 +73,7 @@ $title-padding-bottom: $title-padding - $item-padding-top-bottom - $border-width
         @include font-size("small");
         @include line-height("small");
         padding-right: 2rem;
+        width: inherit;
     }
 
     &__title-icon {


### PR DESCRIPTION
## 📥 Proposed changes

This pull request contains changes that will allow the title of accordion items to be React components, as well as strings.
Allowing these React components will let users style accordion item titles according to their needs.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
