### PR TITLE
make selectedValue optional

### DIFF
--- a/packages/radio-button-react/README.md
+++ b/packages/radio-button-react/README.md
@@ -71,6 +71,25 @@ return (
 );
 ```
 
+Komponenten kan også brukes uten forhåndsvalg. Da lar du `selectedValue` stå tom.
+
+```tsx
+const [selectedValue, setSelectedValue] = useState("");
+
+return (
+    <RadioButtons
+        name="coverage"
+        legend="Hvilken dekning ønsker du?"
+        choices={[
+            { value: "del", label: "Delkasko" },
+            { value: "full", label: "Fullkasko" },
+        ]}
+        selectedValue={selectedValue}
+        onChange={setSelectedValue}
+    />
+);
+```
+
 ### Props
 
 komponenten tar i bruk følgende props:

--- a/packages/radio-button-react/src/RadioButtons.tsx
+++ b/packages/radio-button-react/src/RadioButtons.tsx
@@ -7,7 +7,7 @@ interface Props {
     name: string;
     legend: string;
     choices: Array<string | ValuePair>;
-    selectedValue: string;
+    selectedValue?: string;
     inline?: boolean;
     onChange: ChangeEventHandler<HTMLInputElement>;
     helpLabel?: string;


### PR DESCRIPTION
## 📥 Proposed changes

I portalen står det skrevet at en kan bruke radiobuttons uten forhåndsvalg, men ingen eksempler på hvordan. Siden det er en teknisk detalj bør det kanskje heller stå i readme-filen, men da må i såfall teksten i portalen ha med eksempler eller omformuleres.

Denne PR'en setter `selectedValue` som optional for å muliggjør at radiobutton kan stå unchecked.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Løsningen på hvordan jeg klarte å bruke radiobutton uten forhåndsvalg var å la valgene stå tomme uten en "default"-verdi, men allikevel la `selectedValue` være `choices`.

![image](https://user-images.githubusercontent.com/51901763/81569263-56965f80-939f-11ea-8133-fd59431276e8.png)

![image](https://user-images.githubusercontent.com/51901763/81569462-93625680-939f-11ea-91e3-bd5c954f7aa9.png).
