### PR TITLE
Flytt typografikomponentene

### DIFF
--- a/packages/core/src/components/Label.tsx
+++ b/packages/core/src/components/Label.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React from "react";
 import { LabelVariant } from "../index";
 import classNames from "classnames";
 
@@ -6,12 +6,11 @@ interface Props {
     variant?: LabelVariant;
     forceCompact?: boolean;
     srOnly?: boolean;
-    children: ReactNode;
     standAlone?: boolean;
     htmlFor?: string;
 }
 
-export function Label({ variant = "medium", forceCompact, srOnly, children, standAlone, htmlFor }: Props) {
+export const Label: React.FC<Props> = ({ variant = "medium", forceCompact, srOnly, children, standAlone, htmlFor }) => {
     const className = classNames("jkl-label", {
         [`jkl-label--${variant}`]: variant,
         "jkl-label--compact": forceCompact,
@@ -34,4 +33,4 @@ export function Label({ variant = "medium", forceCompact, srOnly, children, stan
             {children}
         </C>
     );
-}
+};

--- a/packages/core/src/components/Label.tsx
+++ b/packages/core/src/components/Label.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { LabelVariant } from "@fremtind/jkl-core";
+import { LabelVariant } from "../index";
 import classNames from "classnames";
 
 interface Props {

--- a/packages/core/src/components/Label.tsx
+++ b/packages/core/src/components/Label.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode } from "react";
+import { LabelVariant } from "@fremtind/jkl-core";
+import classNames from "classnames";
+
+interface Props {
+    variant?: LabelVariant;
+    forceCompact?: boolean;
+    srOnly?: boolean;
+    children: ReactNode;
+    standAlone?: boolean;
+    htmlFor?: string;
+}
+
+export function Label({ variant = "medium", forceCompact, srOnly, children, standAlone, htmlFor }: Props) {
+    const className = classNames("jkl-label", {
+        [`jkl-label--${variant}`]: variant,
+        "jkl-label--compact": forceCompact,
+        "jkl-label--sr-only": srOnly,
+    });
+
+    const C = standAlone ? "label" : "span";
+
+    if (!standAlone && htmlFor) {
+        htmlFor = undefined;
+        if (process.env.NODE_ENV !== "production") {
+            console.warn(
+                "WARNING: The standard Label component renders as a <span> element, which does not take a htmlFor prop. If you want the Label to belong to a specific input, use the standAlone prop, which renders as a <label> element instead. In most cases the Label component should not be used directly, as it is part of all our input components.",
+            );
+        }
+    }
+
+    return (
+        <C className={className} htmlFor={htmlFor}>
+            {children}
+        </C>
+    );
+}

--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -1,0 +1,20 @@
+import React, { AnchorHTMLAttributes, ReactNode } from "react";
+import classnames from "classnames";
+
+interface Props extends Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "rel" | "target" | "className" | "href"> {
+    negative?: boolean;
+    external?: boolean;
+    children: ReactNode;
+}
+
+export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => (
+    <a
+        className={classnames("jkl-link", className, {
+            "jkl-link--negative": negative,
+            "jkl-link--external": external,
+        })}
+        {...rest}
+    >
+        {children}
+    </a>
+);

--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -1,13 +1,12 @@
-import React, { AnchorHTMLAttributes, ReactNode } from "react";
+import React, { AnchorHTMLAttributes } from "react";
 import classnames from "classnames";
 
-interface Props extends Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "rel" | "target" | "className" | "href"> {
+interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
     negative?: boolean;
     external?: boolean;
-    children: ReactNode;
 }
 
-export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => (
+export const Link: React.FC<Props> = ({ negative = false, external = false, className = "", children, ...rest }) => (
     <a
         className={classnames("jkl-link", className, {
             "jkl-link--negative": negative,

--- a/packages/core/src/components/SupportLabel.test.tsx
+++ b/packages/core/src/components/SupportLabel.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { SupportLabel } from "./SupportLabel";
+
+describe("SupportLabel", () => {
+    afterEach(cleanup);
+
+    const helpLabel = "helpfull text";
+    const errorLabel = "error error error, read in a computer voice";
+
+    it("renders with help text when valid", () => {
+        const { getByText } = render(
+            <SupportLabel errorLabel={false ? errorLabel : undefined} helpLabel={helpLabel} />,
+        );
+
+        expect(getByText(helpLabel)).toBeInTheDocument();
+    });
+
+    it("renders with error text when invalid", () => {
+        const { getByText } = render(<SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} />);
+
+        expect(getByText(errorLabel)).toBeInTheDocument();
+    });
+
+    it("renders with error text when invalid without help text", () => {
+        const { getByText } = render(<SupportLabel errorLabel={errorLabel} />);
+
+        expect(getByText(errorLabel)).toBeInTheDocument();
+    });
+
+    it("renders with help text when valid without error text", () => {
+        const { getByText } = render(<SupportLabel helpLabel={helpLabel} />);
+
+        expect(getByText(helpLabel)).toBeInTheDocument();
+    });
+});

--- a/packages/core/src/components/SupportLabel.tsx
+++ b/packages/core/src/components/SupportLabel.tsx
@@ -11,7 +11,15 @@ interface Props {
     inverted?: boolean;
 }
 
-export const SupportLabel = ({ id, helpLabel, errorLabel, forceCompact, className, srOnly, inverted }: Props) => {
+export const SupportLabel: React.FC<Props> = ({
+    id,
+    helpLabel,
+    errorLabel,
+    forceCompact,
+    className,
+    srOnly,
+    inverted,
+}) => {
     const componentClassName = classNames("jkl-form-support-label", className, {
         "jkl-form-support-label--compact": forceCompact,
         "jkl-form-support-label--error": errorLabel,

--- a/packages/core/src/components/SupportLabel.tsx
+++ b/packages/core/src/components/SupportLabel.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import classNames from "classnames";
+
+interface Props {
+    id?: string;
+    helpLabel?: string;
+    errorLabel?: string;
+    forceCompact?: boolean;
+    className?: string;
+    srOnly?: boolean;
+    inverted?: boolean;
+}
+
+export const SupportLabel = ({ id, helpLabel, errorLabel, forceCompact, className, srOnly, inverted }: Props) => {
+    const componentClassName = classNames("jkl-form-support-label", className, {
+        "jkl-form-support-label--compact": forceCompact,
+        "jkl-form-support-label--error": errorLabel,
+        "jkl-form-support-label--help": !errorLabel,
+        "jkl-form-support-label--sr-only": srOnly,
+        "jkl-form-support-label--inverted": inverted,
+    });
+
+    if (errorLabel || helpLabel) {
+        return (
+            <span id={id} className={componentClassName}>
+                {errorLabel || helpLabel}
+            </span>
+        );
+    }
+
+    return null;
+};

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,1 +1,4 @@
 export { ScreenReaderOnly } from "./ScreenReaderOnly";
+export { Label } from "./Label";
+export { Link } from "./Link";
+export { SupportLabel } from "./SupportLabel";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { initTabListener, getValuePair, breakpoints } from "./utils";
-export { ScreenReaderOnly } from "./components";
+export { Label, Link, ScreenReaderOnly, SupportLabel } from "./components";
 
 export type LabelVariant = "small" | "medium" | "large";
 export type ValuePair = {

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -39,6 +39,7 @@
         "@fremtind/jkl-select-react": "^2.0.0",
         "@fremtind/jkl-text-input-react": "^3.0.0",
         "@fremtind/jkl-typography-react": "^2.3.1",
+        "@fremtind/jkl-core": "^4.3.0",
         "@nrk/core-datepicker": "^3.0.7",
         "@nrk/core-toggle": "^3.0.7"
     },

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -38,7 +38,6 @@
         "@fremtind/jkl-react-hooks": "^1.1.7",
         "@fremtind/jkl-select-react": "^2.0.0",
         "@fremtind/jkl-text-input-react": "^3.0.0",
-        "@fremtind/jkl-typography-react": "^2.3.1",
         "@fremtind/jkl-core": "^4.3.0",
         "@nrk/core-datepicker": "^3.0.7",
         "@nrk/core-toggle": "^3.0.7"

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,10 +1,6 @@
 import React, { ChangeEvent, useState, useEffect, useRef, FocusEvent, useCallback } from "react";
 import nanoid from "nanoid";
 import classNames from "classnames";
-// @ts-ignore
-import CoreDatepicker from "@nrk/core-datepicker/jsx";
-// @ts-ignore
-import CoreToggle from "@nrk/core-toggle/jsx";
 
 import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { BaseInputField } from "@fremtind/jkl-text-input-react";

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,11 +1,14 @@
 import React, { ChangeEvent, useState, useEffect, useRef, FocusEvent, useCallback } from "react";
 import nanoid from "nanoid";
 import classNames from "classnames";
+// @ts-ignore
+import CoreDatepicker from "@nrk/core-datepicker/jsx";
+// @ts-ignore
+import CoreToggle from "@nrk/core-toggle/jsx";
 
-import { LabelVariant } from "@fremtind/jkl-core";
+import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { BaseInputField } from "@fremtind/jkl-text-input-react";
 import { useAnimatedHeight, useKeyListener, useClickOutside } from "@fremtind/jkl-react-hooks";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
 
 import { Calendar } from "./Calendar";

--- a/packages/field-group-react/src/FieldGroup.tsx
+++ b/packages/field-group-react/src/FieldGroup.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from "react";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
-import { LabelVariant } from "@fremtind/jkl-core";
+import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import classNames from "classnames";
 
 interface Props {

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -2,8 +2,7 @@
 
 import React, { FocusEventHandler, ChangeEventHandler, useState, forwardRef } from "react";
 import nanoid from "nanoid";
-import { LabelVariant, ValuePair, getValuePair } from "@fremtind/jkl-core";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
+import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
 import classNames from "classnames";
 
 import { ExpandArrow } from "./ExpandArrow";

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -2,8 +2,7 @@
 import CoreToggle from "@nrk/core-toggle/jsx";
 import React, { useState, useEffect, useCallback } from "react";
 import nanoid from "nanoid";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
-import { LabelVariant, ValuePair, getValuePair } from "@fremtind/jkl-core";
+import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { useListNavigation } from "./useListNavigation";
 import classNames from "classnames";

--- a/packages/text-input-react/README.md
+++ b/packages/text-input-react/README.md
@@ -53,7 +53,7 @@ Husk å sette `label` til en fornuftig beskrivelse av handlingen (f.eks. "nullst
 #### BaseInputField
 
 Denne er kun eksponert for å dekke spesielle behov og anbefales ikke å brukes.
-Skal denne brukes frittstående må den akkompagneres av en `Label` fra [`@fremtind/jkl-typography-react`](https://fremtind.github.io/jokul/komponenter/Typography) hvor `standAlone` og `htmlFor` skal være spesifisert. Eksempel på hvordan denne kan brukes:
+Skal denne brukes frittstående må den akkompagneres av en `Label` fra [`@fremtind/jkl-core`](https://fremtind.github.io/jokul/komponenter/Typography) hvor `standAlone` og `htmlFor` skal være spesifisert. Eksempel på hvordan denne kan brukes:
 
 ```tsx
 <Label standAlone htmlFor="complicatedquestion">

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -1,8 +1,7 @@
 import React, { forwardRef, FocusEvent, useRef, useState, useEffect, RefObject } from "react";
 import classNames from "classnames";
 import nanoid from "nanoid";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
-import { LabelVariant } from "@fremtind/jkl-core";
+import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { BaseProps } from "./BaseInputField";
 
 interface Props extends BaseProps {

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -1,8 +1,7 @@
 import React, { forwardRef, useState, HTMLAttributes, MouseEventHandler } from "react";
 import nanoid from "nanoid";
 import classNames from "classnames";
-import { LabelVariant } from "@fremtind/jkl-core";
-import { Label, SupportLabel } from "@fremtind/jkl-typography-react";
+import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { IconButton, IconVariant } from "@fremtind/jkl-icon-button-react";
 import { BaseInputField, BaseProps } from "./BaseInputField";
 

--- a/packages/typography-react/src/Label.tsx
+++ b/packages/typography-react/src/Label.tsx
@@ -29,6 +29,12 @@ export function Label({ variant = "medium", forceCompact, srOnly, children, stan
         }
     }
 
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: This version of the Label component is deprecated! Please use the Label component found in @fremtind/jkl-core instead",
+        );
+    }
+
     return (
         <C className={className} htmlFor={htmlFor}>
             {children}

--- a/packages/typography-react/src/Link.tsx
+++ b/packages/typography-react/src/Link.tsx
@@ -7,14 +7,21 @@ interface Props extends Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "rel" | "t
     children: ReactNode;
 }
 
-export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => (
-    <a
-        className={classnames("jkl-link", className, {
-            "jkl-link--negative": negative,
-            "jkl-link--external": external,
-        })}
-        {...rest}
-    >
-        {children}
-    </a>
-);
+export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => {
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: This version of the Link component is deprecated! Please use the Link component found in @fremtind/jkl-core instead",
+        );
+    }
+    return (
+        <a
+            className={classnames("jkl-link", className, {
+                "jkl-link--negative": negative,
+                "jkl-link--external": external,
+            })}
+            {...rest}
+        >
+            {children}
+        </a>
+    );
+};

--- a/packages/typography-react/src/SupportLabel.tsx
+++ b/packages/typography-react/src/SupportLabel.tsx
@@ -20,6 +20,12 @@ export const SupportLabel = ({ id, helpLabel, errorLabel, forceCompact, classNam
         "jkl-form-support-label--inverted": inverted,
     });
 
+    if (process.env.NODE_ENV !== "production") {
+        console.warn(
+            "WARNING: This version of the SupportLabel component is deprecated! Please use the SupportLabel component found in @fremtind/jkl-core instead",
+        );
+    }
+
     if (errorLabel || helpLabel) {
         return (
             <span id={id} className={componentClassName}>

--- a/portal/src/components/Info/WebComponentInfo.tsx
+++ b/portal/src/components/Info/WebComponentInfo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { WarningMessage } from "@fremtind/jkl-message-box-react";
-import { Link } from "@fremtind/jkl-typography-react";
+import { Link } from "@fremtind/jkl-core";
 import "./style.scss";
 
 const WebComponentInfo = () => (

--- a/portal/src/components/Typography/FormatProvider.tsx
+++ b/portal/src/components/Typography/FormatProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import { MDXProvider } from "@mdx-js/react";
-import { Link } from "@fremtind/jkl-typography-react";
+import { Link } from "@fremtind/jkl-core";
 import { OrderedList, UnorderedList, ListItem } from "@fremtind/jkl-list-react";
 import { ComponentExample } from "@fremtind/jkl-portal-components";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17487,27 +17487,17 @@ snyk-config@^3.0.0:
     lodash.merge "^4.6.2"
     nconf "^0.10.0"
 
-<<<<<<< HEAD
 snyk-docker-plugin@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.2.0.tgz#5fb1cf045e45b4a3cfcdc9878ab29c80334d9742"
   integrity sha512-LKsvGcRVBYzyTNT/Z5kImm6uHMX3wAs7gvR4dO8zqBVzCsn3zfi//kmRHWh7zhgvIb6reuhUqY1hMXaz0q/mBw==
-=======
-snyk-docker-plugin@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.1.0.tgz#7d139eb1a1f158d55fdc69df51b8a4c4dbf03f93"
-  integrity sha512-ggGTiiCuwLYGdlGW/UBuUXJ7omliH0EnbpLfdlTBoRKvmvgoUo1l4Menk18R1ZVXgcXTwwGK9jmuUpPH+X0VNw==
->>>>>>> fix: import labels and links from core
   dependencies:
     "@snyk/rpm-parser" "^1.1.0"
     debug "^4.1.1"
     dockerfile-ast "0.0.19"
     event-loop-spinner "^1.1.0"
     semver "^6.1.0"
-<<<<<<< HEAD
     snyk-nodejs-lockfile-parser "1.22.0"
-=======
->>>>>>> fix: import labels and links from core
     tar-stream "^2.1.0"
     tslib "^1"
 
@@ -17530,21 +17520,12 @@ snyk-go-plugin@1.14.0:
     tmp "0.1.0"
     tslib "^1.10.0"
 
-<<<<<<< HEAD
 snyk-gradle-plugin@3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.7.tgz#3a4f37afeac00407d7051891a0e3ee4d69f6866f"
   integrity sha512-fBgQpRwfuHGuPvYGEjgNBtuwnkNAV9sv17lG+eWdQO3ntkAKnt1RyzQydAdffK2e8339XM6Mg/1EPYuIGIY3TA==
   dependencies:
     "@snyk/cli-interface" "2.3.2"
-=======
-snyk-gradle-plugin@3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.5.tgz#a0be7ddec568bfec62e7ebf7a6431aa74eec1d27"
-  integrity sha512-XxPi/B16dGkV1USoyFbpn6LlSJ9SUC6Y6z/4lWuF4spLnKtWwpEb1bwTdBFsxnkUfqzIRtPr0+wcxxXvv9Rvcw==
-  dependencies:
-    "@snyk/cli-interface" "2.3.0"
->>>>>>> fix: import labels and links from core
     "@types/debug" "^4.1.4"
     chalk "^2.4.2"
     debug "^4.1.1"
@@ -17708,15 +17689,9 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     then-fs "^2.0.0"
 
 snyk@^1.319.0:
-<<<<<<< HEAD
   version "1.320.1"
   resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.320.1.tgz#15f0efa39d5e7866208a3cb085deffe1d6192664"
   integrity sha512-qCZl9Ab/bFzEEmdzhxWc1IXwTAxD9W2JRT6UT+iiCW8W21z0h50bE8dqviMMtaCb3r4IvSz1GtokGM9jhbSWYg==
-=======
-  version "1.319.2"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.319.2.tgz#39bd9b0258f21de2aa88b0e2a381873680fbcb1c"
-  integrity sha512-IwJTsmwNKUhJ5V7jSnCOsLTB1HKbXkJJkg9nnqRk8iD8BlNJA3vq3D2pptndKWa/ssV7ySZT51Wr5Hbh2dHWqA==
->>>>>>> fix: import labels and links from core
   dependencies:
     "@snyk/cli-interface" "2.6.0"
     "@snyk/configstore" "^3.2.0-rc1"
@@ -17744,15 +17719,9 @@ snyk@^1.319.0:
     proxy-from-env "^1.0.0"
     semver "^6.0.0"
     snyk-config "3.1.0"
-<<<<<<< HEAD
     snyk-docker-plugin "3.2.0"
     snyk-go-plugin "1.14.0"
     snyk-gradle-plugin "3.2.7"
-=======
-    snyk-docker-plugin "3.1.0"
-    snyk-go-plugin "1.14.0"
-    snyk-gradle-plugin "3.2.5"
->>>>>>> fix: import labels and links from core
     snyk-module "1.9.1"
     snyk-mvn-plugin "2.15.1"
     snyk-nodejs-lockfile-parser "1.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,6 +2970,13 @@
   dependencies:
     tslib "^1.9.3"
 
+"@snyk/cli-interface@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-2.3.0.tgz#9d38f815a5cf2be266006954c2a058463d531e08"
+  integrity sha512-ecbylK5Ol2ySb/WbfPj0s0GuLQR+KWKFzUgVaoNHaSoN6371qRWwf2uVr+hPUP4gXqCai21Ug/RDArfOhlPwrQ==
+  dependencies:
+    tslib "^1.9.3"
+
 "@snyk/cli-interface@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-2.3.2.tgz#e93afa82de15b912e657f1ba86f9d7963983e594"
@@ -17480,17 +17487,27 @@ snyk-config@^3.0.0:
     lodash.merge "^4.6.2"
     nconf "^0.10.0"
 
+<<<<<<< HEAD
 snyk-docker-plugin@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.2.0.tgz#5fb1cf045e45b4a3cfcdc9878ab29c80334d9742"
   integrity sha512-LKsvGcRVBYzyTNT/Z5kImm6uHMX3wAs7gvR4dO8zqBVzCsn3zfi//kmRHWh7zhgvIb6reuhUqY1hMXaz0q/mBw==
+=======
+snyk-docker-plugin@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/snyk-docker-plugin/-/snyk-docker-plugin-3.1.0.tgz#7d139eb1a1f158d55fdc69df51b8a4c4dbf03f93"
+  integrity sha512-ggGTiiCuwLYGdlGW/UBuUXJ7omliH0EnbpLfdlTBoRKvmvgoUo1l4Menk18R1ZVXgcXTwwGK9jmuUpPH+X0VNw==
+>>>>>>> fix: import labels and links from core
   dependencies:
     "@snyk/rpm-parser" "^1.1.0"
     debug "^4.1.1"
     dockerfile-ast "0.0.19"
     event-loop-spinner "^1.1.0"
     semver "^6.1.0"
+<<<<<<< HEAD
     snyk-nodejs-lockfile-parser "1.22.0"
+=======
+>>>>>>> fix: import labels and links from core
     tar-stream "^2.1.0"
     tslib "^1"
 
@@ -17513,12 +17530,21 @@ snyk-go-plugin@1.14.0:
     tmp "0.1.0"
     tslib "^1.10.0"
 
+<<<<<<< HEAD
 snyk-gradle-plugin@3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.7.tgz#3a4f37afeac00407d7051891a0e3ee4d69f6866f"
   integrity sha512-fBgQpRwfuHGuPvYGEjgNBtuwnkNAV9sv17lG+eWdQO3ntkAKnt1RyzQydAdffK2e8339XM6Mg/1EPYuIGIY3TA==
   dependencies:
     "@snyk/cli-interface" "2.3.2"
+=======
+snyk-gradle-plugin@3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.5.tgz#a0be7ddec568bfec62e7ebf7a6431aa74eec1d27"
+  integrity sha512-XxPi/B16dGkV1USoyFbpn6LlSJ9SUC6Y6z/4lWuF4spLnKtWwpEb1bwTdBFsxnkUfqzIRtPr0+wcxxXvv9Rvcw==
+  dependencies:
+    "@snyk/cli-interface" "2.3.0"
+>>>>>>> fix: import labels and links from core
     "@types/debug" "^4.1.4"
     chalk "^2.4.2"
     debug "^4.1.1"
@@ -17682,9 +17708,15 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     then-fs "^2.0.0"
 
 snyk@^1.319.0:
+<<<<<<< HEAD
   version "1.320.1"
   resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.320.1.tgz#15f0efa39d5e7866208a3cb085deffe1d6192664"
   integrity sha512-qCZl9Ab/bFzEEmdzhxWc1IXwTAxD9W2JRT6UT+iiCW8W21z0h50bE8dqviMMtaCb3r4IvSz1GtokGM9jhbSWYg==
+=======
+  version "1.319.2"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.319.2.tgz#39bd9b0258f21de2aa88b0e2a381873680fbcb1c"
+  integrity sha512-IwJTsmwNKUhJ5V7jSnCOsLTB1HKbXkJJkg9nnqRk8iD8BlNJA3vq3D2pptndKWa/ssV7ySZT51Wr5Hbh2dHWqA==
+>>>>>>> fix: import labels and links from core
   dependencies:
     "@snyk/cli-interface" "2.6.0"
     "@snyk/configstore" "^3.2.0-rc1"
@@ -17712,9 +17744,15 @@ snyk@^1.319.0:
     proxy-from-env "^1.0.0"
     semver "^6.0.0"
     snyk-config "3.1.0"
+<<<<<<< HEAD
     snyk-docker-plugin "3.2.0"
     snyk-go-plugin "1.14.0"
     snyk-gradle-plugin "3.2.7"
+=======
+    snyk-docker-plugin "3.1.0"
+    snyk-go-plugin "1.14.0"
+    snyk-gradle-plugin "3.2.5"
+>>>>>>> fix: import labels and links from core
     snyk-module "1.9.1"
     snyk-mvn-plugin "2.15.1"
     snyk-nodejs-lockfile-parser "1.22.0"


### PR DESCRIPTION
## 📥 Proposed changes

Flytt de gjenværende komponentene i `jkl-typography-react` til `jkl-core` og merk de gamle utgavene som utgått.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Stilen til `Link`, `Label` og `SupportLabel`, samt typen for `LabelVariant`, ligger allerede i `jkl-core`. Det føles derfor mer naturlig å importere disse komponentene fra samme sted.

Closes #903
