### PR TITLE
Add missing dependency to logo-react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ build/
 *.css
 dist/
 .idea/
+*.iml
 .DS_Store

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -33,12 +33,14 @@
         "dev": "run-p dev:*"
     },
     "dependencies": {
-        "@fremtind/jkl-logo": "^2.1.0"
+        "@fremtind/jkl-logo": "^2.1.0",
+        "nanoid": "^2.1.6"
     },
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.4.14",
         "@fremtind/jkl-field-group-react": "^1.2.1",
-        "@fremtind/jkl-toggle-switch-react": "^2.0.1"
+        "@fremtind/jkl-toggle-switch-react": "^2.0.1",
+        "@types/nanoid": "^2.0.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",


### PR DESCRIPTION
## 📥 Proposed changes

I've added `nanoid` in the `logo-react` package since it is used in that package.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)