### PR TITLE
fix(text-input-react): add missing nanoid dependency

### DIFF
--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -39,7 +39,8 @@
     "dependencies": {
         "@fremtind/jkl-icon-button-react": "^0.2.8",
         "@fremtind/jkl-text-input": "^2.0.5",
-        "@fremtind/jkl-typography-react": "^2.3.6"
+        "@fremtind/jkl-typography-react": "^2.3.6",
+        "nanoid": "^3.1.9"
     },
     "devDependencies": {
         "@fremtind/jkl-portal-components": "^0.2.12"

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, FocusEvent, useRef, useState, useEffect, RefObject } from "react";
 import classNames from "classnames";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { BaseProps } from "./BaseInputField";
 

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState, HTMLAttributes, MouseEventHandler } from "react";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import classNames from "classnames";
 import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
 import { IconButton, IconVariant } from "@fremtind/jkl-icon-button-react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -13820,6 +13820,11 @@ nanoid@^3.1.3:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.7.tgz#3705ccf590b6a51fbd1794fcf204ce7b5dc46c01"
   integrity sha512-ruOwuatdEf4BxQmZopZqhIMudQ9V83aKocr+q2Y7KasnDNvo2OgbgZBYago5hSD0tCmoSl4flIw9ytDLIVM2IQ==
 
+nanoid@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.9.tgz#1f148669c70bb2072dc5af0666e46edb6cd31fb2"
+  integrity sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
## 📥 Proposed changes

Add missing `nanoid` dependency to `text-input-react`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-text-input-react