### PR TITLE
fix(datepicker-react): add handling of empty dates in datepicker

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -25,6 +25,17 @@ describe("Datepicker", () => {
         expect(changeHandler).toHaveBeenCalledTimes(1);
     });
 
+    it("fires onChange method with undefined when text input is cleared", () => {
+        const changeHandler = jest.fn();
+        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
+        const input = getByTestId("jkl-datepicker__input");
+        expect(input).toHaveProperty("value", "");
+        fireEvent.change(input, { target: { value: "some value to be cleared" } });
+        fireEvent.change(input, { target: { value: "" } });
+        expect(input).toHaveProperty("value", "");
+        expect(changeHandler).toHaveBeenCalledWith(undefined);
+    });
+
     it("does not fire onChange on edit input with invalid date", () => {
         const changeHandler = jest.fn();
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -27,7 +27,7 @@ interface Props {
     days?: string[];
     calendarButtonTitle?: string;
     initialDate?: Date;
-    onChange?: (date: Date) => void;
+    onChange?: (date?: Date) => void;
     extended?: boolean;
     initialShow?: boolean;
     className?: string;
@@ -130,6 +130,11 @@ export function DatePicker({
                 if (onChange) {
                     onChange(newDate);
                 }
+            }
+        } else if (newDateString === "") {
+            setDate(undefined);
+            if (onChange) {
+                onChange(undefined);
             }
         }
         setDateString(newDateString);


### PR DESCRIPTION
📥 Proposed changes

Handle "resetting" of the datepicker when the user clears the text input. Will call onChange with
undefined in those cases.

**NB!** This is a **BREAKING CHANGE**, as the `onChange` method passed as a prop to `Datepicker` must now accept a value of `undefined` in addition to a `Date` object:
```ts
onChange?: (date?: Date) => void;
```

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-datepicker-react
Closes #801
