### PR TITLE
refactor: rename compactMode to compact-mode

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -37,7 +37,7 @@ $hover-elevation-distance: -0.25rem;
         line-height: $button-height--small;
     }
 
-    @include compactMode {
+    @include compact-mode {
         height: $button-height--small;
         min-width: $button-height--small;
         line-height: $button-height--small;

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -29,7 +29,7 @@ $checkbox-check-mark-color: $checkbox-background-color--unchecked;
         }
     }
 
-    @include compactMode {
+    @include compact-mode {
         @include text-sizing--small-device("small");
         .jkl-checkbox__check-mark {
             height: $checkbox-size--compact;

--- a/packages/core/headings.scss
+++ b/packages/core/headings.scss
@@ -11,7 +11,7 @@
     @include font-size("xxl");
     @include line-height("xxl");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("xxl");
         @include line-height--small-device("xxl");
     }
@@ -24,7 +24,7 @@
     @include font-size("xl");
     @include line-height("xl");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("xl");
         @include line-height--small-device("xl");
     }
@@ -37,7 +37,7 @@
     @include font-size("large");
     @include line-height("large");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("large");
         @include line-height--small-device("large");
     }
@@ -49,7 +49,7 @@
     @include font-size("medium");
     line-height: $line-height-3; // exeption from scale
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("medium");
         line-height: $line-height-2;
     }

--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -7,7 +7,7 @@
     margin-top: $component-spacing--small;
     @include text-sizing("xxs");
 
-    @include compactMode {
+    @include compact-mode {
         @include text-sizing--small-device("xxs");
     }
 
@@ -41,7 +41,7 @@
         @include text-sizing("xxs");
     }
 
-    @include compactMode {
+    @include compact-mode {
         &.jkl-label--medium {
             @include text-sizing--small-device("medium");
         }

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -12,7 +12,7 @@
     bottom: $bottom;
 }
 
-@mixin compactMode {
+@mixin compact-mode {
     &--compact,
     *[data-compactlayout] & {
         @content;

--- a/packages/core/paragraphs.scss
+++ b/packages/core/paragraphs.scss
@@ -6,7 +6,7 @@
     @include font-size("small");
     @include line-height("small");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("small");
         @include line-height--small-device("small");
     }
@@ -18,7 +18,7 @@
     @include font-size("medium");
     @include line-height("medium");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("medium");
         @include line-height--small-device("medium");
     }
@@ -30,7 +30,7 @@
     @include font-size("xs");
     @include line-height("xs");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("xs");
         @include line-height--small-device("xs");
     }
@@ -42,7 +42,7 @@
     @include font-size("xxs");
     @include line-height("xxs");
 
-    @include compactMode {
+    @include compact-mode {
         @include font-size--small-device("xxs");
         @include line-height--small-device("xxs");
     }

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -59,7 +59,7 @@ $radio-button-color: $svart;
         }
     }
 
-    @include compactMode {
+    @include compact-mode {
         .jkl-radio-button__dot:before {
             height: $radio-button-size--compact;
             width: $radio-button-size--compact;

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -51,7 +51,7 @@ $chevron-weight: rem(1px);
         vertical-align: top;
     }
 
-    @include compactMode {
+    @include compact-mode {
         & .jkl-select__value {
             @include text-sizing--small-device("small");
             padding-right: $chevron-size--compact + $side-padding;

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -37,7 +37,7 @@ $icon-size--compact: $font-size-2;
         }
     }
 
-    @include compactMode {
+    @include compact-mode {
         & .jkl-text-field__input,
         & .jkl-text-field__input::placeholder {
             @include text-sizing--small-device("small");


### PR DESCRIPTION
affects: @fremtind/jkl-button, @fremtind/jkl-checkbox, @fremtind/jkl-core,
@fremtind/jkl-radio-button, @fremtind/jkl-select, @fremtind/jkl-text-input

## 📥 Proposed changes

Refactor to standard naming convention for css

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
