### PR TITLE
fix(portal): use prefix path when loading webfonts

### DIFF
--- a/portal/src/pages/style.scss
+++ b/portal/src/pages/style.scss
@@ -2,6 +2,7 @@
 @import "~@fremtind/jkl-core/mixins/_all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
+$webfonts-dir: "../../static/fonts";
 @import "~@fremtind/jkl-webfonts/webfonts.scss";
 
 $hero-size: rem(700px);


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

The portal tried to load the webfonts from `/fonts` instead of `/jokul/fonts` since scss-files don't get path-prefixed. By specifying a relative path in the scss it sort of works, even though the font files end up in two different folders during the Gatsby build 🤔

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

There might be a more elegant solution to this, but the portal is live in Times New Roman right now, so time is sort of of the ssence here 😅