### PR TITLE
fix(datepicker-react): datepicker fire onChange on edit

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 import { DatePicker } from ".";
 import { formatDate, isSameDay } from "./DatePicker";
 
@@ -12,6 +12,26 @@ describe("Datepicker", () => {
 
         const date = getByTestId("jkl-datepicker__input");
         expect(date).toHaveProperty("value", "24.12.2019");
+    });
+
+    it("should fire onChange on edit input with valid date", () => {
+        const changeHandler = jest.fn();
+        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
+        const input = getByTestId("jkl-datepicker__input");
+        expect(input).toHaveProperty("value", "");
+        fireEvent.change(input, { target: { value: "01.12.2019" } });
+        expect(input).toHaveProperty("value", "01.12.2019");
+        expect(changeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not fire onChange on edit input with invalid date", () => {
+        const changeHandler = jest.fn();
+        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
+        const input = getByTestId("jkl-datepicker__input");
+        expect(input).toHaveProperty("value", "");
+        fireEvent.change(input, { target: { value: "a random string" } });
+        expect(input).toHaveProperty("value", "a random string");
+        expect(changeHandler).toHaveBeenCalledTimes(0);
     });
 });
 

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -94,14 +94,17 @@ export function DatePicker({
     function onInputChange(event: ChangeEvent<HTMLInputElement>) {
         const newDateString = event.target.value;
         const dayMonthYearMatch = dayMonthYearRegex.exec(newDateString);
-
         // Only set the date if it is a valid date
         if (dayMonthYearMatch) {
             const day = parseInt(dayMonthYearMatch[1], 10);
             const month = parseInt(dayMonthYearMatch[2], 10) - 1;
             const year = parseInt(dayMonthYearMatch[3], 10);
 
-            setDate(new Date(year, month, day, 0, 0, 0));
+            const newDate = new Date(year, month, day, 0, 0, 0);
+            setDate(newDate);
+            if (onChange) {
+                onChange(newDate);
+            }
         }
         setDateString(newDateString);
     }

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -101,9 +101,11 @@ export function DatePicker({
             const year = parseInt(dayMonthYearMatch[3], 10);
 
             const newDate = new Date(year, month, day, 0, 0, 0);
-            setDate(newDate);
-            if (onChange) {
-                onChange(newDate);
+            if (dateHasChanged(date, newDate)) {
+                setDate(newDate);
+                if (onChange) {
+                    onChange(newDate);
+                }
             }
         }
         setDateString(newDateString);


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react

date picker should fire onChange when a valid date is entered into the input field

## 📥 Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
