### PR TITLE
docs: add deprecation warning for usage of BulletList

### DIFF
--- a/packages/bullet-list-react/README.md
+++ b/packages/bullet-list-react/README.md
@@ -7,3 +7,13 @@
 ## Kom i gang
 
 [Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+
+## Foreldet (Deprecated)
+
+`BulletList` er foreldet grunnet et behov for å ha både nummererte og unummererte lister, det ga ikke lenger mening at komponenten da inneholder 'bullet' i navnet. Komponenten har blitt erstattet med `OrderedList` & `UnorderedList`.
+
+`BulletListItem` er foreldet og erstattet med `ListItem`.
+
+`@fremtind/jkl-bullet-list` -> `@fremtind/jkl-list`
+
+`@fremtind/jkl-bullet-list-react` -> `@fremtind/jkl-list-react`

--- a/packages/bullet-list-react/README.md
+++ b/packages/bullet-list-react/README.md
@@ -1,5 +1,8 @@
 # [`@fremtind/jkl-bullet-list-react`](https://fremtind.github.io/jokul/components/bulletlist/)
 
+-   **Utgått:** Denne komponenten er utgått, og erstattet av `@fremtind/jkl-list-react`
+-   **Deprecated:** This component is deprecated, and replaced by `@fremtind/jkl-list-react`
+
 ## Beskrivelse
 
 [Bruk og prinsipper](https://fremtind.github.io/jokul/components/bulletlist/) er beskrevet i `@fremtind/jkl-bullet-list` stil-pakken.
@@ -7,13 +10,3 @@
 ## Kom i gang
 
 [Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
-
-## Foreldet (Deprecated)
-
-`BulletList` er foreldet grunnet et behov for å ha både nummererte og unummererte lister, det ga ikke lenger mening at komponenten da inneholder 'bullet' i navnet. Komponenten har blitt erstattet med `OrderedList` & `UnorderedList`.
-
-`BulletListItem` er foreldet og erstattet med `ListItem`.
-
-`@fremtind/jkl-bullet-list` -> `@fremtind/jkl-list`
-
-`@fremtind/jkl-bullet-list-react` -> `@fremtind/jkl-list-react`

--- a/packages/bullet-list-react/src/BulletList.tsx
+++ b/packages/bullet-list-react/src/BulletList.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const BulletList = ({ children, className = "jkl-p" }: Props) => {
     if (process.env.NODE_ENV !== "production") {
         console.warn(
-            "WARNING: The packages 'bullet-list-react' & 'bullet-list' are deprecated and replaced by 'list-react' and 'list'. See developer documentation for further details.",
+            "WARNING: The packages '@fremtind/jkl-bullet-list-react' & '@fremtind/jkl-bullet-list' are deprecated and replaced by '@fremtind/jkl-list-react' and '@fremtind/jkl-list'. Please use the `List` component from @fremtind/jkl-list-react instead.",
         );
     }
 

--- a/packages/bullet-list-react/src/BulletList.tsx
+++ b/packages/bullet-list-react/src/BulletList.tsx
@@ -5,6 +5,12 @@ interface Props {
     className?: string;
 }
 
-export const BulletList = ({ children, className = "jkl-p" }: Props) => (
-    <ul className={`jkl-bullet-list ${className}`}>{children}</ul>
-);
+export const BulletList = ({ children, className = "jkl-p" }: Props) => {
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: The packages 'bullet-list-react' & 'bullet-list' are deprecated and replaced by 'list-react' and 'list'. See developer documentation for further details.",
+        );
+    }
+
+    return <ul className={`jkl-bullet-list ${className}`}>{children}</ul>;
+};

--- a/packages/bullet-list-react/src/BulletListItem.tsx
+++ b/packages/bullet-list-react/src/BulletListItem.tsx
@@ -4,4 +4,11 @@ interface Props {
     children: ReactNode;
 }
 
-export const BulletListItem = ({ children }: Props) => <li className="jkl-bullet-list__item">{children}</li>;
+export const BulletListItem = ({ children }: Props) => {
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: The packages '@fremtind/jkl-bullet-list-react' & '@fremtind/jkl-bullet-list' are deprecated and replaced by '@fremtind/jkl-list-react' and '@fremtind/jkl-list'. Please use the `ListItem` component from @fremtind/jkl-list-react instead.",
+        );
+    }
+    return <li className="jkl-bullet-list__item">{children}</li>;
+};

--- a/packages/bullet-list/README.md
+++ b/packages/bullet-list/README.md
@@ -1,10 +1,20 @@
 # [`@fremtind/jkl-bullet-list`](https://fremtind.github.io/jokul/components/bulletlist/)
 
+-   **Utgått:** Denne komponenten er utgått, og erstattet av `@fremtind/jkl-list`
+-   **Deprecated:** This component is deprecated, and replaced by `@fremtind/jkl-list`
+
 ## Om lister
-Lister er strukturelementer. De gjør at vi kan utheve viktig informasjon for brukerne eller fortelle dem at de må gjøre noe i en bestemt rekkefølge. Det finnes to forskjellige lister: _nummererte_ og _unummererte_. 
+
+Lister er strukturelementer. De gjør at vi kan utheve viktig informasjon for brukerne eller fortelle dem at de må gjøre noe i en bestemt rekkefølge. Det finnes to forskjellige lister: _nummererte_ og _unummererte_.
+
 ### Nummererte lister
+
 Vi bruker nummererte lister når vi skal presentere instruksjoner, der rekkefølgen er viktig.
+
 ### Unummererte lister
+
 I unummererte lister bruker vi kulepunkter. Formålet med en slik liste er å organisere informasjonen og fremheve viktige opplysninger. Her er ikke rekkefølgen brukeren skal utføre noe i viktig, men vi må likevel passe på at vi presenterer det innholdet som er mest relevant først.
+
 ### Innrykk i lister
+
 Vi kan bruke innrykk under et enkelt listepunkt når det punktet har tilleggsinformasjon som vi må dele opp videre. Men bruk det sparsommelig. Før du bruker det, tenk nøye over om dette er et hovedpunkt som kan stå for seg selv, eller om det er informasjon som passer best som underpunkt. Selvstendige punkter skal ikke ha innrykk.


### PR DESCRIPTION
affects: @fremtind/jkl-bullet-list-react

## 📥 Proposed changes

Adds a deprecation warning when using BulletList, as well as changes to the readme.

Connected to #505 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
