### PR TITLE
fix(button): unset min-width on compact tertiary button

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -133,15 +133,21 @@ $hover-elevation-distance: -0.25rem;
         @include jkl-text-style("compact/body");
         font-weight: $bold-weight;
         height: $button-height--compact;
-        min-width: $button-min-width--compact;
         line-height: $button-height--compact;
+        min-width: $button-min-width--compact;
+        &.jkl-button--tertiary {
+            min-width: unset;
+        }
     }
 
     @include compact-mode {
         @include jkl-text-style("compact/body");
         font-weight: $bold-weight;
         height: $button-height--compact;
-        min-width: $button-min-width--compact;
         line-height: $button-height--compact;
+        min-width: $button-min-width--compact;
+        &.jkl-button--tertiary {
+            min-width: unset;
+        }
     }
 }


### PR DESCRIPTION
## 📥 Proposed changes

Fix bug where compact version of `TertiaryButton` had `min-width` even if it should not.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-button

Closes #802
