### PR TITLE
fix(typography-react): make deprecation warnings less intrusive

### DIFF
--- a/packages/typography-react/src/Label.tsx
+++ b/packages/typography-react/src/Label.tsx
@@ -11,6 +11,8 @@ interface Props {
     htmlFor?: string;
 }
 
+let warningHasBeenShown = false;
+
 export function Label({ variant = "medium", forceCompact, srOnly, children, standAlone, htmlFor }: Props) {
     const className = classNames("jkl-label", {
         [`jkl-label--${variant}`]: variant,
@@ -29,10 +31,11 @@ export function Label({ variant = "medium", forceCompact, srOnly, children, stan
         }
     }
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== "production" && !warningHasBeenShown) {
         console.warn(
             "WARNING: This version of the Label component is deprecated! Please use the Label component found in @fremtind/jkl-core instead",
         );
+        warningHasBeenShown = true;
     }
 
     return (

--- a/packages/typography-react/src/Link.tsx
+++ b/packages/typography-react/src/Link.tsx
@@ -7,11 +7,14 @@ interface Props extends Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "rel" | "t
     children: ReactNode;
 }
 
+let warningHasBeenShown = false;
+
 export const Link = ({ negative = false, external = false, children, className = "", ...rest }: Props) => {
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== "production" && !warningHasBeenShown) {
         console.warn(
             "WARNING: This version of the Link component is deprecated! Please use the Link component found in @fremtind/jkl-core instead",
         );
+        warningHasBeenShown = true;
     }
     return (
         <a

--- a/packages/typography-react/src/SupportLabel.tsx
+++ b/packages/typography-react/src/SupportLabel.tsx
@@ -11,6 +11,8 @@ interface Props {
     inverted?: boolean;
 }
 
+let warningHasBeenShown = false;
+
 export const SupportLabel = ({ id, helpLabel, errorLabel, forceCompact, className, srOnly, inverted }: Props) => {
     const componentClassName = classNames("jkl-form-support-label", className, {
         "jkl-form-support-label--compact": forceCompact,
@@ -20,10 +22,11 @@ export const SupportLabel = ({ id, helpLabel, errorLabel, forceCompact, classNam
         "jkl-form-support-label--inverted": inverted,
     });
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== "production" && !warningHasBeenShown) {
         console.warn(
             "WARNING: This version of the SupportLabel component is deprecated! Please use the SupportLabel component found in @fremtind/jkl-core instead",
         );
+        warningHasBeenShown = true;
     }
 
     if (errorLabel || helpLabel) {


### PR DESCRIPTION
## 📥 Proposed changes

Ensure that the deprecation warnings are only shown once, to avoid flooding the console during
development.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-typography-react
