### PR TITLE
test(datepicker): add a11y-tests

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { DatePicker } from ".";
 import { formatDate, isSameDay } from "./DatePicker";
+import { axe, toHaveNoViolations } from "jest-axe";
 
 beforeEach(cleanup);
 
@@ -55,5 +56,27 @@ describe("isSameDay", () => {
         const date2 = new Date("2001-10-14");
 
         expect(isSameDay(date1, date2)).toBeFalsy();
+    });
+});
+
+expect.extend(toHaveNoViolations);
+
+describe("a11y", () => {
+    it("default datepicker should be a11y compliant", async () => {
+        const { container } = render(<DatePicker initialShow />);
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
+
+    it("extended datepicker should be a11y compliant", async () => {
+        const { container } = render(<DatePicker extended initialShow />);
+        const results = await axe(container, {
+            rules: {
+                "form-field-multiple-labels": { enabled: false },
+            },
+        });
+
+        expect(results).toHaveNoViolations();
     });
 });


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react

closes: #705 

## 📥 Proposed changes

Regelen for `form-field-multiple-labels` er disabled: 

Får kun feilmeldingen på extended-variant av datepicker. Den har tilsynelatende ikke flere labels, usikkert hvorfor man får den beskjeden. Axe accessibility gir ikke samme beskjed i browser. Skjermleser leser ikke opp noe rart (dog kun testet med voiceover i chrome)

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments


