### PR TITLE
fix(typography-react): remove capitalization of className for helpLabel

### DIFF
--- a/packages/typography-react/src/SupportLabel.tsx
+++ b/packages/typography-react/src/SupportLabel.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const SupportLabel = ({ helpLabel, errorLabel, forceCompact }: Props) => {
     const className = "jkl-form-support-label".concat(
-        ` jkl-form-support-label--${errorLabel ? "error" : "Help"}`,
+        ` jkl-form-support-label--${errorLabel ? "error" : "help"}`,
         forceCompact ? " jkl-form-support-label--compact" : "",
     );
 


### PR DESCRIPTION
affects: @fremtind/jkl-typography-react

ISSUES CLOSED: #490

## 📥 Proposed changes

Fix a tiny capitalization bug.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments
