### PR TITLE
fix: move browserslist declaration to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
         "typescript": "^3.6.2",
         "vfile-message": "^2.0.2"
     },
+    "browserslist": [
+        "extends @fremtind/browserslist-config-jkl"
+    ],
     "workspaces": [
         "packages/*",
         "portal"

--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -38,7 +38,6 @@
         "@nrk/core-toggle": "^3.0.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -54,8 +53,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -27,9 +27,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -37,8 +34,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -39,7 +39,6 @@
         "@fremtind/jkl-button": "^1.4.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2",
         "@fremtind/jkl-toggle-switch-react": "^2.1.2"
     },
@@ -56,8 +55,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -30,9 +30,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -40,8 +37,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -35,7 +35,6 @@
         "@fremtind/jkl-card": "^1.2.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -51,8 +50,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -27,9 +27,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -37,8 +34,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -38,9 +38,6 @@
         "@fremtind/jkl-core": "^4.1.0",
         "nanoid": "^2.1.11"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "peerDependencies": {
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
@@ -54,8 +51,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -28,9 +28,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -38,8 +35,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,9 +41,6 @@
         "dev:js": "parcel documentation/index.html",
         "dev": "run-p dev:*"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -51,8 +48,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -40,7 +40,6 @@
         "@nrk/core-toggle": "^3.0.7"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-core": "^3.0.0",
         "@fremtind/jkl-portal-components": "^0.2.2",
         "@mdx-js/parcel-plugin-mdx": "^1.5.7"
@@ -58,8 +57,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -29,9 +29,6 @@
         "@fremtind/jkl-select": "^1.3.4",
         "@fremtind/jkl-text-input": "^1.3.4"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -39,8 +36,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/divider-line-react/package.json
+++ b/packages/divider-line-react/package.json
@@ -40,7 +40,6 @@
         "nanoid": "^2.1.6"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2",
         "@types/nanoid": "^2.0.0"
     },
@@ -57,8 +56,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/divider-line/package.json
+++ b/packages/divider-line/package.json
@@ -29,9 +29,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -39,8 +36,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/field-group-react/package.json
+++ b/packages/field-group-react/package.json
@@ -39,7 +39,6 @@
         "@fremtind/jkl-typography-react": "^2.1.2"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-core": "^4.1.0"
     },
     "peerDependencies": {

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -25,9 +25,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -35,8 +32,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/hamburger-react/package.json
+++ b/packages/hamburger-react/package.json
@@ -37,7 +37,6 @@
         "@fremtind/jkl-react-hooks": "^1.1.2"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -53,8 +52,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/hamburger/package.json
+++ b/packages/hamburger/package.json
@@ -27,9 +27,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -37,8 +34,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -38,7 +38,6 @@
         "@fremtind/jkl-list": "^1.2.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -54,8 +53,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -30,9 +30,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -40,8 +37,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -36,7 +36,6 @@
         "@fremtind/jkl-loader": "^1.1.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -52,8 +51,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -27,9 +27,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -37,8 +34,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -37,7 +37,6 @@
         "nanoid": "^2.1.11"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -53,8 +52,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -26,9 +26,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -36,8 +33,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -37,7 +37,6 @@
         "@fremtind/jkl-message-box": "^1.2.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-core": "^4.1.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
@@ -54,8 +53,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -26,9 +26,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -36,8 +33,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -35,7 +35,6 @@
         "dev": "run-p dev:*"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-checkbox-react": "^1.2.2",
         "@fremtind/jkl-core": "^3.0.0",
         "@fremtind/jkl-radio-button-react": "^1.2.1",
@@ -56,9 +55,6 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "dependencies": {
         "@fremtind/jkl-radio-button-react": "^1.3.2"
     },

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -36,7 +36,6 @@
         "@fremtind/jkl-progress-bar": "^1.2.4"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -52,8 +51,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -27,9 +27,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -37,8 +34,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -38,9 +38,6 @@
         "@fremtind/jkl-field-group-react": "^1.3.2",
         "@fremtind/jkl-radio-button": "^1.2.4"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "peerDependencies": {
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
@@ -54,8 +51,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -29,9 +29,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -39,8 +36,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -34,7 +34,6 @@
         "dev": "run-p dev:*"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "dependencies": {
@@ -53,8 +52,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -43,7 +43,6 @@
         "nanoid": "^2.1.6"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2",
         "@types/nanoid": "^2.0.0"
     },
@@ -60,8 +59,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -28,9 +28,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -38,8 +35,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -35,7 +35,6 @@
         "@fremtind/jkl-core": "^4.1.0"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2",
         "npm-run-all": "^4.1.5"
     },
@@ -52,8 +51,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -24,9 +24,6 @@
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev": "parcel example/index.html"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -34,8 +31,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "6e8cfc145a406bc8e38ffe53ad9600bb73ea4ff8"
 }

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -41,7 +41,6 @@
         "@fremtind/jkl-typography-react": "^2.1.2"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
     "peerDependencies": {
@@ -57,8 +56,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -31,9 +31,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -41,8 +38,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -39,7 +39,6 @@
         "@fremtind/jkl-typography-react": "^2.1.2"
     },
     "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0",
         "@fremtind/jkl-core": "^4.1.0",
         "@fremtind/jkl-portal-components": "^0.2.2"
     },
@@ -56,8 +55,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -29,9 +29,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/fremtind/jokul.git"
@@ -39,8 +36,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/typography-react/package.json
+++ b/packages/typography-react/package.json
@@ -39,9 +39,6 @@
     "dependencies": {
         "@fremtind/jkl-core": "^4.1.0"
     },
-    "devDependencies": {
-        "@fremtind/browserslist-config-jkl": "^0.5.0"
-    },
     "peerDependencies": {
         "@types/react": "^16.8.17",
         "@types/react-dom": "^16.8.4",
@@ -55,8 +52,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/webfonts/package.json
+++ b/packages/webfonts/package.json
@@ -29,8 +29,5 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "browserslist": [
-        "extends @fremtind/browserslist-config-jkl"
-    ],
     "gitHead": "6e8cfc145a406bc8e38ffe53ad9600bb73ea4ff8"
 }


### PR DESCRIPTION
## 📥 Proposed changes

Move browserslist declaration to root package.json and remove the browserslist-config-jkl package as a dependency from the other packages. This solves a bug where our packages would cause issues with PostCSS when used in other projects.

Closes #862 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-accordion-react, @fremtind/jkl-accordion, @fremtind/jkl-button-react,
@fremtind/jkl-button, @fremtind/jkl-card-react, @fremtind/jkl-card, @fremtind/jkl-checkbox-react,
@fremtind/jkl-checkbox, @fremtind/jkl-core, @fremtind/jkl-datepicker-react,
@fremtind/jkl-datepicker, @fremtind/jkl-divider-line-react, @fremtind/jkl-divider-line,
@fremtind/jkl-field-group-react, @fremtind/jkl-field-group, @fremtind/jkl-hamburger-react,
@fremtind/jkl-hamburger, @fremtind/jkl-list-react, @fremtind/jkl-list, @fremtind/jkl-loader-react,
@fremtind/jkl-loader, @fremtind/jkl-logo-react, @fremtind/jkl-logo, @fremtind/jkl-message-box-react,
@fremtind/jkl-message-box, @fremtind/jkl-portal-components, @fremtind/jkl-progress-bar-react,
@fremtind/jkl-progress-bar, @fremtind/jkl-radio-button-react, @fremtind/jkl-radio-button,
@fremtind/jkl-react-hooks, @fremtind/jkl-select-react, @fremtind/jkl-select,
@fremtind/jkl-table-react, @fremtind/jkl-table, @fremtind/jkl-text-input-react,
@fremtind/jkl-text-input, @fremtind/jkl-toggle-switch-react, @fremtind/jkl-toggle-switch,
@fremtind/jkl-typography-react, @fremtind/jkl-webfonts
