### PR TITLE
feat(toggle-switch): change toggle switch to button element (from input)

### DIFF
--- a/packages/button-react/documentation/Example.tsx
+++ b/packages/button-react/documentation/Example.tsx
@@ -23,10 +23,10 @@ const Example = () => {
     return (
         <section className={exampleClassName}>
             <aside className="buttons-example__controls">
-                <ToggleSwitch onChange={toggleCompact} className="jkl-spacing--bottom-1">
+                <ToggleSwitch onClick={toggleCompact} className="jkl-spacing--bottom-1">
                     Kompakt variant
                 </ToggleSwitch>
-                <ToggleSwitch onChange={toggleInverted}>Inverterte farger</ToggleSwitch>
+                <ToggleSwitch onClick={toggleInverted}>Inverterte farger</ToggleSwitch>
             </aside>
             <PrimaryButton
                 forceCompact={isCompact}

--- a/packages/select-react/documentation/Example.tsx
+++ b/packages/select-react/documentation/Example.tsx
@@ -30,13 +30,13 @@ const Example = () => {
     return (
         <section className={"example-page " + (!darkMode ? "example-page--light-mode" : "example-page--dark-mode")}>
             <fieldset className="example-page__controls">
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setDarkMode(!darkMode)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setDarkMode(!darkMode)}>
                     Dark Mode
                 </ToggleSwitch>
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setHasError(!hasError)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setHasError(!hasError)}>
                     Vis feilmelding
                 </ToggleSwitch>
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setIsCompact(!isCompact)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setIsCompact(!isCompact)}>
                     Kompakt variant
                 </ToggleSwitch>
                 <Select

--- a/packages/text-input-react/documentation/Example.tsx
+++ b/packages/text-input-react/documentation/Example.tsx
@@ -27,13 +27,13 @@ const Example = () => {
     return (
         <section className={"example-page " + (!darkMode ? "example-page--light-mode" : "example-page--dark-mode")}>
             <fieldset className="example-page__controls">
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setDarkMode(!darkMode)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setDarkMode(!darkMode)}>
                     Dark Mode
                 </ToggleSwitch>
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setHasError(!hasError)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setHasError(!hasError)}>
                     Vis feilmelding
                 </ToggleSwitch>
-                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onChange={() => setIsCompact(!isCompact)}>
+                <ToggleSwitch className={"toggle-switch"} inverted={darkMode} onClick={() => setIsCompact(!isCompact)}>
                     Kompakt variant
                 </ToggleSwitch>
                 <Select

--- a/packages/toggle-switch-react/README.md
+++ b/packages/toggle-switch-react/README.md
@@ -34,12 +34,12 @@ Som standard blir `ToggleSwitch` fremvist som en komponent tiltenkt lys bakgrunn
 </ToggleSwitch>
 ```
 
-`ToggleSwitch` brukes som en kontrollert komponent gjennom prop-en `checked` og en `onChange`-handler som tar et `ChangeEvent` som første argument:
+`ToggleSwitch` brukes som en kontrollert komponent gjennom prop-en `pressed` og en `onClick`-handler som tar et `MouseEvent` som første argument:
 
 ```jsx
 const [darkmodeIsOn, setDarkmodeIsOn] = useState(false);
 
-<ToggleSwitch checked={darkmodeIsOn} onChange={() => setDarkmodeIsOn(!darkmodeIsOn)}>
+<ToggleSwitch pressed={darkmodeIsOn} onClick={() => setDarkmodeIsOn(!darkmodeIsOn)}>
     Darkmode
 </ToggleSwitch>;
 ```
@@ -57,9 +57,9 @@ Skal bryteren være deaktivert legges prop-en `disabled` til. Hvis det ønskes a
 Komponenten tar i bruk følgende props:
 
 -   `children`: **Påkrevd**. Etiketten til bryteren. `ReactNode`
--   `checked`: Angir om bryterens status er av/på. `boolean`
+-   `pressed`: Angir om bryterens status er av/på. `boolean`
 -   `className`: Eventuell(e) css-klassenavn for komponenten. `string`
--   `onChange`: Angir funksjon for å håndtere endring i verdi. Får en `ChangeEvent` som første argument.
+-   `onClick`: Angir funksjon for å håndtere endring i verdi. Får en `MouseEvent` som første argument.
 -   `disabled`: Angir om bryteren er deaktivert. `boolean`
 -   `inverted`: Angir om bryteren skal bruke inverterte farger (til mørke bakgrunner). `boolean`
 -   `helpLabel`: Hjelpetekst som vises under bryterne. `string`

--- a/packages/toggle-switch-react/documentation/Example.tsx
+++ b/packages/toggle-switch-react/documentation/Example.tsx
@@ -14,19 +14,19 @@ const Example = () => {
         <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
             <div style={{ margin: "36px", padding: "36px", backgroundColor: "#fafafa" }}>
                 <div style={{ margin: "20px" }}>
-                    <ToggleSwitch checked={gpsDummySwitch} onChange={() => setGpsDummySwitch(!gpsDummySwitch)}>
+                    <ToggleSwitch pressed={gpsDummySwitch} onClick={() => setGpsDummySwitch(!gpsDummySwitch)}>
                         GPS
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
-                    <ToggleSwitch checked={switch2IsOn} onChange={() => setSwitch2IsOn(!switch2IsOn)} disabled>
+                    <ToggleSwitch pressed={switch2IsOn} onClick={() => setSwitch2IsOn(!switch2IsOn)} disabled>
                         Disabled Switch (On)
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
                     <ToggleSwitch
-                        checked={switchIsOn}
-                        onChange={() => setSwitchIsOn(!switchIsOn)}
+                        pressed={switchIsOn}
+                        onClick={() => setSwitchIsOn(!switchIsOn)}
                         disabled
                         helpLabel="Reason switch is disabled"
                     >
@@ -34,7 +34,7 @@ const Example = () => {
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
-                    <ToggleSwitch checked={glonassIsOn} onChange={() => setGlonassIsOn(!glonassIsOn)}>
+                    <ToggleSwitch pressed={glonassIsOn} onClick={() => setGlonassIsOn(!glonassIsOn)}>
                         Glonass
                     </ToggleSwitch>
                 </div>
@@ -48,14 +48,14 @@ const Example = () => {
             </div>
             <div style={{ margin: "36px", padding: "36px", backgroundColor: "#000000", color: "#ffffff" }}>
                 <div style={{ margin: "20px" }}>
-                    <ToggleSwitch checked={gpsIsOn} onChange={() => setGpsIsOn(!gpsIsOn)} inverted>
+                    <ToggleSwitch pressed={gpsIsOn} onClick={() => setGpsIsOn(!gpsIsOn)} inverted>
                         GPS
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
                     <ToggleSwitch
-                        checked={switch2IsOn}
-                        onChange={() => setSwitch2IsOn(!switch2IsOn)}
+                        pressed={switch2IsOn}
+                        onClick={() => setSwitch2IsOn(!switch2IsOn)}
                         disabled
                         inverted
                         helpLabel="Reason switch is disabled"
@@ -64,14 +64,14 @@ const Example = () => {
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
-                    <ToggleSwitch checked={switchIsOn} onChange={() => setSwitchIsOn(!switchIsOn)} disabled inverted>
+                    <ToggleSwitch pressed={switchIsOn} onClick={() => setSwitchIsOn(!switchIsOn)} disabled inverted>
                         Disabled Switch (Off)
                     </ToggleSwitch>
                 </div>
                 <div style={{ margin: "20px" }}>
                     <ToggleSwitch
-                        checked={glonassDummySwitch}
-                        onChange={() => setGlonassDummySwitch(!glonassDummySwitch)}
+                        pressed={glonassDummySwitch}
+                        onClick={() => setGlonassDummySwitch(!glonassDummySwitch)}
                         inverted
                     >
                         Glonass

--- a/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
@@ -4,69 +4,64 @@ import { ToggleSwitch } from ".";
 
 afterEach(cleanup);
 
-it("should be checked after clicking the input ", function() {
-    const { getByTestId } = render(<ToggleSwitch>GPS</ToggleSwitch>);
+it("should be pressed after clicking the button", function() {
+    const TestToggleSwitch = () => {
+        const [pressed, toggle] = React.useState(false);
+        return (
+            <ToggleSwitch pressed={pressed} onClick={() => toggle(!pressed)}>
+                GPS
+            </ToggleSwitch>
+        );
+    };
+    const { getByText } = render(<TestToggleSwitch />);
 
-    const input = getByTestId("jkl-toggle-input");
-    const label = getByTestId("jkl-toggle-input--label");
+    const input = getByText("GPS");
 
-    expect(input).toHaveProperty("checked", false);
-
-    label.click();
-
-    expect(input).toHaveProperty("checked", true);
-});
-
-it("should be checked after clicking the input ", function() {
-    const { getByTestId } = render(<ToggleSwitch>I am groot!</ToggleSwitch>);
-
-    const input = getByTestId("jkl-toggle-input");
-
-    expect(input).toHaveProperty("checked", false);
+    expect(input).toHaveAttribute("aria-pressed", "false");
 
     input.click();
 
-    expect(input).toHaveProperty("checked", true);
+    expect(input).toHaveAttribute("aria-pressed", "true");
 });
 
-it("should be checked if checked is true", function() {
-    const { getByTestId } = render(
-        <ToggleSwitch checked={true} onChange={() => ""}>
+it("should be pressed if pressed is true", function() {
+    const { getByText } = render(
+        <ToggleSwitch pressed={true} onClick={() => ""}>
             I am groot!
         </ToggleSwitch>,
     );
 
-    const input = getByTestId("jkl-toggle-input");
+    const input = getByText("I am groot!");
 
-    expect(input).toHaveProperty("checked", true);
+    expect(input).toHaveAttribute("aria-pressed", "true");
 });
 
-it("should be unchecked if checked is true and input is clicked", function() {
+it("should be unchecked if pressed is true and input is clicked", function() {
     const TestToggleSwitch = () => {
-        const [checked, toggle] = React.useState(true);
+        const [pressed, toggle] = React.useState(true);
         return (
-            <ToggleSwitch checked={checked} onChange={() => toggle(!checked)}>
+            <ToggleSwitch pressed={pressed} onClick={() => toggle(!pressed)}>
                 I am groot!
             </ToggleSwitch>
         );
     };
-    const { getByTestId } = render(<TestToggleSwitch />);
+    const { getByText } = render(<TestToggleSwitch />);
 
-    const input = getByTestId("jkl-toggle-input");
+    const input = getByText("I am groot!");
 
-    expect(input).toHaveProperty("checked", true);
+    expect(input).toHaveAttribute("aria-pressed", "true");
 
     input.click();
 
-    expect(input).toHaveProperty("checked", false);
+    expect(input).toHaveAttribute("aria-pressed", "false");
 });
 
-it("should call the passed onChange method when clicked", () => {
-    const onChange = jest.fn();
-    const { getByLabelText } = render(<ToggleSwitch onChange={onChange}>Switch me!</ToggleSwitch>);
+it("should call the passed onClick method when clicked", () => {
+    const onClick = jest.fn();
+    const { getByText } = render(<ToggleSwitch onClick={onClick}>Switch me!</ToggleSwitch>);
 
-    const input = getByLabelText("Switch me!");
+    const input = getByText("Switch me!");
     input.click();
 
-    expect(onChange).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalled();
 });

--- a/packages/toggle-switch-react/src/ToggleSwitch.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.tsx
@@ -29,7 +29,7 @@ export const ToggleSwitch = ({ children, pressed, onClick, className, disabled, 
                 <span className="jkl-toggle-switch__slider">
                     <span className="jkl-toggle-switch__expanding-pill"></span>
                 </span>
-                <span className="jkl-toggle-switch__label">{children}</span>
+                {children}
             </button>
             {helpLabel && <SupportLabel className="jkl-toggle-switch__help-label" helpLabel={helpLabel} />}
         </>

--- a/packages/toggle-switch-react/src/ToggleSwitch.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.tsx
@@ -1,38 +1,37 @@
-import React, { ReactNode, ChangeEvent } from "react";
+import React, { ReactNode, MouseEventHandler } from "react";
 import { SupportLabel } from "@fremtind/jkl-typography-react";
 
 interface Props {
     children: ReactNode;
-    checked?: boolean;
+    pressed?: boolean;
     className?: string;
-    onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
     disabled?: boolean;
     inverted?: boolean;
     helpLabel?: string;
 }
 
-export const ToggleSwitch = ({ children, checked, onChange, className, disabled, inverted, helpLabel }: Props) => {
+export const ToggleSwitch = ({ children, pressed, onClick, className, disabled, inverted, helpLabel }: Props) => {
     const componentClassName = "jkl-toggle-switch".concat(
         className ? ` ${className}` : "",
         inverted ? " jkl-toggle-switch--inverted" : "",
     );
+
     return (
         <>
-            <label data-testid="jkl-toggle-input--label" className={componentClassName}>
-                <input
-                    className="jkl-toggle-switch__input"
-                    data-testid="jkl-toggle-input"
-                    type="checkbox"
-                    checked={checked}
-                    onChange={onChange}
-                    disabled={disabled}
-                />
+            <button
+                type="button"
+                aria-pressed={!!pressed}
+                disabled={disabled}
+                className={componentClassName}
+                onClick={onClick}
+            >
                 <span className="jkl-toggle-switch__slider">
                     <span className="jkl-toggle-switch__expanding-pill"></span>
                 </span>
                 <span className="jkl-toggle-switch__label">{children}</span>
-            </label>
-            <SupportLabel className="jkl-toggle-switch__helplabel" helpLabel={helpLabel} />
+            </button>
+            {helpLabel && <SupportLabel className="jkl-toggle-switch__help-label" helpLabel={helpLabel} />}
         </>
     );
 };

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -17,6 +17,7 @@ $inverted-disabled-color: #969696;
 .jkl-toggle-switch {
     @include reset-outline;
     cursor: pointer;
+    position: relative;
     display: flex;
     height: $toggle-height;
     padding: 0;
@@ -24,13 +25,7 @@ $inverted-disabled-color: #969696;
 
     background-color: transparent;
     color: currentColor;
-    position: relative;
-
-    &__label {
-        @include body-paragraph--desktop;
-        color: currentColor;
-        padding-left: $component-spacing--small;
-    }
+    @include body-paragraph--desktop;
 
     &__help-label {
         margin-top: $component-spacing--medium;
@@ -42,6 +37,7 @@ $inverted-disabled-color: #969696;
         height: $toggle-height;
         position: relative;
         width: $toggle-width;
+        margin-right: $component-spacing--small;
 
         /* The line the dot slides on */
         &:before {

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -16,76 +16,15 @@ $inverted-disabled-color: #969696;
 
 .jkl-toggle-switch {
     @include reset-outline;
-    height: $toggle-height;
-    display: flex;
-    align-items: center;
     cursor: pointer;
+    display: flex;
+    height: $toggle-height;
+    padding: 0;
+    align-items: center;
 
-    &--inverted {
-        .jkl-toggle-switch {
-            &__slider {
-                &:before {
-                    background-color: $helhvit;
-                }
-                &:after {
-                    background-color: $helhvit;
-                    box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $helhvit,
-                        inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $svart;
-                }
-                & .jkl-toggle-switch__expanding-pill {
-                    background-color: $expanding-pill-background-color;
-                    border-color: $helhvit;
-                }
-            }
-
-            &__input[disabled] {
-                + .jkl-toggle-switch__slider {
-                    &:before {
-                        background-color: $inverted-disabled-color;
-                    }
-                    &:after {
-                        background-color: $inverted-disabled-color;
-                        box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $inverted-disabled-color,
-                            inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $svart;
-                    }
-                    & .jkl-toggle-switch__expanding-pill {
-                        border-color: $inverted-disabled-color;
-                    }
-                }
-            }
-        }
-    }
-
-    &__input[disabled] {
-        + .jkl-toggle-switch__slider,
-        ~ .jkl-toggle-switch__label {
-            cursor: default;
-        }
-        + .jkl-toggle-switch__slider {
-            &:before {
-                background-color: $disabled-color;
-            }
-            &:after {
-                background-color: $disabled-color;
-                box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $disabled-color,
-                    inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $helhvit;
-            }
-            & .jkl-toggle-switch__expanding-pill {
-                background-color: transparent;
-                border-color: $disabled-color;
-            }
-        }
-
-        &:checked + .jkl-toggle-switch__slider:before {
-            background-color: transparent;
-        }
-    }
-
-    &__input {
-        /* Hide the actual input field */
-        opacity: 0;
-        position: absolute;
-    }
+    background-color: transparent;
+    color: currentColor;
+    position: relative;
 
     &__label {
         @include body-paragraph--desktop;
@@ -93,7 +32,7 @@ $inverted-disabled-color: #969696;
         padding-left: $component-spacing--small;
     }
 
-    &__helplabel {
+    &__help-label {
         margin-top: $component-spacing--medium;
     }
 
@@ -122,6 +61,8 @@ $inverted-disabled-color: #969696;
             content: "";
             border-radius: 99rem;
             position: absolute;
+            left: 0;
+            top: 0;
             width: $toggle-height;
             height: $toggle-height;
             background-color: $main-slider-color;
@@ -142,6 +83,7 @@ $inverted-disabled-color: #969696;
         width: $toggle-height;
 
         &:after {
+            // Focus ring for keyboard navigation
             content: "";
             position: absolute;
             top: -3px;
@@ -151,11 +93,72 @@ $inverted-disabled-color: #969696;
             background-color: transparent;
             border-radius: 99rem;
             width: $toggle-width + rem(4px);
+            box-shadow: 0 0 0 rem(2px) transparent;
+            @include motion("standard");
+            transition-property: box-shadow;
+        }
+    }
+
+    &--inverted {
+        .jkl-toggle-switch {
+            &__slider {
+                &:before {
+                    background-color: $helhvit;
+                }
+                &:after {
+                    background-color: $helhvit;
+                    box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $helhvit,
+                        inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $svart;
+                }
+                & .jkl-toggle-switch__expanding-pill {
+                    background-color: $expanding-pill-background-color;
+                    border-color: $helhvit;
+                }
+            }
+        }
+
+        &[disabled] > .jkl-toggle-switch__slider {
+            &:before {
+                background-color: $inverted-disabled-color;
+            }
+            &:after {
+                background-color: $inverted-disabled-color;
+                box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $inverted-disabled-color,
+                    inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $svart;
+            }
+            & .jkl-toggle-switch__expanding-pill {
+                border-color: $inverted-disabled-color;
+            }
+        }
+    }
+
+    &:disabled {
+        > .jkl-toggle-switch__slider,
+        ~ .jkl-toggle-switch__label {
+            cursor: default;
+        }
+        > .jkl-toggle-switch__slider {
+            &:before {
+                background-color: $disabled-color;
+            }
+            &:after {
+                background-color: $disabled-color;
+                box-shadow: inset 0 0 0 $toggle-dot-white-line-inset $disabled-color,
+                    inset 0 0 0 $toggle-dot-white-line-inset + rem(2px) $helhvit;
+            }
+            & .jkl-toggle-switch__expanding-pill {
+                background-color: transparent;
+                border-color: $disabled-color;
+            }
+        }
+
+        &[aria-pressed="true"] > .jkl-toggle-switch__slider:before {
+            background-color: transparent;
         }
     }
 
     /* Toggled/checked state */
-    &__input:checked + &__slider {
+    &[aria-pressed="true"] > &__slider {
         & > .jkl-toggle-switch__expanding-pill {
             width: $toggle-width;
             top: 0;
@@ -167,7 +170,7 @@ $inverted-disabled-color: #969696;
     }
 
     /* Keyboard focused state */
-    html:not([data-mousenavigation]) &__input:focus + &__slider > &__expanding-pill:after {
+    html:not([data-mousenavigation]) &:focus > &__slider > &__expanding-pill:after {
         box-shadow: 0 0 0 rem(2px) $toggle-focus-outline-color;
     }
 }

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -38,6 +38,7 @@ $inverted-disabled-color: #969696;
         position: relative;
         width: $toggle-width;
         margin-right: $component-spacing--small;
+        pointer-events: none;
 
         /* The line the dot slides on */
         &:before {

--- a/portal/src/components/Menu/Menu.tsx
+++ b/portal/src/components/Menu/Menu.tsx
@@ -119,8 +119,8 @@ export function Menu() {
                         <ToggleSwitch
                             inverted={theme === "dark"}
                             className="jkl-spacing--top-2 jkl-spacing--bottom-3"
-                            checked={theme === "dark"}
-                            onChange={(e) => toggleTheme(e.target.checked)}
+                            pressed={theme === "dark"}
+                            onClick={() => toggleTheme(theme === "light")}
                         >
                             Dark(beta)
                         </ToggleSwitch>


### PR DESCRIPTION
affects: @fremtind/jkl-toggle-switch-react, @fremtind/jkl-toggle-switch

## 📥 Proposed changes

Change the ToggleSwitch component to an implementation using a `<button>` with the `aria-pressed` attribute indicating toggled state. This is best practice according to W3C, and makes screenreaders announce the button as a toggle button rather than as a checkbox.

BREAKING CHANGE:
`checked` prop is replaced by `pressed`, `onChange` prop is replaced by `onClick`

Closes #726 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

We shouold consider whether we want to let the old props (`checked` and `onChange`) live on as deprecated for a while to avoid a breaking change, but right now is probably the least problematic time to include breaking changes.