### PR TITLE
feat(button): add inverted color mode for buttons

### DIFF
--- a/packages/button-react/documentation/Example.tsx
+++ b/packages/button-react/documentation/Example.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from "../src";
 import { ToggleSwitch } from "@fremtind/jkl-toggle-switch-react";
+import "@fremtind/jkl-toggle-switch/toggle-switch.css";
 import "@fremtind/jkl-button/button.css";
 import "@fremtind/jkl-core/core.css";
 import "./index.scss";

--- a/packages/button-react/documentation/Example.tsx
+++ b/packages/button-react/documentation/Example.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from "../src";
+import { ToggleSwitch } from "@fremtind/jkl-toggle-switch-react";
 import "@fremtind/jkl-button/button.css";
 import "@fremtind/jkl-core/core.css";
 import "./index.scss";
@@ -8,35 +9,50 @@ function onClick() {
     console.log("Hello!");
 }
 
-const Example = () => (
-    <section className="jkl-spacing--all-3 jkl-button-example">
-        <div className="side-by-side">
-            <pre>
-                <code>{`forceCompact={false}`}</code>
-            </pre>
-            <pre>
-                <code>{`forceCompact={true}`}</code>
-            </pre>
-        </div>
-        <div className="side-by-side">
-            <PrimaryButton onClick={onClick}>PrimaryButton</PrimaryButton>
-            <PrimaryButton forceCompact onClick={onClick}>
+const Example = () => {
+    const [isCompact, setCompact] = useState(false);
+    const toggleCompact = () => setCompact(!isCompact);
+    const [isInverted, setIsInverted] = useState(false);
+    const toggleInverted = () => setIsInverted(!isInverted);
+
+    const exampleClassName = "buttons-example jkl-spacing--top-3 jkl-spacing--bottom-3".concat(
+        isInverted ? " buttons-example--inverted" : "",
+    );
+
+    return (
+        <section className={exampleClassName}>
+            <aside className="buttons-example__controls">
+                <ToggleSwitch onChange={toggleCompact} className="jkl-spacing--bottom-1">
+                    Kompakt variant
+                </ToggleSwitch>
+                <ToggleSwitch onChange={toggleInverted}>Inverterte farger</ToggleSwitch>
+            </aside>
+            <PrimaryButton
+                forceCompact={isCompact}
+                inverted={isInverted}
+                onClick={onClick}
+                className="portal-example-button"
+            >
                 PrimaryButton
             </PrimaryButton>
-        </div>
-        <div className="side-by-side">
-            <SecondaryButton onClick={onClick}>SecondaryButton</SecondaryButton>
-            <SecondaryButton forceCompact onClick={onClick}>
+            <SecondaryButton
+                forceCompact={isCompact}
+                inverted={isInverted}
+                onClick={onClick}
+                className="portal-example-button"
+            >
                 SecondaryButton
             </SecondaryButton>
-        </div>
-        <div className="side-by-side">
-            <TertiaryButton onClick={onClick}>TertiaryButton</TertiaryButton>
-            <TertiaryButton forceCompact onClick={onClick}>
+            <TertiaryButton
+                forceCompact={isCompact}
+                inverted={isInverted}
+                onClick={onClick}
+                className="portal-example-button"
+            >
                 TertiaryButton
             </TertiaryButton>
-        </div>
-    </section>
-);
+        </section>
+    );
+};
 
 export default Example;

--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -7,9 +7,9 @@ react: button-react
 import Example from "./Example";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from "../src";
 
-<Example />
-
 Knapper starter en handling. Teksten på knappen forteller hva som vil skje når brukeren klikker på den.
+
+<Example />
 
 ## Knappetyper
 

--- a/packages/button-react/documentation/index.scss
+++ b/packages/button-react/documentation/index.scss
@@ -1,26 +1,60 @@
-@import "~@fremtind/jkl-core/variables/_spacing.scss";
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 
-.jkl-button-example {
-    height: 100%;
+$controls-width: rem(300px);
+
+.buttons-example {
+    position: relative;
+    background-color: #f8f8f8;
+    box-shadow: inset 0 0 0 rem(1px) #b8b8b8;
     display: flex;
     align-items: center;
     justify-content: center;
-    flex-direction: column;
-    background-color: white;
+    padding: $layout-spacing--xl $layout-spacing--small;
+    padding-right: $controls-width + $layout-spacing--small;
+    user-select: none;
 
-    & > * + * {
-        margin-bottom: $layout-spacing--small;
+    &:before {
+        content: "Eksempel";
+        color: $svart;
+        display: block;
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        @include h5-heading;
+        margin-bottom: $component-spacing--large;
     }
-}
 
-.side-by-side {
-    width: 100%;
-    max-width: 50rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    &__controls {
+        position: absolute;
+        right: 0;
+        top: 0;
+        height: 100%;
+        width: $controls-width;
+        box-sizing: border-box;
 
-    & > * + * {
+        background-color: #f8f8f8;
+        color: $svart;
+        box-shadow: inset 0 0 0 rem(1px) #b8b8b8;
+
+        padding: $component-spacing--xl;
+    }
+
+    & > .portal-example-button + .portal-example-button {
+        margin: 0;
         margin-left: $layout-spacing--medium;
+    }
+
+    &--inverted {
+        background-color: $svart;
+        color: $helhvit;
+    }
+
+    @include small-device {
+        flex-direction: column;
+        & > .portal-example-button + .portal-example-button {
+            margin: 0;
+            margin-top: $layout-spacing--medium;
+        }
     }
 }

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -39,6 +39,7 @@
         "@fremtind/jkl-button": "^1.2.1"
     },
     "devDependencies": {
+        "@fremtind/jkl-toggle-switch-react": "1.1.1",
         "@fremtind/browserslist-config-jkl": "^0.4.14"
     },
     "peerDependencies": {

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -5,16 +5,18 @@ interface Props {
     className?: string;
     onClick: MouseEventHandler<HTMLButtonElement>;
     forceCompact?: boolean;
+    inverted?: boolean;
 }
 
 type ValidButtons = "primary" | "secondary" | "tertiary";
 
 function makeButtonComponent(buttonType: ValidButtons) {
     return function button(props: Props) {
-        const { children, className = "", onClick, forceCompact } = props;
+        const { children, className = "", onClick, forceCompact, inverted } = props;
         const componentClassName = "jkl-button".concat(
             ` jkl-button--${buttonType}`,
             forceCompact ? ` jkl-button--compact` : "",
+            inverted ? ` jkl-button--inverted` : "",
             className ? ` ${className}` : "",
         );
         return (

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -80,7 +80,7 @@ $hover-elevation-distance: -0.25rem;
 
     &--primary,
     &--secondary {
-        border: solid $button-border-width currentColor;
+        border: solid $button-border-width $button-border-color;
         border-radius: 999px;
         padding: 0 $button-padding;
 
@@ -120,6 +120,24 @@ $hover-elevation-distance: -0.25rem;
 
         html:not([data-mousenavigation]) &:focus {
             border-bottom-color: $focus-color;
+        }
+    }
+
+    &--inverted {
+        &.jkl-button--primary {
+            background-color: $button-bg-color;
+            color: $button-text-color;
+            border-color: $button-bg-color;
+        }
+
+        &.jkl-button--secondary {
+            background-color: $button-bg-color--primary;
+            color: $button-text-color--primary;
+            border-color: $button-text-color--primary;
+        }
+
+        &.jkl-button--tertiary {
+            color: $button-text-color--primary;
         }
     }
 }


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-button

## 📥 Proposed changes

Legger til invertert fargemodus for knappene, til bruk på mørke bakgrunner. Fikser også en bug der `PrimaryButton` har hvitt omriss i stedet for svart.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Ønsker tilbakemeldinger fra design på om en ren invertering er veien å gå. Et konkret brukseksempel er redigering i de mørke kortene i Flyt.
