### PR TITLE
chore: remove greenkeeper-specific github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,3 @@ jobs:
                   yarn install --frozen-lockfile
                   yarn build
                   yarn ci:test
-            - name: Lint and test (greenkeeper)
-              if: contains(github.ref, 'greenkeeper/')
-              run: |
-                  yarn install
-                  yarn build
-                  yarn ci:test


### PR DESCRIPTION
## 📥 Proposed changes

Remove the GitHub action for testing/linting Greenkeeper branches, since Greenkeeper is no more..

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
