### PR TITLE
fix(text-input): change to bigger line-height

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -8,7 +8,7 @@ $border-color: $svart;
 $border-color--focus: $focus-color;
 
 $input-height: $line-height-4;
-$input-height--small-device: $line-height-2;
+$input-height--small-device: $line-height-3;
 $bottom-padding: $component-spacing--small;
 
 $textarea-expanded-height: $input-height * 7 + $bottom-padding;


### PR DESCRIPTION
affects: @fremtind/jkl-text-input

ISSUES CLOSED: #611

## 📥 Proposed changes

The line-height between text and line in text-area when set to compact is too small. 
![image](https://user-images.githubusercontent.com/51901763/71969584-3b57ef80-3207-11ea-8bce-f0ee438963ac.png)

Setting the line-height from 2 to 3 will fix it.
![image](https://user-images.githubusercontent.com/51901763/71969638-5e829f00-3207-11ea-9e54-3f62c6688111.png)


## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

Earlier it made the line-height for desktop version too big. I didn't get this bug this time, but it might occur on other screens. I tested with chrome and firefox.
