### PR TITLE
chore(lint): use eslint to perform prettier, cleans up pkgjson

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
         },
     },
     parser: "@typescript-eslint/parser",
-    plugins: ["jsx-a11y"],
+    plugins: ["prettier", "jsx-a11y"],
     extends: [
         "plugin:react/recommended",
         "plugin:@typescript-eslint/recommended",
@@ -30,5 +30,6 @@ module.exports = {
         "@typescript-eslint/no-use-before-define": ["error", { functions: false }],
         "@typescript-eslint/ban-ts-ignore": 0, // We use ts-ignore for modules that don't have type definition files
         "react/prop-types": 0,
+        "prettier/prettier": "error",
     },
 };

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
         "predeploy:docs": "yarn run build:docs",
         "deploy:docs": "gh-pages -d portal/public",
         "typecheck": "tsc --noEmit",
-        "lint:formatting": "prettier -c '**/*.{js,jsx,ts,tsx}' '**/*.scss' '**/*.html'",
-        "lint:scripts": "eslint '**/*.{js,jsx,ts,tsx}'",
-        "lint": "yarn run lint:formatting && yarn run lint:scripts",
+        "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
         "ci:test": "run-p test",
         "test": "run-p test:unit",
         "test:unit": "jest -c './jest/jest.unit.js'",
@@ -50,6 +48,7 @@
         "eslint": "^6.0.0",
         "eslint-config-prettier": "^6.0.0",
         "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-prettier": "^3.1.1",
         "eslint-plugin-react": "^7.14.3",
         "fibers": "^4.0.1",
         "gh-pages": "^2.0.1",
@@ -97,9 +96,8 @@
             "git add"
         ],
         "*.{ts,tsx,js,jsx}": [
-            "prettier --write",
-            "git add",
-            "eslint"
+            "eslint --fix",
+            "git add"
         ]
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6202,6 +6202,13 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
@@ -6631,6 +6638,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.2, fast-glob@^2.2.6:
   version "2.2.7"
@@ -12881,6 +12893,13 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^1.17.1:
   version "1.19.1"


### PR DESCRIPTION
affects: @fremtind/jkl-typography-react

## 📥 Proposed changes

I dagens så bruker vi prettier til å gjøre ting mer eller mindre pent og eslint til å gjøre ting mer eller mindre riktig. Dette er igrunn sider av samme sak, og eslint kan fint gjøre hele jobben ved å gi linteren tilgang på prettier-pluginen. Det gjør at vi kan fjerne en del script og shave et millisekund eller to av bygg og commit osv. Legger man sammen flere millisekund, så blir det for mange millisekund, og det kan bli sekunder etter hvert. I know math. 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
