### PR TITLE
fix(webfonts): update @font-face rules to handle locally installed fonts

### DIFF
--- a/packages/webfonts/webfonts.scss
+++ b/packages/webfonts/webfonts.scss
@@ -5,7 +5,8 @@ $webfonts-dir: "/fonts" !default;
     font-display: fallback;
     font-weight: 400;
     font-style: normal;
-    src: local("Fremtind Grotesk"), url("#{$webfonts-dir}/FremtindGrotesk-Regular-Web.woff2") format("woff2"),
+    src: local("Fremtind Grotesk"), local("FremtindGrotesk-Regular"),
+        url("#{$webfonts-dir}/FremtindGrotesk-Regular-Web.woff2") format("woff2"),
         url("#{$webfonts-dir}/FremtindGrotesk-Regular-Web.woff") format("woff");
 }
 @font-face {
@@ -13,7 +14,8 @@ $webfonts-dir: "/fonts" !default;
     font-display: fallback;
     font-weight: 700;
     font-style: normal;
-    src: local("Fremtind Grotesk"), url("#{$webfonts-dir}/FremtindGrotesk-Bold-Web.woff2") format("woff2"),
+    src: local("Fremtind Grotesk Bold"), local("FremtindGrotesk-Bold"),
+        url("#{$webfonts-dir}/FremtindGrotesk-Bold-Web.woff2") format("woff2"),
         url("#{$webfonts-dir}/FremtindGrotesk-Bold-Web.woff") format("woff");
 }
 @font-face {
@@ -21,7 +23,8 @@ $webfonts-dir: "/fonts" !default;
     font-display: fallback;
     font-weight: 400;
     font-style: italic;
-    src: local("Fremtind Grotesk"), url("#{$webfonts-dir}/FremtindGrotesk-Italic-Web.woff2") format("woff2"),
+    src: local("Fremtind Grotesk Italic"), local("FremtindGrotesk-Italic"),
+        url("#{$webfonts-dir}/FremtindGrotesk-Italic-Web.woff2") format("woff2"),
         url("#{$webfonts-dir}/FremtindGrotesk-Italic-Web.woff") format("woff");
 }
 @font-face {
@@ -29,7 +32,8 @@ $webfonts-dir: "/fonts" !default;
     font-display: fallback;
     font-weight: 700;
     font-style: italic;
-    src: local("Fremtind Grotesk"), url("#{$webfonts-dir}/FremtindGrotesk-BoldItalic-Web.woff2") format("woff2"),
+    src: local("Fremtind Grotesk Bold Italic"), local("FremtindGrotesk-BoldItalic"),
+        url("#{$webfonts-dir}/FremtindGrotesk-BoldItalic-Web.woff2") format("woff2"),
         url("#{$webfonts-dir}/FremtindGrotesk-BoldItalic-Web.woff") format("woff");
 }
 @font-face {
@@ -37,7 +41,8 @@ $webfonts-dir: "/fonts" !default;
     font-display: fallback;
     font-weight: 400;
     font-style: normal;
-    src: local("Fremtind Grotesk"), url("#{$webfonts-dir}/FremtindGrotesk-Display-Web.woff2") format("woff2"),
+    src: local("Fremtind Grotesk Display"), local("FremtindGrotesk-Display"),
+        url("#{$webfonts-dir}/FremtindGrotesk-Display-Web.woff2") format("woff2"),
         url("#{$webfonts-dir}/FremtindGrotesk-Display-Web.woff") format("woff");
 }
 @font-face {


### PR DESCRIPTION
affects: @fremtind/jkl-webfonts

## 📥 Proposed changes

Update the local font names in the `@font-face` rules to work with other variants than regular. Should restore bold/italic styles when on a computer that has Fremtind Grotesk installed.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
