### PR TITLE
docs(portal): correct heading levels in component docs

### DIFF
--- a/packages/list-react/documentation/Example.tsx
+++ b/packages/list-react/documentation/Example.tsx
@@ -4,7 +4,7 @@ import "@fremtind/jkl-list/list.scss";
 import "@fremtind/jkl-core/core.scss";
 
 export const Ordered = () => (
-    <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
+    <section>
         <h3 className="jkl-h5">Nummerert liste</h3>
         <OrderedList>
             <ListItem>Steg 1</ListItem>
@@ -28,7 +28,7 @@ export const Ordered = () => (
 );
 
 export const Unordered = () => (
-    <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
+    <section>
         <h3 className="jkl-h5">Standard liste</h3>
         <UnorderedList>
             <ListItem>Listeelement 1</ListItem>
@@ -46,7 +46,7 @@ export const Unordered = () => (
 );
 
 export const Indent = () => (
-    <section className="jkl-spacing--top-3 jkl-spacing--bottom-3">
+    <section>
         <h3 className="jkl-h5">Nøstet liste</h3>
         <UnorderedList>
             <ListItem>

--- a/packages/list-react/documentation/Example.tsx
+++ b/packages/list-react/documentation/Example.tsx
@@ -5,7 +5,7 @@ import "@fremtind/jkl-core/core.scss";
 
 export const Ordered = () => (
     <section>
-        <h3 className="jkl-h5">Nummerert liste</h3>
+        <h3 className="jkl-heading-small">Nummerert liste</h3>
         <OrderedList>
             <ListItem>Steg 1</ListItem>
             <ListItem>
@@ -29,14 +29,14 @@ export const Ordered = () => (
 
 export const Unordered = () => (
     <section>
-        <h3 className="jkl-h5">Standard liste</h3>
+        <h3 className="jkl-heading-small">Standard liste</h3>
         <UnorderedList>
             <ListItem>Listeelement 1</ListItem>
             <ListItem>Listeelement 2</ListItem>
             <ListItem>Listelement 3</ListItem>
         </UnorderedList>
         <br></br>
-        <h3 className="jkl-h5">Mobile/Compact liste</h3>
+        <h3 className="jkl-heading-small">Mobile/Compact liste</h3>
         <UnorderedList className="jkl-small">
             <ListItem>Listeelement 1</ListItem>
             <ListItem>Listeelement 2</ListItem>
@@ -47,7 +47,7 @@ export const Unordered = () => (
 
 export const Indent = () => (
     <section>
-        <h3 className="jkl-h5">Nøstet liste</h3>
+        <h3 className="jkl-heading-small">Nøstet liste</h3>
         <UnorderedList>
             <ListItem>
                 Listeelement 1

--- a/packages/list-react/documentation/List.mdx
+++ b/packages/list-react/documentation/List.mdx
@@ -8,19 +8,19 @@ import { Ordered, Unordered, Indent } from "./Example";
 
 Lister er strukturelementer. De gjør at vi kan utheve viktig informasjon for brukerne eller fortelle dem at de må gjøre noe i en bestemt rekkefølge. Det finnes to forskjellige lister: _nummererte_ og _unummererte_.
 
-### Nummererte lister
+## Nummererte lister
 
 Vi bruker nummererte lister når vi skal presentere instruksjoner, der rekkefølgen er viktig.
 
 <Ordered />
 
-### Unummererte lister
+## Unummererte lister
 
 I unummererte lister bruker vi kulepunkter. Formålet med en slik liste er å organisere informasjonen og fremheve viktige opplysninger. Her er ikke rekkefølgen brukeren skal utføre noe i viktig, men vi må likevel passe på at vi presenterer det innholdet som er mest relevant først.
 
 <Unordered />
 
-### Innrykk i lister
+## Innrykk i lister
 
 Vi kan bruke innrykk under et enkelt listepunkt når det punktet har tilleggsinformasjon som vi må dele opp videre. Men bruk det sparsommelig. Før du bruker det, tenk nøye over om dette er et hovedpunkt som kan stå for seg selv, eller om det er informasjon som passer best som underpunkt. Selvstendige punkter skal ikke ha innrykk.
 

--- a/packages/react-hooks/documentation/hooks.mdx
+++ b/packages/react-hooks/documentation/hooks.mdx
@@ -14,37 +14,37 @@ import IntersectionObserverExample from "./IntersectionObserverExample";
     <span class="jkl-lead">Denne pakken innholder støttefunksjoner i form av React hooks.</span>
 </p>
 
-### useAnimatedHeight
+## useAnimatedHeight
 
 Animering av ting inn og ut av DOMet i React er ikke lett, men med useAnimatedHeight blir jobben en god del lettere.
 
 <AnimationExample />
 
-### useMutationObserver
+## useMutationObserver
 
 Med `useMutationObserver` kan du lytte på endringer i DOMet. Dette er en tynn wrapper over MutationObserver APIet som gjør det lettere å ta det i bruk i React. Den er nyttig om du f.eks. ønsker å spore når en bruker trykker på et element der du ikke har tilgang på `onChange`-funksjonen, som `Accordion`.
 
 <MutationObserverExample />
 
-### useClickOutside
+## useClickOutside
 
 `useClickOutside` lar deg lytte på klikk utenfor et element. Det kan være nyttig for å lukke modaler o.l.
 
 <ClickOutsideExample />
 
-### useFocusOutside
+## useFocusOutside
 
 `useFocusOutside` lar deg lytte etter elementfokus utenfor et gitt element, for eksempel når du tabber ut av en datovelger, og utføre en gitt handling.
 
 <FocusOutsideExample />
 
-### useKeyListener
+## useKeyListener
 
 `useKeyListener` lar deg lytte etter spesifiserte tastetrykk når fokus er inne i et gitt element. Dette kan være nyttig for blandt annet søkefunksjonalitet i lister, og tastaturnavigasjon i karuseller o.l.
 
 <KeyListenerExample />
 
-### useIntersectionObserver
+## useIntersectionObserver
 
 IntersectionObserver lar deg lytte på om et element er synlig eller ikke. Det gjør det mulig å animere innhold inn, eller prelaste innhold som er rett uten for viewporten. I eksemplet brukes det til å bytte bakgrunnsfarge når andre paragrafen kommer helt inn i visning.
 

--- a/portal/src/components/Header/Header.tsx
+++ b/portal/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export const Header = ({ siteHeader = "Jøkul", siteTitle }: Props) => (
                         <html lang="no-nb" />
                         <title>{siteTitle ? `${siteTitle} - ` : ""}Jøkul designsystem</title>
                     </Helmet>
-                    <TitleElm className="portal-header__title jkl-h2">
+                    <TitleElm className="portal-header__title jkl-title-small">
                         <Link to="/">{siteHeader}</Link>
                     </TitleElm>
                 </header>


### PR DESCRIPTION
affects: @fremtind/jkl-list-react, @fremtind/jkl-react-hooks

## 📥 Proposed changes

Fix incorrect heading levels on some documentation pages/examples.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments