### PR TITLE
feat(radio-button): add inverted mode

### DIFF
--- a/packages/radio-button-react/documentation/Example.tsx
+++ b/packages/radio-button-react/documentation/Example.tsx
@@ -10,6 +10,7 @@ const choices = ["Yes", "No", "I don't know"];
 const Example = () => {
     const [selectedValue, setSelectedValue] = React.useState();
     const [inline, setInline] = useState(false);
+    const [inverted, setInverted] = useState(false);
     const [invalid, setInvalid] = useState("");
     const [variant, setVariant] = useState<LabelVariant | undefined>("medium");
     const typecheckAndSetVariant = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -20,12 +21,16 @@ const Example = () => {
             setVariant(undefined);
         }
     };
+    const style = inverted ? { backgroundColor: "#000", color: "#FFF" } : undefined;
 
     return (
-        <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
+        <section className="jkl-spacing--top-3 jkl-spacing--bottom-3" style={style}>
             <div className="jkl-spacing--bottom-3">
                 <button className="jkl-spacing--right-1" onClick={() => setInline(!inline)}>
                     Toggle inlined radio buttons
+                </button>
+                <button className="jkl-spacing--right-1" onClick={() => setInverted(!inverted)}>
+                    Toggle inverted
                 </button>
                 <button
                     className="jkl-spacing--right-1"
@@ -55,6 +60,7 @@ const Example = () => {
                 helpLabel="Who dosent like radio buttons?"
                 errorLabel={invalid}
                 variant={variant}
+                inverted={inverted}
             />
         </section>
     );

--- a/packages/radio-button-react/src/RadioButtonOption.tsx
+++ b/packages/radio-button-react/src/RadioButtonOption.tsx
@@ -10,6 +10,7 @@ interface Props {
     checked?: boolean;
     invalid?: boolean;
     forceCompact?: boolean;
+    inverted?: boolean;
 }
 
 export const RadioButtonOption = ({
@@ -21,6 +22,7 @@ export const RadioButtonOption = ({
     checked,
     invalid = false,
     forceCompact,
+    inverted,
 }: Props) => (
     <label
         data-testid="jkl-radio-button__label-tag"
@@ -28,6 +30,7 @@ export const RadioButtonOption = ({
             "jkl-radio-button--compact": forceCompact,
             "jkl-radio-button--inline": inline,
             "jkl-radio-button--error": invalid,
+            "jkl-radio-button--inverted": inverted,
         })}
     >
         <input

--- a/packages/radio-button-react/src/RadioButtons.tsx
+++ b/packages/radio-button-react/src/RadioButtons.tsx
@@ -15,6 +15,7 @@ interface Props {
     variant?: LabelVariant;
     forceCompact?: boolean;
     className?: string;
+    inverted?: boolean;
 }
 
 export const RadioButtons = ({
@@ -29,6 +30,7 @@ export const RadioButtons = ({
     variant,
     forceCompact,
     className,
+    inverted,
 }: Props) => (
     <FieldGroup
         legend={legend}
@@ -49,6 +51,7 @@ export const RadioButtons = ({
                 onChange={onChange}
                 invalid={!!errorLabel}
                 forceCompact={forceCompact}
+                inverted={inverted}
             />
         ))}
     </FieldGroup>

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -148,6 +148,18 @@ $radio-button-color: $svart;
         }
     }
 
+    &--inverted {
+        .jkl-radio-button__dot {
+            &:before {
+                border-color: $hvit;
+                background-color: transparent;
+            }
+            &:after {
+                background-color: $hvit;
+            }
+        }
+    }
+
     @include compact-mode {
         .jkl-radio-button__label {
             @include body-paragraph--mobile;


### PR DESCRIPTION
affects: @fremtind/jkl-radio-button-react, @fremtind/jkl-radio-button

## 📥 Proposed changes

Implement dark mode for radio buttons. This is not run by any designers, but is probably not a controversial solution 😅

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
