### PR TITLE
feat(react-hooks): add hook for responsivity in js

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { initTabListener, getValuePair } from "./utils";
+export { initTabListener, getValuePair, breakpoints } from "./utils";
 export { ScreenReaderOnly } from "./components";
 
 export type LabelVariant = "small" | "medium" | "large";

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -1,0 +1,6 @@
+export const breakpoints = {
+    small: 768,
+    medium: 992,
+    large: 1200,
+    xl: 1600,
+};

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { initTabListener } from "./tabListener";
 export { getValuePair } from "./getValuePair";
+export { breakpoints } from "./breakpoints";

--- a/packages/react-hooks/documentation/Example.tsx
+++ b/packages/react-hooks/documentation/Example.tsx
@@ -8,6 +8,7 @@ import ClickOutsideExample from "./ClickOutsideExample";
 import FocusOutsideExample from "./FocusOutsideExample";
 import KeyListenerExample from "./KeyListenerExample";
 import IntersectionObserverExample from "./IntersectionObserverExample";
+import ScreenExample from "./ScreenExample";
 
 const Example = () => (
     <>
@@ -17,6 +18,7 @@ const Example = () => (
         <FocusOutsideExample />
         <KeyListenerExample />
         <IntersectionObserverExample />
+        <ScreenExample />
     </>
 );
 

--- a/packages/react-hooks/documentation/ScreenExample.tsx
+++ b/packages/react-hooks/documentation/ScreenExample.tsx
@@ -1,0 +1,68 @@
+import React, { useContext } from "react";
+import { useScreen, initialScreenState } from "../src";
+
+interface State {
+    isSmallDevice: boolean;
+    isMediumDevice: boolean;
+    isLargeDevice: boolean;
+    isXlDevice: boolean;
+    isLandscape: boolean;
+    isPortrait: boolean;
+    inner: {
+        height: number;
+        width: number;
+    };
+}
+
+const ScreenContext = React.createContext<State>(initialScreenState);
+
+const ScreenExample = () => {
+    const {
+        isSmallDevice,
+        isMediumDevice,
+        isLargeDevice,
+        isXlDevice,
+        isLandscape,
+        isPortrait,
+        inner: { width, height },
+    } = useContext(ScreenContext);
+
+    const getDeviceName = () => {
+        switch (true) {
+            case isSmallDevice:
+                return "liten";
+            case isMediumDevice:
+                return "litt større";
+            case isLargeDevice:
+                return "ganske stor";
+            case isXlDevice:
+                return "stor";
+            default:
+                return "";
+        }
+    };
+
+    return (
+        <section className="hooks-example key-listener-example jkl-spacing--bottom-3">
+            <h2 className="jkl-h2 jkl-spacing--bottom-2">Din dings har en {getDeviceName()} skjerm</h2>
+            <h3 className="jkl-h3 jkl-spacing--bottom-2">{`Den er i ${isLandscape ? "landskaps" : ""}${
+                isPortrait ? "portrett" : ""
+            }modus`}</h3>
+            <p className="jkl-p jkl-spacing--bottom-2">
+                {width} x {height}
+            </p>
+        </section>
+    );
+};
+
+const Provider = () => {
+    const screen = useScreen();
+
+    return (
+        <ScreenContext.Provider value={screen}>
+            <ScreenExample />
+        </ScreenContext.Provider>
+    );
+};
+
+export default Provider;

--- a/packages/react-hooks/documentation/hooks.mdx
+++ b/packages/react-hooks/documentation/hooks.mdx
@@ -9,6 +9,7 @@ import FocusOutsideExample from "./FocusOutsideExample";
 import KeyListenerExample from "./KeyListenerExample";
 import MutationObserverExample from "./MutationObserverExample";
 import IntersectionObserverExample from "./IntersectionObserverExample";
+import ScreenExample from "./ScreenExample";
 
 <p>
     <span class="jkl-lead">Denne pakken innholder støttefunksjoner i form av React hooks.</span>
@@ -49,3 +50,9 @@ Med `useMutationObserver` kan du lytte på endringer i DOMet. Dette er en tynn w
 IntersectionObserver lar deg lytte på om et element er synlig eller ikke. Det gjør det mulig å animere innhold inn, eller prelaste innhold som er rett uten for viewporten. I eksemplet brukes det til å bytte bakgrunnsfarge når andre paragrafen kommer helt inn i visning.
 
 <IntersectionObserverExample />
+
+## useScreen
+
+`useScreen` lar deg få tilgang til de samme breakpoints som cssen bruker til media queries. Av og til er kan det være nødvendig å endre strukturen på innholdet bassert på hvor stor skjerm innholdet skal presenteres på. Anbefalt implementasjon er å legge `useScreen` så høyt oppe i applikasjonen din som du mener er nødvendig i en `context`, for å benytte den contexten når du trenger å plukke ut verdiene i en komponent. Dette er for å unngå å sette opp flere eventlyttere enn nødvendig. Om du bruker server side rendering bør denne brukes med forsiktighet, da serveren ikke vil vite hvilken size den skal rendre for.
+
+<ScreenExample />

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -37,6 +37,7 @@
         "@fremtind/browserslist-config-jkl": "^0.4.14"
     },
     "peerDependencies": {
+        "@fremtind/jkl-core": "^3.0.0",
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
         "react": "^16.8.6",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -36,8 +36,10 @@
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.4.14"
     },
+    "dependencies": {
+        "@fremtind/jkl-core": "^3.0.0"
+    },
     "peerDependencies": {
-        "@fremtind/jkl-core": "^3.0.0",
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
         "react": "^16.8.6",

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -4,3 +4,5 @@ export { useFocusOutside } from "./useFocusOutside";
 export { useKeyListener } from "./useKeyListener";
 export { useMutationObserver } from "./useMutationObserver/useMutationObserver";
 export { useIntersectionObserver } from "./useIntersectionObserver/useIntersectionObserver";
+export { useScreen } from "./useScreen/useScreen";
+export { initialState as initialScreenState } from "./useScreen/state";

--- a/packages/react-hooks/src/useScreen/state.ts
+++ b/packages/react-hooks/src/useScreen/state.ts
@@ -1,0 +1,70 @@
+import { breakpoints } from "@fremtind/jkl-core";
+
+interface State {
+    isSmallDevice: boolean;
+    isMediumDevice: boolean;
+    isLargeDevice: boolean;
+    isXlDevice: boolean;
+    isLandscape: boolean;
+    isPortrait: boolean;
+    inner: {
+        height: number;
+        width: number;
+    };
+}
+
+enum ActionTypes {
+    resized = "WINDOW_RESIZED",
+}
+
+interface Action {
+    type: ActionTypes;
+    width: number;
+    height: number;
+}
+
+export const actionTypes = {
+    resized: ActionTypes.resized,
+};
+
+const setDeviceSize = (width: number, height: number) => ({
+    isSmallDevice: width < breakpoints.small,
+    isMediumDevice: width > breakpoints.small && width < breakpoints.medium,
+    isLargeDevice: width > breakpoints.medium && width < breakpoints.large,
+    isXlDevice: width > breakpoints.large,
+    isPortrait: height >= width,
+    isLandscape: height < width,
+    inner: {
+        height,
+        width,
+    },
+});
+
+export const initialState = {
+    isSmallDevice: false,
+    isMediumDevice: false,
+    isLargeDevice: false,
+    isXlDevice: false,
+    isLandscape: false,
+    isPortrait: false,
+    inner: {
+        height: 0,
+        width: 0,
+    },
+};
+
+export const init = () => {
+    const width = typeof window !== undefined ? window.innerWidth : 0;
+    const height = typeof window !== undefined ? window.innerHeight : 0;
+    return setDeviceSize(width, height);
+};
+
+export const reducer = (state: State, { type, width, height }: Action) => {
+    switch (type) {
+        case actionTypes.resized:
+            return {
+                ...state,
+                ...setDeviceSize(width, height),
+            };
+    }
+};

--- a/packages/react-hooks/src/useScreen/useScreen.ts
+++ b/packages/react-hooks/src/useScreen/useScreen.ts
@@ -1,0 +1,24 @@
+import { useEffect, useReducer } from "react";
+import { reducer, initialState, init, actionTypes } from "./state";
+
+export const useScreen = () => {
+    const [device, deviceDispatch] = useReducer(reducer, initialState, init);
+
+    const handleScreenChange = () =>
+        requestAnimationFrame(() =>
+            deviceDispatch({ type: actionTypes.resized, width: window.innerWidth, height: window.innerHeight }),
+        );
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            window.addEventListener("resize", handleScreenChange);
+        }
+        return () => {
+            if (typeof window !== "undefined") {
+                window.removeEventListener("resize", handleScreenChange);
+            }
+        };
+    }, []);
+
+    return { ...device };
+};


### PR DESCRIPTION
affects: @fremtind/jkl-core, @fremtind/jkl-react-hooks



## 📥 Proposed changes

Eksponerer våre breakpoints i javascript kontekst som en hook.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Per nå eksponerte jeg bare breakpointene i en ts fil. Kan også eksportere fra scss til js, men det virker til å være funksjonalitet lagt inn i webpack og ikke standard funksjonalitet. Virker ikke med parcel ut av boksen. 
Kanskje dette burde kommet fra Figma?
Alternativ implementasjon er å sette content på body elementet i scss, og plukke opp den derifra isteden for å bruke breakpointsa til å måle i js-kontekst.
document.getOrientation() kan brukes for å få landskap/portett modus, men det er bare støttet av mobilbrowsere, denne implementajsonen fungere i alle browsere(men gir kanskje bare mening i mobil)
