### PR TITLE
Alert message fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "ci:test": "run-p test lint typecheck",
         "test": "run-p test:unit",
         "test:unit": "jest -c './jest/jest.unit.js'",
+        "test:watch": "jest -c './jest/jest.unit.js' --watch",
         "prerelease": "yarn build",
         "release": "lerna publish",
         "dev": "lerna run --scope @fremtind/portal dev --stream",

--- a/packages/alert-message-react/README.md
+++ b/packages/alert-message-react/README.md
@@ -30,7 +30,6 @@ import "@fremtind/jkl-alert-message/alert-message.min.css";
 
 Komponenten tar følgende props:
 
--   `messageType`: **Påkrevd**. Meldingsboks type. `string`
 -   `children`: **Påkrevd**. Innholdet i meldingsboksen. `ReactNode`
 -   `maxContentWidth`: Setter maks bredde på innholdet. Innholdet vil søke mot senter av siden `string`
 -   `paddingLeft`: Setter padding på venstre side av innholdet. `string`
@@ -39,13 +38,13 @@ Komponenten tar følgende props:
 En enkel bruk av meldingsboksen kan se slik ut:
 
 ```jsx
-<SystemMessage messageType="info">Filopplasting er for tiden slått av</SystemMessage>
+<InfoAlertMessage>Filopplasting er for tiden slått av</InfoAlertMessage>
 ```
 
 For å aligne innholdet i meldingen med teksten på resten av siden:
 
 ```jsx
-<SystemMessage messageType="error" maxContentWidth="1532px" paddingLeft="1rem">
+<ErrorAlertMessage maxContentWidth="1532px" paddingLeft="1rem">
     Feilopplastingtjenesten opplever for tiden problemer
-</SystemMessage>
+</ErrorAlertMessage>
 ```

--- a/packages/alert-message-react/src/AlertMessage.test.tsx
+++ b/packages/alert-message-react/src/AlertMessage.test.tsx
@@ -22,39 +22,31 @@ const types = [
 ];
 
 describe("Alert messages", () => {
-    [messageWithStyles, messageWitoutStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+    [messageWithStyles, messageWitoutStyles].forEach((messageStyleProps) => {
         types.map(([name, E]) => {
             it(name + " should render message content", () => {
-                const { getByText } = render(
-                    <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
-                        content
-                    </E>,
-                );
+                const { getByText } = render(<E {...messageStyleProps}>content</E>);
                 getByText("content");
             });
         });
     });
-    [messageWithStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+    [messageWithStyles].forEach((messageStyleProps) => {
         types.map(([name, E]) => {
             it(name + " should take css properties", () => {
-                render(
-                    <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
-                        content
-                    </E>,
+                render(<E {...messageStyleProps}>content</E>);
+                expect(screen.getByTestId("alert-message-content")).toHaveStyle(
+                    `padding-left: ${messageStyleProps.paddingLeft}`,
                 );
-                expect(screen.getByTestId("alert-message-content")).toHaveStyle(`padding-left: ${paddingLeft}`);
-                expect(screen.getByTestId("alert-message-content")).toHaveStyle(`max-width: ${maxContentWidth}`);
+                expect(screen.getByTestId("alert-message-content")).toHaveStyle(
+                    `max-width: ${messageStyleProps.maxContentWidth}`,
+                );
             });
         });
     });
-    [messageWitoutStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+    [messageWitoutStyles].forEach((messageStyleProps) => {
         types.map(([name, E]) => {
             it(name + " should not add style attribute if styles are undefined", () => {
-                render(
-                    <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
-                        content
-                    </E>,
-                );
+                render(<E {...messageStyleProps}>content</E>);
                 expect(screen.getByTestId("alert-message-content")).not.toHaveAttribute("style");
             });
         });

--- a/packages/alert-message-react/src/AlertMessage.test.tsx
+++ b/packages/alert-message-react/src/AlertMessage.test.tsx
@@ -1,29 +1,61 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { InfoAlertMessage, ErrorAlertMessage, WarningAlertMessage, SuccessAlertMessage } from ".";
 import { axe } from "jest-axe";
 
+const messageWithStyles = {
+    inverted: true,
+    maxContentWidth: "1234px",
+    paddingLeft: "1rem",
+};
+const messageWitoutStyles = {
+    inverted: true,
+    maxContentWidth: undefined,
+    paddingLeft: undefined,
+};
+
+const types = [
+    ["InfoAlertMessage", InfoAlertMessage],
+    ["WarningAlertMessage", WarningAlertMessage],
+    ["ErrorAlertMessage", ErrorAlertMessage],
+    ["SuccessAlertMessage", SuccessAlertMessage],
+];
+
 describe("Alert messages", () => {
-    [
-        {
-            inverted: true,
-            maxContentWidth: "1234px",
-            paddingLeft: "1rem",
-        },
-        {
-            inverted: false,
-            maxContentWidth: undefined,
-            paddingLeft: undefined,
-        },
-    ].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
-        [InfoAlertMessage, WarningAlertMessage, ErrorAlertMessage, SuccessAlertMessage].map((E) => {
-            it("should render message content", () => {
+    [messageWithStyles, messageWitoutStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+        types.map(([name, E]) => {
+            it(name + " should render message content", () => {
                 const { getByText } = render(
                     <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
                         content
                     </E>,
                 );
                 getByText("content");
+            });
+        });
+    });
+    [messageWithStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+        types.map(([name, E]) => {
+            it(name + " should take css properties", () => {
+                render(
+                    <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
+                        content
+                    </E>,
+                );
+                expect(screen.getByTestId("alert-message-content")).toHaveStyle(`padding-left: ${paddingLeft}`);
+                expect(screen.getByTestId("alert-message-content")).toHaveStyle(`max-width: ${maxContentWidth}`);
+            });
+        });
+    });
+    [messageWitoutStyles].forEach(({ inverted, maxContentWidth, paddingLeft }) => {
+        types.map(([name, E]) => {
+            it(name + " should not add style attribute if styles are undefined", () => {
+                render(
+                    <E inverted={inverted} maxContentWidth={maxContentWidth} paddingLeft={paddingLeft}>
+                        content
+                    </E>,
+                );
+                expect(screen.getByTestId("alert-message-content")).not.toHaveAttribute("style");
             });
         });
     });

--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -13,16 +13,6 @@ interface Props {
     role?: string;
 }
 
-interface StyleMap {
-    [key: string]: string;
-}
-
-// map css properties to more descriptive names
-const styleMap: StyleMap = {
-    maxContentWidth: "maxWidth",
-    paddingLeft: "paddingLeft",
-};
-
 function alertFactory(messageType: messageTypes) {
     return function alertMessage({
         className = "",
@@ -36,16 +26,10 @@ function alertFactory(messageType: messageTypes) {
             "jkl-alert-message--dark": inverted,
         });
 
-        const styles = Object.entries({
-            maxContentWidth,
+        const styles = {
+            maxWidth: maxContentWidth,
             paddingLeft,
-        }).reduce((styleObject: { [key: string]: string }, [style, value]) => {
-            if (!!value) {
-                styleObject[styleMap[style] || style] = value;
-            }
-
-            return styleObject;
-        }, {});
+        };
 
         return (
             <div className={componentClassName} role={role}>

--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -13,6 +13,16 @@ interface Props {
     role?: string;
 }
 
+interface StyleMap {
+    [key: string]: string;
+}
+
+// map css properties to more descriptive names
+const styleMap: StyleMap = {
+    maxContentWidth: "maxWidth",
+    paddingLeft: "paddingLeft",
+};
+
 function alertFactory(messageType: messageTypes) {
     return function alertMessage({
         className = "",
@@ -31,7 +41,7 @@ function alertFactory(messageType: messageTypes) {
             paddingLeft,
         }).reduce((styleObject: { [key: string]: string }, [style, value]) => {
             if (!!value) {
-                styleObject[style] = value;
+                styleObject[styleMap[style] || style] = value;
             }
 
             return styleObject;
@@ -39,7 +49,7 @@ function alertFactory(messageType: messageTypes) {
 
         return (
             <div className={componentClassName} role={role}>
-                <div className="jkl-alert-message__content" style={{ ...styles }}>
+                <div className="jkl-alert-message__content" data-testid="alert-message-content" style={{ ...styles }}>
                     <div className="jkl-alert-message__icon">
                         <MessageIcon messageType={messageType} />
                     </div>


### PR DESCRIPTION
## 📥 Proposed changes

Ettersom Pio hadde et godt forslag med å bruke mer deskriptive props knakk koblingen mellom prop og CSS-egenskap. Denne er nå fikset ved å lage et map mellom deskriptive navn og CSS-egenskaper.

Lagt til tester for å se at denne koblingen funker senere. 

Oppdatert litt utdatert dokumentasjon, og lagt til `test:watch` for ikke å klikke av å kjøre test runneren på nytt hele tiden 😅

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
