### PR TITLE
fix(accordion): make accordion fill entire width of container

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -1,6 +1,10 @@
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/mixins/_all.scss";
 
+.jkl-accordion {
+    width: 100%;
+}
+
 .jkl-accordion-item {
     @include reset-outline;
 


### PR DESCRIPTION
affects: @fremtind/jkl-accordion

## 📥 Proposed changes

Fixes an issue where accordion does not take up the full width of its container, causing it to grow/shrink in width as it reveals/hides its content.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

