### PR TITLE
feat(accordion-react): add support for custom className on AccordionItem

### DIFF
--- a/packages/accordion-react/src/AccordionItem.test.tsx
+++ b/packages/accordion-react/src/AccordionItem.test.tsx
@@ -10,6 +10,15 @@ describe("AccordionItem", () => {
 
         expect(getByTestId("jkl-accordion-item")).toBeInTheDocument();
     });
+    it("should apply custom classnames", () => {
+        const { getByTestId } = render(
+            <AccordionItem title="Hello" className="custom-class">
+                Something
+            </AccordionItem>,
+        );
+
+        expect(getByTestId("jkl-accordion-item")).toHaveClass("custom-class");
+    });
     it("should render its children", () => {
         const { getByText } = render(<AccordionItem title="Hello">Something</AccordionItem>);
         const child = getByText("Something");

--- a/packages/accordion-react/src/AccordionItem.tsx
+++ b/packages/accordion-react/src/AccordionItem.tsx
@@ -9,17 +9,21 @@ interface Props {
     title: string;
     children: ReactNode;
     startExpanded?: boolean;
+    className?: string;
 }
 
-export function AccordionItem({ children, title, startExpanded = false }: Props) {
+export function AccordionItem({ children, title, className, startExpanded = false }: Props) {
     const [isOpen, setIsOpen] = useState(startExpanded);
     const [elementRef] = useAnimatedHeight(isOpen);
-    const openClassName = isOpen ? " jkl-accordion-item--expanded" : "";
+    const componentClassName = "jkl-accordion-item".concat(
+        isOpen ? " jkl-accordion-item--expanded" : "",
+        className ? ` ${className}` : "",
+    );
 
     const onToggle = () => setIsOpen(!isOpen);
 
     return (
-        <div data-testid="jkl-accordion-item" className={`jkl-accordion-item${openClassName}`}>
+        <div data-testid="jkl-accordion-item" className={componentClassName}>
             <button className="jkl-accordion-item__title" type="button">
                 <span className="jkl-accordion-item__title-text">{title}</span>
                 <span className="jkl-accordion-item__title-icon" />


### PR DESCRIPTION
affects: @fremtind/jkl-accordion-react

## 📥 Proposed changes

Add support for custom className on the `AccordionItem` component.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Closes #569