### PR TITLE
fix(portal): fix usage of deleted mixin

### DIFF
--- a/portal/src/components/Example/Example.scss
+++ b/portal/src/components/Example/Example.scss
@@ -5,7 +5,7 @@
 .portal-content {
     &__code {
         &-editor {
-            @include font-size("xxs");
+            @include body-small-paragraph;
         }
         &-highlight {
             font-size: 1rem !important;

--- a/portal/src/components/Menu/Menu.scss
+++ b/portal/src/components/Menu/Menu.scss
@@ -116,7 +116,7 @@ $menu-width: rem(320px);
     }
 
     & .jkl-accordion-item__content {
-        @include font-size(small);
+        @include body-paragraph;
         padding: $layout-spacing--small;
     }
 


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

`@include font-size` caused an error when building the portal. The mixin got deleted in #591.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments
