### PR TITLE
fix(BaseInputField): fix proper passing of className prop

### DIFF
--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -40,7 +40,7 @@ function getWidthAsStyle(width?: string, maxLength?: number): CSSProperties | un
 }
 
 export const BaseInputField = forwardRef<HTMLInputElement, Props>(
-    ({ id, describedBy, invalid, maxLength, width, type = "text", className, ...rest }, ref) => (
+    ({ id, describedBy, invalid, maxLength, width, type = "text", className = "", ...rest }, ref) => (
         <input
             ref={ref}
             id={id}

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -44,7 +44,7 @@ export const BaseInputField = forwardRef<HTMLInputElement, Props>(
         <input
             ref={ref}
             id={id}
-            className={`jkl-text-input__input ${className}`}
+            className={`jkl-text-input__input ${className ? className : ""}`}
             style={getWidthAsStyle(width, maxLength)}
             aria-describedby={describedBy}
             aria-invalid={invalid}

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -40,11 +40,11 @@ function getWidthAsStyle(width?: string, maxLength?: number): CSSProperties | un
 }
 
 export const BaseInputField = forwardRef<HTMLInputElement, Props>(
-    ({ id, describedBy, invalid, maxLength, width, type = "text", ...rest }, ref) => (
+    ({ id, describedBy, invalid, maxLength, width, type = "text", className, ...rest }, ref) => (
         <input
             ref={ref}
             id={id}
-            className="jkl-text-input__input"
+            className={`jkl-text-input__input ${className}`}
             style={getWidthAsStyle(width, maxLength)}
             aria-describedby={describedBy}
             aria-invalid={invalid}

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -44,7 +44,7 @@ export const BaseInputField = forwardRef<HTMLInputElement, Props>(
         <input
             ref={ref}
             id={id}
-            className={`jkl-text-input__input ${className ? className : ""}`}
+            className={`jkl-text-input__input ${className}`}
             style={getWidthAsStyle(width, maxLength)}
             aria-describedby={describedBy}
             aria-invalid={invalid}


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react

closes #947 

## 📥 Proposed changes

PR-en åpner for at man kan legge til custom className ved siden av `jkl-text-input__input`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
