### PR TITLE
fix: align nanoid version, and migrate to 3

### DIFF
--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@fremtind/jkl-checkbox": "^1.2.9",
         "@fremtind/jkl-core": "^4.5.4",
-        "nanoid": "^2.1.11"
+        "nanoid": "^3.1.10"
     },
     "peerDependencies": {
         "@types/react": "^16.8.17",

--- a/packages/checkbox-react/src/Checkbox.tsx
+++ b/packages/checkbox-react/src/Checkbox.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, ChangeEvent, useState } from "react";
 import classNames from "classnames";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 
 interface Props {
     children: ReactNode;

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useState, useEffect, useRef, FocusEvent, useCallback } from "react";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import classNames from "classnames";
 
 import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";

--- a/packages/divider-line-react/package.json
+++ b/packages/divider-line-react/package.json
@@ -37,11 +37,10 @@
     "dependencies": {
         "@fremtind/jkl-divider-line": "^1.1.18",
         "@fremtind/jkl-react-hooks": "^1.2.5",
-        "nanoid": "^2.1.6"
+        "nanoid": "^3.1.10"
     },
     "devDependencies": {
-        "@fremtind/jkl-portal-components": "^0.3.5",
-        "@types/nanoid": "^2.0.0"
+        "@fremtind/jkl-portal-components": "^0.3.5"
     },
     "peerDependencies": {
         "@types/react": "^16.9.4",

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-logo": "^2.1.17",
-        "nanoid": "^2.1.11"
+        "nanoid": "^3.1.10"
     },
     "devDependencies": {
         "@fremtind/jkl-portal-components": "^0.3.5"

--- a/packages/logo-react/src/Logo.tsx
+++ b/packages/logo-react/src/Logo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import classNames from "classnames";
 
 interface Props {

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -40,11 +40,10 @@
         "@fremtind/jkl-select": "^2.0.9",
         "@fremtind/jkl-typography-react": "^2.3.11",
         "@nrk/core-toggle": "3.0.7",
-        "nanoid": "^2.1.6"
+        "nanoid": "^3.1.10"
     },
     "devDependencies": {
-        "@fremtind/jkl-portal-components": "^0.3.5",
-        "@types/nanoid": "^2.0.0"
+        "@fremtind/jkl-portal-components": "^0.3.5"
     },
     "peerDependencies": {
         "@types/react": "^16.9.4",

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -1,7 +1,7 @@
 /* eslint "jsx-a11y/no-onchange": 0 */
 
 import React, { FocusEventHandler, ChangeEventHandler, useState, forwardRef } from "react";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
 import classNames from "classnames";
 

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore
 import CoreToggle from "@nrk/core-toggle/jsx";
 import React, { useState, useEffect, useCallback } from "react";
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { useListNavigation } from "./useListNavigation";

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -40,7 +40,7 @@
         "@fremtind/jkl-icon-button-react": "^0.2.14",
         "@fremtind/jkl-text-input": "^2.0.10",
         "@fremtind/jkl-typography-react": "^2.3.11",
-        "nanoid": "^3.1.9"
+        "nanoid": "^3.1.10"
     },
     "devDependencies": {
         "@fremtind/jkl-portal-components": "^0.3.5"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ const defaultPlugins = [
     babel({
         rootMode: "upward",
         extensions,
-        exclude: ["node_modules/**"], // only transpile our source code
+        exclude: [/node_modules\/(?!nanoid)/], // only transpile our source code
     }),
     commonjs({
         namedExports: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,7 +3265,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/nanoid@^2.0.0":
+"@types/nanoid@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/nanoid/-/nanoid-2.1.0.tgz#41edfda78986e9127d0dc14de982de766f994020"
   integrity sha512-xdkn/oRTA0GSNPLIKZgHWqDTWZsVrieKomxJBOQUK9YDD+zfSgmwD5t4WJYra5S7XyhTw7tfvwznW+pFexaepQ==
@@ -13769,20 +13769,10 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^2.1.11, nanoid@^2.1.6:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
-nanoid@^3.1.3:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.7.tgz#3705ccf590b6a51fbd1794fcf204ce7b5dc46c01"
-  integrity sha512-ruOwuatdEf4BxQmZopZqhIMudQ9V83aKocr+q2Y7KasnDNvo2OgbgZBYago5hSD0tCmoSl4flIw9ytDLIVM2IQ==
-
-nanoid@^3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.9.tgz#1f148669c70bb2072dc5af0666e46edb6cd31fb2"
-  integrity sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==
+nanoid@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.10.tgz#69a8a52b77892de0d11cede96bc9762852145bc4"
+  integrity sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
affects: @fremtind/jkl-checkbox-react, @fremtind/jkl-datepicker-react,
@fremtind/jkl-divider-line-react, @fremtind/jkl-logo-react, @fremtind/jkl-select-react,
@fremtind/jkl-text-input-react

## 📥 Proposed changes

Vi hadde 3 ulike versjoner av nanoid depdendencyen i ulike pakker. Det i seg selv er som regel ikke et stort problem, men det lagde problemer i portalen når man brukte portal-components komponenten og checkbox hvor det var konflikt i versjoner. Men det som kanskje er mer kritisk er at mellom versjon 2 og 3, så har nanoid droppet støtte for IE. 

Denne PR oppdater alle nanoid til nyeste, oppdaterer importen i alle som brukte v2. Legger også til nanoid til å transpileres ved bygg.
## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
