### PR TITLE
test(text-input-react): add a11y-tests

### DIFF
--- a/packages/text-input-react/src/ActionTextField.test.tsx
+++ b/packages/text-input-react/src/ActionTextField.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { ActionTextField } from ".";
+import { axe } from "jest-axe";
+
+afterEach(cleanup);
 
 describe("InlineTextField", () => {
-    afterEach(cleanup);
-
     it("renders as compact when specified", () => {
         const { getByTestId } = render(
             <ActionTextField
@@ -74,5 +75,33 @@ describe("InlineTextField", () => {
 
         const component = getByDisplayValue("3");
         expect(component).toBeInTheDocument();
+    });
+});
+
+describe("a11y", () => {
+    test("action-text-field should be a11y compliant", async () => {
+        const { container } = render(
+            <ActionTextField
+                label="testing"
+                helpLabel="tips"
+                action={{ icon: "clear", label: "testing", onClick: jest.fn() }}
+            />,
+        );
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
+
+    test("compact action-text-field should be a11y compliant", async () => {
+        const { container } = render(
+            <ActionTextField
+                forceCompact
+                label="testing"
+                action={{ icon: "clear", label: "testing", onClick: jest.fn() }}
+            />,
+        );
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/text-input-react/src/BaseInputField.test.tsx
+++ b/packages/text-input-react/src/BaseInputField.test.tsx
@@ -26,7 +26,7 @@ describe("a11y", () => {
         const { container } = render(<BaseInputField />);
         const results = await axe(container, {
             rules: {
-                label: { enabled: false },
+                label: { enabled: false }, //This component renders without a label because it's not intended for standalone usage. See the documentation for a usage pattern.
             },
         });
 
@@ -37,7 +37,7 @@ describe("a11y", () => {
         const { container } = render(<BaseInputField forceCompact />);
         const results = await axe(container, {
             rules: {
-                label: { enabled: false },
+                label: { enabled: false }, //This component renders without a label because it's not intended for standalone usage. See the documentation for a usage pattern.
             },
         });
 

--- a/packages/text-input-react/src/BaseInputField.test.tsx
+++ b/packages/text-input-react/src/BaseInputField.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { BaseInputField } from ".";
+import { axe } from "jest-axe";
+
+afterEach(cleanup);
 
 describe("BaseInputField", () => {
-    afterEach(cleanup);
-
     it("has the max-length given", () => {
         const { getByTestId } = render(<BaseInputField maxLength={10} />);
 
@@ -17,5 +18,29 @@ describe("BaseInputField", () => {
 
         const component = getByTestId("jkl-text-field__input");
         expect(component).toHaveAttribute("readonly");
+    });
+});
+
+describe("a11y", () => {
+    test("base-input-field should be a11y compliant", async () => {
+        const { container } = render(<BaseInputField />);
+        const results = await axe(container, {
+            rules: {
+                label: { enabled: false },
+            },
+        });
+
+        expect(results).toHaveNoViolations();
+    });
+
+    test("compact base-input-field should be a11y compliant", async () => {
+        const { container } = render(<BaseInputField forceCompact />);
+        const results = await axe(container, {
+            rules: {
+                label: { enabled: false },
+            },
+        });
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/text-input-react/src/InlineTextField.test.tsx
+++ b/packages/text-input-react/src/InlineTextField.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { InlineTextField } from ".";
+import { axe } from "jest-axe";
+
+afterEach(cleanup);
 
 describe("InlineTextField", () => {
-    afterEach(cleanup);
-
     it("renders with correct label", () => {
         const { getByLabelText } = render(<InlineTextField label="The best label" />);
 
@@ -66,5 +67,14 @@ describe("InlineTextField", () => {
 
         const component = getByLabelText("testing");
         expect(component).toHaveAttribute("aria-invalid", "true");
+    });
+});
+
+describe("a11y", () => {
+    test("inline-text-feild should be a11y compliant", async () => {
+        const { container } = render(<InlineTextField label="testing" />);
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/text-input-react/src/TextArea.test.tsx
+++ b/packages/text-input-react/src/TextArea.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { TextArea } from ".";
+import { axe } from "jest-axe";
+
+afterEach(cleanup);
 
 describe("TextArea", () => {
-    afterEach(cleanup);
-
     it("renders with correct label", () => {
         const { getByLabelText } = render(<TextArea label="Cool text field" />);
 
@@ -16,5 +17,14 @@ describe("TextArea", () => {
 
         const component = getByTestId("jkl-text-field");
         expect(component).toHaveClass("test-class");
+    });
+});
+
+describe("a11y", () => {
+    test("text-area should be a11y compliant", async () => {
+        const { container } = render(<TextArea label="testing" helpLabel="tips" />);
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/text-input-react/src/TextField.test.tsx
+++ b/packages/text-input-react/src/TextField.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { TextField } from ".";
+import { axe } from "jest-axe";
+
+afterEach(cleanup);
 
 describe("TextField", () => {
-    afterEach(cleanup);
-
     it("renders with correct label", () => {
         const { getByLabelText } = render(<TextField label="Cool text field" />);
 
@@ -79,5 +80,14 @@ describe("TextField", () => {
 
         const component = getByPlaceholderText("test-ph");
         expect(component).toHaveAttribute("type", "password");
+    });
+});
+
+describe("a11y", () => {
+    test("text-field should be a11y compliant", async () => {
+        const { container } = render(<TextField label="testing" type="text" helpLabel="some help 4 u" />);
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react

## 📥 Proposed changes

Add a11y tests

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Testet med VoiceOver

Deaktiverte regelen `label` for BaseInputField. Label er tatt bort med vilje. Ønsket bruksmønster er dokumentert under "[Særskilt bruk](https://github.com/fremtind/jokul/tree/master/packages/text-input-react#særskilt-bruk)" i pakken.
