### PR TITLE
docs(profile): improve documentation of colors

### DIFF
--- a/portal/src/components/Documentation/Colors/ColorDescription.scss
+++ b/portal/src/components/Documentation/Colors/ColorDescription.scss
@@ -1,0 +1,95 @@
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
+
+.jkl-portal-color-description {
+    width: 100%;
+    max-width: rem(768px);
+    margin-top: $layout-spacing--xl;
+
+    @include small-device {
+        &__title,
+        &__swatch {
+            margin-bottom: $layout-spacing--medium;
+        }
+    }
+
+    @include from-medium-device {
+        display: grid;
+        grid-template-columns: rem(340px) 1fr;
+
+        &__title {
+            grid-column: 2 / 3;
+        }
+    }
+}
+
+.jkl-portal-two-tone-description {
+    width: 100%;
+    max-width: rem(768px);
+
+    &__title {
+        margin-top: $layout-spacing--large;
+        margin-bottom: $component-spacing--medium;
+    }
+
+    &__info {
+        margin-bottom: $layout-spacing--medium;
+    }
+
+    &__light-color,
+    &__dark-color {
+        position: relative;
+        padding: $layout-spacing--large 0;
+    }
+
+    &__light-color:before,
+    &__dark-color:before {
+        @include jkl-text-style("compact/micro");
+        position: absolute;
+        top: $component-spacing--medium;
+    }
+
+    &__light-color:before {
+        content: "Lys bakgrunn";
+    }
+
+    &__dark-color {
+        color: $hvit;
+        background-color: $svart;
+
+        &:before {
+            content: "Mørk bakgrunn";
+        }
+    }
+
+    @include small-device {
+        &__dark-color {
+            margin: 0 -#{$component-spacing--large};
+            padding-left: $component-spacing--large;
+            padding-right: $component-spacing--large;
+
+            &:before {
+                left: $component-spacing--large;
+            }
+        }
+    }
+
+    @include from-medium-device {
+        display: grid;
+        grid-template-columns: rem(390px) 1fr 1fr;
+
+        &__info-wrapper {
+            padding-right: $layout-spacing--medium;
+        }
+
+        &__light-color,
+        &__dark-color {
+            padding: $layout-spacing--large $component-spacing--large;
+        }
+
+        &:nth-of-type(1) {
+            margin-top: $layout-spacing--large;
+        }
+    }
+}

--- a/portal/src/components/Documentation/Colors/ColorDescription.tsx
+++ b/portal/src/components/Documentation/Colors/ColorDescription.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useScreen } from "@fremtind/jkl-react-hooks";
+
+import { ColorInfo, Color } from "./Colors";
+import "./ColorDescription.scss";
+
+interface ColorDescriptionProps extends Color {
+    title: string;
+}
+
+export const ColorDescription: React.FC<ColorDescriptionProps> = ({ title, children, ...colorInfo }) => (
+    <article className="jkl-portal-color-description">
+        <h3 className="jkl-portal-color-description__title jkl-heading-medium">{title}</h3>
+        <ColorInfo className="jkl-portal-color-description__swatch" {...colorInfo} />
+        <p className="jkl-portal-color-description__text jkl-body jkl-portal-paragraph">{children}</p>
+    </article>
+);
+
+interface TwoToneProps extends ColorDescriptionProps {
+    color: Color;
+    darkColor: Color;
+    className?: string;
+}
+export const TwoToneColorDescription: React.FC<TwoToneProps> = ({ title, color, darkColor, className, children }) => {
+    const screen = useScreen();
+    return (
+        <article className={`jkl-portal-two-tone-description ${className ? className : ""}`}>
+            <div className="jkl-portal-two-tone-description__info-wrapper">
+                <h3 className="jkl-portal-two-tone-description__title jkl-heading-medium">{title}</h3>
+                <p className="jkl-portal-two-tone-description__info jkl-body">{children}</p>
+            </div>
+            <div className="jkl-portal-two-tone-description__light-color">
+                <ColorInfo vertical={!screen.isSmallDevice} {...color} />
+            </div>
+            <div className="jkl-portal-two-tone-description__dark-color">
+                <ColorInfo vertical={!screen.isSmallDevice} {...darkColor} />
+            </div>
+        </article>
+    );
+};

--- a/portal/src/components/Documentation/Colors/ColorTable.scss
+++ b/portal/src/components/Documentation/Colors/ColorTable.scss
@@ -1,0 +1,68 @@
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
+
+.jkl-portal-color-table {
+    border: 0;
+    width: 100%;
+    max-width: rem(750px);
+    margin-top: $layout-spacing--medium;
+    margin-bottom: $layout-spacing--large;
+
+    &__header,
+    &__data {
+        padding: $component-spacing--small;
+        @include jkl-text-style("desktop/small");
+        text-align: left;
+        box-sizing: border-box;
+        margin: 0;
+
+        & * {
+            margin: 0;
+        }
+    }
+
+    &__header {
+        font-weight: $bold-weight;
+        vertical-align: bottom;
+        box-shadow: inset 0 rem(-1px) 0 0 $svart;
+    }
+
+    &__data {
+        vertical-align: top;
+        box-shadow: inset 0 rem(-1px) 0 0 $gra-50;
+    }
+
+    &__swatch {
+        height: rem(32px);
+        width: rem(32px);
+    }
+
+    @include small-device {
+        &__header {
+            display: none;
+        }
+
+        &__data {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+
+            &::before {
+                content: attr(data-header);
+            }
+
+            &:first-of-type::before {
+                font-weight: $bold-weight;
+            }
+        }
+
+        &__row {
+            display: block;
+
+            &:not(:last-of-type) {
+                margin-bottom: $layout-spacing--medium;
+            }
+        }
+    }
+}

--- a/portal/src/components/Documentation/Colors/ColorTable.tsx
+++ b/portal/src/components/Documentation/Colors/ColorTable.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Color, ColorSwatch, rgbToHex } from "./Colors";
+
+import "./ColorTable.scss";
+
+const ColorTableRow = ({ colorVariable, rgbValue }: Color) => (
+    <tr className="jkl-portal-color-table__row">
+        <td className="jkl-portal-color-table__data" data-header="Valør:">
+            <ColorSwatch className="jkl-portal-color-table__swatch" colorVariable={colorVariable} />
+        </td>
+        <td className="jkl-portal-color-table__data" data-header="Variabelnavn:">
+            {colorVariable}
+        </td>
+        <td className="jkl-portal-color-table__data" data-header="Hex:">
+            {rgbToHex(rgbValue)}
+        </td>
+        <td
+            className="jkl-portal-color-table__data"
+            data-header="RGB:"
+        >{`${rgbValue.r}, ${rgbValue.g}, ${rgbValue.b}`}</td>
+    </tr>
+);
+
+interface ColorTableProps {
+    colors: Color[];
+}
+export const ColorTable: React.FC<ColorTableProps> = ({ colors }) => {
+    return (
+        <table className="jkl-portal-color-table">
+            <thead>
+                <tr>
+                    <th className="jkl-portal-color-table__header">Valør</th>
+                    <th className="jkl-portal-color-table__header">Variabelnavn i Figma</th>
+                    <th className="jkl-portal-color-table__header">Hex</th>
+                    <th className="jkl-portal-color-table__header">RGB</th>
+                </tr>
+            </thead>
+            <tbody>
+                {colors.map((color) => (
+                    <ColorTableRow key={color.colorVariable} {...color} />
+                ))}
+            </tbody>
+        </table>
+    );
+};
+
+const gratoner: Color[] = [
+    {
+        colorVariable: "gra-10",
+        rgbValue: { r: 248, g: 248, b: 248 },
+    },
+    {
+        colorVariable: "gra-20",
+        rgbValue: { r: 235, g: 235, b: 235 },
+    },
+    {
+        colorVariable: "gra-30",
+        rgbValue: { r: 214, g: 214, b: 214 },
+    },
+    {
+        colorVariable: "gra-40",
+        rgbValue: { r: 184, g: 184, b: 184 },
+    },
+    {
+        colorVariable: "gra-50",
+        rgbValue: { r: 153, g: 153, b: 153 },
+    },
+    {
+        colorVariable: "gra-60",
+        rgbValue: { r: 111, g: 111, b: 111 },
+    },
+    {
+        colorVariable: "gra-70",
+        rgbValue: { r: 82, g: 82, b: 82 },
+    },
+    {
+        colorVariable: "gra-80",
+        rgbValue: { r: 61, g: 61, b: 61 },
+    },
+    {
+        colorVariable: "gra-90",
+        rgbValue: { r: 41, g: 41, b: 41 },
+    },
+    {
+        colorVariable: "gra-100",
+        rgbValue: { r: 23, g: 23, b: 23 },
+    },
+];
+
+const vardetoner: Color[] = [
+    {
+        colorVariable: "varde-10",
+        rgbValue: { r: 249, g: 246, b: 244 },
+    },
+    {
+        colorVariable: "varde-20",
+        rgbValue: { r: 244, g: 240, b: 236 },
+    },
+    {
+        colorVariable: "varde-30",
+        rgbValue: { r: 237, g: 231, b: 224 },
+    },
+    {
+        colorVariable: "varde-40",
+        rgbValue: { r: 229, g: 221, b: 211 },
+    },
+    {
+        colorVariable: "varde-50",
+        rgbValue: { r: 222, g: 212, b: 199 },
+    },
+    {
+        colorVariable: "varde-60",
+        rgbValue: { r: 207, g: 193, b: 174 },
+    },
+    {
+        colorVariable: "varde-70",
+        rgbValue: { r: 186, g: 165, b: 137 },
+    },
+    {
+        colorVariable: "varde-80",
+        rgbValue: { r: 171, g: 146, b: 113 },
+    },
+    {
+        colorVariable: "varde-90",
+        rgbValue: { r: 141, g: 116, b: 83 },
+    },
+    {
+        colorVariable: "varde-100",
+        rgbValue: { r: 104, g: 86, b: 62 },
+    },
+];
+
+export const GraTable = () => <ColorTable colors={gratoner} />;
+
+export const VardeTable = () => <ColorTable colors={vardetoner} />;

--- a/portal/src/components/Documentation/Colors/Colors.scss
+++ b/portal/src/components/Documentation/Colors/Colors.scss
@@ -1,0 +1,133 @@
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
+@import "~@fremtind/jkl-core/_functions.scss";
+
+.jkl-portal-color-info {
+    display: inline-flex;
+
+    &__swatch {
+        width: rem(104px);
+        height: rem(104px);
+        flex-shrink: 0;
+        margin-right: $layout-spacing--small;
+    }
+
+    &--vertical {
+        flex-direction: column;
+
+        .jkl-portal-color-info__swatch {
+            margin-bottom: $layout-spacing--medium;
+        }
+    }
+}
+
+.jkl-portal-color-swatch {
+    min-height: rem(20px);
+    min-width: rem(20px);
+    position: relative;
+
+    &__diamond {
+        fill: currentColor;
+        stroke-width: 0.1;
+        stroke: currentColor;
+    }
+
+    &--hvit {
+        color: $hvit;
+        .jkl-portal-color-swatch__diamond {
+            stroke: $svart;
+        }
+    }
+    &--varde {
+        color: $varde;
+    }
+    &--svart {
+        color: $svart;
+    }
+    &--suksess {
+        color: $suksess;
+    }
+    &--advarsel {
+        color: $advarsel;
+    }
+    &--feil {
+        color: $feil;
+    }
+    &--info {
+        color: $info;
+    }
+    &--suksess--darkbg {
+        color: $suksess--darkbg;
+    }
+    &--advarsel--darkbg {
+        color: $advarsel--darkbg;
+    }
+    &--feil--darkbg {
+        color: $feil--darkbg;
+    }
+    &--info--darkbg {
+        color: $info--darkbg;
+    }
+
+    &--varde-10 {
+        color: $varde-10;
+    }
+    &--varde-20 {
+        color: $varde-20;
+    }
+    &--varde-30 {
+        color: $varde-30;
+    }
+    &--varde-40 {
+        color: $varde-40;
+    }
+    &--varde-50 {
+        color: $varde-50;
+    }
+    &--varde-60 {
+        color: $varde-60;
+    }
+    &--varde-70 {
+        color: $varde-70;
+    }
+    &--varde-80 {
+        color: $varde-80;
+    }
+    &--varde-90 {
+        color: $varde-90;
+    }
+    &--varde-100 {
+        color: $varde-100;
+    }
+
+    &--gra-10 {
+        color: $gra-10;
+    }
+    &--gra-20 {
+        color: $gra-20;
+    }
+    &--gra-30 {
+        color: $gra-30;
+    }
+    &--gra-40 {
+        color: $gra-40;
+    }
+    &--gra-50 {
+        color: $gra-50;
+    }
+    &--gra-60 {
+        color: $gra-60;
+    }
+    &--gra-70 {
+        color: $gra-70;
+    }
+    &--gra-80 {
+        color: $gra-80;
+    }
+    &--gra-90 {
+        color: $gra-90;
+    }
+    &--gra-100 {
+        color: $gra-100;
+    }
+}

--- a/portal/src/components/Documentation/Colors/Colors.tsx
+++ b/portal/src/components/Documentation/Colors/Colors.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import classNames from "classnames";
+
+import "./Colors.scss";
+
+interface RgbValue {
+    r: number;
+    g: number;
+    b: number;
+}
+
+export interface Color {
+    colorVariable: string;
+    rgbValue: RgbValue;
+    cmyk?: string;
+    pantone?: string;
+}
+
+const componentToHex = (numValue: number) => {
+    const hexVal = numValue.toString(16).toUpperCase();
+    return hexVal.length === 1 ? `0${hexVal}` : hexVal;
+};
+export const rgbToHex = (rgbValue: RgbValue) =>
+    componentToHex(rgbValue.r) + componentToHex(rgbValue.g) + componentToHex(rgbValue.b);
+
+interface ColorSwatchProps {
+    colorVariable: string;
+    className?: string;
+}
+
+export const ColorSwatch = ({ colorVariable, className }: ColorSwatchProps) => (
+    <svg
+        role="img"
+        aria-label={`Fargeprøve av fargen ${colorVariable}`}
+        className={`jkl-portal-color-swatch jkl-portal-color-swatch--${colorVariable} ${className ? className : ""}`}
+        viewBox="0 0 20 20"
+        fill="none"
+    >
+        <title>{`Fargeprøve av fargen ${colorVariable}`}</title>
+        <path
+            className="jkl-portal-color-swatch__diamond"
+            d="M0.0707109 10L10 0.0707109L19.9293 10L10 19.9293L0.0707109 10Z"
+        />
+    </svg>
+);
+
+interface ColorInfoProps extends Color {
+    vertical?: boolean;
+    className?: string;
+}
+
+export const ColorInfo = ({ colorVariable, rgbValue, cmyk, pantone, vertical, className }: ColorInfoProps) => {
+    const colorInfoClassName = classNames(
+        {
+            "jkl-portal-color-info": true,
+            "jkl-portal-color-info--vertical": vertical,
+        },
+        className,
+    );
+    return (
+        <article className={colorInfoClassName}>
+            <ColorSwatch className="jkl-portal-color-info__swatch" colorVariable={colorVariable} />
+            <p className="jkl-portal-color-info__values jkl-small">
+                {`RGB: ${rgbValue.r} ${rgbValue.g} ${rgbValue.b}`}
+                <br />
+                {`HEX: ${rgbToHex(rgbValue)}`}
+                {cmyk && <br />}
+                {cmyk && `CMYK: ${cmyk}`}
+                {pantone && <br />}
+                {pantone}
+            </p>
+        </article>
+    );
+};

--- a/portal/src/texts/profile/colors.mdx
+++ b/portal/src/texts/profile/colors.mdx
@@ -4,71 +4,148 @@ path: /profil/farger
 order: 3
 ---
 
+import { ColorDescription, TwoToneColorDescription } from "../../components/Documentation/Colors/ColorDescription";
+import { GraTable, VardeTable } from "../../components/Documentation/Colors/ColorTable";
+
 # Farger
 
-Farger er en viktig del av Fremtinds identitet. Det etterlatte inntrykket av våre løsninger skal være hvitt, med svart og varde som profilbærende farger. Profilen støttes av funksjonelle farger, som er inspirert av norsk natur. 
-
-Fargepaletten vår er delt inn i tre grupper: Primærfarger, grå- og vardevalører og meldingsfarger. 
+<Ingress>
+    Farger er en viktig del av Fremtinds identitet. Det etterlatte inntrykket av våre løsninger skal være hvitt, med
+    svart og varde som profilbærende farger. Profilen støttes av funksjonelle farger, som er inspirert av norsk natur.
+</Ingress>
 
 ## Primærfargene
-Hvit, svart og varde. Disse fargene bruker vi både på trykk og i digitale flater. Disse bærer profilen vår og er de mest gjenkjennelige fargene i vårt uttrykk. Primærfargene våre er:
 
-### Svart #000000 
-Svart bruker vi gjerne i elementer vi vil fremheve. Et godt eksempel er den svarte primærknappen. Vi kan bruke store, svarte flater, men de bør ha lite innhold i forhold til størrelsen. Unngå å sette svarte flater nær bakgrunner med fargen varde.
+Disse fargene bruker vi både på trykk og i digitale flater. Disse bærer profilen vår og er de mest gjenkjennelige fargene i vårt uttrykk. Primærfargene våre er:
 
-### Hvit #FFFFFF 
-Hvit bruker vi mest som bakgrunnsfarge, og som tekstfarge der vi har mørke flater. I tillegg er den fokusfarge, for eksempel på kort som er opphøyd over annet innhold, eller på inndataelementer som brukeren har valgt, for eksempel et felt i et skjema.
+<ColorDescription title="Hvit" colorVariable="hvit" rgbValue={{ r: 255, g: 255, b: 255 }} cmyk="0 0 0 0">
+    Hvit bruker vi mest som bakgrunnsfarge, og som tekstfarge der vi har mørke flater. I tillegg er den fokusfarge, for
+    eksempel på kort som er opphøyd over annet innhold, eller på inndataelementer som brukeren har valgt, for eksempel
+    et felt i et skjema.
+</ColorDescription>
 
-### Varde #DED4C7 
-Varde bruker vi som bakgrunnsfarge eller på elementer for å fremheve innhold. Når vi velger å bruke den på en flate, unngår vi å ha mye innhold på den, i forhold til størrelsen. Bruk svart på teksten, for å sikre god kontrast. Ikke bruke varde på flater som står nærme grå bakgrunner og elementer, eller svarte flater.
+<ColorDescription
+    title="Svart"
+    colorVariable="svart"
+    rgbValue={{ r: 0, g: 0, b: 0 }}
+    cmyk="15 15 15 100"
+    pantone="Pantone Black U"
+>
+    Svart bruker vi gjerne i elementer vi vil fremheve. Et godt eksempel er den svarte primærknappen. Vi kan bruke
+    store, svarte flater, men de bør ha lite innhold i forhold til størrelsen. Unngå å sette svarte flater nær
+    bakgrunner med fargen varde.
+</ColorDescription>
 
-## Grå- og vardevalører. 
+<ColorDescription
+    title="Varde"
+    colorVariable="varde"
+    rgbValue={{ r: 222, g: 212, b: 199 }}
+    cmyk="12 13 19 0"
+    pantone="Pantone 2310 U"
+>
+    Varde bruker vi som bakgrunnsfarge eller på elementer for å fremheve innhold. Når vi velger å bruke den på en flate,
+    unngår vi å ha mye innhold på den, i forhold til størrelsen. Bruk svart på teksten, for å sikre god kontrast. Ikke
+    bruke varde på flater som står nærme grå bakgrunner og elementer, eller svarte flater.
+</ColorDescription>
+
+## Grå- og vardevalørene
+
 Vi har et sett av valører for grå og varde. Disse kan vi bruke til å skape nyanser og nivåer i løsningene våre. Vi bruker disse i hovedsak bare på digitale flater.
 
 ### Gråvalører (Grå 10 - Grå 100)
+
+<GraTable />
+
 Disse kan brukes på elementer for å bryte opp layout og for å ha flere nyanser enn svart og hvit. For bruk til større flater og bakgrunner skal det bare brukes Grå-10, Grå-20, Grå-90 og Grå-100. Ikke bruk grå flater sammen med Varde, og vær obs på kontrast til innholdet når du bruker de ulike valørene.
 
 Grå 10 til Grå 50 kan brukes med svart tekst, mens Grå 60 til Grå 100 kan brukes med hvit tekst.
 
 ### Vardevalører (Varde 10 - Varde 100)
+
+<VardeTable />
+
 De lysere vardevalørene (Varde 50 og lavere) kan brukes som bakgrunnsflater eller på elementer for å bryte opp layout. Bruk de mørkere vardevalørene (Varde 60 og opp) med omhu. Ikke benytt de aller mørkeste som bakgrunnsfarge eller farge på større flater.
 
 For Varde 10 til Varde 90 skal man bruke svart tekst.
 
 ## Meldingsfargene
-Meldingsfargene bruker vi på digitale flater, for eksempel når vi trenger å gi informasjon fra systemet. Feil, advarsler, informasjonsmeldinger, grafer og fokusringer ved tastaturnavigasjon er eksempler på hva vi bruker meldingsfargene til.  Meldingsfargene skal bare brukes funksjonelt, det vil si ikke som rene dekorelementer.
 
-_For lyse flater (husk å sjekke kontrast for din løsning):_
+Meldingsfargene bruker vi på digitale flater, for eksempel når vi trenger å gi informasjon fra systemet. Feil, advarsler, informasjonsmeldinger, grafer og fokusringer ved tastaturnavigasjon er eksempler på hva vi bruker meldingsfargene til. Meldingsfargene skal bare brukes funksjonelt, det vil si ikke som rene dekorelementer.
 
-### Suksess #005F47
-En grønnfarge som vi bruker til å vise at en handling er vellykket, for eksempel at brukeren er ferdig med noe.
+Meldingsfargene finnes for mørk og lys bakgrunn.
 
-### Info #000AFA
-Denne blåfargen bruker vi til informasjonsmeldinger og fokustilstander.
+<TwoToneColorDescription
+    className="jkl-spacing--top-3"
+    title="Suksessfarge"
+    color={{
+        colorVariable: "suksess",
+        rgbValue: { r: 0, g: 95, b: 71 },
+    }}
+    darkColor={{
+        colorVariable: "suksess--darkbg",
+        rgbValue: { r: 95, g: 255, b: 160 },
+    }}
+>
+    En grønnfarge som vi bruker til å vise at en handling er vellykket, for eksempel at brukeren er ferdig med noe.
+</TwoToneColorDescription>
 
-### Feil #AA1F23
-En rødfarge som vi bruker til feilmeldinger eller andre viktige varsler.
+<TwoToneColorDescription
+    title="Infofarge"
+    color={{
+        colorVariable: "info",
+        rgbValue: { r: 0, g: 10, b: 250 },
+    }}
+    darkColor={{
+        colorVariable: "info--darkbg",
+        rgbValue: { r: 0, g: 250, b: 255 },
+    }}
+>
+    Blåfargen bruker vi til informasjonsmeldinger og fokustilstander.
+</TwoToneColorDescription>
 
-### Advarsel #FBB15B
-Denne gulfargen er til advarsler. Denne oppfyller ikke kontrastkravet mot hvit så kan ikke være funksjonsbærende mot hvite flater uten andre virkemiddler (e.g. tekst).
+<TwoToneColorDescription
+    title="Advarselsfarge"
+    color={{
+        colorVariable: "advarsel",
+        rgbValue: { r: 251, g: 177, b: 91 },
+    }}
+    darkColor={{
+        colorVariable: "advarsel--darkbg",
+        rgbValue: { r: 251, g: 177, b: 91 },
+    }}
+>
+    Denne gulfargen er til advarsler. Denne oppfyller ikke kontrastkravet mot hvit så den kan ikke være funksjonsbærende
+    mot hvite flater uten andre virkemiddler (e.g. tekst).
+</TwoToneColorDescription>
 
-_For mørke flater (husk å sjekke kontrast for din løsning):_
-
-### Suksess #5EFFA0
-En grønnfarge som vi bruker til å vise at en handling er vellykket, for eksempel at brukeren er ferdig med noe. Til å bruke mot mørke bakgrunner.
-
-### Info #00FAFF
-Denne blåfargen bruker vi til informasjonsmeldinger og fokustilstander. Til å bruke mot mørke bakgrunner.
-
-### Feil #FF8B79
-En rødfarge som vi bruker til feilmeldinger eller andre viktige varsler. Til å bruke mot mørke bakgrunner.
-
-### Advarsel #FEC97B
-Denne gulfargen er til advarsler. Til å bruke mot mørke bakgrunner.
+<TwoToneColorDescription
+    title="Feilfarge"
+    color={{
+        colorVariable: "feil",
+        rgbValue: { r: 0, g: 95, b: 71 },
+    }}
+    darkColor={{
+        colorVariable: "feil--darkbg",
+        rgbValue: { r: 255, g: 139, b: 121 },
+    }}
+>
+    En rødfarge som vi bruker til feilmeldinger eller andre viktige varsler.
+</TwoToneColorDescription>
 
 ## Tilgjengelighet
+
 Tilgjengelighet er noe av det viktigste å tenke på når vi bruker farger i digitale løsninger. Vi skal alltid følge kravene til universell utforming. For farger betyr det AA-kravet for kontrast. Kontrastkravet gjelder ikke bare tekst på bakgrunn, men også komponentenes kontrast mot sin egen bakgrunn, når det har betydning for å forstå funksjonaliteten.
 
 I tillegg til å tenke på tekst mot knappebakgrunnen, må vi også tenke på knappebakgrunnen mot sidens bakgrunnsfarge dersom det er viktig for å forstå funksjonen til komponenten.
 
 Tekstfargene våre er helhvit eller svart. Se fargebeskrivelsene for å finne ut hvilken farge du skal bruke mot hvilken bakgrunn, for å overholde kontrastkravet.
+
+### Plugins til Figma
+
+-   [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker)
+-   Se også [denne listen](https://www.figma.com/blog/design-for-everyone-with-these-accessibility-focused-plugins/) over nyttige plugins.
+
+### Andre verktøy
+
+-   [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+-   [Colour Contrast Analyzer](https://developer.paciellogroup.com/resources/contrastanalyser/)


### PR DESCRIPTION
## 📥 Proposed changes

Oppgrader fargedokumentasjonen under "profilen vår".

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Jeg kunne sikkert ha delt opp støttekomponentene i et par filer for lesbarhetens skyld. Si fra om dere synes jeg bør det. Har også brukt CSS-grid her, men kun i et omfang som bør støttes av IE med `-ms-grid` om vi vil ha inn støtte for IE i portalen senere.

affects: @fremtind/portal

Closes: #1015 
