### PR TITLE
fix(accordion-react): only scale title when on active state

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -4,16 +4,10 @@
 .jkl-accordion-item {
     $title-padding: $component-spacing--large;
 
-    @include motion("standard");
-    transition-property: transform;
     margin-bottom: $component-spacing--small;
 
     &:last-child {
         margin-bottom: 0;
-    }
-
-    &:active {
-        transform: scale(0.99);
     }
 
     &--expanded {
@@ -35,11 +29,18 @@
         text-align: left;
         width: 100%;
 
+        @include motion("standard");
+        transition-property: transform, color, background-color;
+
         /* Remove button styles */
         outline: none;
         background-color: $varde;
         color: inherit; // stops Safari from changing color on :active
         border: none;
+
+        &:active {
+            transform: scale(0.99);
+        }
 
         &:hover {
             cursor: pointer;
@@ -50,9 +51,6 @@
         html:not([data-mousenavigation]) &:focus {
             box-shadow: inset 0 0 0 2px $focus-color;
         }
-
-        @include motion("standard");
-        transition-property: color, background-color;
     }
 
     &__title-text {


### PR DESCRIPTION
## 📥 Proposed changes

Remove scale effect from entire accordion item on press, and scale just the title instead

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-accordion

ISSUES CLOSED: #489
