### PR TITLE
Add missing event handlers to Select and DatePicker

### DIFF
--- a/packages/datepicker-react/documentation/Example.tsx
+++ b/packages/datepicker-react/documentation/Example.tsx
@@ -9,6 +9,8 @@ export const Example = ({ boolValues, choiceValues }: ExampleComponentProps) => 
     const errorLabel = boolValues && boolValues["Med feil"] ? "Du kan ikke velge en dato som har vært" : undefined;
     const variant = choiceValues && (choiceValues["Variant"] as LabelVariant);
 
+    const logDate = (message: string) => (date: Date | undefined) => console.log(message, date);
+
     return (
         <DatePicker
             label="Velg startdato for forsikringen"
@@ -17,6 +19,9 @@ export const Example = ({ boolValues, choiceValues }: ExampleComponentProps) => 
             variant={variant}
             errorLabel={errorLabel}
             helpLabel={helpLabel}
+            onFocus={logDate("hello from onFocus")}
+            onBlur={logDate("hello from onBlur")}
+            onChange={logDate("hello from onChange")}
         />
     );
 };

--- a/packages/select-react/documentation/Example.tsx
+++ b/packages/select-react/documentation/Example.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent } from "react";
+import React, { FocusEvent, useState, ChangeEvent } from "react";
 import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
 import { Select, NativeSelect } from "../src";
 import { LabelVariant } from "@fremtind/jkl-core";
@@ -13,12 +13,19 @@ export const Example = ({ boolValues, choiceValues }: ExampleComponentProps) => 
         { value: "secondvalue", label: "Value 2" },
     ];
     const [value, setValue] = useState<string>();
-    const universalSetValue = (input: string | ChangeEvent<HTMLSelectElement>) => {
+    const universalSetValue = (input: string | ChangeEvent<HTMLSelectElement> | undefined) => {
         if (typeof input === "string") {
             setValue(input);
-        } else {
+        } else if (input) {
             setValue(input.target.value);
         }
+    };
+
+    const onFocus = (input: string | FocusEvent<HTMLSelectElement> | undefined) => {
+        console.log("Focus: ", input);
+    };
+    const onBlur = (input: string | FocusEvent<HTMLSelectElement> | undefined) => {
+        console.log("Blur: ", input);
     };
 
     const errorLabel = boolValues && boolValues["Med feil"] ? "Beskrivende feilmelding" : undefined;
@@ -35,6 +42,8 @@ export const Example = ({ boolValues, choiceValues }: ExampleComponentProps) => 
             helpLabel={helpLabel}
             errorLabel={errorLabel}
             onChange={universalSetValue}
+            onBlur={onBlur}
+            onFocus={onFocus}
         />
     );
 };

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -1,6 +1,6 @@
 /* eslint "jsx-a11y/no-onchange": 0 */
 
-import React from "react";
+import React, { FocusEventHandler, ChangeEventHandler } from "react";
 import { LabelVariant, ValuePair, getValuePair } from "@fremtind/jkl-core";
 import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 import classNames from "classnames";
@@ -8,22 +8,23 @@ import classNames from "classnames";
 interface Props {
     label: string;
     items: Array<string | ValuePair>;
-    inline?: boolean;
     className?: string;
-    onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    inline?: boolean;
     helpLabel?: string;
     errorLabel?: string;
     variant?: LabelVariant;
     placeholder?: string;
     value?: string;
     forceCompact?: boolean;
+    onChange?: ChangeEventHandler<HTMLSelectElement>;
+    onFocus?: FocusEventHandler<HTMLSelectElement>;
+    onBlur?: FocusEventHandler<HTMLSelectElement>;
 }
 
 export function NativeSelect({
     label,
     items,
     className = "",
-    onChange,
     inline = false,
     helpLabel,
     errorLabel,
@@ -31,6 +32,9 @@ export function NativeSelect({
     placeholder,
     value,
     forceCompact,
+    onChange,
+    onBlur,
+    onFocus,
 }: Props) {
     // If no value is given, set it to first item, or to empty string if there is a placeholder
     if (!value) {
@@ -56,8 +60,9 @@ export function NativeSelect({
                 value={value}
                 defaultValue={defaultValue}
                 className="jkl-select__value"
-                onBlur={onChange}
                 onChange={onChange}
+                onBlur={onBlur || onChange}
+                onFocus={onFocus}
             >
                 {placeholder && !value && (
                     <option disabled value="">

--- a/packages/text-input-react/documentation/Example.tsx
+++ b/packages/text-input-react/documentation/Example.tsx
@@ -14,7 +14,7 @@ const Example = () => {
     const [hasError, setHasError] = useState(false);
     const [isCompact, setIsCompact] = useState(false);
     const [variant, setVariant] = useState<LabelVariant | undefined>("medium");
-    const typecheckAndSetVariant = (val: string) => {
+    const typecheckAndSetVariant = (val?: string) => {
         if (val === "large" || val === "medium" || val === "small") {
             setVariant(val);
         } else {


### PR DESCRIPTION
## 📥 Proposed changes

Adds `onFocus`and `onBlur` props to Select, NativeSelect and DatePicker.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Should close #886 
