### PR TITLE
fix(codeblock): account for code blocks without language

### DIFF
--- a/portal/src/components/Typography/Typography.tsx
+++ b/portal/src/components/Typography/Typography.tsx
@@ -56,7 +56,7 @@ export const CodeBlock: React.FC = ({ children, ...rest }) => {
         // if there is more than one child, or it is text return a normal pre
         return <pre {...rest}>{children}</pre>;
     }
-    const language = child.props.className.replace("language-", "");
+    const language = child.props.className?.replace("language-", "");
     const style = {
         ...prism,
         'pre[class*="language-"]': {


### PR DESCRIPTION
## 📥 Proposed changes

Fixes a bug in the `CodeBlock` typographic component in the Portal, that caused page builds to fail if a Markdown code block had no assigned language.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal
