### PR TITLE
test(accordion-item): add a11y-test

### DIFF
--- a/packages/accordion-react/src/AccordionItem.test.tsx
+++ b/packages/accordion-react/src/AccordionItem.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { AccordionItem } from ".";
+import { axe, toHaveNoViolations } from "jest-axe";
 
 afterEach(cleanup);
 
@@ -40,5 +41,20 @@ describe("AccordionItem", () => {
         const wrapper = getByTestId("jkl-accordion-item__content-wrapper");
 
         expect(wrapper).toHaveProperty("hidden", false);
+    });
+});
+
+expect.extend(toHaveNoViolations);
+
+describe("a11y", () => {
+    it("accordion-item should be a11y compliant", async () => {
+        const { container } = render(
+            <AccordionItem title="Hello" startExpanded>
+                Something
+            </AccordionItem>,
+        );
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/accordion-react/src/AccordionItem.test.tsx
+++ b/packages/accordion-react/src/AccordionItem.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { AccordionItem } from ".";
-import { axe, toHaveNoViolations } from "jest-axe";
+import { axe } from "jest-axe";
 
 afterEach(cleanup);
 
@@ -43,8 +43,6 @@ describe("AccordionItem", () => {
         expect(wrapper).toHaveProperty("hidden", false);
     });
 });
-
-expect.extend(toHaveNoViolations);
 
 describe("a11y", () => {
     it("accordion-item should be a11y compliant", async () => {


### PR DESCRIPTION
affects: @fremtind/jkl-accordion-react

## 📥 Proposed changes

Add missing a11y-test for AccordionItem

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Testet med VoiceOver samtidig
