### PR TITLE
feat(portal): add ids to level 2 headings for linking

### DIFF
--- a/portal/src/components/Typography/Typography.tsx
+++ b/portal/src/components/Typography/Typography.tsx
@@ -8,11 +8,14 @@ export const PageTitle: React.FC = ({ children, ...rest }) => (
     </h1>
 );
 
-export const HeadingLarge: React.FC = ({ children, ...rest }) => (
-    <h2 className="jkl-heading-large jkl-portal-heading-large" {...rest}>
-        {children}
-    </h2>
-);
+export const HeadingLarge: React.FC = ({ children, ...rest }) => {
+    const id = typeof children === "string" ? children.toLowerCase().replace(/[^\wæøåÆØÅ]+/g, "-") : undefined;
+    return (
+        <h2 className="jkl-heading-large jkl-portal-heading-large" id={id} {...rest}>
+            {children}
+        </h2>
+    );
+};
 
 export const HeadingMedium: React.FC = ({ children, ...rest }) => (
     <h3 className="jkl-heading-medium jkl-portal-heading-medium" {...rest}>


### PR DESCRIPTION
## 📥 Proposed changes

Add `id` attribute to all level 2 headings in the portal to facilitate TOC-style linking within documentation.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal