### PR TITLE
Document deprecation of the Dropdown packages

### DIFF
--- a/packages/dropdown-react/README.md
+++ b/packages/dropdown-react/README.md
@@ -1,4 +1,7 @@
-# [`@fremtind/jlk-dropdown`](https://fremtind.github.io/jokul/components/dropdown/)
+# [`@fremtind/jkl-dropdown-react`](https://fremtind.github.io/jokul/components/dropdown/)
+
+-   **Utgått**: Denne komponenten er utgått, og erstattet av `@fremtind/jkl-select-react`
+-   **Deprecated**: This component is deprecated, and replaced by `@fremtind/jkl-select-react`
 
 ## Beskrivelse
 

--- a/packages/dropdown-react/src/Dropdown.tsx
+++ b/packages/dropdown-react/src/Dropdown.tsx
@@ -88,6 +88,12 @@ export function Dropdown({
         onChange && onChange(nextValue || "");
     }
 
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: The Dropdown component in @fremtind/jkl-dropdown-react has been deprecated. Please use the Select component from @fremtind/jkl-select-react instead.",
+        );
+    }
+
     return (
         <div data-testid="jkl-dropdown" className={componentClassName}>
             <Label variant={variant} forceCompact={forceCompact}>

--- a/packages/dropdown-react/src/Select.tsx
+++ b/packages/dropdown-react/src/Select.tsx
@@ -52,6 +52,13 @@ export function Select({
         value === "" ? ` jkl-dropdown--no-value` : "",
         className ? ` ${className}` : "",
     );
+
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: The Select component in @fremtind/jkl-dropdown-react has been deprecated. Please use the NativeSelect component from @fremtind/jkl-select-react instead.",
+        );
+    }
+
     return (
         <label data-testid="jkl-dropdown" className={componentClassName}>
             <Label variant={variant} forceCompact={forceCompact}>


### PR DESCRIPTION
affects: @fremtind/jkl-dropdown-react

## 📥 Proposed changes

- Add documentation about the dropdown packages being deprecated
- Throw warnings in dev when using the deprecated components

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
