### PR TITLE
feat: add support for global compact mode

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -1,5 +1,6 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/mixins/_screens.scss";
+@import "~@fremtind/jkl-core/mixins/_helpers.scss";
 
 @import "~@fremtind/jkl-core/_functions.scss";
 
@@ -35,8 +36,7 @@ $hover-elevation-distance: -0.25rem;
         line-height: $button-height--small;
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         height: $button-height--small;
         min-width: $button-height--small;
         line-height: $button-height--small;

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -35,7 +35,8 @@ $hover-elevation-distance: -0.25rem;
         line-height: $button-height--small;
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         height: $button-height--small;
         min-width: $button-height--small;
         line-height: $button-height--small;

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -27,7 +27,8 @@ $checkbox-check-mark-color: $checkbox-background-color--unchecked;
         }
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         @include text-sizing--small-device("small");
         .jkl-checkbox__check-mark {
             height: $checkbox-size--compact;

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -1,4 +1,5 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_helpers.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
 $checkbox-size: rem(24px);
@@ -27,8 +28,7 @@ $checkbox-check-mark-color: $checkbox-background-color--unchecked;
         }
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         @include text-sizing--small-device("small");
         .jkl-checkbox__check-mark {
             height: $checkbox-size--compact;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -90,7 +90,7 @@ Det er utviklet mixins for å lette bruk av vanlige mønstre. For eksempel kan d
 
 Noen løsninger, spesielt rådgiverløsninger, har behov for å vise veldig mye informasjon på skjermen samtidig. Derfor ønsker vi å tilby kompakte versjoner av komponentene til dette formålet. Vi bruker BEM-modifieren `--compact` for å markere kompakt variant av en komponent.
 
-For å gjøre det enklere å ha kompakt modus tillater vi å sette en attributt `data-compactlayout` på `<body>` (eller et annet element) slik at alle komponenter inne i dette elementet blir kompakte. Når du skriver kompakt versjon av en komoponent i Jøkul skal selektoren derfor se slik ut:
+For å gjøre det enklere å ha kompakt modus på en hel løsning tillater vi å sette en attributt `data-compactlayout` på `<body>` (eller et annet element) slik at alle komponenter inne i dette elementet blir kompakte. Når du skriver kompakt versjon av en komponent i Jøkul skal selektoren derfor se slik ut:
 
 ```scss
 .jkl-my-component {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,9 +1,142 @@
 # [`@fremtind/jkl-core`](https://fremtind.github.io/jokul/components/)
 
+-   Stil
+    -   Bruk av stilark
+    -   Bruk av variabler og mixins
+        -   Variabler
+        -   mixins
+    -   Implementere kompakt modus
+-   Javascript
+    -   initTabListener()
+    -   getValuePair()
+
 ## Stil
 
 Inneholder grunnstilen til designsystemet Jøkul i form av CSS, minifisert CSS og SCSS. Inneholder også et normaliserings-stilark som sørger for at alle nettlesere har samme utgangspunkt når de skal vise en Fremtind-side. Dersom du skal bygge komponenter for Fremtind, utover de som finnes i Jøkul, bør du bruke variablene her. Det sørger for at farger, sperring, typografisk skala, o.l. holder seg oppdatert mot endringer i designsystemet.
 
+### Bruk av stilark
+
+For å ta i bruk grunnstilen anbefaler vi å importere det minifiserte stilarket på denne måten:
+
+```js
+import "@fremtind/jkl-core/core.min.css";
+```
+
+Dette stilarket inneholder all grunnstilen du trenger for å bruke Jøkul videre, inkludert stiler for avsnitt, etiketter, hjelpetekster og overskrifter.
+
+### Bruk av variabler og mixins
+
+Når du skal utvikle egne komponenter basert på Jøkul anbefaler vi at du tar inn `@fremtind/jkl-core` som en avhengighet, og benytter deg av variablene for farger, avstand etc. Slik sørger du for at designet holder seg oppdatert og følger retningslinjene. Variablene, og mixins som letter bruken av dem, får du tilgang til gjennom egne `.scss`-filer:
+
+```
+@fremtind/jkl-core
+  |
+  |- variables/
+  |   |
+  |   |- _all.scss
+  |   |- _breakpoints.scss
+  |   |- _colors.scss
+  |   |- _font-size.scss
+  |   |- _shadow.scss
+  |   |- _spacing.scss
+  |   |- _z-index.scss
+  |
+  |- mixins/
+  |   |
+  |   |- _all.scss
+  |   |- _helpers.scss
+  |   |- _motion.scss
+  |   |- _ornaments.scss
+  |   |- _screenreader.scss
+  |   |- _screens.scss
+```
+
+#### Variabler
+
+Vi anbefaler å bruke variablene som design tokens, det vil si at du lager egne variabler for egenskapene til komponenten din, som henter verdier fra variablene i Jøkul. For eksempel kan det se slik ut i en knapp:
+
+```scss
+$button-background-color: $svart;
+/* ... */
+.jkl-button {
+    background-color: $button-background-color;
+    /* ... */
+}
+```
+
+#### Mixins
+
+Det er utviklet mixins for å lette bruk av vanlige mønstre. For eksempel kan du håndtere riktig skriftstørrelse og linjehøyde på desktop og mobil med mixin'en `text-sizing`:
+
+```scss
+.jkl-some-component {
+    @include text-sizing("small");
+}
+
+/* Resulterer i følgende css: */
+@media (min-width: 0) and (max-width: 767px) {
+    .jkl-some-component {
+        font-size: 1rem;
+        line-height: 1.5rem;
+    }
+}
+.jkl-some-component {
+    font-size: 1.375rem;
+    line-height: 2rem;
+}
+```
+
+### Implementere kompakt modus
+
+Noen løsninger, spesielt rådgiverløsninger, har behov for å vise veldig mye informasjon på skjermen samtidig. Derfor ønsker vi å tilby kompakte versjoner av komponentene til dette formålet. Vi bruker BEM-modifieren `--compact` for å markere kompakt variant av en komponent.
+
+For å gjøre det enklere å ha kompakt modus tillater vi å sette en attributt `data-compactlayout` på `<body>` (eller et annet element) slik at alle komponenter inne i dette elementet blir kompakte. Når du skriver kompakt versjon av en komoponent i Jøkul skal selektoren derfor se slik ut:
+
+```scss
+.jkl-my-component {
+    // Normal stil
+
+    &--compact,
+    *[data-compactlayout] & {
+        // Kompakt stil
+    }
+}
+```
+
 ## Javascript
 
-Pakken inneholder også noen nyttige funksjoner som brukes av flere komponenter, eller som anbefales brukt på Fremtind-sider. Et eksempel er funksjonen `initTabListener`, som sørger for å differensiere elementfokus ut fra navigasjonstype (tastatur eller mus/touch). 
+Pakken inneholder også noen nyttige funksjoner som brukes av flere komponenter, eller som anbefales brukt på Fremtind-sider.
+
+### `initTabListener()`
+
+Av tilgjengelighetshensyn viser vi fokusomriss på interaktive elementer når man navigerer en løsning ved hjelp av tastaturet. Normalt blir disse omrissene også vist når man bruker musen for navigasjon, noe vi ikke ønsker. Hjelpefunksjonen `initTabListener()` sørger for å sette et flagg på `<body>` når man navigerer med musen, som skjuler omrissene. Importer og kall funksjonen på rot i prosjektet ditt (der siden rendres):
+
+```js
+import { initTabListener } from "@fremtind/jkl-core";
+
+initTabListener();
+```
+
+### `getValuePair()`
+
+Noen komponenter, som `Select` og `RadioButtons`, kan ta inn verdier enten som en streng eller som et `ValuePair`-objekt med en `value` og et `label`. Hjelpefunksjonen `getValuePair` konstruerer et `ValuePair` fra en `string`, for å sikre enkel implementasjon av disse komponentene. Funksjonen sender gjennom `ValuePair`-objekter uendret:
+
+```js
+import { getValuePair } from "@fremtind/jkl-core";
+
+getValuePair("En verdi"); // { label: "En verdi", value: "En verdi" }
+
+const value = { label: "En annen verdi", value: "value2" };
+getValuePair(value); // returnerer objektet som det er
+```
+
+Denne er fin å bruke sammen med `map()` for å rendre valg:
+
+```jsx
+const choices = ["Valg 1", "Valg 2", "Valg 3"];
+return choices.map(getValuePair).map((choice) => (
+    <option selected={choice.value === selectedValue} value={choice.value}>
+        choice.label
+    </option>
+));
+```

--- a/packages/core/headings.scss
+++ b/packages/core/headings.scss
@@ -9,6 +9,12 @@
     @extend %normal-font-weight;
     @include font-size("xxl");
     @include line-height("xxl");
+
+    @include compactMode {
+        @include font-size--small-device("xxl");
+        @include line-height--small-device("xxl");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
@@ -16,6 +22,12 @@
     @extend %normal-font-weight;
     @include font-size("xl");
     @include line-height("xl");
+
+    @include compactMode {
+        @include font-size--small-device("xl");
+        @include line-height--small-device("xl");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
@@ -23,13 +35,23 @@
     @extend %normal-font-weight;
     @include font-size("large");
     @include line-height("large");
+
+    @include compactMode {
+        @include font-size--small-device("large");
+        @include line-height--small-device("large");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
 .jkl-h4 {
-    @extend %normal-font-weight;
     @include font-size("medium");
     line-height: $line-height-3; // exeption from scale
+
+    @include compactMode {
+        @include font-size--small-device("medium");
+        line-height: $line-height-2;
+    }
+
     margin-bottom: $layout-spacing--small;
-    font-weight: 600;
 }

--- a/packages/core/headings.scss
+++ b/packages/core/headings.scss
@@ -1,5 +1,6 @@
 @import "./variables/font-size";
 @import "./variables/spacing";
+@import "./mixins/helpers";
 
 %normal-font-weight {
     font-weight: normal;

--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -7,7 +7,8 @@
     margin-top: $component-spacing--small;
     @include text-sizing("xxs");
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         @include text-sizing--small-device("xxs");
     }
 
@@ -45,7 +46,8 @@
         @include text-sizing("xxs");
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         &.jkl-label--medium {
             @include text-sizing--small-device("medium");
         }

--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -7,8 +7,7 @@
     margin-top: $component-spacing--small;
     @include text-sizing("xxs");
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         @include text-sizing--small-device("xxs");
     }
 
@@ -46,8 +45,7 @@
         @include text-sizing("xxs");
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         &.jkl-label--medium {
             @include text-sizing--small-device("medium");
         }

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -11,3 +11,10 @@
     right: $right;
     bottom: $bottom;
 }
+
+@mixin compactMode {
+    &--compact,
+    *[data-compactlayout] & {
+        @content;
+    }
+}

--- a/packages/core/paragraphs.scss
+++ b/packages/core/paragraphs.scss
@@ -1,26 +1,51 @@
 @import "./variables/font-size";
 @import "./variables/spacing";
+@import "./mixins/helpers";
 
 .jkl-p {
     @include font-size("small");
     @include line-height("small");
+
+    @include compactMode {
+        @include font-size--small-device("small");
+        @include line-height--small-device("small");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
 .jkl-lead {
     @include font-size("medium");
     @include line-height("medium");
+
+    @include compactMode {
+        @include font-size--small-device("medium");
+        @include line-height--small-device("medium");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
 .jkl-small {
     @include font-size("xs");
     @include line-height("xs");
+
+    @include compactMode {
+        @include font-size--small-device("xs");
+        @include line-height--small-device("xs");
+    }
+
     margin-bottom: $layout-spacing--small;
 }
 
 .jkl-tiny {
     @include font-size("xxs");
     @include line-height("xxs");
+
+    @include compactMode {
+        @include font-size--small-device("xxs");
+        @include line-height--small-device("xxs");
+    }
+
     margin-bottom: $layout-spacing--small;
 }

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -57,7 +57,8 @@ $radio-button-color: $svart;
         }
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         .jkl-radio-button__dot:before {
             height: $radio-button-size--compact;
             width: $radio-button-size--compact;

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -1,4 +1,5 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 
 $radio-button-size: rem(24px);
 $radio-button-size--compact: rem(18px);
@@ -57,8 +58,7 @@ $radio-button-color: $svart;
         }
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         .jkl-radio-button__dot:before {
             height: $radio-button-size--compact;
             width: $radio-button-size--compact;

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -50,8 +50,7 @@ $chevron-weight: rem(1px);
         vertical-align: top;
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         & .jkl-select__value {
             @include text-sizing--small-device("small");
             padding-right: $chevron-size--compact + $side-padding;

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -50,7 +50,8 @@ $chevron-weight: rem(1px);
         vertical-align: top;
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         & .jkl-select__value {
             @include text-sizing--small-device("small");
             padding-right: $chevron-size--compact + $side-padding;

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -33,7 +33,8 @@ $textarea-expanded-height--small-device: $input-height--small-device * 7 + $bott
         }
     }
 
-    &--compact {
+    &--compact,
+    *[data-compactlayout] & {
         & .jkl-text-field__input,
         & .jkl-text-field__input::placeholder {
             @include text-sizing--small-device("small");

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -33,8 +33,7 @@ $textarea-expanded-height--small-device: $input-height--small-device * 7 + $bott
         }
     }
 
-    &--compact,
-    *[data-compactlayout] & {
+    @include compactMode {
         & .jkl-text-field__input,
         & .jkl-text-field__input::placeholder {
             @include text-sizing--small-device("small");


### PR DESCRIPTION
## 📥 Proposed changes

For å lette implementasjonen av kompakt modus i løsninger som f.eks. Flyt, legger denne PR'en til støtte for å sette kompakt modus globalt:

Ved å sette attributten `data-compactlayout` på et HTML-element vil alle Jøkul-komponenter inne i dette elementet vises i kompakt modus. Man kan dermed sette kompakt modus på hele applikasjonen med `<body data-compactlayout>`, eller bare på en del av den med f.eks. `<aside data-compactlayout>`.

Se #494 for diskusjon av for- og bakdeler med dette.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-button, @fremtind/jkl-checkbox, @fremtind/jkl-radio-button,
@fremtind/jkl-select, @fremtind/jkl-text-input

ISSUES CLOSED: #494