### PR TITLE
(select-react) fix: fix visual jump when value is empty

### DIFF
--- a/packages/select-react/example/index.html
+++ b/packages/select-react/example/index.html
@@ -1,6 +1,6 @@
 <html lang="no" xml:lang="no" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Dropdown Demo</title>
+        <title>Select Demo</title>
     </head>
     <body>
         <div id="app" class="jkl-spacing--bottom-4"></div>

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -57,7 +57,7 @@ export function Select({
     initialInputValue,
 }: Props) {
     const [selectedValue, setSelectedValue] = useState(value);
-    const hasSelectedValue = typeof selectedValue !== "undefined";
+    const hasSelectedValue = typeof selectedValue !== "undefined" && selectedValue !== "";
 
     function getLabelFromValue(value: string | undefined) {
         const matchingItem = items.map(getValuePair).filter((item) => item.value === value)[0];


### PR DESCRIPTION
affects: @fremtind/jkl-select-react

closes #531

## 📥 Proposed changes

Fixes a bug where an empty value for `<Select />` resulted in the outer wrapper shrinking in height.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
