### PR TITLE
fix(example-knobs): use unique field names on knobs

### DIFF
--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -56,7 +56,8 @@
         "url": "https://github.com/fremtind/jokul/issues"
     },
     "dependencies": {
-        "@fremtind/jkl-radio-button-react": "^1.3.5"
+        "classnames": "^2.2.6",
+        "nanoid": "^3.1.3"
     },
     "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
 }

--- a/packages/portal-components/src/ComponentExample.tsx
+++ b/packages/portal-components/src/ComponentExample.tsx
@@ -1,5 +1,6 @@
 import React, { createElement, useState, useLayoutEffect } from "react";
 import classNames from "classnames";
+import { nanoid } from "nanoid";
 import { Checkbox } from "@fremtind/jkl-checkbox-react";
 import { RadioButtons } from "@fremtind/jkl-radio-button-react";
 import { Dictionary, ExampleComponentProps, ChoiceProp } from "../src";
@@ -12,6 +13,7 @@ export interface Props {
     };
 }
 export function ComponentExample({ component, knobs }: Props) {
+    const [uid] = useState(`example${nanoid(8)}`);
     const [boolValues, setBoolValues] = useState<Dictionary<boolean>>({});
     const [choices, setChoices] = useState<Dictionary<string[]>>({});
     const [choiceValues, setChoiceValues] = useState<Dictionary<string>>({});
@@ -65,7 +67,7 @@ export function ComponentExample({ component, knobs }: Props) {
                         {Object.entries(boolValues).map(([key, value]) => (
                             <Checkbox
                                 key={key}
-                                name={key}
+                                name={`${uid}-${key}`}
                                 value={key}
                                 checked={value}
                                 onChange={(e) => setBoolValue(key, e.target.checked)}
@@ -79,7 +81,7 @@ export function ComponentExample({ component, knobs }: Props) {
                                     className="jkl-portal-component-example__choice-option"
                                     variant="small"
                                     key={key}
-                                    name={key}
+                                    name={`${uid}-${key}`}
                                     legend={key}
                                     choices={[...choices[key]]}
                                     selectedValue={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12909,6 +12909,11 @@ nanoid@^2.1.11, nanoid@^2.1.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
+nanoid@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.3.tgz#b2bcfcfda4b4d6838bc22a0c8dd3c0a17a204c20"
+  integrity sha512-Zw8rTOUfh6FlKgkEbHiB1buOF2zOPOQyGirABUWn+9Z7m9PpyoLVkh6Ksc53vBjndINQ2+9LfRPaHxb/u45EGg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
## 📥 Proposed changes

Use unique field names in the `ComponentExample` component, to avoid issues when several examples with the same variable names are used on the same page.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

ISSUES CLOSED: #920

affects: @fremtind/jkl-portal-components
