### PR TITLE
fix(portal): make home link close open menus

### DIFF
--- a/portal/src/components/Header/Header.tsx
+++ b/portal/src/components/Header/Header.tsx
@@ -26,9 +26,17 @@ export const Header = ({ className }: { className?: string }) => {
         className,
     );
 
+    function hideOpenMenus() {
+        const openMenus = document && document.querySelectorAll(".jkl-portal-full-screen-menu--open");
+        openMenus.forEach((menu) => {
+            menu.setAttribute("hidden", "true"); // hide all open full screen menus
+        });
+        setMenuIsOpen(""); // reset open menu in context to remove active marker
+    }
+
     return (
         <header className={componentClassName}>
-            <Link onClick={() => setMenuIsOpen("")} to="/" className="jkl-portal-header__title">
+            <Link to="/" onClick={hideOpenMenus} className="jkl-portal-header__title">
                 Jøkul
             </Link>
             <nav className="jkl-portal-header__navigation">


### PR DESCRIPTION
## 📥 Proposed changes

Ensure the home link closes any open full screen menus when clicked

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal

ISSUES CLOSED: #917
