### PR TITLE
feat(links): add external prop and style to links

### DIFF
--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -31,8 +31,7 @@ $link-side-padding: 0.075em; // relative value to work with all paragraph styles
     /* Show arrow after external links, or links opening
     in a new window or tab: */
     &[target="_blank"],
-    &[href^="http://"],
-    &[href^="https://"] {
+    &--external {
         &:after {
             content: "\2197"; // unicode north east arrow (up/right)
         }

--- a/packages/typography-react/documentation/Example.tsx
+++ b/packages/typography-react/documentation/Example.tsx
@@ -18,6 +18,13 @@ const Example = () => (
         <SupportLabel errorLabel="Feilmelding" />
         <h2 className="jkl-heading-small jkl-spacing--bottom-1 jkl-spacing--top-3">Link</h2>
         <p className="jkl-body" style={{ padding: "1.5rem" }}>
+            Lorem ipsum dolor sin amet{" "}
+            <Link href="#" external>
+                External Link
+            </Link>{" "}
+            consectetur adipiscing elit
+        </p>
+        <p className="jkl-body" style={{ padding: "1.5rem" }}>
             Lorem ipsum dolor sin amet <Link href="#">Link</Link> consectetur adipiscing elit
         </p>
         <p className="jkl-body" style={{ backgroundColor: "#181818", color: "#FFF", padding: "1.5rem" }}>

--- a/packages/typography-react/src/Link.tsx
+++ b/packages/typography-react/src/Link.tsx
@@ -1,12 +1,20 @@
 import React, { AnchorHTMLAttributes, ReactNode } from "react";
+import classnames from "classnames";
 
 interface Props extends Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "rel" | "target" | "className" | "href"> {
     negative?: boolean;
+    external?: boolean;
     children: ReactNode;
 }
 
-export const Link = ({ negative = false, children, className = "", ...rest }: Props) => (
-    <a className={`jkl-link  ${negative ? "jkl-link--negative" : ""} ${className}`} {...rest}>
+export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => (
+    <a
+        className={classnames("jkl-link", className, {
+            "jkl-link--negative": negative,
+            "jkl-link--external": external,
+        })}
+        {...rest}
+    >
         {children}
     </a>
 );


### PR DESCRIPTION
affects: @fremtind/jkl-core, @fremtind/jkl-typography-react

ISSUES CLOSED: #905

## 📥 Proposed changes

Ettersom vi har funnet at http/https-sjekk på `.jkl-link` kan være for aggressivt, er denne sjekken byttet ut med `.jkl-link--external` for å få samme styling.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
