### PR TITLE
Refactor portal header

### DIFF
--- a/portal/src/components/Header/header-react/src/header.tsx
+++ b/portal/src/components/Header/header-react/src/header.tsx
@@ -1,53 +1,15 @@
-import React, { ReactNode, MouseEventHandler } from "react";
-import classNames from "classnames";
+import React from "react";
+import { Link } from "gatsby";
 import { Logo } from "@fremtind/jkl-logo-react";
 import "../../header/header.scss";
 
-type validButtons = "primary" | "secondary" | "tertiary";
-
-type Action = {
-    type: validButtons;
-    name: string;
-    onClick: MouseEventHandler<HTMLButtonElement>;
-};
-
-type Clickable = {
-    href?: string;
-    onClick?: MouseEventHandler<HTMLAnchorElement>;
-};
-
-interface Props {
-    title?: string;
-    brand?: string;
-    children?: ReactNode;
-    className?: string;
-    action?: Action;
-    dark?: boolean;
-    clickable?: Clickable;
-}
-
-export const Header = ({ title, brand, children, className, dark, clickable }: Props) => {
-    const componentClassName = classNames("portal-header", className, { "portal-header--dark": dark });
-
-    return (
-        <header data-testid="portal-header" className={componentClassName}>
-            {title && (
-                <div data-testid="portal-header__title" className="portal-header__title">
-                    {clickable ? (
-                        <a className="portal-header__link" href={clickable.href} onClick={clickable.onClick}>
-                            {brand && <span className="portal-header__link--brand">{brand}</span>} {title}
-                        </a>
-                    ) : (
-                        <span>
-                            {brand && <span className="portal-header__link--brand">{brand}</span>} {title}
-                        </span>
-                    )}
-                </div>
-            )}
-            {children}
-            <div className="portal-header__logo">
-                <Logo isSymbol centered={false} />
-            </div>
-        </header>
-    );
-};
+export const Header = () => (
+    <header className="portal-header">
+        <Link to="/" className="portal-header__title">
+            <strong>Jøkul</strong> Designsystem
+        </Link>
+        <div className="portal-header__logo">
+            <Logo isSymbol centered={false} />
+        </div>
+    </header>
+);

--- a/portal/src/components/Header/header/header.scss
+++ b/portal/src/components/Header/header/header.scss
@@ -1,25 +1,25 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
-@import "~@fremtind/jkl-core/mixins/_all.scss";
-@import "~@fremtind/jkl-button/button.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
 
 $header-bg-color: $hvit;
-$header-padding: 33px 24px;
+$header-height: rem(96px);
+$header-padding: 0 $component-spacing--xl;
 
 .portal-header {
-    align-items: center;
-    background-color: $header-bg-color;
+    grid-area: header;
     display: flex;
-    height: 96px;
+    height: $header-height;
+    background-color: $header-bg-color;
+    padding: $header-padding;
+    align-items: center;
     justify-content: space-between;
-    z-index: 1;
-    background-color: $hvit;
+    z-index: $z-index--header;
 
     &__title {
-        font-size: 21px;
-        padding: $header-padding;
-    }
-    &__link--brand {
-        font-weight: 700;
+        @include h5-heading--desktop;
+        color: $svart;
+        text-decoration: none;
+        font-weight: $normal-weight;
     }
     &__logo {
         float: right;

--- a/portal/src/components/Layout/layout-react/src/Layout.tsx
+++ b/portal/src/components/Layout/layout-react/src/Layout.tsx
@@ -26,7 +26,7 @@ export const Layout = ({ children }: Props) => {
     return (
         <ThemeContext.Provider value={{ theme, toggleTheme }}>
             <div className="portal-content">
-                <Header brand="Jøkul" title="Designsystem" className="portal-content__header" />
+                <Header />
                 <Sidebar className="portal-content__sidebar">
                     <Menu />
                 </Sidebar>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,6 +2877,15 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
+"@typescript-eslint/experimental-utils@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.16.0.tgz#bba65685728c532e0ddc811a0376e8d38e671f77"
+  integrity sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.16.0"
+    eslint-scope "^5.0.0"
+
 "@typescript-eslint/experimental-utils@2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz#d5ca732f22c009e515ba09fcceb5f2127d841568"
@@ -2905,6 +2914,19 @@
     "@typescript-eslint/experimental-utils" "2.16.0"
     "@typescript-eslint/typescript-estree" "2.16.0"
     eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.16.0.tgz#b444943a76c716ed32abd08cbe96172d2ca0ab75"
+  integrity sha512-hyrCYjFHISos68Bk5KjUAXw0pP/455qq9nxqB1KkT67Pxjcfw+r6Yhcmqnp8etFL45UexCHUMrADHH7dI/m2WQ==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.19.0":
   version "2.19.0"
@@ -7353,6 +7375,11 @@ fancy-log@^1.3.2:
     color-support "^1.1.3"
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## 📥 Proposed changes

Greatly simplify the structure of the `Header` component. It seems like the `Card` component from Jøkul was used as a basis, and a lot of the props/functionality from that was still implemented.

I realize I've also made it a bit less generalized, but I don't think we need to implement patterns for headers we don't really _have_ a pattern for yet.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

This is not directly related to this PR, but I'm not sure that i like this architecture:

![Skjermbilde 2020-02-19 kl  09 34 33](https://user-images.githubusercontent.com/25739615/74817455-35245b00-52fd-11ea-9ba5-026b6588bf6c.png)

I presume it is meant to approximate the structure of the packages in Jøkul, but is this the right place to do that? If we assume that our code will be "stolen" by the teams, we should write the portal and its architecture in the way we would like the teams to write their projects, not as a library.

As it stands now, we get a lot of folders, winding paths, and not-so-pretty imports like this:

![Skjermbilde 2020-02-19 kl  09 51 45](https://user-images.githubusercontent.com/25739615/74817771-c7c4fa00-52fd-11ea-9f1b-16e5b29fb5be.png)

The packages in Jøkul (which you will automatically have available if you edit the portal) already illustrate the architecture of the library, so shouldn't we rather illustrate the architecture we proposed to the teams earlier?:

![Skjermbilde 2020-02-19 kl  09 55 50](https://user-images.githubusercontent.com/25739615/74817922-078be180-52fe-11ea-8b03-523e6699fe52.png)

**Edit**: This could also be a great teaching exercise for a Jøkul bootcamp/hackathon: refactoring a component from a project (the portal?) to a Jøkul library style- and React package.