### PR TITLE
Update list to new design

### DIFF
--- a/packages/list-react/documentation/Example.tsx
+++ b/packages/list-react/documentation/Example.tsx
@@ -5,74 +5,58 @@ import "@fremtind/jkl-core/core.scss";
 
 export const Ordered = () => (
     <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
-        <OrderedList className="jkl-spacing--all-4">
-            <ListItem>jkl-body ordered</ListItem>
+        <h3 className="jkl-h5">Nummerert liste</h3>
+        <OrderedList>
+            <ListItem>Steg 1</ListItem>
             <ListItem>
-                Hilda Robbins
+                Steg 2
                 <OrderedList>
-                    <ListItem>Mattie Lawrence</ListItem>
-                    <ListItem>Eric Huff</ListItem>
+                    <ListItem>Steg 2a</ListItem>
+                    <ListItem>Steg 2b</ListItem>
                 </OrderedList>
             </ListItem>
-            <ListItem>Adam Norris</ListItem>
-            <ListItem>Essie Diaz</ListItem>
+            <ListItem>Steg 3</ListItem>
+            <ListItem>Steg 4</ListItem>
+            <ListItem>Steg 5</ListItem>
+            <ListItem>Steg 6</ListItem>
+            <ListItem>Steg 7</ListItem>
+            <ListItem>Steg 8</ListItem>
+            <ListItem>Steg 9</ListItem>
+            <ListItem>Steg 10</ListItem>
         </OrderedList>
     </section>
 );
 
 export const Unordered = () => (
     <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
-        <UnorderedList className="jkl-spacing--all-4">
-            <ListItem>jkl-body</ListItem>
-            <ListItem>
-                Linnie Gill
-                <UnorderedList>
-                    <ListItem>Grace Cortez</ListItem>
-                    <ListItem>
-                        Dette er en veldig lang setning som er veldig lang og repeterende for å sjekke hvordan wrapping
-                        funker. Sa jeg at setningen er lang?
-                    </ListItem>
-                </UnorderedList>
-            </ListItem>
-            <ListItem>Cory Wagner</ListItem>
-            <ListItem>Lora Carroll</ListItem>
+        <h3 className="jkl-h5">Standard liste</h3>
+        <UnorderedList>
+            <ListItem>Listeelement 1</ListItem>
+            <ListItem>Listeelement 2</ListItem>
+            <ListItem>Listelement 3</ListItem>
         </UnorderedList>
+        <br></br>
+        <h3 className="jkl-h5">Mobile/Compact liste</h3>
+        <UnorderedList className="jkl-small">
+            <ListItem>Listeelement 1</ListItem>
+            <ListItem>Listeelement 2</ListItem>
+            <ListItem>Listelement 3</ListItem>
+        </UnorderedList>
+    </section>
+);
 
-        <UnorderedList className="jkl-lead jkl-spacing--all-4">
-            <ListItem>jkl-lead</ListItem>
+export const Indent = () => (
+    <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
+        <h3 className="jkl-h5">Nøstet liste</h3>
+        <UnorderedList>
             <ListItem>
-                Linnie Gill
-                <UnorderedList className="jkl-lead">
-                    <ListItem>Grace Cortez</ListItem>
-                    <ListItem>Madge Hodges</ListItem>
+                Listeelement 1
+                <UnorderedList>
+                    <ListItem>Nøstet listeelement 1</ListItem>
+                    <ListItem>Nøstet listeelement 2</ListItem>
                 </UnorderedList>
             </ListItem>
-            <ListItem>Cory Wagner</ListItem>
-            <ListItem>Lora Carroll</ListItem>
-        </UnorderedList>
-        <UnorderedList className="jkl-small jkl-spacing--all-4">
-            <ListItem>jkl-small</ListItem>
-            <ListItem>
-                Linnie Gill
-                <UnorderedList className="jkl-small">
-                    <ListItem>Grace Cortez</ListItem>
-                    <ListItem>Madge Hodges</ListItem>
-                </UnorderedList>
-            </ListItem>
-            <ListItem>Cory Wagner</ListItem>
-            <ListItem>Lora Carroll</ListItem>
-        </UnorderedList>
-        <UnorderedList className="jkl-micro jkl-spacing--all-4">
-            <ListItem>jkl-micro</ListItem>
-            <ListItem>
-                Linnie Gill
-                <UnorderedList className="jkl-micro">
-                    <ListItem>Grace Cortez</ListItem>
-                    <ListItem>Madge Hodges</ListItem>
-                </UnorderedList>
-            </ListItem>
-            <ListItem>Cory Wagner</ListItem>
-            <ListItem>Lora Carroll</ListItem>
+            <ListItem>Listelement 2</ListItem>
         </UnorderedList>
     </section>
 );
@@ -81,6 +65,7 @@ const Example = () => (
     <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
         <Ordered />
         <Unordered />
+        <Indent />
     </section>
 );
 

--- a/packages/list-react/documentation/List.mdx
+++ b/packages/list-react/documentation/List.mdx
@@ -4,7 +4,7 @@ react: list-react
 scss: list
 ---
 
-import { Ordered, Unordered } from "./Example";
+import { Ordered, Unordered, Indent } from "./Example";
 
 Lister er strukturelementer. De gjør at vi kan utheve viktig informasjon for brukerne eller fortelle dem at de må gjøre noe i en bestemt rekkefølge. Det finnes to forskjellige lister: _nummererte_ og _unummererte_.
 
@@ -23,3 +23,5 @@ I unummererte lister bruker vi kulepunkter. Formålet med en slik liste er å or
 ### Innrykk i lister
 
 Vi kan bruke innrykk under et enkelt listepunkt når det punktet har tilleggsinformasjon som vi må dele opp videre. Men bruk det sparsommelig. Før du bruker det, tenk nøye over om dette er et hovedpunkt som kan stå for seg selv, eller om det er informasjon som passer best som underpunkt. Selvstendige punkter skal ikke ha innrykk.
+
+<Indent />

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -1,27 +1,24 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
-$item-space-between: $component-spacing--large;
-$item-indent: $component-spacing--xxl;
+$item-space-between: $component-spacing--small;
+$list-padding-left: $layout-spacing--small;
 
-$diamond: "\25C6";
-$diamond-hollow: "\25C7";
-$square: "\25A0";
+$black-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%' height='100%' viewBox='1 0 9 9' fill='none'%3E%3Cpath fill='%23000' d='M5 0l4.002 4.002L5 8.004.998 4.002z'/%3E%3C/svg%3E");
+$white-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%' height='100%' viewBox='0 0 9 9' fill='none'%3E%3Cpath stroke='%23000' d='M4.002.707l3.295 3.295-3.295 3.295L.707 4.002z'/%3E%3C/svg%3E");
 
 .jkl-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    list-style: disc $black-diamond;
+    padding-left: $list-padding-left;
+
+    &.jkl-body {
+        & > .jkl-list__item {
+            padding-left: rem(4px);
+        }
+    }
 
     & > .jkl-list__item {
         margin: $item-space-between 0;
-        padding-left: $item-indent;
-
-        &::before {
-            content: $diamond;
-            position: absolute;
-            margin-left: -3ch;
-        }
 
         &:first-of-type {
             margin-top: 0;
@@ -29,12 +26,15 @@ $square: "\25A0";
         &:last-of-type {
             margin-bottom: 0;
         }
-    }
-    & & > .jkl-list__item {
-        &:before {
-            content: $diamond-hollow;
+        & > .jkl-list {
+            margin-bottom: 0;
         }
-        padding-left: $item-indent;
+    }
+
+    & & > .jkl-list__item {
+        list-style: disc $white-diamond;
+        margin: 0;
+
         &:first-of-type {
             margin-top: $item-space-between;
         }
@@ -44,19 +44,12 @@ $square: "\25A0";
     }
 
     &--ordered {
-        counter-reset: my-counter;
-
         & > .jkl-list__item {
-            counter-increment: my-counter;
-
-            &::before {
-                content: counter(my-counter) ". ";
-                font-weight: bold;
-            }
+            list-style: decimal;
         }
 
-        & & > .jkl-list__item::before {
-            content: counter(my-counter, lower-alpha) ". ";
+        & & > .jkl-list__item {
+            list-style: lower-alpha;
         }
     }
 }

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -4,8 +4,8 @@
 $item-space-between: $component-spacing--small;
 $list-padding-left: $layout-spacing--small;
 
-$black-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%' height='100%' viewBox='1 0 9 9' fill='none'%3E%3Cpath fill='%23000' d='M5 0l4.002 4.002L5 8.004.998 4.002z'/%3E%3C/svg%3E");
-$white-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%' height='100%' viewBox='0 0 9 9' fill='none'%3E%3Cpath stroke='%23000' d='M4.002.707l3.295 3.295-3.295 3.295L.707 4.002z'/%3E%3C/svg%3E");
+$black-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9' width='9px' height='9px'%3E%3Cpath d='M4.01 0l4.002 4.002L4.01 8.004.008 4.002z'/%3E%3C/svg%3E");
+$white-diamond: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9' width='9px' height='9px' fill='transparent'%3E%3Cpath stroke='%23000' d='M4.002.707l3.295 3.295-3.295 3.295L.707 4.002z'/%3E%3C/svg%3E");
 
 .jkl-list {
     list-style: disc $black-diamond;


### PR DESCRIPTION
closes #647, closes #650 

## 📥 Proposed changes

Et lite avvik fra designet i Figma:

Padding på venstre side av listen måtte være `layout-spacing--small` (24px) for at punktene ikke skulle ligge bittelitt til venstre for resten av teksten på siden. Det neste steget ned på skalaen vår er 16px og det ble for lite. Fått ok fra @Murstam på det.

---

Ellers skal alt være riktig. Samt at screen reader nå ikke leser opp bullet, men den leser fortsatt siffer foran nummerert liste så for det første punktet i en liste på fire med innhold "tekst" blir det lest opp "1 tekst 1 av 4". Regner med dette er riktig siden det nå bare er et \<ol>-element med `list-style: decimal`.

Endret også litt på dokumentasjonen slik jeg følte ble naturlig.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
