### PR TITLE
fix(table): fix bug causing shadow not to be drawn in IE 11

### DIFF
--- a/packages/table/table.scss
+++ b/packages/table/table.scss
@@ -36,7 +36,7 @@ $row-end-padding: $component-spacing--large;
     }
 
     &__row {
-        box-shadow: 0 $bottom-border-size 0 0 rgba(0, 0, 0, 0.2);
+        box-shadow: inset 0 -#{$bottom-border-size} 0 0 rgba(0, 0, 0, 0.2);
 
         &--anchor-row {
             cursor: pointer;


### PR DESCRIPTION
affects: @fremtind/jkl-table

is it then really a bug? what even is a bug? is zero a number? is 2 a prime?

## 📥 Proposed changes

Changed the styling of jkl-table__row into something that IE 11 can understand.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
