### PR TITLE
fix(portal): reset style of accordions in main menu

### DIFF
--- a/portal/src/components/Menu/Menu.scss
+++ b/portal/src/components/Menu/Menu.scss
@@ -96,8 +96,12 @@ $menu-width: rem(320px);
 
     & .jkl-accordion,
     & .jkl-accordion-item,
-    & .jkl-accordion-item:first-of-type {
+    & .jkl-accordion-item:first-of-type,
+    & .jkl-accordion-item__title {
         border: 0;
+        background-color: transparent;
+        color: inherit;
+        box-shadow: none;
     }
 
     & .jkl-accordion-item:first-of-type {


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

Reset the style of the accordions used in the main menu. The new style broke them completely.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
