### PR TITLE
fix(datepicker): fix alignment of year value in picker

### DIFF
--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -103,9 +103,11 @@ $bottom-margin: $component-spacing--large;
     &__year-selector {
         max-width: 30%;
         margin-right: $component-spacing--xxl;
-    }
-    &__year-value {
-        text-align: left;
+
+        // must be nested to override default right-alignment
+        & > .jkl-datepicker__year-value {
+            text-align: left;
+        }
     }
 
     &__month-selector {


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker

## 📥 Proposed changes

Make sure the year value in the datepicker (for selecting year in the open state) is left-aligned as per the design sketches.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
