### PR TITLE
fix(select): stop native arrow from showing in IE11

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -107,6 +107,10 @@ $chevron-side-padding: (2 * $component-spacing--small);
         position: relative;
         @include underline-color($border-color, $border-color--focus);
 
+        &::-ms-expand {
+            display: none; // remove dropdown arrow in IE11
+        }
+
         &:active {
             color: currentColor; // Safari text will blink on click without this
         }


### PR DESCRIPTION
ISSUES CLOSED: #572

## 📥 Proposed changes

Stop the native dropdown toggle button from showing in IE11.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
