### PR TITLE
chore(ci): run CI script on all branches (also with slashes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: lint-test-typecheck
 
-on:
-    push:
-        branches:
-            - "*"
+on: push
 
 jobs:
     build:


### PR DESCRIPTION
## 📥 Proposed changes

The greenkeeper branches keep waiting for CI because the script only runs on "base" branches without slashes in the name. This updates the trigger to the default (`"**"`) so that it will run on `greenkeeper/**`-branches as well.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
