### PR TITLE
fix: fiks en bug hvor CSP vil blokkere inline CSS

### DIFF
--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -108,6 +108,9 @@ $calendar-focus-color--inverted: $info--darkbg;
 }
 
 .jkl-calendar {
+    // hard code for CSP blocking inline styling
+    display: block;
+
     justify-content: center;
     flex-direction: column;
     width: $calendar-width;


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker

i miljøer hvor CSP er i bruk, og konfigurert til å blokkere inline CSS
vil stylingen av kalenderen i datepickeren feile.

## 📥 Proposed changes

Sett `display:block` statisk fra CSS-filen.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

