### PR TITLE
test(toggle-switch-react): add a11y-tests

### DIFF
--- a/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
@@ -1,72 +1,95 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { ToggleSwitch } from ".";
+import { axe } from "jest-axe";
 
 afterEach(cleanup);
 
-it("should be checked after clicking the input ", function() {
-    const { getByTestId } = render(<ToggleSwitch>GPS</ToggleSwitch>);
+describe("ToggleSwitch", () => {
+    it("should be checked after clicking the input ", function() {
+        const { getByTestId } = render(<ToggleSwitch>GPS</ToggleSwitch>);
 
-    const input = getByTestId("jkl-toggle-input");
-    const label = getByTestId("jkl-toggle-input--label");
+        const input = getByTestId("jkl-toggle-input");
+        const label = getByTestId("jkl-toggle-input--label");
 
-    expect(input).toHaveProperty("checked", false);
+        expect(input).toHaveProperty("checked", false);
 
-    label.click();
+        label.click();
 
-    expect(input).toHaveProperty("checked", true);
-});
+        expect(input).toHaveProperty("checked", true);
+    });
 
-it("should be checked after clicking the input ", function() {
-    const { getByTestId } = render(<ToggleSwitch>I am groot!</ToggleSwitch>);
+    it("should be checked after clicking the input ", function() {
+        const { getByTestId } = render(<ToggleSwitch>I am groot!</ToggleSwitch>);
 
-    const input = getByTestId("jkl-toggle-input");
+        const input = getByTestId("jkl-toggle-input");
 
-    expect(input).toHaveProperty("checked", false);
+        expect(input).toHaveProperty("checked", false);
 
-    input.click();
+        input.click();
 
-    expect(input).toHaveProperty("checked", true);
-});
+        expect(input).toHaveProperty("checked", true);
+    });
 
-it("should be checked if checked is true", function() {
-    const { getByTestId } = render(
-        <ToggleSwitch checked={true} onChange={() => ""}>
-            I am groot!
-        </ToggleSwitch>,
-    );
-
-    const input = getByTestId("jkl-toggle-input");
-
-    expect(input).toHaveProperty("checked", true);
-});
-
-it("should be unchecked if checked is true and input is clicked", function() {
-    const TestToggleSwitch = () => {
-        const [checked, toggle] = React.useState(true);
-        return (
-            <ToggleSwitch checked={checked} onChange={() => toggle(!checked)}>
+    it("should be checked if checked is true", function() {
+        const { getByTestId } = render(
+            <ToggleSwitch checked={true} onChange={() => ""}>
                 I am groot!
-            </ToggleSwitch>
+            </ToggleSwitch>,
         );
-    };
-    const { getByTestId } = render(<TestToggleSwitch />);
 
-    const input = getByTestId("jkl-toggle-input");
+        const input = getByTestId("jkl-toggle-input");
 
-    expect(input).toHaveProperty("checked", true);
+        expect(input).toHaveProperty("checked", true);
+    });
 
-    input.click();
+    it("should be unchecked if checked is true and input is clicked", function() {
+        const TestToggleSwitch = () => {
+            const [checked, toggle] = React.useState(true);
+            return (
+                <ToggleSwitch checked={checked} onChange={() => toggle(!checked)}>
+                    I am groot!
+                </ToggleSwitch>
+            );
+        };
+        const { getByTestId } = render(<TestToggleSwitch />);
 
-    expect(input).toHaveProperty("checked", false);
+        const input = getByTestId("jkl-toggle-input");
+
+        expect(input).toHaveProperty("checked", true);
+
+        input.click();
+
+        expect(input).toHaveProperty("checked", false);
+    });
+
+    it("should call the passed onChange method when clicked", () => {
+        const onChange = jest.fn();
+        const { getByLabelText } = render(<ToggleSwitch onChange={onChange}>Switch me!</ToggleSwitch>);
+
+        const input = getByLabelText("Switch me!");
+        input.click();
+
+        expect(onChange).toHaveBeenCalled();
+    });
 });
 
-it("should call the passed onChange method when clicked", () => {
-    const onChange = jest.fn();
-    const { getByLabelText } = render(<ToggleSwitch onChange={onChange}>Switch me!</ToggleSwitch>);
+describe("a11y", () => {
+    test("toggle-switch should be a11y compliant", async () => {
+        const { container } = render(<ToggleSwitch helpLabel="tip">Switch</ToggleSwitch>);
+        const results = await axe(container);
 
-    const input = getByLabelText("Switch me!");
-    input.click();
+        expect(results).toHaveNoViolations();
+    });
 
-    expect(onChange).toHaveBeenCalled();
+    test("inverted toggle-switch should be a11y compliant", async () => {
+        const { container } = render(
+            <ToggleSwitch inverted helpLabel="tip">
+                Switch
+            </ToggleSwitch>,
+        );
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
 });


### PR DESCRIPTION
affects: @fremtind/jkl-toggle-switch-react

## 📥 Proposed changes

Add missing a11y tests

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Tested med VoiceOver: Resulterte i et funn om at toggle switches (toggle button som det tydeligvis egt heter) skal være et button-element med attribute `aria-pressed="true/false". Issue blir opprettet.
