### PR TITLE
docs(divider-line-react): import core style in example

### DIFF
--- a/packages/divider-line-react/example/index.tsx
+++ b/packages/divider-line-react/example/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { DividerLine } from "../src";
+import "@fremtind/jkl-core/core.min.css";
 import "@fremtind/jkl-divider-line/divider-line.css";
 
 const Line = () => (


### PR DESCRIPTION
affects: @fremtind/jkl-divider-line-react

## 📥 Proposed changes

Import `core.min.css` in the dev example so that the divider actually shows up in Chrome.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Closes #532 
