### PR TITLE
fix(toggle-switch): fix formatting of toggle switch label

### DIFF
--- a/packages/toggle-switch-react/src/ToggleSwitch.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.tsx
@@ -30,7 +30,7 @@ export const ToggleSwitch = ({ children, checked, onChange, className, disabled,
                 <span className="jkl-toggle-switch__slider">
                     <span className="jkl-toggle-switch__expanding-pill"></span>
                 </span>
-                <span className="jkl-p jkl-toggle-switch__label">{children}</span>
+                <span className="jkl-toggle-switch__label">{children}</span>
             </label>
             <SupportLabel className="jkl-toggle-switch__helplabel" helpLabel={helpLabel} />
         </>

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -1,5 +1,5 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
-@import "~@fremtind/jkl-core/mixins/_helpers.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
 $toggle-width: rem(48px);
@@ -36,10 +36,6 @@ $inverted-disabled-color: #969696;
                     background-color: $expanding-pill-background-color;
                     border-color: $helhvit;
                 }
-            }
-
-            &__label {
-                color: currentColor;
             }
 
             &__input[disabled] {
@@ -92,7 +88,8 @@ $inverted-disabled-color: #969696;
     }
 
     &__label {
-        margin-bottom: 0;
+        @include text-sizing("small");
+        color: currentColor;
         padding-left: $component-spacing--small;
     }
 


### PR DESCRIPTION
affects: @fremtind/jkl-toggle-switch-react, @fremtind/jkl-toggle-switch

## 📥 Proposed changes

Remove the usage of `jkl-p` in the toggle switch label to get rid of bottom margin.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
