### PR TITLE
fix: use correct height for compact text inputs

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -10,7 +10,7 @@ $border-color--focus: $focus-color;
 $bottom-padding: $component-spacing--small;
 $input-line-height: $line-height-4;
 $input-height: $input-line-height + $bottom-padding;
-$input-line-height--small-device: $line-height-3;
+$input-line-height--small-device: $line-height-2;
 $input-height--small-device: $input-line-height--small-device + $bottom-padding;
 
 $textarea-expanded-height: $input-line-height * 7 + $bottom-padding;


### PR DESCRIPTION
## 📥 Proposed changes

Hotfix for wrong height on compact text inputs

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-text-input

Closes #877
