### PR TITLE
Add compact mode for text fields

### DIFF
--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -5,7 +5,11 @@
 .jkl-form-support-label {
     display: block;
     margin-top: $component-spacing--small;
-    @include text-sizing("xs");
+    @include text-sizing("xxs");
+
+    &--compact {
+        @include text-sizing--small-device("xxs");
+    }
 
     &--help {
         color: $svart;
@@ -18,25 +22,38 @@
 
 .jkl-label {
     display: block;
-    margin-bottom: $component-spacing--xl;
-    margin-left: rem(-1px); // adjust visual alignment
-    @include text-sizing("xl");
+    // Medium size is default
+    margin-bottom: $component-spacing--large;
+    margin-left: initial;
+    @include text-sizing("medium");
     @include small-device {
-        margin-bottom: $component-spacing--large;
+        margin-bottom: $component-spacing--small;
     }
 
-    &--secondary {
-        margin-bottom: $component-spacing--large;
-        margin-left: initial;
-        @include text-sizing("medium");
+    &--large {
+        margin-bottom: $component-spacing--xl;
+        margin-left: rem(-1px); // adjust visual alignment
+        @include text-sizing("xl");
         @include small-device {
-            margin-bottom: $component-spacing--small;
+            margin-bottom: $component-spacing--large;
         }
     }
 
     &--small {
         margin-bottom: 0;
         margin-left: initial;
-        @include text-sizing("xs");
+        @include text-sizing("xxs");
+    }
+
+    &--compact {
+        &.jkl-label--medium {
+            @include text-sizing--small-device("medium");
+        }
+        &.jkl-label--small {
+            @include text-sizing--small-device("xxs");
+        }
+        &.jkl-label--large {
+            @include text-sizing--small-device("xl");
+        }
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export { initTabListener } from "./utils";
 
-export type LabelVariant = "secondary" | "small";
+export type LabelVariant = "small" | "medium" | "large";

--- a/packages/core/variables/_font-size.scss
+++ b/packages/core/variables/_font-size.scss
@@ -96,3 +96,13 @@ $line-height--large-device: (
     @include font-size($size);
     @include line-height($size);
 }
+
+@mixin text-sizing--small-device($size) {
+    font-size: map-get($font-size--small-device, $size);
+    line-height: map-get($line-height--small-device, $size);
+}
+
+@mixin text-sizing--large-device($size) {
+    font-size: map-get($font-size--large-device, $size);
+    line-height: map-get($line-height--large-device, $size);
+}

--- a/packages/datepicker-react/example/index.tsx
+++ b/packages/datepicker-react/example/index.tsx
@@ -31,7 +31,7 @@ const App = () => (
         </div>
         <div className="jkl-spacing--all-3">
             <DatePicker
-                variant="secondary"
+                variant="large"
                 initialDate={new Date(new Date().setFullYear(new Date().getFullYear() + 1))}
                 months={englishMonthNames}
                 days={englishDayNames}

--- a/packages/dropdown-react/example/index.tsx
+++ b/packages/dropdown-react/example/index.tsx
@@ -27,7 +27,7 @@ const SelectDemo = () => {
                 onChange={setFavoriteScene}
                 helpLabel="The room is the greatest movie"
                 errorLabel={favoriteScene !== "" ? "You can't pick, they are all the best" : undefined}
-                variant="secondary"
+                variant="large"
             />
             <Dropdown
                 inline
@@ -54,7 +54,7 @@ const SelectDemo = () => {
                 items={items}
                 onChange={(e) => setFavoriteScene(e.target.value)}
                 placeholder="Choose your favorite"
-                variant="secondary"
+                variant="large"
                 value={favoriteScene}
             />
 

--- a/packages/field-group-react/example/index.tsx
+++ b/packages/field-group-react/example/index.tsx
@@ -5,7 +5,11 @@ import { FieldGroup } from "../src/index";
 const FieldGroupExample = () => (
     <div className="form-section">
         <h2 className="jkl-h3 form-section__header">Livsstil og helse</h2>
-        <FieldGroup className="jkl-spacing--bottom-3" legend="Har du bodd fast i Norge de siste 5 årene?">
+        <FieldGroup
+            variant="large"
+            className="jkl-spacing--bottom-3"
+            legend="Har du bodd fast i Norge de siste 5 årene?"
+        >
             <p className="jkl-lead">
                 Du trenger ikke ta hensyn til korte utenlandsopphold på grunn av studier eller feriereiser når du skal
                 svare på spørsmålet.
@@ -14,12 +18,12 @@ const FieldGroupExample = () => (
                 <strong>[Felt settes inn her]</strong>
             </p>
         </FieldGroup>
-        <FieldGroup variant="secondary" legend="Hvor bodde du før du flyttet til Norge?">
+        <FieldGroup legend="Hvor bodde du før du flyttet til Norge?">
             <p className="jkl-p">
                 <strong>[Velg land her]</strong>
             </p>
         </FieldGroup>
-        <FieldGroup variant="small" legend="Hvor bodde du før du flyttet til Norge?">
+        <FieldGroup variant="small" forceCompact legend="Hvor bodde du før du flyttet til Norge?">
             <p className="jkl-p">
                 <strong>[Velg land her]</strong>
             </p>

--- a/packages/field-group-react/src/FieldGroup.tsx
+++ b/packages/field-group-react/src/FieldGroup.tsx
@@ -9,11 +9,23 @@ interface Props {
     helpLabel?: string;
     errorLabel?: string;
     variant?: LabelVariant;
+    forceCompact?: boolean;
 }
 
-export const FieldGroup = ({ legend, className, children, helpLabel, errorLabel, variant }: Props) => {
+export const FieldGroup = ({
+    legend,
+    className,
+    children,
+    helpLabel,
+    errorLabel,
+    variant = "medium",
+    forceCompact,
+}: Props) => {
     const componentClassName = "jkl-field-group".concat(className ? ` ${className}` : "");
-    const labelClassName = "jkl-label".concat(variant ? ` jkl-label--${variant}` : "");
+    const labelClassName = "jkl-label".concat(
+        variant ? ` jkl-label--${variant}` : "",
+        forceCompact ? " jkl-label--compact" : "",
+    );
     return (
         <fieldset className={componentClassName}>
             <legend className={labelClassName}>{legend}</legend>

--- a/packages/radio-button-react/example/index.tsx
+++ b/packages/radio-button-react/example/index.tsx
@@ -18,7 +18,7 @@ const Demo = () => {
     const [variant, setVariant] = useState<LabelVariant | undefined>();
     const typecheckAndSetVariant = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const val = e.target.value;
-        if (val === "secondary" || val === "small") {
+        if (val === "large" || val === "medium" || val === "small") {
             setVariant(val);
         } else {
             setVariant(undefined);
@@ -39,8 +39,8 @@ const Demo = () => {
                 <label style={{ margin: ".5rem" }}>
                     {`Choose variant: `}
                     <select onChange={typecheckAndSetVariant} value={variant}>
-                        <option value={undefined}>Normal</option>
-                        <option value="secondary">Secondary</option>
+                        <option value="large">Large</option>
+                        <option value="medium">Medium</option>
                         <option value="small">Small</option>
                     </select>
                 </label>

--- a/packages/text-input-react/example/index.scss
+++ b/packages/text-input-react/example/index.scss
@@ -6,12 +6,16 @@ body {
 .side-by-side {
     display: flex;
     justify-content: space-evenly;
-    margin-bottom: 64px;
 
     & > .jkl-text-area,
     & > .jkl-text-field {
+        margin-top: 0;
         max-width: 20rem;
-        margin: 0 !important;
+    }
+
+    & > .jkl-text-area + .jkl-text-area,
+    & > .jkl-text-field + .jkl-text-field {
+        margin-left: 2.5rem;
     }
 }
 

--- a/packages/text-input-react/example/index.tsx
+++ b/packages/text-input-react/example/index.tsx
@@ -15,7 +15,7 @@ const TextFieldDemo = () => {
     }
     return (
         <>
-            <div className="side-by-side">
+            <div className="side-by-side jkl-spacing--bottom-2">
                 <TextField
                     label="Fornavn"
                     value={value}
@@ -23,18 +23,49 @@ const TextFieldDemo = () => {
                     placeholder={"Norsk"}
                     variant="small"
                     helpLabel="La oss se..."
+                    forceCompact
                 />
                 <TextField label="Fornavn" value={"Per"} onChange={handleChange} readOnly variant="small" />
             </div>
 
-            <TextField label="Telefon" type="tel" value={value} onChange={handleChange} placeholder="999 99 999" />
+            <div className="side-by-side jkl-spacing--bottom-2">
+                <TextField
+                    forceCompact
+                    label="Telefon"
+                    type="tel"
+                    value={value}
+                    onChange={handleChange}
+                    placeholder="999 99 999"
+                />
+                <TextField label="Telefon" type="tel" value={value} onChange={handleChange} placeholder="999 99 999" />
+            </div>
+
+            <div className="side-by-side jkl-spacing--bottom-5">
+                <TextField
+                    forceCompact
+                    label="Passord"
+                    type="password"
+                    value={value}
+                    onChange={handleChange}
+                    helpLabel="Passord er en vanlig form for autentisering"
+                    variant="large"
+                />
+                <TextField
+                    label="Passord"
+                    type="password"
+                    value={value}
+                    onChange={handleChange}
+                    helpLabel="Passord er en vanlig form for autentisering"
+                    variant="large"
+                />
+            </div>
             <TextField
                 label="Passord"
                 type="password"
                 value={value}
                 onChange={handleChange}
                 helpLabel="Passord er en vanlig form for autentisering"
-                variant="secondary"
+                variant="large"
             />
             <TextField
                 label="Epost"
@@ -53,7 +84,7 @@ const TextFieldDemo = () => {
                 //variant="small"
                 placeholder="Begrens deg til tre linjer"
             />
-            <TextArea label="Din livshistorie" value={value} onChange={handleChange} variant="secondary" />
+            <TextArea label="Din livshistorie" value={value} onChange={handleChange} variant="large" />
         </>
     );
 };

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, FocusEvent } from "react";
+import React, { ChangeEvent, FocusEvent } from "react";
 import { LabelVariant } from "@fremtind/jkl-core";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
 
@@ -28,30 +28,15 @@ export const TextArea = ({
     placeholder = " ",
     ...restProps
 }: Props) => {
-    const [isFocused, setIsFocused] = useState(false);
-
-    const height = isFocused || restProps.value ? `${rows * 2 + 0.5}rem` : undefined;
-
     const componentClassName = "jkl-text-field jkl-text-area".concat(className ? ` ${className}` : "");
     const labelClassName = "jkl-label".concat(variant ? ` jkl-label--${variant}` : "");
-    function onBlur(event: FocusEvent<HTMLTextAreaElement>) {
-        setIsFocused(false);
-        restProps.onBlur && restProps.onBlur(event);
-    }
-
-    function onFocus() {
-        return setIsFocused(true);
-    }
 
     return (
         <label data-testid="jkl-text-field" className={componentClassName}>
             <span className={labelClassName}>{label}</span>
             <textarea
-                onFocus={onFocus}
-                onBlur={onBlur}
-                style={{ height }}
                 aria-invalid={!!errorLabel}
-                className="jkl-text-field__input"
+                className={`jkl-text-field__input jkl-text-field__input--${rows}-rows`}
                 id={id}
                 placeholder={placeholder}
                 {...restProps}

--- a/packages/text-input-react/src/TextField.tsx
+++ b/packages/text-input-react/src/TextField.tsx
@@ -19,6 +19,7 @@ interface Props {
     className?: string;
     placeholder?: string;
     variant?: LabelVariant;
+    forceCompact?: boolean;
 }
 
 export const TextField = ({
@@ -33,13 +34,18 @@ export const TextField = ({
     placeholder,
     value,
     variant,
+    forceCompact,
     ...rest
 }: Props) => {
     const componentClassName = "jkl-text-field".concat(
         inline ? " jkl-text-field--inline" : "",
+        forceCompact ? " jkl-text-field--compact" : "",
         className ? ` ${className}` : "",
     );
-    const labelClassName = "jkl-label".concat(variant ? ` jkl-label--${variant}` : "");
+    const labelClassName = "jkl-label".concat(
+        variant ? ` jkl-label--${variant}` : "",
+        forceCompact ? " jkl-label--compact" : "",
+    );
     return (
         <label data-testid="jkl-text-field" className={componentClassName}>
             <span className={labelClassName}>{label}</span>
@@ -53,7 +59,7 @@ export const TextField = ({
                 value={value}
                 {...rest}
             />
-            <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} />
+            <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} forceCompact={forceCompact} />
         </label>
     );
 };

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -1,5 +1,5 @@
 @import "~@fremtind/jkl-core/variables/all";
-@import "~@fremtind/jkl-core/mixins/_helpers.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 
 $transition-timing: 200ms cubic-bezier(0.7, 0, 0.3, 1);
 
@@ -8,10 +8,11 @@ $border-color: $svart;
 $border-color--focus: $focus-color;
 
 $input-height: $line-height-3;
-$input-font-size: $font-size-3;
+$input-height--small-device: $line-height-2;
 $bottom-padding: $component-spacing--small;
 
-$textarea-height--expanded: $input-height * 7 + $bottom-padding;
+$textarea-expanded-height: $input-height * 7 + $bottom-padding;
+$textarea-expanded-height--small-device: $input-height--small-device * 7 + $bottom-padding;
 
 .jkl-text-field {
     display: block;
@@ -25,6 +26,16 @@ $textarea-height--expanded: $input-height * 7 + $bottom-padding;
         vertical-align: bottom;
     }
 
+    &--compact {
+        & .jkl-text-field__input,
+        & .jkl-text-field__input::placeholder {
+            @include text-sizing--small-device("small");
+        }
+        & .jkl-text-field__input {
+            height: $input-height--small-device + $bottom-padding;
+        }
+    }
+
     &__input {
         border: none;
         outline: none;
@@ -33,9 +44,12 @@ $textarea-height--expanded: $input-height * 7 + $bottom-padding;
         box-sizing: border-box;
         width: 100%;
         height: $input-height + $bottom-padding;
+        @include small-device {
+            height: $input-height--small-device + $bottom-padding;
+        }
         padding: 0 0 $bottom-padding;
-        font-size: $input-font-size;
-        line-height: $input-height;
+
+        @include text-sizing("small");
         font-weight: bold;
         background-color: transparent;
         transition: box-shadow $transition-timing;
@@ -49,7 +63,7 @@ $textarea-height--expanded: $input-height * 7 + $bottom-padding;
             opacity: 1;
             color: $varm-fjellgra;
             font-weight: normal;
-            line-height: $input-height;
+            @include text-sizing("small");
         }
 
         &:hover,
@@ -74,14 +88,21 @@ $textarea-height--expanded: $input-height * 7 + $bottom-padding;
     }
 }
 
+/* Utility classes for number of rows */
+@for $num from 3 through 10 {
+    .jkl-text-field__input--#{$num}-rows:focus,
+    .jkl-text-field__input--#{$num}-rows:not(:placeholder-shown) {
+        height: $input-height * $num + $bottom-padding;
+        @include small-device {
+            height: $input-height--small-device * $num + $bottom-padding;
+        }
+    }
+}
+
 .jkl-text-area {
     height: auto;
     & .jkl-text-field__input {
         transition: height 175ms ease, box-shadow $transition-timing;
         font-weight: normal;
-        &:focus,
-        &:not(:placeholder-shown) {
-            height: $textarea-height--expanded; // CSS default height (is overridden in react component)
-        }
     }
 }

--- a/packages/typography-react/src/SupportLabel.tsx
+++ b/packages/typography-react/src/SupportLabel.tsx
@@ -3,15 +3,17 @@ import React from "react";
 interface Props {
     helpLabel?: string;
     errorLabel?: string;
+    forceCompact?: boolean;
 }
 
-export const SupportLabel = ({ helpLabel, errorLabel }: Props) => {
+export const SupportLabel = ({ helpLabel, errorLabel, forceCompact }: Props) => {
+    const className = "jkl-form-support-label".concat(
+        ` jkl-form-support-label--${errorLabel ? "error" : "Help"}`,
+        forceCompact ? " jkl-form-support-label--compact" : "",
+    );
+
     if (errorLabel || helpLabel) {
-        return (
-            <span className={`jkl-form-support-label jkl-form-support-label--${errorLabel ? "error" : "help"}`}>
-                {errorLabel || helpLabel}
-            </span>
-        );
+        return <span className={className}>{errorLabel || helpLabel}</span>;
     }
 
     return null;

--- a/portal/src/examples/DatepickerExample.tsx
+++ b/portal/src/examples/DatepickerExample.tsx
@@ -8,7 +8,7 @@ import datepickerType from "!raw-loader!@fremtind/jkl-datepicker-react/build/Dat
 const example = `<>
         <DatePicker label="Når skjedde skaden?" initialDate={new Date('August 19, 2024 23:15:30')} />
         <DatePicker
-            variant="secondary"
+            variant="large"
             onlyFuture={true}
             label="On what date will you take ownership of the apartment?"
             yearLabel="Year"

--- a/portal/src/examples/DropdownExample.tsx
+++ b/portal/src/examples/DropdownExample.tsx
@@ -11,7 +11,7 @@ const example = `() => {
         <>
             <Dropdown className="jkl-spacing--bottom-2" label="Merke" items={["Mercedes", "Opel", "Skoda"]} />
             <Dropdown
-                variant="secondary"
+                variant="large"
                 className="jkl-spacing--bottom-2"
                 label="Merke"
                 items={["Mercedes", "Opel", "Skoda"]}

--- a/portal/src/examples/TextAreaExample.tsx
+++ b/portal/src/examples/TextAreaExample.tsx
@@ -16,7 +16,7 @@ const example = `() => {
                 onChange={(e) => setValue(e.target.value)}
                 />
             <TextArea
-                variant="secondary"
+                variant="large"
                 className="jkl-spacing--bottom-3"
                 label="Livshistorie"
                 value="gobjop uvucenli bdachukme sotw uvliljai suibki"

--- a/portal/src/examples/TextFieldExample.tsx
+++ b/portal/src/examples/TextFieldExample.tsx
@@ -21,7 +21,7 @@ const example = `() => {
             />
 
             <TextField
-                variant="secondary"
+                variant="large"
                 className="jkl-spacing--bottom-5"
                 label="Og etternavnet?"
                 errorLabel={hasError ? "Kun ett navn her" : undefined}


### PR DESCRIPTION
## 📥 Proposed changes

- Change the names of the label size variants to `small`, `medium` and `large`, and make the `medium` size default (was `large`) to ease transition from old version.
- Add the possibility to force compact ("mobile") mode on the `TextField`, `TextArea` and `FieldGroup` components.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

I'd really like to get this in today's release, since I lied about there not being big changes in the forum yesterday 😅 This should make the transition a bit less jarring. There should be no breaking changes functionality wise.
