### PR TITLE
feat(text-input): tweak action icon placement and add focus state

### DIFF
--- a/packages/text-input-react/src/Icons/IconClear.tsx
+++ b/packages/text-input-react/src/Icons/IconClear.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 export const IconClear = () => (
-    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fillRule="evenodd" clipRule="evenodd">
-        <path d="M12 11.293l10.293-10.293.707.707-10.293 10.293 10.293 10.293-.707.707-10.293-10.293-10.293 10.293-.707-.707 10.293-10.293-10.293-10.293.707-.707 10.293 10.293z" />
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M1 23L23 1" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M1 1L23 23" stroke="currentColor" strokeWidth="1.5" />
     </svg>
 );

--- a/packages/text-input-react/src/Icons/IconSearch.tsx
+++ b/packages/text-input-react/src/Icons/IconSearch.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export const IconSearch = () => (
     <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="9" cy="9" r="8.5" stroke="currentColor" strokeWidth="1.5" />
+        <circle cx="9.5" cy="9.5" r="8.5" stroke="currentColor" strokeWidth="1.5" />
         <path d="M23 23L15 15" stroke="currentColor" strokeWidth="1.5" />
     </svg>
 );

--- a/packages/text-input-react/src/Icons/IconSearch.tsx
+++ b/packages/text-input-react/src/Icons/IconSearch.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 
 export const IconSearch = () => (
-    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fillRule="evenodd" clipRule="evenodd">
-        <path
-            d="M15.853 16.56c-1.683 1.517-3.911 2.44-6.353 2.44-5.243 0-9.5-4.257-9.5-9.5s4.257-9.5 9.5-9.5 9.5 
-        4.257 9.5 9.5c0 2.442-.923 4.67-2.44 6.353l7.44 7.44-.707.707-7.44-7.44zm-6.353-15.56c4.691 0 8.5 3.809 8.5 
-        8.5s-3.809 8.5-8.5 8.5-8.5-3.809-8.5-8.5 3.809-8.5 8.5-8.5z"
-        />
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="9" cy="9" r="8.5" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M23 23L15 15" stroke="currentColor" strokeWidth="1.5" />
     </svg>
 );

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -7,14 +7,16 @@ $input-bg-color: inherit;
 $border-color: $svart;
 $border-color--focus: $focus-color;
 
-$input-height: $line-height-4;
-$input-height--small-device: $line-height-3;
 $bottom-padding: $component-spacing--small;
+$input-line-height: $line-height-4;
+$input-height: $input-line-height + $bottom-padding;
+$input-line-height--small-device: $line-height-3;
+$input-height--small-device: $input-line-height--small-device + $bottom-padding;
 
-$textarea-expanded-height: $input-height * 7 + $bottom-padding;
-$textarea-expanded-height--small-device: $input-height--small-device * 7 + $bottom-padding;
+$textarea-expanded-height: $input-line-height * 7 + $bottom-padding;
+$textarea-expanded-height--small-device: $input-line-height--small-device * 7 + $bottom-padding;
 
-$icon-size: $font-size-6;
+$icon-size: rem(20px);
 $icon-size--compact: $font-size-2;
 
 .jkl-text-field {
@@ -34,7 +36,7 @@ $icon-size--compact: $font-size-2;
 
         box-sizing: border-box;
         width: 100%;
-        height: $input-height + $bottom-padding;
+        height: $input-height;
         padding: 0 0 $bottom-padding;
 
         font-weight: $bold-weight;
@@ -76,12 +78,21 @@ $icon-size--compact: $font-size-2;
     &__action-button {
         position: absolute;
         right: 0;
-        bottom: $component-spacing--small;
+        display: flex;
+        align-items: center;
+        top: 0;
         appearance: none;
         border: none;
         background-color: transparent;
         cursor: pointer;
         padding: 0;
+        padding-bottom: $component-spacing--small;
+        height: $input-height;
+        color: $svart;
+
+        *:not([data-mousenavigation]) &:focus {
+            color: $focus-color;
+        }
     }
 
     &__action-icon {
@@ -120,7 +131,10 @@ $icon-size--compact: $font-size-2;
             @include jkl-text-style("compact/body");
         }
         & .jkl-text-field__input {
-            height: $input-height--small-device + $bottom-padding;
+            height: $input-height--small-device;
+        }
+        & .jkl-text-input__action-button {
+            height: $input-height--small-device;
         }
         & .jkl-text-field__action-icon {
             width: $icon-size--compact;
@@ -133,7 +147,10 @@ $icon-size--compact: $font-size-2;
             @include jkl-text-style("compact/body");
         }
         & .jkl-text-field__input {
-            height: $input-height--small-device + $bottom-padding;
+            height: $input-height--small-device;
+        }
+        & .jkl-text-input__action-button {
+            height: $input-height--small-device;
         }
         & .jkl-text-field__action-icon {
             width: $icon-size--compact;
@@ -145,12 +162,12 @@ $icon-size--compact: $font-size-2;
 @for $num from 3 through 10 {
     .jkl-text-field__input--#{$num}-rows:focus,
     .jkl-text-field__input--#{$num}-rows:not(:placeholder-shown) {
-        height: $input-height * $num + $bottom-padding;
+        height: $input-line-height * $num + $bottom-padding;
         @include small-device {
-            height: $input-height--small-device * $num + $bottom-padding;
+            height: $input-line-height--small-device * $num + $bottom-padding;
         }
         .jkl-text-field--compact & {
-            height: $input-height--small-device * $num + $bottom-padding;
+            height: $input-line-height--small-device * $num + $bottom-padding;
         }
     }
 }


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react, @fremtind/jkl-text-input

## 📥 Proposed changes

Tweaks size and position of the action icon in `ActionTextField`, and adds keyboard focus indication to it in the form of blue focus color.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

We should probably find a better way of indicating focus state, but this is better than nothing, and was easy to implement via CSS.
