### PR TITLE
feat(text-input-react): add functionality to pass onKey events

### DIFF
--- a/packages/text-input-react/documentation/TextAreaExample.tsx
+++ b/packages/text-input-react/documentation/TextAreaExample.tsx
@@ -26,6 +26,7 @@ export function TextAreaExample({ choiceValues, boolValues }: ExampleComponentPr
             autoExpand={autoExpand}
             value={value}
             onChange={handleChange}
+            onKeyDown={() => console.log("onKeyDown event")}
         />
     );
 }

--- a/packages/text-input-react/documentation/TextInputExample.tsx
+++ b/packages/text-input-react/documentation/TextInputExample.tsx
@@ -36,6 +36,7 @@ export function TextInputExample({ choiceValues, boolValues }: ExampleComponentP
             maxLength={35}
             value={value}
             onChange={handleChange}
+            onKeyDown={() => console.log("onKeyDown event")}
         />
     );
 }

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, FocusEventHandler, CSSProperties, forwardRef } from "react";
+import React, { ChangeEventHandler, FocusEventHandler, CSSProperties, forwardRef, KeyboardEventHandler } from "react";
 
 export interface BaseProps {
     id?: string;
@@ -9,6 +9,9 @@ export interface BaseProps {
     onChange?: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     onFocus?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+    onKeyDown?: KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+    onKeyUp?: KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+    onKeyPress?: KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     placeholder?: string;
     readOnly?: boolean;
     autoComplete?: string;


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react

closes #927 

## 📥 Proposed changes

La til onKeyDown, onKeyUp og onKeyPress til interface.

Jeg la også til en console.log i eksemplene.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
