### PR TITLE
feat(core): move fieldset styling to reset.css

### DIFF
--- a/packages/core/reset.scss
+++ b/packages/core/reset.scss
@@ -25,6 +25,10 @@ p {
 
 fieldset {
     margin: 0;
+    border: 0;
+    padding: 0;
+    display: block;
+    line-height: 1;
 }
 
 /* Forms

--- a/packages/field-group-react/src/FieldGroup.tsx
+++ b/packages/field-group-react/src/FieldGroup.tsx
@@ -24,7 +24,7 @@ export const FieldGroup = ({
     const componentClassName = "jkl-field-group".concat(className ? ` ${className}` : "");
     return (
         <fieldset className={componentClassName}>
-            <legend>
+            <legend className="jkl-field-group__legend">
                 <Label variant={variant} forceCompact={forceCompact}>
                     {legend}
                 </Label>

--- a/packages/field-group/field-group.scss
+++ b/packages/field-group/field-group.scss
@@ -1,8 +1,15 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
 
 .jkl-field-group {
-    border: 0;
-    padding: 0;
-    display: block;
-    line-height: 1;
+    /* 
+     * Field set legends are displayed straddling the top of the field set by default.
+     * This makes sure the entire legend falls within the field set background. 
+     **/
+    &__legend {
+        float: left;
+
+        & + * {
+            clear: both;
+        }
+    }
 }


### PR DESCRIPTION
affects: @fremtind/jkl-core

## 📥 Proposed changes

Move styling of fieldset from `jkl-field-group` to `core/reset.css`, to remove hidden dependency in `jkl-radio-button-react`

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
