### PR TITLE
feat(datepicker): add button to open datepicker calendar

### DIFF
--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -36,7 +36,8 @@
         "@fremtind/jkl-datepicker": "^1.3.0",
         "@fremtind/jkl-react-hooks": "^0.4.1",
         "@fremtind/jkl-typography-react": "^2.0.2",
-        "@nrk/core-datepicker": "^3.0.7"
+        "@nrk/core-datepicker": "^3.0.7",
+        "@nrk/core-toggle": "^3.0.7"
     },
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.4.14",

--- a/packages/datepicker-react/src/CalendarIcon.tsx
+++ b/packages/datepicker-react/src/CalendarIcon.tsx
@@ -5,21 +5,11 @@ interface Props {
 }
 
 export const CalendarIcon = ({ className }: Props) => (
-    <svg className={className ? className : ""} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="0.5" y="3.5" width="23" height="20" stroke="currentColor" />
-        <line x1="6.5" x2="6.5" y2="7" stroke="currentColor" />
-        <line x1="17.5" x2="17.5" y2="7" stroke="currentColor" />
-        <rect x="4.5" y="9.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="4.5" y="14" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="4.5" y="18.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="9" y="9.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="9" y="14" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="9" y="18.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="13.5" y="9.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="13.5" y="14" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="13.5" y="18.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="18" y="9.5" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="18" y="14" width="1.5" height="1.5" fill="currentColor" />
-        <rect x="18" y="18.5" width="1.5" height="1.5" fill="currentColor" />
+    <svg className={className ? className : ""} viewBox="0 0 24 24" fill="none">
+        <path stroke="currentColor" d="M.5 3.5h23v20H.5zM6.5 0v7M17.5 0v7" />
+        <path
+            fill="currentColor"
+            d="M4.5 9.5H6V11H4.5zM4.5 14H6v1.5H4.5zM4.5 18.5H6V20H4.5zM9 9.5h1.5V11H9zM9 14h1.5v1.5H9zM9 18.5h1.5V20H9zM13.5 9.5H15V11h-1.5zM13.5 14H15v1.5h-1.5zM13.5 18.5H15V20h-1.5zM18 9.5h1.5V11H18zM18 14h1.5v1.5H18zM18 18.5h1.5V20H18z"
+        />
     </svg>
 );

--- a/packages/datepicker-react/src/CalendarIcon.tsx
+++ b/packages/datepicker-react/src/CalendarIcon.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface Props {
+    className?: string;
+}
+
+export const CalendarIcon = ({ className }: Props) => (
+    <svg className={className ? className : ""} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0.5" y="3.5" width="23" height="20" stroke="currentColor" />
+        <line x1="6.5" x2="6.5" y2="7" stroke="currentColor" />
+        <line x1="17.5" x2="17.5" y2="7" stroke="currentColor" />
+        <rect x="4.5" y="9.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="4.5" y="14" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="4.5" y="18.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="9" y="9.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="9" y="14" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="9" y="18.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="13.5" y="9.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="13.5" y="14" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="13.5" y="18.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="18" y="9.5" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="18" y="14" width="1.5" height="1.5" fill="currentColor" />
+        <rect x="18" y="18.5" width="1.5" height="1.5" fill="currentColor" />
+    </svg>
+);

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -7,7 +7,7 @@ import { axe } from "jest-axe";
 beforeEach(cleanup);
 
 describe("Datepicker", () => {
-    it("should render with the correct format", () => {
+    it("renders with the correct format", () => {
         const thePast = new Date(2019, 11, 24);
         const { getByTestId } = render(<DatePicker initialDate={thePast} />);
 
@@ -15,7 +15,7 @@ describe("Datepicker", () => {
         expect(date).toHaveProperty("value", "24.12.2019");
     });
 
-    it("should fire onChange on edit input with valid date", () => {
+    it("fires onChange method on edit input with valid date", () => {
         const changeHandler = jest.fn();
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
         const input = getByTestId("jkl-datepicker__input");
@@ -25,7 +25,7 @@ describe("Datepicker", () => {
         expect(changeHandler).toHaveBeenCalledTimes(1);
     });
 
-    it("should not fire onChange on edit input with invalid date", () => {
+    it("does not fire onChange on edit input with invalid date", () => {
         const changeHandler = jest.fn();
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
         const input = getByTestId("jkl-datepicker__input");
@@ -34,10 +34,18 @@ describe("Datepicker", () => {
         expect(input).toHaveProperty("value", "a random string");
         expect(changeHandler).toHaveBeenCalledTimes(0);
     });
+
+    it("uses the supplied title for the calendar button", () => {
+        const { getByTestId } = render(<DatePicker calendarButtonTitle="hallo" />);
+        const button = getByTestId("jkl-datepicker__calendar-button");
+
+        expect(button).toHaveAttribute("aria-label", "hallo");
+        expect(button).toHaveAttribute("title", "hallo");
+    });
 });
 
 describe("formatDate", () => {
-    it("should render the given date correctly", () => {
+    it("renders the given date correctly", () => {
         const date = new Date("1986-10-14");
         const formattedDate = formatDate(date);
 
@@ -46,12 +54,12 @@ describe("formatDate", () => {
 });
 
 describe("isSameDay", () => {
-    it("should return true for equal dates", () => {
+    it("returns true for equal dates", () => {
         const date = new Date("1986-10-14");
 
         expect(isSameDay(date, date)).toBeTruthy();
     });
-    it("should return false for different dates", () => {
+    it("returns false for different dates", () => {
         const date1 = new Date("1986-10-14");
         const date2 = new Date("2001-10-14");
 

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -39,8 +39,15 @@ describe("Datepicker", () => {
         const { getByTestId } = render(<DatePicker calendarButtonTitle="hallo" />);
         const button = getByTestId("jkl-datepicker__calendar-button");
 
-        expect(button).toHaveAttribute("aria-label", "hallo");
         expect(button).toHaveAttribute("title", "hallo");
+    });
+
+    it("renders the supplied button title as sr-only text", () => {
+        const { getByTestId } = render(<DatePicker calendarButtonTitle="hallo" />);
+        const button = getByTestId("jkl-datepicker__calendar-button-text");
+
+        expect(button).toHaveClass("jkl-sr-only");
+        expect(button.textContent).toBe("hallo");
     });
 });
 

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -174,7 +174,9 @@ export function DatePicker({
                     className="jkl-text-field__action-button"
                 >
                     <CalendarIcon className="jkl-text-field__action-icon" />
-                    <span className="jkl-sr-only">{calendarButtonTitle}</span>
+                    <span data-testid="jkl-datepicker__calendar-button-text" className="jkl-sr-only">
+                        {calendarButtonTitle}
+                    </span>
                 </button>
                 <CoreToggle
                     popup

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -168,19 +168,19 @@ export function DatePicker({
                     onChange={onInputChange}
                 />
                 <button
-                    aria-label={calendarButtonTitle}
+                    type="button"
                     title={calendarButtonTitle}
                     data-testid="jkl-datepicker__calendar-button"
                     className="jkl-text-field__action-button"
                 >
                     <CalendarIcon className="jkl-text-field__action-icon" />
+                    <span className="jkl-sr-only">{calendarButtonTitle}</span>
                 </button>
                 <CoreToggle
                     popup
                     hidden={datepickerHidden}
                     onToggle={toggleDatepicker}
                     onToggleSelect={(e: CoreToggleSelectEvent) => {
-                        console.log("onToggleSelect");
                         e.target.hidden = true;
                     }}
                 >

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -14,7 +14,7 @@ interface ChangeDate {
 }
 
 interface CoreToggleSelectEvent {
-    detail: { textContent: string; value: string };
+    detail: { textContent: string; value: string; classList: DOMTokenList };
     target: { hidden: boolean; button: HTMLButtonElement; value: { textContent: string } };
 }
 
@@ -109,6 +109,11 @@ export function DatePicker({
     }, [disableBeforeDate, disableAfterDate]);
 
     const toggleDatepicker = () => setDatepickerHidden(!datepickerHidden);
+    const handleCalendarClick = (e: CoreToggleSelectEvent) => {
+        if (!e.detail.classList.contains("jkl-datepicker__month-button")) {
+            e.target.hidden = true;
+        }
+    };
 
     function onInputChange(event: ChangeEvent<HTMLInputElement>) {
         const newDateString = event.target.value;
@@ -182,9 +187,7 @@ export function DatePicker({
                     popup
                     hidden={datepickerHidden}
                     onToggle={toggleDatepicker}
-                    onToggleSelect={(e: CoreToggleSelectEvent) => {
-                        e.target.hidden = true;
-                    }}
+                    onToggleSelect={handleCalendarClick}
                 >
                     <CoreDatepicker
                         timestamp={date ? date.getTime() : undefined}

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, useRef, useState, useEffect } from "react";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 import { useClickOutside, useFocusOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
 import { LabelVariant } from "@fremtind/jkl-core";
+import { CalendarIcon } from "./CalendarIcon";
 // @ts-ignore
 import CoreDatepicker from "@nrk/core-datepicker/jsx";
 import classNames from "classnames";
@@ -73,10 +74,15 @@ export function DatePicker({
     const [date, setDate] = useState(initialDate);
     const [datepickerHidden, setDatepickerHidden] = useState(!initialShow);
     const [dateString, setDateString] = useState(initialDate ? formatDate(initialDate) : "");
-    const componentClassName = classNames("jkl-datepicker", className, {
-        "jkl-datepicker--extended": extended,
-        "jkl-datepicker--open": !datepickerHidden,
-    });
+    const componentClassName = classNames(
+        "jkl-datepicker",
+        {
+            "jkl-datepicker--extended": extended,
+            "jkl-datepicker--open": !datepickerHidden,
+        },
+        "jkl-text-field--action",
+        className,
+    );
     const inputClassName = classNames("jkl-text-field jkl-datepicker__input", {
         "jkl-text-field--compact": forceCompact,
     });
@@ -93,14 +99,8 @@ export function DatePicker({
         }
     }, [disableBeforeDate, disableAfterDate]);
 
-    const openDatepicker = (e: React.FocusEvent<HTMLInputElement>) => {
-        // Workaround for loosing focus when opening in chrome:
-        // https://github.com/nrkno/core-components/issues/322
-        e.persist();
-        setTimeout(() => e.target.focus(), 0);
-        setDatepickerHidden(false);
-    };
     const closeDatepicker = () => setDatepickerHidden(true);
+    const toggleDatepicker = () => setDatepickerHidden(!datepickerHidden);
 
     const datepickerRef = useRef<HTMLDivElement>(null);
     useClickOutside(datepickerRef, closeDatepicker);
@@ -156,16 +156,25 @@ export function DatePicker({
                     <Label variant={variant} forceCompact={forceCompact}>
                         {label}
                     </Label>
-                    <input
-                        placeholder={placeholder}
-                        type="text"
-                        aria-invalid={!!errorLabel}
-                        className={`jkl-text-field__input`}
-                        data-testid="jkl-datepicker__input"
-                        value={dateString}
-                        onChange={onInputChange}
-                        onFocus={openDatepicker}
-                    />
+                    <div className="jkl-text-field__input-wrapper  jkl-datepicker__input">
+                        <input
+                            placeholder={placeholder}
+                            type="text"
+                            aria-invalid={!!errorLabel}
+                            className="jkl-text-field__input"
+                            data-testid="jkl-datepicker__input"
+                            value={dateString}
+                            onChange={onInputChange}
+                        />
+                        <button
+                            aria-label="Vis kalender"
+                            title="Vis kalender"
+                            onClick={toggleDatepicker}
+                            className="jkl-text-field__action-button"
+                        >
+                            <CalendarIcon className="jkl-text-field__action-icon" />
+                        </button>
+                    </div>
                 </label>
 
                 <div hidden={datepickerHidden}>

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,14 +1,21 @@
-import React, { ChangeEvent, useRef, useState, useEffect } from "react";
+import React, { ChangeEvent, useState, useEffect } from "react";
+import nanoid from "nanoid";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
-import { useClickOutside, useFocusOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
 import { LabelVariant } from "@fremtind/jkl-core";
 import { CalendarIcon } from "./CalendarIcon";
 // @ts-ignore
 import CoreDatepicker from "@nrk/core-datepicker/jsx";
+// @ts-ignore
+import CoreToggle from "@nrk/core-toggle/jsx";
 import classNames from "classnames";
 
 interface ChangeDate {
     date: Date;
+}
+
+interface CoreToggleSelectEvent {
+    detail: { textContent: string; value: string };
+    target: { hidden: boolean; button: HTMLButtonElement; value: { textContent: string } };
 }
 
 interface Props {
@@ -73,6 +80,7 @@ export function DatePicker({
     disableBeforeDate,
     disableAfterDate,
 }: Props) {
+    const uuid = `jkl-datepicker-${nanoid(8)}`;
     const [date, setDate] = useState(initialDate);
     const [datepickerHidden, setDatepickerHidden] = useState(!initialShow);
     const [dateString, setDateString] = useState(initialDate ? formatDate(initialDate) : "");
@@ -82,10 +90,9 @@ export function DatePicker({
             "jkl-datepicker--extended": extended,
             "jkl-datepicker--open": !datepickerHidden,
         },
-        "jkl-text-field--action",
         className,
     );
-    const inputClassName = classNames("jkl-text-field jkl-datepicker__input", {
+    const inputClassName = classNames("jkl-text-field jkl-text-field--action jkl-datepicker__input", {
         "jkl-text-field--compact": forceCompact,
     });
 
@@ -101,13 +108,7 @@ export function DatePicker({
         }
     }, [disableBeforeDate, disableAfterDate]);
 
-    const closeDatepicker = () => setDatepickerHidden(true);
     const toggleDatepicker = () => setDatepickerHidden(!datepickerHidden);
-
-    const datepickerRef = useRef<HTMLDivElement>(null);
-    useClickOutside(datepickerRef, closeDatepicker);
-    useFocusOutside(datepickerRef, closeDatepicker);
-    useKeyListener(datepickerRef, ["Enter", "Escape"], closeDatepicker);
 
     function onInputChange(event: ChangeEvent<HTMLInputElement>) {
         const newDateString = event.target.value;
@@ -135,7 +136,6 @@ export function DatePicker({
 
     function onClickCalendarDay(event: ChangeEvent<ChangeDate>) {
         const newDate = event.target.date;
-        setDatepickerHidden(true);
 
         if (dateHasChanged(date, newDate)) {
             setDateString(formatDate(newDate));
@@ -152,35 +152,38 @@ export function DatePicker({
     }
 
     return (
-        <div className={componentClassName} ref={datepickerRef}>
-            <div className="jkl-datepicker__outer-wrapper">
-                <label className={inputClassName}>
-                    <Label variant={variant} forceCompact={forceCompact}>
-                        {label}
-                    </Label>
-                    <div className="jkl-text-field__input-wrapper  jkl-datepicker__input">
-                        <input
-                            placeholder={placeholder}
-                            type="text"
-                            aria-invalid={!!errorLabel}
-                            className="jkl-text-field__input"
-                            data-testid="jkl-datepicker__input"
-                            value={dateString}
-                            onChange={onInputChange}
-                        />
-                        <button
-                            aria-label={calendarButtonTitle}
-                            title={calendarButtonTitle}
-                            onClick={toggleDatepicker}
-                            data-testid="jkl-datepicker__calendar-button"
-                            className="jkl-text-field__action-button"
-                        >
-                            <CalendarIcon className="jkl-text-field__action-icon" />
-                        </button>
-                    </div>
-                </label>
-
-                <div hidden={datepickerHidden}>
+        <div className={componentClassName}>
+            <Label htmlFor={uuid} standAlone variant={variant} forceCompact={forceCompact}>
+                {label}
+            </Label>
+            <div className={inputClassName}>
+                <input
+                    id={uuid}
+                    placeholder={placeholder}
+                    type="text"
+                    aria-invalid={!!errorLabel}
+                    className="jkl-text-field__input"
+                    data-testid="jkl-datepicker__input"
+                    value={dateString}
+                    onChange={onInputChange}
+                />
+                <button
+                    aria-label={calendarButtonTitle}
+                    title={calendarButtonTitle}
+                    data-testid="jkl-datepicker__calendar-button"
+                    className="jkl-text-field__action-button"
+                >
+                    <CalendarIcon className="jkl-text-field__action-icon" />
+                </button>
+                <CoreToggle
+                    popup
+                    hidden={datepickerHidden}
+                    onToggle={toggleDatepicker}
+                    onToggleSelect={(e: CoreToggleSelectEvent) => {
+                        console.log("onToggleSelect");
+                        e.target.hidden = true;
+                    }}
+                >
                     <CoreDatepicker
                         timestamp={date ? date.getTime() : undefined}
                         months={months}
@@ -225,7 +228,7 @@ export function DatePicker({
                         )}
                         <table data-testid="jkl-datepicker-calendar" />
                     </CoreDatepicker>
-                </div>
+                </CoreToggle>
             </div>
             <SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} forceCompact={forceCompact} />
         </div>

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, useEffect } from "react";
+import React, { ChangeEvent, useState, useEffect, useRef } from "react";
 import nanoid from "nanoid";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 import { LabelVariant } from "@fremtind/jkl-core";
@@ -80,7 +80,7 @@ export function DatePicker({
     disableBeforeDate,
     disableAfterDate,
 }: Props) {
-    const uuid = `jkl-datepicker-${nanoid(8)}`;
+    const { current: uuid } = useRef(`jkl-datepicker-${nanoid(8)}`);
     const [date, setDate] = useState(initialDate);
     const [datepickerHidden, setDatepickerHidden] = useState(!initialShow);
     const [dateString, setDateString] = useState(initialDate ? formatDate(initialDate) : "");

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -18,6 +18,7 @@ interface Props {
     placeholder?: string;
     months?: string[];
     days?: string[];
+    calendarButtonTitle?: string;
     initialDate?: Date;
     onChange?: (date: Date) => void;
     extended?: boolean;
@@ -59,6 +60,7 @@ export function DatePicker({
     placeholder = "dd.mm.åååå",
     months,
     days,
+    calendarButtonTitle = "Vis kalender",
     initialDate,
     onChange,
     extended = false,
@@ -167,9 +169,10 @@ export function DatePicker({
                             onChange={onInputChange}
                         />
                         <button
-                            aria-label="Vis kalender"
-                            title="Vis kalender"
+                            aria-label={calendarButtonTitle}
+                            title={calendarButtonTitle}
                             onClick={toggleDatepicker}
+                            data-testid="jkl-datepicker__calendar-button"
                             className="jkl-text-field__action-button"
                         >
                             <CalendarIcon className="jkl-text-field__action-icon" />

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -22,12 +22,10 @@ $bottom-margin: $component-spacing--large;
         position: relative;
     }
 
-    &__input > .jkl-text-field__input {
-        width: 10.5ch;
-
-        .jkl-datepicker--open & {
-            width: 100%;
-        }
+    &__input {
+        // $icon-size comes from text-input.scss
+        // using it ensures correct layout even if we change the text input styling
+        width: calc(12ch + #{$component-spacing--medium} + #{$icon-size});
     }
 
     /* Navigation in normal (compact) mode
@@ -136,7 +134,7 @@ $bottom-margin: $component-spacing--large;
        ================ */
 
     &__calendar {
-        @include position(absolute, $top: 100%, $left: 0, $right: 0);
+        @include position(absolute, $top: calc(100% - 4px), $left: 0, $right: 0);
         z-index: $z-index--dropdown;
         justify-content: center;
         flex-direction: column;
@@ -145,6 +143,7 @@ $bottom-margin: $component-spacing--large;
         background-color: $background-color;
         box-shadow: $drop-shadow--small;
         color: $svart;
+        border-top: 4px solid $svart;
 
         caption {
             font-size: $font-size-6;

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -13,16 +13,9 @@ $background-color: $hvit;
 $bottom-margin: $component-spacing--large;
 
 .jkl-datepicker {
-    @include reset-outline;
-    position: relative;
-    width: $calendar-width + ($calendar-padding * 2);
-    margin-bottom: $bottom-margin;
-
-    &__outer-wrapper {
-        position: relative;
-    }
-
     &__input {
+        position: relative;
+        display: block;
         // $icon-size comes from text-input.scss
         // using it ensures correct layout even if we change the text input styling
         width: calc(12ch + #{$component-spacing--medium} + #{$icon-size});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,7 @@
   resolved "https://registry.yarnpkg.com/@nrk/core-datepicker/-/core-datepicker-3.0.8.tgz#7e3905d9b9b9c0d6709bd6fae49c7e94c365d160"
   integrity sha512-3j8O/RyonYBuTymPrphA+G9CnwOJnb4+HHNRyFHNgx3AHYXhwm5sbl+A+QJwPk4nkTXhmFtfnyODsm3vqHQM7Q==
 
-"@nrk/core-toggle@^3.0.4":
+"@nrk/core-toggle@^3.0.4", "@nrk/core-toggle@^3.0.7":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@nrk/core-toggle/-/core-toggle-3.0.7.tgz#0f00c88b5ab3860c4e330c9a088a8ef8a9f41dae"
   integrity sha512-HTJ3hYoOXXwHYjQ8PnLIQgq1bDkJrKReb437MztKDGUJw9L1d4Tr2hV4BQVswJoZNIbipaxi69Xhvba35r1GRQ==


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react, @fremtind/jkl-datepicker

## 📥 Proposed changes

Calendar will no longer open when the input is focused, but instead when a button is pressed. This should address most/all issues in #593, #773 and #774.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

 Closes #593, closes #773, closes #774