### PR TITLE
refactor: clean up scss for mobile and compact versions of components

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -56,7 +56,7 @@
     }
 
     &__title-text {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
         display: block;
         padding-right: 2rem;
     }
@@ -75,7 +75,7 @@
     }
 
     &__content {
-        @include lead-paragraph;
+        @include lead-paragraph--desktop;
         height: auto;
         padding: $layout-spacing--xl $component-spacing--large;
         color: inherit; // Make content same color as rest of page text

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -26,27 +26,14 @@ $animation-timing: 100ms cubic-bezier(0.6, 0.2, 0.35, 1);
 $hover-elevation-distance: -0.25rem;
 
 .jkl-button {
+    @include reset-outline;
     display: inline-flex;
     justify-content: center;
-    @include body-paragraph;
-    @include reset-outline;
+    @include body-paragraph--desktop;
     height: $button-height--normal;
     min-width: $button-min-width--normal;
     line-height: $button-height--normal;
     cursor: pointer;
-
-    @include small-device {
-        height: $button-height--compact;
-        min-width: $button-min-width--compact;
-        line-height: $button-height--compact;
-    }
-
-    @include compact-mode {
-        @include body-paragraph--mobile;
-        height: $button-height--compact;
-        min-width: $button-min-width--compact;
-        line-height: $button-height--compact;
-    }
 
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: auto;
@@ -121,5 +108,19 @@ $hover-elevation-distance: -0.25rem;
         html:not([data-mousenavigation]) &:focus {
             border-bottom-color: $focus-color;
         }
+    }
+
+    @include small-device {
+        @include body-paragraph--mobile;
+        height: $button-height--compact;
+        min-width: $button-min-width--compact;
+        line-height: $button-height--compact;
+    }
+
+    @include compact-mode {
+        @include body-paragraph--mobile;
+        height: $button-height--compact;
+        min-width: $button-min-width--compact;
+        line-height: $button-height--compact;
     }
 }

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -11,48 +11,14 @@ $checkbox-background-color--error: $error-color;
 $checkbox-check-mark-color: $checkbox-background-color--unchecked;
 
 .jkl-checkbox {
-    @include body-paragraph;
     @include reset-outline;
+    @include body-paragraph--desktop;
     display: flex;
     align-items: center;
     cursor: pointer;
 
     & + & {
         margin-top: $component-spacing--large;
-    }
-
-    &--inline {
-        display: inline-flex;
-        & + & {
-            margin-top: unset;
-            margin-left: $component-spacing--xl;
-        }
-    }
-
-    @include compact-mode {
-        @include body-paragraph--mobile;
-        .jkl-checkbox__check-mark {
-            height: $checkbox-size--compact;
-            width: $checkbox-size--compact;
-        }
-    }
-
-    &--error {
-        .jkl-checkbox__check-mark {
-            border-color: $checkbox-background-color--error;
-        }
-
-        .jkl-checkbox__input:checked + .jkl-checkbox__check-mark,
-        .jkl-checkbox__input:active + .jkl-checkbox__check-mark {
-            background-color: $checkbox-background-color--error;
-        }
-    }
-
-    @include small-device {
-        .jkl-checkbox__check-mark {
-            height: $checkbox-size--compact;
-            width: $checkbox-size--compact;
-        }
     }
 
     &:hover > .jkl-checkbox__check-mark {
@@ -62,26 +28,6 @@ $checkbox-check-mark-color: $checkbox-background-color--unchecked;
     &:active > .jkl-checkbox__check-mark {
         transform: scale(0.9);
         background-color: $checkbox-background-color--checked;
-    }
-
-    &__input {
-        /* Hide native checkbox */
-        opacity: 0;
-        position: absolute;
-
-        /* Handle fake checkmark based on checked state */
-        &:checked + .jkl-checkbox__check-mark {
-            background-color: $checkbox-background-color--checked;
-        }
-
-        &:checked + .jkl-checkbox__check-mark:after {
-            animation: jkl-checkbox-checked-animation 150ms ease-in-out 0ms forwards;
-            content: " ";
-        }
-
-        html:not([data-mousenavigation]) &:focus + .jkl-checkbox__check-mark {
-            box-shadow: 0 0 0 rem(2px) #fff, 0 0px 0 rem(4px) $focus-color;
-        }
     }
 
     &__check-mark {
@@ -115,6 +61,61 @@ $checkbox-check-mark-color: $checkbox-background-color--unchecked;
             border: solid rem(2px) $checkbox-check-mark-color;
             border-left-width: 0;
             border-top-width: 0;
+        }
+    }
+
+    &__input {
+        // Hide native checkbox
+        opacity: 0;
+        position: absolute;
+
+        // Handle fake checkmark based on checked state
+        &:checked + .jkl-checkbox__check-mark {
+            background-color: $checkbox-background-color--checked;
+        }
+
+        &:checked + .jkl-checkbox__check-mark:after {
+            animation: jkl-checkbox-checked-animation 150ms ease-in-out 0ms forwards;
+            content: " ";
+        }
+
+        html:not([data-mousenavigation]) &:focus + .jkl-checkbox__check-mark {
+            box-shadow: 0 0 0 rem(2px) #fff, 0 0px 0 rem(4px) $focus-color;
+        }
+    }
+
+    &--inline {
+        display: inline-flex;
+        & + & {
+            margin-top: unset;
+            margin-left: $component-spacing--xl;
+        }
+    }
+
+    &--error {
+        .jkl-checkbox__check-mark {
+            border-color: $checkbox-background-color--error;
+        }
+
+        .jkl-checkbox__input:checked + .jkl-checkbox__check-mark,
+        .jkl-checkbox__input:active + .jkl-checkbox__check-mark {
+            background-color: $checkbox-background-color--error;
+        }
+    }
+
+    @include compact-mode {
+        @include body-paragraph--mobile;
+        .jkl-checkbox__check-mark {
+            height: $checkbox-size--compact;
+            width: $checkbox-size--compact;
+        }
+    }
+
+    @include small-device {
+        @include body-paragraph--mobile;
+        .jkl-checkbox__check-mark {
+            height: $checkbox-size--compact;
+            width: $checkbox-size--compact;
         }
     }
 }

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -18,10 +18,6 @@ $bottom-margin: $component-spacing--large;
     width: $calendar-width + ($calendar-padding * 2);
     margin-bottom: $bottom-margin;
 
-    @include small-device {
-        width: $calendar-width + ($calendar-padding--compact * 2);
-    }
-
     &__outer-wrapper {
         position: relative;
     }
@@ -150,10 +146,6 @@ $bottom-margin: $component-spacing--large;
         box-shadow: $drop-shadow--small;
         color: $svart;
 
-        @include small-device {
-            padding: $calendar-padding $calendar-padding--compact;
-        }
-
         caption {
             font-size: $font-size-6;
             line-height: $line-height-4;
@@ -224,6 +216,14 @@ $bottom-margin: $component-spacing--large;
             &:focus {
                 box-shadow: 0 0 0 rem(1px) $snohvit, 0 0 0 rem(3px) $focus-color;
             }
+        }
+    }
+
+    @include small-device {
+        width: $calendar-width + ($calendar-padding--compact * 2);
+
+        &__calendar {
+            padding: $calendar-padding $calendar-padding--compact;
         }
     }
 }

--- a/packages/divider-line/divider-line.scss
+++ b/packages/divider-line/divider-line.scss
@@ -28,17 +28,6 @@ $line-size: 0.125rem;
         transform: scaleX(0.5);
     }
 
-    &--spin {
-        &.jkl-divider {
-            &::after {
-                transform: scaleX(1);
-            }
-            &::before {
-                transform: rotate($diamond-rotation);
-            }
-        }
-    }
-
     &::before {
         content: " ";
         @include animate-in();
@@ -49,5 +38,16 @@ $line-size: 0.125rem;
         width: $diamond-size;
         height: $diamond-size;
         transform: scale(1.2) rotate(-$diamond-rotation);
+    }
+
+    &--spin {
+        &.jkl-divider {
+            &::after {
+                transform: scaleX(1);
+            }
+            &::before {
+                transform: rotate($diamond-rotation);
+            }
+        }
     }
 }

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -36,25 +36,6 @@ $hamburger-line-spacing: rem(-10px);
         box-shadow: 0 0 0 rem(2px) $button-focus-ring-color;
     }
 
-    &--is-active {
-        & .jkl-hamburger__inner {
-            margin: auto;
-            transform: translateY(-50%) rotate(45deg);
-            transition-delay: 0.12s;
-            transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
-        }
-        & .jkl-hamburger__inner::before {
-            top: 0;
-            opacity: 0;
-            transition: top 0.075s ease, opacity 0.075s 0.12s ease;
-        }
-        & .jkl-hamburger__inner::after {
-            bottom: 0;
-            transform: rotate(-90deg);
-            transition: bottom 0.075s ease, transform 0.075s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
-        }
-    }
-
     &__inner {
         position: absolute;
         display: block;
@@ -88,6 +69,25 @@ $hamburger-line-spacing: rem(-10px);
         position: absolute;
         transition-property: transform;
         @include motion(standard, productive);
+    }
+
+    &--is-active {
+        & .jkl-hamburger__inner {
+            margin: auto;
+            transform: translateY(-50%) rotate(45deg);
+            transition-delay: 0.12s;
+            transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+        }
+        & .jkl-hamburger__inner::before {
+            top: 0;
+            opacity: 0;
+            transition: top 0.075s ease, opacity 0.075s 0.12s ease;
+        }
+        & .jkl-hamburger__inner::after {
+            bottom: 0;
+            transform: rotate(-90deg);
+            transition: bottom 0.075s ease, transform 0.075s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+        }
     }
 
     &--negative {

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -12,10 +12,6 @@ $message-width: rem(560px);
     background-color: $snohvit;
     box-sizing: border-box;
 
-    @include small-device {
-        width: 100%;
-    }
-
     &:before {
         content: "";
         position: absolute;
@@ -23,6 +19,15 @@ $message-width: rem(560px);
         left: 0;
         height: 100%;
         width: $colored-line-width;
+    }
+
+    &__title {
+        margin-bottom: $component-spacing--large;
+    }
+
+    &__message,
+    &__message:last-child {
+        margin-bottom: 0;
     }
 
     &--full {
@@ -45,12 +50,7 @@ $message-width: rem(560px);
         background-color: $suksess;
     }
 
-    &__title {
-        margin-bottom: $component-spacing--large;
-    }
-
-    &__message,
-    &__message:last-child {
-        margin-bottom: 0;
+    @include small-device {
+        width: 100%;
     }
 }

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -51,48 +51,6 @@ $radio-button-color: $svart;
         margin-top: $radio-button-vertical-spacing;
     }
 
-    &--inline {
-        display: inline-flex;
-        & + & {
-            margin-top: unset;
-            margin-left: $component-spacing--xl;
-        }
-    }
-
-    @include compact-mode {
-        .jkl-radio-button__dot:before {
-            height: $radio-button-size--compact;
-            width: $radio-button-size--compact;
-        }
-        .jkl-radio-button__dot:after {
-            left: $radio-button-dot-padding--compact;
-            top: $radio-button-dot-padding--compact;
-            height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
-            width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
-        }
-
-        &:not(.jkl-radio-button--inline) + &:not(.jkl-radio-button--inline) {
-            margin-top: $radio-button-vertical-spacing--compact;
-        }
-    }
-
-    @include small-device {
-        .jkl-radio-button__dot:before {
-            height: $radio-button-size--compact;
-            width: $radio-button-size--compact;
-        }
-        .jkl-radio-button__dot:after {
-            left: $radio-button-dot-padding--compact;
-            top: $radio-button-dot-padding--compact;
-            height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
-            width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
-        }
-
-        &:not(.jkl-radio-button--inline) + &:not(.jkl-radio-button--inline) {
-            margin-top: $radio-button-vertical-spacing--compact;
-        }
-    }
-
     &__input {
         /* hide default radio button */
         position: absolute;
@@ -168,7 +126,15 @@ $radio-button-color: $svart;
     }
 
     &__label {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
+    }
+
+    &--inline {
+        display: inline-flex;
+        & + & {
+            margin-top: unset;
+            margin-left: $component-spacing--xl;
+        }
     }
 
     &--error {
@@ -179,6 +145,46 @@ $radio-button-color: $svart;
             &:after {
                 background-color: $error-color;
             }
+        }
+    }
+
+    @include compact-mode {
+        .jkl-radio-button__label {
+            @include body-paragraph--mobile;
+        }
+        .jkl-radio-button__dot:before {
+            height: $radio-button-size--compact;
+            width: $radio-button-size--compact;
+        }
+        .jkl-radio-button__dot:after {
+            left: $radio-button-dot-padding--compact;
+            top: $radio-button-dot-padding--compact;
+            height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+            width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+        }
+
+        &:not(.jkl-radio-button--inline) + &:not(.jkl-radio-button--inline) {
+            margin-top: $radio-button-vertical-spacing--compact;
+        }
+    }
+
+    @include small-device {
+        .jkl-radio-button__label {
+            @include body-paragraph--mobile;
+        }
+        .jkl-radio-button__dot:before {
+            height: $radio-button-size--compact;
+            width: $radio-button-size--compact;
+        }
+        .jkl-radio-button__dot:after {
+            left: $radio-button-dot-padding--compact;
+            top: $radio-button-dot-padding--compact;
+            height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+            width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+        }
+
+        &:not(.jkl-radio-button--inline) + &:not(.jkl-radio-button--inline) {
+            margin-top: $radio-button-vertical-spacing--compact;
         }
     }
 }

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -49,25 +49,6 @@ $chevron-side-padding: (2 * $component-spacing--small);
     width: $select-width;
     position: relative;
 
-    &--inline {
-        display: inline-block;
-        vertical-align: top;
-    }
-
-    @include compact-mode {
-        & .jkl-select__value {
-            @include body-paragraph--mobile;
-            padding-right: $chevron-size--compact + $chevron-side-padding;
-        }
-        & .jkl-select__option {
-            @include body-paragraph--mobile;
-            min-height: rem(40px);
-        }
-        & .jkl-select__chevron {
-            @include chevron($chevron-size--compact, currentcolor, $weight: $chevron-weight);
-        }
-    }
-
     & *:focus {
         // Remove default focus outline for all elements within
         outline: none;
@@ -93,7 +74,7 @@ $chevron-side-padding: (2 * $component-spacing--small);
     }
 
     &__value {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -117,23 +98,6 @@ $chevron-side-padding: (2 * $component-spacing--small);
 
         &:active {
             color: currentColor; // Safari text will blink on click without this
-        }
-    }
-
-    &--no-value {
-        .jkl-select__value {
-            color: currentColor;
-            font-weight: normal;
-        }
-    }
-
-    &--open {
-        .jkl-select__arrow {
-            transform: rotate(180deg);
-        }
-
-        .jkl-select__chevron {
-            transform: rotate((-45 + 180) * 1deg); // default orientation is pointing down
         }
     }
 
@@ -182,7 +146,7 @@ $chevron-side-padding: (2 * $component-spacing--small);
     }
 
     &__option {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
         border: 0; // removes native styling
         width: 100%;
         background-color: inherit;
@@ -205,17 +169,50 @@ $chevron-side-padding: (2 * $component-spacing--small);
 
     &__chevron {
         @include chevron($chevron-size, currentcolor, $weight: $chevron-weight);
-        @include small-device {
-            @include chevron($chevron-size--compact, currentcolor, $weight: $chevron-weight);
-        }
         position: absolute;
         right: 0;
         pointer-events: none;
     }
 
+    &--inline {
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    &--no-value {
+        .jkl-select__value {
+            color: currentColor;
+            font-weight: normal;
+        }
+    }
+
+    &--open {
+        .jkl-select__arrow {
+            transform: rotate(180deg);
+        }
+
+        .jkl-select__chevron {
+            transform: rotate((-45 + 180) * 1deg); // default orientation is pointing down
+        }
+    }
+
     &--invalid {
         .jkl-select__value {
             @include underline-color($error-color, $error-color);
+        }
+    }
+
+    @include compact-mode {
+        & .jkl-select__value {
+            @include body-paragraph--mobile;
+            padding-right: $chevron-size--compact + $chevron-side-padding;
+        }
+        & .jkl-select__option {
+            @include body-paragraph--mobile;
+            min-height: rem(40px);
+        }
+        & .jkl-select__chevron {
+            @include chevron($chevron-size--compact, currentcolor, $weight: $chevron-weight);
         }
     }
 }

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -25,47 +25,8 @@ $icon-size--compact: $font-size-2;
     width: 100%;
     background-color: $input-bg-color;
 
-    &--inline {
-        display: inline-block;
-        width: unset;
-        margin-top: rem(-4px);
-        vertical-align: top;
-
-        .jkl-body & .jkl-text-field__input {
-            padding: 0;
-            text-align: center;
-        }
-    }
-
-    @include compact-mode {
-        & .jkl-text-field__input,
-        & .jkl-text-field__input::placeholder {
-            @include body-paragraph--mobile;
-        }
-        & .jkl-text-field__input {
-            height: $input-height--small-device + $bottom-padding;
-        }
-        & .jkl-text-field__action-icon {
-            width: $icon-size--compact;
-        }
-    }
-
-    @include small-device {
-        & .jkl-text-field__action-icon {
-            width: $icon-size--compact;
-        }
-    }
-
-    &--action {
-        position: relative;
-
-        .jkl-text-field__input {
-            padding-right: $component-spacing--small + $icon-size;
-        }
-    }
-
     &__input {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
         border: none;
         outline: none;
         border-radius: 0;
@@ -74,9 +35,6 @@ $icon-size--compact: $font-size-2;
         box-sizing: border-box;
         width: 100%;
         height: $input-height + $bottom-padding;
-        @include small-device {
-            height: $input-height--small-device + $bottom-padding;
-        }
         padding: 0 0 $bottom-padding;
 
         font-weight: $bold-weight;
@@ -88,7 +46,7 @@ $icon-size--compact: $font-size-2;
         resize: none; // Disable textarea resize
 
         &::placeholder {
-            @include body-paragraph;
+            @include body-paragraph--desktop;
             opacity: 1;
             color: $varm-fjellgra;
         }
@@ -133,6 +91,52 @@ $icon-size--compact: $font-size-2;
     &__input-wrapper {
         display: inline-block;
         position: relative;
+    }
+
+    &--inline {
+        display: inline-block;
+        width: unset;
+        margin-top: rem(-4px);
+        vertical-align: top;
+
+        .jkl-body & .jkl-text-field__input {
+            padding: 0;
+            text-align: center;
+        }
+    }
+
+    &--action {
+        position: relative;
+
+        .jkl-text-field__input {
+            padding-right: $component-spacing--small + $icon-size;
+        }
+    }
+
+    @include compact-mode {
+        & .jkl-text-field__input,
+        & .jkl-text-field__input::placeholder {
+            @include body-paragraph--mobile;
+        }
+        & .jkl-text-field__input {
+            height: $input-height--small-device + $bottom-padding;
+        }
+        & .jkl-text-field__action-icon {
+            width: $icon-size--compact;
+        }
+    }
+
+    @include small-device {
+        .jkl-text-field__input,
+        .jkl-text-field__input::placeholder {
+            @include body-paragraph--mobile;
+        }
+        & .jkl-text-field__input {
+            height: $input-height--small-device + $bottom-padding;
+        }
+        & .jkl-text-field__action-icon {
+            width: $icon-size--compact;
+        }
     }
 }
 

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -88,7 +88,7 @@ $inverted-disabled-color: #969696;
     }
 
     &__label {
-        @include body-paragraph;
+        @include body-paragraph--desktop;
         color: currentColor;
         padding-left: $component-spacing--small;
     }


### PR DESCRIPTION
affects: @fremtind/jkl-accordion, @fremtind/jkl-button, @fremtind/jkl-checkbox,
@fremtind/jkl-datepicker, @fremtind/jkl-divider-line, @fremtind/jkl-hamburger,
@fremtind/jkl-message-box, @fremtind/jkl-radio-button, @fremtind/jkl-select,
@fremtind/jkl-text-input, @fremtind/jkl-toggle-switch

## 📥 Proposed changes

Flytter alle stilendringer for kompakt- og mobilversjon til slutten av komponentens stil, etter eventuelle varianter (som `--active`, `--secondary`, etc.). Dette gir ryddigere css etter kompilering, og reduserer risikoen for at vi overskriver allerede definerte regler.

Fjerner også all bruk av de responsive tekststil-hjelpeklassene til fordel for de spesifikke, siden de responsive introduserer en skjult `@include small-device`. Se nyeste blogginnlegg på Confluence for mer diskusjon rundt det.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

closes #702 
