### PR TITLE
feat(text-field): implement in line version of TextField

### DIFF
--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -56,4 +56,8 @@
             @include text-sizing--small-device("xl");
         }
     }
+
+    &--sr-only {
+        @include screenreader-only;
+    }
 }

--- a/packages/text-input-react/example/index.scss
+++ b/packages/text-input-react/example/index.scss
@@ -6,6 +6,7 @@ body {
 .side-by-side {
     display: flex;
     justify-content: space-evenly;
+    margin-top: 2.5rem;
 
     & > .jkl-text-area,
     & > .jkl-text-field {
@@ -17,8 +18,4 @@ body {
     & > .jkl-text-field + .jkl-text-field {
         margin-left: 2.5rem;
     }
-}
-
-.jkl-text-field {
-    margin-top: 2.5rem;
 }

--- a/packages/text-input-react/example/index.tsx
+++ b/packages/text-input-react/example/index.tsx
@@ -15,6 +15,9 @@ const TextFieldDemo = () => {
     }
     return (
         <>
+            <p className="jkl-p">
+                Jeg tjener <TextField type="number" maxLength={5} inline label="kronebeløp" /> kroner i måneden.
+            </p>
             <div className="side-by-side jkl-spacing--bottom-2">
                 <pre>
                     <code>{`forceCompact={true}`}</code>
@@ -28,7 +31,7 @@ const TextFieldDemo = () => {
                     label="Fornavn"
                     value={value}
                     onChange={handleChange}
-                    placeholder={"Norsk"}
+                    placeholder={"f.eks. Ola"}
                     variant="small"
                     helpLabel="La oss se..."
                     forceCompact

--- a/packages/text-input-react/src/TextField.tsx
+++ b/packages/text-input-react/src/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent } from "react";
+import React, { ChangeEvent, FocusEvent, CSSProperties } from "react";
 import { LabelVariant } from "@fremtind/jkl-core";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 
@@ -46,13 +46,13 @@ export const TextField = ({
         forceCompact ? " jkl-text-field--compact" : "",
         className ? ` ${className}` : "",
     );
-    function getLength(): string | undefined {
+    function getWidthAsStyle(): CSSProperties | undefined {
         if (width) {
-            return width; // prioritize width
+            return { width }; // prioritize width prop
         }
 
         if (maxLength && maxLength < 15) {
-            return `${maxLength + 3}ch`; // else use maxLength if not large
+            return { width: `${maxLength + 3}ch` }; // else use maxLength if not large
         }
 
         return undefined;
@@ -71,7 +71,7 @@ export const TextField = ({
                 readOnly={readOnly}
                 value={value}
                 maxLength={maxLength}
-                style={getLength() ? { width: getLength() } : undefined}
+                style={getWidthAsStyle()}
                 {...rest}
             />
             {!inline && <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} forceCompact={forceCompact} />}

--- a/packages/text-input-react/src/TextField.tsx
+++ b/packages/text-input-react/src/TextField.tsx
@@ -21,6 +21,7 @@ interface Props {
     variant?: LabelVariant;
     forceCompact?: boolean;
     maxLength?: number;
+    width?: string;
 }
 
 export const TextField = ({
@@ -37,6 +38,7 @@ export const TextField = ({
     variant,
     forceCompact,
     maxLength,
+    width,
     ...rest
 }: Props) => {
     const componentClassName = "jkl-text-field".concat(
@@ -44,9 +46,18 @@ export const TextField = ({
         forceCompact ? " jkl-text-field--compact" : "",
         className ? ` ${className}` : "",
     );
+    function getLength(): string | undefined {
+        if (width) return width; // prioritize width
+
+        if (maxLength && maxLength < 15) {
+            return `${maxLength + 3}ch`; // else use maxLength if not large
+        }
+
+        return undefined;
+    }
     return (
         <label data-testid="jkl-text-field" className={componentClassName}>
-            <Label variant={variant} forceCompact={forceCompact}>
+            <Label srOnly={inline} variant={variant} forceCompact={forceCompact}>
                 {label}
             </Label>
             <input
@@ -58,9 +69,10 @@ export const TextField = ({
                 readOnly={readOnly}
                 value={value}
                 maxLength={maxLength}
+                style={getLength() ? { width: getLength() } : undefined}
                 {...rest}
             />
-            <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} forceCompact={forceCompact} />
+            {!inline && <SupportLabel helpLabel={helpLabel} errorLabel={errorLabel} forceCompact={forceCompact} />}
         </label>
     );
 };

--- a/packages/text-input-react/src/TextField.tsx
+++ b/packages/text-input-react/src/TextField.tsx
@@ -47,7 +47,9 @@ export const TextField = ({
         className ? ` ${className}` : "",
     );
     function getLength(): string | undefined {
-        if (width) return width; // prioritize width
+        if (width) {
+            return width; // prioritize width
+        }
 
         if (maxLength && maxLength < 15) {
             return `${maxLength + 3}ch`; // else use maxLength if not large

--- a/packages/text-input-react/src/TextField.tsx
+++ b/packages/text-input-react/src/TextField.tsx
@@ -41,6 +41,15 @@ export const TextField = ({
     width,
     ...rest
 }: Props) => {
+    // Give warning when errorLabel or helpLabel is used on an inline TextField
+    if (process.env.NODE_ENV !== "production") {
+        if (inline && (helpLabel || errorLabel)) {
+            console.warn(
+                "WARNING: Inline TextFields do not display help- or error labels! The errorLabel prop can still be used to trigger an invalid state, but the reason will have to be described elsewhere.",
+            );
+        }
+    }
+
     const componentClassName = "jkl-text-field".concat(
         inline ? " jkl-text-field--inline" : "",
         forceCompact ? " jkl-text-field--compact" : "",

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -1,13 +1,17 @@
 # [`@fremtind/jkl-text-field`](https://fremtind.github.io/jokul/components/textfield/)
 
 ## Om tekstfelt
-I et tekstfelt kan brukerne legge inn egne opplysninger. Et tekstfelt kan være kort eller langt, og det kan gå over en eller flere linjer.
 
-- Vi legger inn validering på tekstfelt, slik at brukeren ikke kan fylle det inn feil. Ledeteksten skal tydelig vise hva brukeren kan skrive i feltet.
-- Vi bruker helst bare ledetekst, men hvis vi trenger hjelpetekst i tillegg, skal den plasseres under feltet.
-- Vi bruker bredden på tekstfeltet til å styre hvor mye vi vil at brukeren skal skrive inn. _Et felt for fødselsnummer bør ikke ta mer plass enn det 11 siffer gjør._ 
+I et tekstfelt kan brukerne legge inn egne opplysninger. Et tekstfelt kan være kort eller langt, og det kan gå over en eller flere linjer. Vi kan også legge et tekstfelt inne i en setning for å la brukeren fylle ut et manglende ord eller tall.
+
+-   Vi legger inn validering på tekstfelt, slik at brukeren ikke kan fylle det inn feil. Ledeteksten skal tydelig vise hva brukeren kan skrive i feltet.
+-   Vi bruker helst bare ledetekst, men hvis vi trenger hjelpetekst i tillegg, skal den plasseres under feltet.
+-   Vi bruker bredden på tekstfeltet til å styre hvor mye vi vil at brukeren skal skrive inn. _Et felt for fødselsnummer bør ikke ta mer plass enn det 11 siffer gjør._
+
+> Tekstfelter som er inne i en setning kan ikke ha feil- eller hjelpetekst. Dersom det er feil i utfyllingen av disse må årsaken gjøres klar på annen måte.
 
 ### Langt tekstfelt
+
 Vi kan bruke et langt tekstfelt når vi vil at brukerne skal skrive en lengre tekst, eller de må ha mulighet til å kunne gjøre det. Dette feltet utvider seg, slik at det blir tydelig for brukerne at de kan skrive mye.
 
 Når vi bruker lange tekstfelt, må vi ha en god ledetekst, som forklarer hva vi forventer at brukeren skal skrive i feltet. Vi kan også angi hvor mange tegn de kan bruke.

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -23,7 +23,14 @@ $textarea-expanded-height--small-device: $input-height--small-device * 7 + $bott
 
     &--inline {
         display: inline-block;
-        vertical-align: bottom;
+        width: unset;
+        margin-top: rem(-4px);
+        vertical-align: top;
+
+        .jkl-p & .jkl-text-field__input {
+            padding: 0; // $component-spacing--small;
+            text-align: center;
+        }
     }
 
     &--compact {
@@ -73,6 +80,10 @@ $textarea-expanded-height--small-device: $input-height--small-device * 7 + $bott
 
         html:not([data-mousenavigation]) &:focus {
             box-shadow: inset 0 rem(-4px) 0 0 $border-color--focus;
+        }
+
+        &[type="number"] {
+            text-align: right;
         }
 
         &[aria-invalid="true"],

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -28,7 +28,7 @@ $textarea-expanded-height--small-device: $input-height--small-device * 7 + $bott
         vertical-align: top;
 
         .jkl-p & .jkl-text-field__input {
-            padding: 0; // $component-spacing--small;
+            padding: 0;
             text-align: center;
         }
     }

--- a/packages/typography-react/src/Label.tsx
+++ b/packages/typography-react/src/Label.tsx
@@ -4,13 +4,15 @@ import { LabelVariant } from "@fremtind/jkl-core";
 interface Props {
     variant?: LabelVariant;
     forceCompact?: boolean;
+    srOnly?: boolean;
     children: ReactNode;
 }
 
-export function Label({ variant = "medium", forceCompact, children }: Props) {
+export function Label({ variant = "medium", forceCompact, srOnly, children }: Props) {
     const className = "jkl-label".concat(
         variant ? ` jkl-label--${variant}` : "",
         forceCompact ? ` jkl-label--compact` : "",
+        srOnly ? ` jkl-label--sr-only` : "",
     );
     return <span className={className}>{children}</span>;
 }

--- a/portal/src/examples/TextFieldExample.tsx
+++ b/portal/src/examples/TextFieldExample.tsx
@@ -12,37 +12,45 @@ const example = `() => {
     return (
         <>
             <TextField
+                variant="large"
                 label="Hva er fornavnet ditt?"
                 className="jkl-spacing--bottom-2"
                 errorLabel={hasError ? "Kun ett navn her" : undefined}
                 placeholder="Ditt første navn"
                 value={value}
+                maxLength={10}
                 onChange={(e) => setValue(e.target.value)}
             />
 
             <TextField
-                variant="large"
-                className="jkl-spacing--bottom-5"
+                className="jkl-spacing--bottom-4"
                 label="Og etternavnet?"
                 errorLabel={hasError ? "Kun ett navn her" : undefined}
-                value="Hannah Hart"
+                value="Andersen"
+                width="20em"
                 onChange={() => {}}
             />
             <TextField
                 variant="small"
                 className="jkl-spacing--bottom-3"
                 label="Din mors pikenavn"
+                errorLabel={hasError ? "Kan ikke inneholde spesialtegn" : undefined}
                 onChange={() => {}}
+                width="30em"
                 onBlur={(e) => console.log("It blurred with value: ", e.target.value)}
             />
+            <p className="jkl-p">
+                Jeg har hatt sykdommen i <TextField inline type="number" errorLabel={hasError ? "Det var lenge!" : undefined} label="sykdomsvarighet i år" width="2em" maxLength={2} /> år.
+            </p>
             <PrimaryButton onClick={() => setError(!hasError)}>{hasError ? "Skjul" : "Vis"} feilmelding</PrimaryButton>
         </>
     );
 }`;
 
-const exampleImport = `
+const exampleImport = `;
 import { TextField } from "@fremtind/jkl-text-input-react";
-import "@fremtind/jkl-text-input/text-input.min.css";`;
+import "@fremtind/jkl-text-input/text-input.min.css";
+`;
 
 const TextFieldExample = () => (
     <Example


### PR DESCRIPTION
## 📥 Proposed changes

Implement inline (in-text) version of `TextField` as discussed in #426 . This also adds a screenreader-only version of the label so it can be hidden without creating an empty `<label>` element.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-core, @fremtind/jkl-text-input-react, @fremtind/jkl-text-input,
@fremtind/jkl-typography-react

### Implementation details

- Repurposes the existing `inline` prop (which had no real effect) for this, which strictly speaking breaks current functionality; We should give a heads-up to the teams before publishing.
- Adds both a manual and an automatic way of controlling input length: The new `width` prop takes a string, which is passed to the css `width` property as-is; If no `width` is passed, the field will use any `maxLength` value of less than 15 to decide the input length. This system ensures good affordance, and enables fine control.

### Further implications

We should probably create similar versions of the `Dropdown`/`Select` and `DatePicker` components.