### PR TITLE
refactor: unify titles in examples

### DIFF
--- a/packages/accordion-react/example/index.html
+++ b/packages/accordion-react/example/index.html
@@ -2,5 +2,6 @@
     <body>
         <div id="app" style="padding: 100px"></div>
         <script src="index.tsx"></script>
+        <title>Jøkul Accordion Example</title>
     </body>
 </html>

--- a/packages/accordion/example/index.html
+++ b/packages/accordion/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Accordion</title>
+        <title>Jøkul Accordion Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/button-react/example/index.html
+++ b/packages/button-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Button example</title>
+        <title>Jøkul Button Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/button/example/index.html
+++ b/packages/button/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Button</title>
+        <title>Jøkul Button Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/card-react/example/index.html
+++ b/packages/card-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Card</title>
+        <title>Jøkul Card Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/card/example/index.html
+++ b/packages/card/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Card</title>
+        <title>Jøkul Card Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/checkbox-react/example/index.html
+++ b/packages/checkbox-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Checkboxes</title>
+        <title>Jøkul Checkbox Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/checkbox/example/index.html
+++ b/packages/checkbox/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Checkboxes</title>
+        <title>Jøkul Checkbox Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/datepicker-react/example/index.html
+++ b/packages/datepicker-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Example datepicker</title>
+        <title>Jøkul Datepicker Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="background-color: #fafafa">

--- a/packages/divider-line-react/example/index.html
+++ b/packages/divider-line-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Dividerline example</title>
+        <title>Jøkul Divider Line Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>

--- a/packages/divider-line/example/index.html
+++ b/packages/divider-line/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Divider line</title>
+        <title>Jøkul Divider Line Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/field-group-react/example/index.html
+++ b/packages/field-group-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Field Group example</title>
+        <title>Jøkul Field Group Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" type="text/css" media="screen" href="index.scss" />
     </head>

--- a/packages/field-group/example/index.html
+++ b/packages/field-group/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Field Group example</title>
+        <title>Jøkul Field Group Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" type="text/css" media="screen" href="../field-group.min.css" />
         <link rel="stylesheet" type="text/css" media="screen" href="index.scss" />

--- a/packages/hamburger-react/example/index.html
+++ b/packages/hamburger-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Hamburger example</title>
+        <title>Jøkul Hamburger Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="display: flex; justify-content: center; margin: 32px">

--- a/packages/hamburger/example/index.html
+++ b/packages/hamburger/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Hamburger example</title>
+        <title>Jøkul Hamburger Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="./index.tsx"></script>
     </head>

--- a/packages/list-react/example/index.html
+++ b/packages/list-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>List</title>
+        <title>Jøkul List Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/list/example/index.html
+++ b/packages/list/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>List</title>
+        <title>Jøkul List Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/loader-react/example/index.html
+++ b/packages/loader-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Example loader</title>
+        <title>Jøkul Loader Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="height: 100vh; display: flex; justify-content: center; align-items: center;">

--- a/packages/loader/example/index.html
+++ b/packages/loader/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Loader example</title>
+        <title>Jøkul Loader Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" type="text/css" media="screen" href="../loader.min.css" />
         <link rel="stylesheet" type="text/css" media="screen" href="index.scss" />

--- a/packages/logo-react/example/index.html
+++ b/packages/logo-react/example/index.html
@@ -2,5 +2,6 @@
     <body>
         <div id="app"></div>
         <script src="index.tsx"></script>
+        <title>Jøkul Logo Example</title>
     </body>
 </html>

--- a/packages/message-box-react/example/index.html
+++ b/packages/message-box-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Example message-box</title>
+        <title>Jøkul Message Box Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/message-box/example/index.html
+++ b/packages/message-box/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Example message-box</title>
+        <title>Jøkul Message Box Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
         <script src="index.tsx"></script>

--- a/packages/progress-bar-react/example/index.html
+++ b/packages/progress-bar-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Progress bar example</title>
+        <title>Jøkul Progress Bar Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="display: flex; justify-content: center; align-items: center; margin: 32px">

--- a/packages/progress-bar/example/index.html
+++ b/packages/progress-bar/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Example progressbar</title>
+        <title>Jøkul Progress Bar Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="index.tsx"></script>
     </head>

--- a/packages/radio-button-react/example/index.html
+++ b/packages/radio-button-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul RadioButtonOption</title>
+        <title>Jøkul Radio Button Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
 

--- a/packages/radio-button/example/index.html
+++ b/packages/radio-button/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul RadioButtonOption</title>
+        <title>Jøkul Radio Button Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="height: 100%; display: flex; justify-content: space-evenly; align-items: center;">

--- a/packages/select-react/example/index.html
+++ b/packages/select-react/example/index.html
@@ -1,6 +1,6 @@
 <html lang="no" xml:lang="no" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Select Demo</title>
+        <title>Jøkul Select Example</title>
     </head>
     <body>
         <div id="app" class="jkl-spacing--bottom-4"></div>

--- a/packages/select/example/index.html
+++ b/packages/select/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Select</title>
+        <title>Jøkul Select Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>

--- a/packages/table-react/example/index.html
+++ b/packages/table-react/example/index.html
@@ -1,6 +1,6 @@
 <html lang="no">
     <head>
-        <title>Table Demo</title>
+        <title>Jøkul Table Example</title>
     </head>
     <body>
         <div id="app"></div>

--- a/packages/table/example/index.html
+++ b/packages/table/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Jøkul Table</title>
+        <title>Jøkul Table Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="index.scss" />
     </head>

--- a/packages/text-input-react/example/index.html
+++ b/packages/text-input-react/example/index.html
@@ -1,6 +1,6 @@
 <html lang="no" xml:lang="no" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Text field Demo</title>
+        <title>Jøkul Text Field Example</title>
     </head>
     <body>
         <div id="app"></div>

--- a/packages/text-input/example/index.html
+++ b/packages/text-input/example/index.html
@@ -1,6 +1,6 @@
 <html lang="no" xml:lang="no" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>Text input Demo</title>
+        <title>Jøkul Text Input Example</title>
     </head>
     <body style="margin:0; padding:0;">
         <div id="app"></div>

--- a/packages/toggle-switch-react/example/index.html
+++ b/packages/toggle-switch-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Toggle switch example</title>
+        <title>Jøkul Toggle Switch Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>

--- a/packages/toggle-switch/example/index.html
+++ b/packages/toggle-switch/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Toggle switch example</title>
+        <title>Jøkul Toggle Switch Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>

--- a/packages/typography-react/example/index.html
+++ b/packages/typography-react/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <title>Typography</title>
+        <title>Jøkul Typography Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body style="padding: 10px;">


### PR DESCRIPTION
affects: @fremtind/jkl-accordion-react, @fremtind/jkl-accordion, @fremtind/jkl-button-react,
@fremtind/jkl-button, @fremtind/jkl-card-react, @fremtind/jkl-card, @fremtind/jkl-checkbox-react,
@fremtind/jkl-checkbox, @fremtind/jkl-datepicker-react, @fremtind/jkl-divider-line-react,
@fremtind/jkl-divider-line, @fremtind/jkl-field-group-react, @fremtind/jkl-field-group,
@fremtind/jkl-hamburger-react, @fremtind/jkl-hamburger, @fremtind/jkl-list-react,
@fremtind/jkl-list, @fremtind/jkl-loader-react, @fremtind/jkl-loader, @fremtind/jkl-logo-react,
@fremtind/jkl-message-box-react, @fremtind/jkl-message-box, @fremtind/jkl-progress-bar-react,
@fremtind/jkl-progress-bar, @fremtind/jkl-radio-button-react, @fremtind/jkl-radio-button,
@fremtind/jkl-select-react, @fremtind/jkl-select, @fremtind/jkl-table-react, @fremtind/jkl-table,
@fremtind/jkl-text-input-react, @fremtind/jkl-text-input, @fremtind/jkl-toggle-switch-react,
@fremtind/jkl-toggle-switch, @fremtind/jkl-typography-react

## 📥 Proposed changes

A quick little PR to unify the title in the examples. My suggested formatting is "Jøkul [component] Example" so it's easy to find in the browser tabs.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
