### PR TITLE
chore(jest-axe): move repeated setup to global

### DIFF
--- a/jest/setupTests.ts
+++ b/jest/setupTests.ts
@@ -2,3 +2,6 @@ import "@testing-library/jest-dom/extend-expect";
 // Polyfill fill to make parts of Web components (used by @nrk/core-toggle) work.
 // Hopefully this will land one day https://github.com/jsdom/jsdom/issues/1030
 import "document-register-element";
+import { toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { DatePicker } from ".";
 import { formatDate, isSameDay } from "./DatePicker";
-import { axe, toHaveNoViolations } from "jest-axe";
+import { axe } from "jest-axe";
 
 beforeEach(cleanup);
 
@@ -58,8 +58,6 @@ describe("isSameDay", () => {
         expect(isSameDay(date1, date2)).toBeFalsy();
     });
 });
-
-expect.extend(toHaveNoViolations);
 
 describe("a11y", () => {
     it("default datepicker should be a11y compliant", async () => {


### PR DESCRIPTION
## 📥 Proposed changes

Flytte `expect.extend(toHaveNoViolations)` til `setupTests.ts` slik at den ikke må repeteres i hver eneste `.test.tsx`-fil.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
