### PR TITLE
refactor(text-input): set placeholder font weight to normal

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -47,6 +47,7 @@ $icon-size--compact: $font-size-2;
 
         &::placeholder {
             @include body-paragraph--desktop;
+            font-weight: normal;
             opacity: 1;
             color: $varm-fjellgra;
         }


### PR DESCRIPTION
affects: @fremtind/jkl-text-input

## 📥 Proposed changes

Fix placeholder font weight to match design in Figma.

Placeholder _almost_ looks like input when set to bold.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

