### PR TITLE
fix(core): make text style util classes respect compact mode

### DIFF
--- a/packages/core/headings.scss
+++ b/packages/core/headings.scss
@@ -1,9 +1,13 @@
 @import "./variables/font-size";
+@import "./mixins/screens";
 
 .jkl-title-large {
     @include jkl-text-style("desktop/title-large");
 
     @include small-device {
+        @include jkl-text-style("compact/title-large");
+    }
+    *[data-compactlayout] & {
         @include jkl-text-style("compact/title-large");
     }
 }
@@ -13,11 +17,17 @@
     @include small-device {
         @include jkl-text-style("compact/title-small");
     }
+    *[data-compactlayout] & {
+        @include jkl-text-style("compact/title-small");
+    }
 }
 .jkl-heading-large {
     @include jkl-text-style("desktop/heading-large");
 
     @include small-device {
+        @include jkl-text-style("compact/heading-large");
+    }
+    *[data-compactlayout] & {
         @include jkl-text-style("compact/heading-large");
     }
 }
@@ -27,11 +37,17 @@
     @include small-device {
         @include jkl-text-style("compact/heading-medium");
     }
+    *[data-compactlayout] & {
+        @include jkl-text-style("compact/heading-medium");
+    }
 }
 .jkl-heading-small {
     @include jkl-text-style("desktop/heading-small");
 
     @include small-device {
+        @include jkl-text-style("compact/heading-small");
+    }
+    *[data-compactlayout] & {
         @include jkl-text-style("compact/heading-small");
     }
 }

--- a/packages/core/paragraphs.scss
+++ b/packages/core/paragraphs.scss
@@ -1,9 +1,13 @@
 @import "./variables/font-size";
+@import "./mixins/screens";
 
 .jkl-lead {
     @include jkl-text-style("desktop/lead");
 
     @include small-device {
+        @include jkl-text-style("compact/lead");
+    }
+    *[data-compactlayout] & {
         @include jkl-text-style("compact/lead");
     }
 }
@@ -14,6 +18,9 @@
     @include small-device {
         @include jkl-text-style("compact/body");
     }
+    *[data-compactlayout] & {
+        @include jkl-text-style("compact/body");
+    }
 }
 
 .jkl-small {
@@ -22,12 +29,18 @@
     @include small-device {
         @include jkl-text-style("compact/small");
     }
+    *[data-compactlayout] & {
+        @include jkl-text-style("compact/small");
+    }
 }
 
 .jkl-micro {
     @include jkl-text-style("desktop/micro");
 
     @include small-device {
+        @include jkl-text-style("compact/micro");
+    }
+    *[data-compactlayout] & {
         @include jkl-text-style("compact/micro");
     }
 }


### PR DESCRIPTION
## 📥 Proposed changes

Sørg for at kompakt variant brukes i kompakt modus

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-core

