### PR TITLE
feat(formatting): add code highlighting to mdx parser

### DIFF
--- a/portal/gatsby-browser.js
+++ b/portal/gatsby-browser.js
@@ -28,6 +28,8 @@ import "@fremtind/jkl-text-input/text-input.min.css";
 import "@fremtind/jkl-toggle-switch/toggle-switch.min.css";
 import { initTabListener } from "@fremtind/jkl-core";
 
+import "@fremtind/jkl-portal-components/component-example.scss";
+
 import "./src/components/Typography/typography.scss";
 import { ThemeContextProvider } from "./src/contexts/themeContext";
 import { FSMenuContextProvider } from "./src/contexts/fullscreenMenuContext";

--- a/portal/src/components/Typography/FormatProvider.tsx
+++ b/portal/src/components/Typography/FormatProvider.tsx
@@ -3,10 +3,8 @@ import { MDXProvider } from "@mdx-js/react";
 import { Link } from "@fremtind/jkl-typography-react";
 import { OrderedList, UnorderedList, ListItem } from "@fremtind/jkl-list-react";
 import { ComponentExample } from "@fremtind/jkl-portal-components";
-import "@fremtind/jkl-portal-components/component-example.scss";
-import { DoDontExample } from "../DoDontExample";
-import "./typography.scss";
 
+import { DoDontExample } from "../DoDontExample";
 import {
     PageTitle,
     HeadingLarge,
@@ -14,6 +12,8 @@ import {
     HeadingSmall,
     HeadingXS,
     Paragraph,
+    InlineCode,
+    CodeBlock,
     ArticleLead as Ingress,
 } from "../Typography";
 
@@ -28,6 +28,8 @@ const components = {
     ol: OrderedList,
     li: ListItem,
     a: Link,
+    pre: CodeBlock,
+    inlineCode: InlineCode,
     Ingress,
     ComponentExample,
     DoDontExample,

--- a/portal/src/components/Typography/Typography.tsx
+++ b/portal/src/components/Typography/Typography.tsx
@@ -1,46 +1,81 @@
-import React, { HTMLAttributes } from "react";
+import React, { ReactElement } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { prism } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-type HeadingProps = HTMLAttributes<HTMLHeadingElement>;
-type ParagraphProps = HTMLAttributes<HTMLParagraphElement>;
-
-export const PageTitle = ({ children, ...rest }: HeadingProps) => (
+export const PageTitle: React.FC = ({ children, ...rest }) => (
     <h1 className="jkl-title-large jkl-portal-page-title" {...rest}>
         {children}
     </h1>
 );
 
-export const HeadingLarge = ({ children, ...rest }: HeadingProps) => (
+export const HeadingLarge: React.FC = ({ children, ...rest }) => (
     <h2 className="jkl-heading-large jkl-portal-heading-large" {...rest}>
         {children}
     </h2>
 );
 
-export const HeadingMedium = ({ children, ...rest }: HeadingProps) => (
+export const HeadingMedium: React.FC = ({ children, ...rest }) => (
     <h3 className="jkl-heading-medium jkl-portal-heading-medium" {...rest}>
         {children}
     </h3>
 );
 
-export const HeadingSmall = ({ children, ...rest }: HeadingProps) => (
+export const HeadingSmall: React.FC = ({ children, ...rest }) => (
     <h4 className="jkl-heading-small jkl-portal-heading-small" {...rest}>
         {children}
     </h4>
 );
 
-export const HeadingXS = ({ children, ...rest }: HeadingProps) => (
+export const HeadingXS: React.FC = ({ children, ...rest }) => (
     <h5 className="jkl-micro jkl-portal-heading-xs" {...rest}>
         {children}
     </h5>
 );
 
-export const ArticleLead = ({ children, ...rest }: ParagraphProps) => (
+export const ArticleLead: React.FC = ({ children, ...rest }) => (
     <p className="jkl-lead jkl-portal-article-lead" {...rest}>
         {children}
     </p>
 );
 
-export const Paragraph = ({ children, ...rest }: ParagraphProps) => (
+export const Paragraph: React.FC = ({ children, ...rest }) => (
     <p className="jkl-body jkl-portal-paragraph" {...rest}>
         {children}
     </p>
 );
+
+export const InlineCode: React.FC = ({ children, ...rest }) => (
+    <code className="jkl-portal-inline-code" {...rest}>
+        {children}
+    </code>
+);
+
+export const CodeBlock: React.FC = ({ children, ...rest }) => {
+    const child: ReactElement = React.Children.only(children) as ReactElement;
+    if (!child.props) {
+        // if there is more than one child, or it is text return a normal pre
+        return <pre {...rest}>{children}</pre>;
+    }
+    const language = child.props.className.replace("language-", "");
+    const style = {
+        ...prism,
+        'pre[class*="language-"]': {
+            lineHeight: "1.4",
+        },
+        operator: {
+            ...prism.operator,
+            background: "transparent",
+        },
+    };
+    return (
+        <SyntaxHighlighter
+            className="jkl-portal-code-block"
+            style={style}
+            codeTagProps={{ style: {}, className: "jkl-portal-code-block__code" }}
+            language={language}
+            data-language={language}
+        >
+            {child.props.children}
+        </SyntaxHighlighter>
+    );
+};

--- a/portal/src/components/Typography/index.ts
+++ b/portal/src/components/Typography/index.ts
@@ -1,2 +1,12 @@
-export { Paragraph, HeadingLarge, HeadingMedium, HeadingSmall, HeadingXS, ArticleLead, PageTitle } from "./Typography";
+export {
+    Paragraph,
+    HeadingLarge,
+    HeadingMedium,
+    HeadingSmall,
+    HeadingXS,
+    ArticleLead,
+    PageTitle,
+    InlineCode,
+    CodeBlock,
+} from "./Typography";
 export { FormatProvider } from "./FormatProvider";

--- a/portal/src/components/Typography/typography.scss
+++ b/portal/src/components/Typography/typography.scss
@@ -54,10 +54,8 @@
 .jkl-portal-inline-code {
     display: inline-block;
     background-color: $gra-20;
-    font-size: rem(16px);
+    font-size: 0.8em;
     padding: 0 $component-spacing--small;
-    margin: 0 $component-spacing--xxs;
-    transform: translateY(rem(-2px));
     border-radius: rem(2px);
 
     *[data-theme="dark"] & {
@@ -68,8 +66,9 @@
 .jkl-portal-code-block {
     position: relative;
     background-color: $gra-20;
-    padding: $component-spacing--xl $component-spacing--large;
     border-radius: rem(2px);
+    width: 100%;
+    max-width: rem(768px);
 
     &:before {
         position: absolute;
@@ -81,6 +80,12 @@
         @include jkl-text-style("desktop/micro");
         text-transform: uppercase;
         content: attr(data-language);
+    }
+
+    &__code {
+        display: block;
+        padding: $component-spacing--xl $component-spacing--large;
+        overflow-x: scroll;
     }
 
     *[data-theme="dark"] & {


### PR DESCRIPTION
## 📥 Proposed changes

Add back code highlighting (both inline and for blocks) that we lost when moving from markdownRemark to mdx

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal
