### PR TITLE
docs(portal): remove empty category from main menu

### DIFF
--- a/portal/src/components/Menu/links.ts
+++ b/portal/src/components/Menu/links.ts
@@ -44,11 +44,6 @@ const profile = (rawPages: GeneralDocPages) => ({
     sectionTitle: "Profilelementer",
     matchingLocation: (location: WindowLocation) => location.pathname.includes("profil"),
 });
-const core = (rawPages: GeneralDocPages) => ({
-    pages: rawPages.edges.filter(by(/^\/kjerne/)).map(edgeToPage),
-    sectionTitle: "Grunnleggende",
-    matchingLocation: (location: WindowLocation) => !!location.pathname.match(/kjerne/) || location.pathname === "/",
-});
 const developer = (rawPages: GeneralDocPages) => ({
     pages: rawPages.edges.filter(by(/^\/utvikler/)).map(edgeToPage),
     sectionTitle: "For utviklere",
@@ -89,7 +84,6 @@ const examples = {
 };
 
 export const mainMenu = (rawPages: GeneralDocPages, rawComponents: ComponentDocPages) => [
-    core(rawPages),
     profile(rawPages),
     designer(rawPages),
     developer(rawPages),


### PR DESCRIPTION
affects: @fremtind/portal
closes: #655 

## 📥 Proposed changes

Fjern den tomme "Grunnleggende"-kategorien fra hovedmenyen i portalen

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
