### PR TITLE
fix(links): adjust padding around links for new font

### DIFF
--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -4,6 +4,8 @@
 @mixin background-color($color) {
     background-image: linear-gradient(to bottom, $color 0%, $color 100%);
 }
+$link-underline-width: rem(1px);
+$link-side-padding: 0.075em; // relative value to work with all paragraph styles
 
 .jkl-link {
     @include background-color($svart);
@@ -13,8 +15,8 @@
     outline: none;
     text-decoration: none;
     color: currentColor;
-    background-size: rem(1px) rem(1px);
-    padding: 4px 0; // Add padding to push the underline down and make the hover/focus background height higher
+    background-size: $link-underline-width $link-underline-width;
+    padding: 0 $link-side-padding; // Add slight padding to sides to keep hover effect from "clipping" letters
 
     html:not([data-mousenavigation]) &:focus,
     &:hover {
@@ -28,7 +30,7 @@
 
     &--negative {
         @include background-color($snohvit);
-        background-size: rem(1px) rem(1px);
+        background-size: $link-underline-width $link-underline-width;
 
         &:hover {
             color: $svart;

--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -4,7 +4,7 @@
 @mixin background-color($color) {
     background-image: linear-gradient(to bottom, $color 0%, $color 100%);
 }
-$link-underline-width: rem(1px);
+$link-underline-thickness: rem(1px);
 $link-side-padding: 0.075em; // relative value to work with all paragraph styles
 
 .jkl-link {
@@ -15,7 +15,7 @@ $link-side-padding: 0.075em; // relative value to work with all paragraph styles
     outline: none;
     text-decoration: none;
     color: currentColor;
-    background-size: $link-underline-width $link-underline-width;
+    background-size: $link-underline-thickness $link-underline-thickness;
     padding: 0 $link-side-padding; // Add slight padding to sides to keep hover effect from "clipping" letters
 
     html:not([data-mousenavigation]) &:focus,
@@ -30,7 +30,6 @@ $link-side-padding: 0.075em; // relative value to work with all paragraph styles
 
     &--negative {
         @include background-color($snohvit);
-        background-size: $link-underline-width $link-underline-width;
 
         &:hover {
             color: $svart;


### PR DESCRIPTION
affects: @fremtind/jkl-core

## 📥 Proposed changes

Lenkene våre har sett rare ut etter bytte til ny font og nye avsnittstiler. Understreken ligger veldig langt nede, og nærmere linjen under enn lenken den er en del av:

<img width="158" alt="Skjermbilde 2020-01-14 kl  13 02 24" src="https://user-images.githubusercontent.com/25739615/72343461-34315580-36cf-11ea-8ffb-a8c75f793844.png">

Foreslår å ta vekk paddingen over og under lenketeksten som er der i dag, og samtidig legge på bittelitt padding på sidene, slik at hovereffekten ikke "kutter av" de ytterste bokstavene:

<img width="180" alt="Skjermbilde 2020-01-14 kl  13 02 58" src="https://user-images.githubusercontent.com/25739615/72343638-a144eb00-36cf-11ea-9bb2-81490e2f8d46.png"> <img width="166" alt="Skjermbilde 2020-01-14 kl  13 02 50" src="https://user-images.githubusercontent.com/25739615/72343640-a43fdb80-36cf-11ea-88b5-716a1babdfae.png">

Det er sikkert plass til en piksel eller to med padding over/under dersom man vil ha et enda luftigere uttrykk.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
