### PR TITLE
fix(ci): make git history available to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
               uses: actions/checkout@v2
               with:
                   token: ${{ secrets.BOT_PUBLISH_TOKEN }}
+                  fetch-depth: "0" # fetch entire git history
+            - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # fetch version tags
 
             - name: Configure CI Git User
               run: |


### PR DESCRIPTION
## 📥 Proposed changes

Fix a bug where continuous release always bumps version numbers. See https://github.com/actions/checkout/issues/217 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
