### PR TITLE
fix(select-react): make Select & NativeSelect useable as uncontrolled

### DIFF
--- a/packages/select-react/example/index.tsx
+++ b/packages/select-react/example/index.tsx
@@ -13,7 +13,7 @@ const SelectDemo = () => {
     const valuePairs = [{ value: "firstvalue", label: "Value 1" }, { value: "secondvalue", label: "Value 2" }];
     const years = [...Array(120)].map((_, i) => (i + 1900).toString()); // 1900 - 2019
 
-    const [favoriteScene, setFavoriteScene] = useState("The flower shop");
+    const [favoriteScene, setFavoriteScene] = useState<string>();
     const [valuePair, setValuePair] = useState<string>();
 
     return (
@@ -27,7 +27,7 @@ const SelectDemo = () => {
                 onChange={setFavoriteScene}
                 value={favoriteScene}
                 helpLabel="The room is the greatest movie"
-                errorLabel={favoriteScene !== "" ? "You can't pick, they are all the best" : undefined}
+                errorLabel={favoriteScene ? "You can't pick, they are all the best" : undefined}
                 variant="large"
             />
             <Select
@@ -51,7 +51,7 @@ const SelectDemo = () => {
             <NativeSelect
                 className="jkl-spacing--top-3"
                 helpLabel="The room is the greatest movie"
-                errorLabel={favoriteScene !== "" ? "You can't pick, they are all the best" : undefined}
+                errorLabel={favoriteScene ? "You can't pick, they are all the best" : undefined}
                 label="Native select"
                 items={items}
                 onChange={(e) => setFavoriteScene(e.target.value)}

--- a/packages/select-react/src/NativeSelect.test.tsx
+++ b/packages/select-react/src/NativeSelect.test.tsx
@@ -2,24 +2,28 @@ import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { NativeSelect } from ".";
 
+const dummyFunc = () => {};
+
 describe("NativeSelect", () => {
     afterEach(cleanup);
 
     it("should render the correct label", () => {
-        const { getByText } = render(<NativeSelect label="testing" items={["test"]} />);
+        const { getByText } = render(<NativeSelect label="testing" items={["test"]} onChange={dummyFunc} />);
 
         expect(getByText("testing")).toBeInTheDocument();
     });
 
     it("should render the correct number of options", () => {
-        const { getAllByTestId } = render(<NativeSelect label="testing" items={["1", "2", "3"]} />);
+        const { getAllByTestId } = render(
+            <NativeSelect label="testing" items={["1", "2", "3"]} onChange={dummyFunc} />,
+        );
 
         expect(getAllByTestId("jkl-select__option")).toHaveLength(3);
     });
 
     it("should render correct label and value when given values as strings", () => {
         const items = ["item 1", "item 2", "item 3"];
-        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} />);
+        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} onChange={dummyFunc} />);
 
         expect(getAllByTestId("jkl-select__option")[0]).toHaveAttribute("value", "item 1");
         expect(getAllByTestId("jkl-select__option")[0]).toHaveTextContent("item 1");
@@ -27,7 +31,7 @@ describe("NativeSelect", () => {
 
     it("should render correct label and value when given values as objects", () => {
         const items = [{ value: "item1", label: "Item 1" }, { value: "item2", label: "Item 2" }];
-        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} />);
+        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} onChange={dummyFunc} />);
 
         expect(getAllByTestId("jkl-select__option")[1]).toHaveAttribute("value", "item2");
         expect(getAllByTestId("jkl-select__option")[1]).toHaveTextContent("Item 2");
@@ -35,13 +39,17 @@ describe("NativeSelect", () => {
 
     it("should render placeholder when given and field has no value", () => {
         const items = ["item 1", "item 2", "item 3"];
-        const { getByText } = render(<NativeSelect label="testing" items={items} placeholder="Please choose" />);
+        const { getByText } = render(
+            <NativeSelect label="testing" items={items} placeholder="Please choose" onChange={dummyFunc} />,
+        );
 
         expect(getByText("Please choose")).toBeInTheDocument();
     });
 
     it("can be forced into compact mode", () => {
-        const { getByTestId } = render(<NativeSelect items={["1", "2"]} label="test" forceCompact />);
+        const { getByTestId } = render(
+            <NativeSelect items={["1", "2"]} label="test" onChange={dummyFunc} forceCompact />,
+        );
 
         expect(getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -30,34 +30,38 @@ export function NativeSelect({
     placeholder,
     value,
     forceCompact,
-    ...rest
 }: Props) {
     // If no value is given, set it to first item, or to empty string if there is a placeholder
     if (!value) {
         if (!placeholder && items.length) {
             value = getValuePair(items[0]).value;
-        } else {
-            value = "";
         }
     }
-    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        onChange && onChange(event);
-    };
     const componentClassName = "jkl-select".concat(
         inline ? ` jkl-select--inline` : "",
         forceCompact ? ` jkl-select--compact` : "",
         !!errorLabel ? ` jkl-select--invalid` : "",
-        value === "" ? ` jkl-select--no-value` : "",
         className ? ` ${className}` : "",
     );
+    const defaultValue = value ? undefined : "";
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        onChange && onChange(event);
+    };
 
     return (
         <label data-testid="jkl-select" className={componentClassName}>
             <Label variant={variant} forceCompact={forceCompact}>
                 {label}
             </Label>
-            <select value={value} className="jkl-select__value" onBlur={handleChange} onChange={handleChange} {...rest}>
-                {placeholder && value === "" && (
+            <select
+                value={value}
+                defaultValue={defaultValue}
+                className="jkl-select__value"
+                onBlur={handleChange}
+                onChange={handleChange}
+            >
+                {placeholder && !value && (
                     <option disabled value="">
                         {placeholder}
                     </option>

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -45,10 +45,6 @@ export function NativeSelect({
     );
     const defaultValue = value ? undefined : "";
 
-    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        onChange && onChange(event);
-    };
-
     return (
         <label data-testid="jkl-select" className={componentClassName}>
             <Label variant={variant} forceCompact={forceCompact}>
@@ -58,8 +54,8 @@ export function NativeSelect({
                 value={value}
                 defaultValue={defaultValue}
                 className="jkl-select__value"
-                onBlur={handleChange}
-                onChange={handleChange}
+                onBlur={onChange}
+                onChange={onChange}
             >
                 {placeholder && !value && (
                     <option disabled value="">

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -20,22 +20,17 @@ describe("Select", () => {
         expect(dropdown).toHaveClass("jkl-select--inline");
     });
 
-    it("should set inital value as input value", () => {
+    it("should use the specified value", () => {
         const onChange = jest.fn();
-        const initialInput = "drop";
+        const value = "drop";
         const { getByTestId } = render(
-            <Select
-                onChange={onChange}
-                items={["drop", "it", "like", "its", "hot"]}
-                label="Snoop"
-                initialInputValue={initialInput}
-            />,
+            <Select onChange={onChange} items={["drop", "it", "like", "its", "hot"]} label="Snoop" value={value} />,
         );
 
         const button = getByTestId("jkl-select__value");
 
         expect(onChange).toHaveBeenCalledTimes(0);
-        expect(button).toHaveTextContent(initialInput);
+        expect(button).toHaveTextContent(value);
     });
 
     it("should have default text value in button when no option selected", () => {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -45,7 +45,6 @@ function focusSelected(listEl: HTMLElement, listId: string, selected: string | u
 export function Select({
     items,
     value,
-    initialInputValue,
     label,
     onChange,
     className,
@@ -56,8 +55,8 @@ export function Select({
     variant,
     forceCompact,
 }: Props) {
-    const [selectedValue, setSelectedValue] = useState(value || initialInputValue);
-    const [displayedValue, setDisplayedValue] = useState(value || initialInputValue);
+    const [selectedValue, setSelectedValue] = useState(value);
+    const [displayedValue, setDisplayedValue] = useState(value);
     const [dropdownIsShown, setShown] = useState(false);
     const [listId] = useState(`dropdown${nanoid(16)}`);
     const hasSelectedValue = typeof selectedValue !== "undefined";
@@ -82,13 +81,11 @@ export function Select({
     function onToggleSelect(e: CoreToggleSelectEvent) {
         e.target.hidden = true;
         e.target.button.focus();
-        if (value && onChange) {
-            e.target.value = e.detail;
-            const nextValue = e.detail.value;
-            setDisplayedValue(e.detail.textContent);
-            setSelectedValue(nextValue);
-            onChange(nextValue || "");
-        }
+        e.target.value = e.detail;
+        const nextValue = e.detail.value;
+        setDisplayedValue(e.detail.textContent);
+        setSelectedValue(nextValue);
+        onChange && onChange(nextValue || "");
     }
 
     return (

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -85,7 +85,7 @@ export function Select({
         const nextValue = e.detail.value;
         setDisplayedValue(e.detail.textContent);
         setSelectedValue(nextValue);
-        onChange && onChange(nextValue || "");
+        onChange && onChange(nextValue);
     }
 
     return (

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import CoreToggle from "@nrk/core-toggle/jsx";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import nanoid from "nanoid";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 import { LabelVariant, ValuePair, getValuePair } from "@fremtind/jkl-core";
@@ -87,6 +87,11 @@ export function Select({
         setSelectedValue(nextValue);
         onChange && onChange(nextValue);
     }
+
+    useEffect(() => {
+        setSelectedValue(value);
+        items.map(getValuePair).map((item) => item.value === value && setDisplayedValue(item.label));
+    }, [value]);
 
     return (
         <div data-testid="jkl-select" className={componentClassName}>


### PR DESCRIPTION
## 📥 Proposed changes

`Select` and `NativeSelect` no longer requires an initial value to function.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
affects: @fremtind/jkl-select-react

ISSUES CLOSED: #500
