### PR TITLE
feat: expose prop interface for textinput and button

### DIFF
--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes } from "react";
 import classNames from "classnames";
 
-interface Props extends Exclude<HTMLAttributes<HTMLButtonElement>, "disabled"> {
+export interface Props extends Exclude<HTMLAttributes<HTMLButtonElement>, "disabled"> {
     forceCompact?: boolean;
     inverted?: boolean;
 }

--- a/packages/button-react/src/index.ts
+++ b/packages/button-react/src/index.ts
@@ -1,1 +1,1 @@
-export { PrimaryButton, SecondaryButton, TertiaryButton } from "./Button";
+export { PrimaryButton, SecondaryButton, TertiaryButton, Props as ButtonPropsInterface } from "./Button";

--- a/packages/button-react/src/index.ts
+++ b/packages/button-react/src/index.ts
@@ -1,1 +1,5 @@
-export { PrimaryButton, SecondaryButton, TertiaryButton, Props as ButtonPropsInterface } from "./Button";
+import { PrimaryButton, SecondaryButton, TertiaryButton, Props as ButtonPropsInterface } from "./Button";
+
+interface ButtonProps extends ButtonPropsInterface {}
+
+export { PrimaryButton, SecondaryButton, TertiaryButton, ButtonProps };

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -19,7 +19,7 @@ export interface BaseProps {
     type?: "text" | "number" | "tel" | "password" | "email" | "year";
 }
 
-interface Props extends BaseProps {
+export interface Props extends BaseProps {
     describedBy?: string;
     style?: CSSProperties;
     invalid?: boolean;

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -4,7 +4,7 @@ import nanoid from "nanoid";
 import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { BaseProps } from "./BaseInputField";
 
-interface Props extends BaseProps {
+export interface Props extends BaseProps {
     label: string;
     helpLabel?: string;
     errorLabel?: string;

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -11,7 +11,7 @@ export interface Action extends Exclude<HTMLAttributes<HTMLButtonElement>, "disa
     onClick: MouseEventHandler<HTMLButtonElement>;
 }
 
-interface Props extends BaseProps {
+export interface Props extends BaseProps {
     label: string;
     helpLabel?: string;
     errorLabel?: string;

--- a/packages/text-input-react/src/index.ts
+++ b/packages/text-input-react/src/index.ts
@@ -1,3 +1,3 @@
-export { TextArea } from "./TextArea";
-export { TextInput } from "./TextInput";
-export { BaseInputField } from "./BaseInputField";
+export { TextArea, Props as TextAreaPropsInterface } from "./TextArea";
+export { TextInput, Props as TextInputPropsInterface } from "./TextInput";
+export { BaseInputField, Props as BaseInputPropsInterface } from "./BaseInputField";

--- a/packages/text-input-react/src/index.ts
+++ b/packages/text-input-react/src/index.ts
@@ -1,3 +1,9 @@
-export { TextArea, Props as TextAreaPropsInterface } from "./TextArea";
-export { TextInput, Props as TextInputPropsInterface } from "./TextInput";
-export { BaseInputField, Props as BaseInputPropsInterface } from "./BaseInputField";
+import { TextArea, Props as TextAreaPropsInterface } from "./TextArea";
+import { TextInput, Props as TextInputPropsInterface } from "./TextInput";
+import { BaseInputField, Props as BaseInputPropsInterface } from "./BaseInputField";
+
+interface BaseInputProps extends BaseInputPropsInterface {}
+interface TextInputProps extends TextInputPropsInterface {}
+interface TextAreaProps extends TextAreaPropsInterface {}
+
+export { TextArea, TextAreaProps, TextInput, TextInputProps, BaseInputField, BaseInputProps };


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-text-input-react

will be used to extend interfaces with required props in BM

## 📥 Proposed changes

I BM utvider vi noen komponenter med større krav til props. Dette kan være obligatorisk tracking key til mixpanel i knapper. Men i dette tilfellet er det å legge til obligatorisk data-testautoid prop til bruk for TestComplete.
Eksponering av prop interfacene fra komponenter vil gjøre det enklere å extende disse til å ta flere props når komponenter blir definert internt i prosjekter.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

