### PR TITLE
fix(icon-button): specify height of icon to correct alignment

### DIFF
--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -1,4 +1,5 @@
 @import "~@fremtind/jkl-core/mixins/_helpers.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
 
 .jkl-icon-button {
     @include reset-outline;
@@ -8,6 +9,7 @@
 
     &__icon {
         display: inline-block;
-        width: 1.25rem;
+        width: rem(20px);
+        height: rem(20px);
     }
 }


### PR DESCRIPTION
affects: @fremtind/jkl-icon-button

## 📥 Proposed changes

Specify the height of the icon in `IconButton` to avoid alignment issues like the one illustradet below.

Before: uneven spacing
<img width="303" alt="Skjermbilde 2020-04-27 kl  17 11 32" src="https://user-images.githubusercontent.com/25739615/80388780-95f68380-88aa-11ea-86c3-82a9b9364a50.png">

After: even spacing
<img width="316" alt="Skjermbilde 2020-04-27 kl  17 12 54" src="https://user-images.githubusercontent.com/25739615/80388828-a4dd3600-88aa-11ea-949f-29ca64da82c2.png">

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
