### PR TITLE
Nye util-klasser for spacing, og dokumentasjon av spacing

### DIFF
--- a/packages/core/documentation/Spacing/Spacing.scss
+++ b/packages/core/documentation/Spacing/Spacing.scss
@@ -1,0 +1,83 @@
+@import "../../variables/all";
+@import "../../functions";
+
+.jkl-portal-spacing-example-table {
+    border: 0;
+    width: 100%;
+    max-width: rem(768px);
+
+    &__data,
+    &__header {
+        padding: $component-spacing--small;
+        @include jkl-text-style("desktop/small");
+        text-align: left;
+        vertical-align: top;
+        border-bottom: rem(1px) solid;
+        box-sizing: border-box;
+
+        &:nth-of-type(1) {
+            width: 30%;
+        }
+        &:nth-of-type(2),
+        &:nth-of-type(3) {
+            width: 35%;
+        }
+    }
+
+    &__header {
+        font-weight: $bold-weight;
+        border-bottom-color: $svart;
+        min-height: rem(40px);
+    }
+
+    &__data {
+        border-bottom-color: $gra-50;
+        padding-bottom: $component-spacing--large;
+        min-height: rem(48px);
+    }
+
+    @include small-device {
+        &__header,
+        &__data {
+            &:nth-of-type(1),
+            &:nth-of-type(2),
+            &:nth-of-type(3) {
+                width: initial;
+            }
+        }
+
+        &__header {
+            display: none;
+        }
+
+        &__data {
+            display: flex;
+            align-items: center;
+            text-align: end;
+            justify-content: space-between;
+
+            &::before {
+                content: attr(data-header);
+                margin-right: $component-spacing--medium;
+            }
+
+            &:first-of-type::before {
+                font-weight: $bold-weight;
+            }
+        }
+
+        &__row {
+            display: block;
+
+            &:not(:last-of-type) {
+                margin-bottom: $layout-spacing--medium;
+            }
+        }
+    }
+
+    *[data-theme="dark"] & {
+        &__header {
+            border-bottom-color: $hvit;
+        }
+    }
+}

--- a/packages/core/documentation/Spacing/Spacing.tsx
+++ b/packages/core/documentation/Spacing/Spacing.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from "react";
+
+import "./Spacing.scss";
+
+function stringLiteralArray<T extends string>(a: T[]) {
+    return a;
+}
+
+const componentSpacings = stringLiteralArray([
+    "component-spacing--xxs",
+    "component-spacing--xs",
+    "component-spacing--small",
+    "component-spacing--medium",
+    "component-spacing--large",
+    "component-spacing--xl",
+    "component-spacing--xxl",
+    "component-spacing--giant",
+]);
+
+const layoutSpacings = stringLiteralArray([
+    "layout-spacing--small",
+    "layout-spacing--medium",
+    "layout-spacing--large",
+    "layout-spacing--xl",
+    "layout-spacing--xxl",
+]);
+
+type spacingClass = typeof componentSpacings[number] | typeof layoutSpacings[number];
+
+const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const getComputed = (cssProperty: string) => {
+        if (ref.current) {
+            return window?.getComputedStyle(ref.current)?.getPropertyValue(cssProperty);
+        }
+        return "N/A";
+    };
+    const baseFontSize = 16; // 1rem = 16px
+    const pxValue = parseInt(getComputed("margin-top"));
+    const remValue = pxValue ? pxValue / baseFontSize : pxValue;
+    return (
+        <tr className="jkl-portal-spacing-example-table__row">
+            <td data-header="Spacing:" className="jkl-portal-spacing-example-table__data">
+                <div className={`jkl-${spacing}-top`} style={{ display: "none" }} ref={ref} />
+                <div
+                    aria-label={spacing}
+                    style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }}
+                />
+            </td>
+            <td data-header="Variabel:" className="jkl-portal-spacing-example-table__data">
+                <code className="jkl-portal-inline-code">${spacing}</code>
+            </td>
+            <td data-header="Klasse:" className="jkl-portal-spacing-example-table__data">
+                <code className="jkl-portal-inline-code">{`.jkl-${spacing}-<top|right|bottom|left|all>`}</code>
+            </td>
+        </tr>
+    );
+};
+
+const SpacingTable: React.FC<{ values: spacingClass[] }> = ({ values }) => (
+    <table className="jkl-portal-spacing-example-table">
+        <thead>
+            <tr>
+                <th className="jkl-portal-spacing-example-table__header">Spacing</th>
+                <th className="jkl-portal-spacing-example-table__header">Variabel</th>
+                <th className="jkl-portal-spacing-example-table__header">Klasse</th>
+            </tr>
+        </thead>
+        <tbody>
+            {values.map((value, idx) => (
+                <SpacingTableRow key={idx} spacing={value} />
+            ))}
+        </tbody>
+    </table>
+);
+
+export const ComponentSpacingTable = () => <SpacingTable values={componentSpacings} />;
+export const LayoutSpacingTable = () => <SpacingTable values={layoutSpacings} />;

--- a/packages/core/documentation/spacing.mdx
+++ b/packages/core/documentation/spacing.mdx
@@ -1,0 +1,42 @@
+---
+title: Spacing
+scss: core
+react: core
+---
+
+import { ComponentSpacingTable, LayoutSpacingTable } from "./Spacing/Spacing";
+
+<Ingress>Vi tilbyr Sass-variabler og utility-klasser for verdiene i spacing-skalaene til Jøkul.</Ingress>
+
+## Bruk
+
+Det er to spacing-skalaer i Jøkul; en til bruk innad i komponenter og en til bruk i layout og flyt. Du kan bruke skalaene ved hjelp av Sass-variabler du kan sette inn i ditt eget stilark, eller bruke hjelpeklassene direkte på elementer i koden.
+
+Variablene importerer du fra `@fremtind/jkl-core/variables/_spacing.scss`. Husk å bruke riktig importsyntaks for byggverktøyet ditt når du importerer. De kan da brukes slik:
+
+```scss
+@import "~@fremtind/jkl-core/variables/_spacing.scss";
+
+.jkl-your-component {
+    padding-left: $component-spacing--medium;
+}
+```
+
+Utility-klassene setter en verdi fra spacingskalaene som margin på elementet som har klassen. Det finnes varianter for å sette margin på `top`, `right`, `bottom` og `left`, samt for `all`e sider. Klassene kan brukes slik:
+
+```html
+<div class="jkl-layout-spacing--xl-all">
+    <span class="jkl-layout-spacing--small-right">Hallo</span>
+    verden
+</div>
+```
+
+<div class="jkl-layout-spacing--xl-top" />
+
+### Komponentskala
+
+<ComponentSpacingTable />
+
+### Layoutskala
+
+<LayoutSpacingTable />

--- a/packages/core/spacing.scss
+++ b/packages/core/spacing.scss
@@ -16,3 +16,29 @@ $positions: top, bottom, left, right;
     }
     $counter: $counter + 1;
 }
+
+@each $name, $spacing in $component-spacing-new {
+    .jkl-component-spacing--#{$name} {
+        &-all {
+            margin: $spacing;
+        }
+        @each $position in $positions {
+            &-#{$position} {
+                margin-#{$position}: $spacing;
+            }
+        }
+    }
+}
+
+@each $name, $spacing in $layout-spacing-new {
+    .jkl-layout-spacing--#{$name} {
+        &-all {
+            margin: $spacing;
+        }
+        @each $position in $positions {
+            &-#{$position} {
+                margin-#{$position}: $spacing;
+            }
+        }
+    }
+}

--- a/packages/core/variables/_spacing.scss
+++ b/packages/core/variables/_spacing.scss
@@ -20,6 +20,21 @@ $component-spacing--xl: $spacing-6;
 $component-spacing--xxl: $spacing-7;
 $component-spacing--giant: $spacing-8;
 
+$component-spacing: $component-spacing--xxs, $component-spacing--xs, $component-spacing--small,
+    $component-spacing--medium, $component-spacing--large, $component-spacing--xl, $component-spacing--xxl,
+    $component-spacing--giant;
+
+$component-spacing-new: (
+    "xxs": $component-spacing--xxs,
+    "xs": $component-spacing--xs,
+    "small": $component-spacing--small,
+    "medium": $component-spacing--medium,
+    "large": $component-spacing--large,
+    "xl": $component-spacing--xl,
+    "xxl": $component-spacing--xxl,
+    "giant": $component-spacing--giant,
+);
+
 // Layout scale
 $layout-spacing--small: $spacing-6;
 $layout-spacing--medium: $spacing-7;
@@ -29,3 +44,11 @@ $layout-spacing--xxl: $spacing-10;
 
 $layout-spacing: $layout-spacing--small, $layout-spacing--medium, $layout-spacing--large, $layout-spacing--xl,
     $layout-spacing--xxl;
+
+$layout-spacing-new: (
+    "small": $layout-spacing--small,
+    "medium": $layout-spacing--medium,
+    "large": $layout-spacing--large,
+    "xl": $layout-spacing--xl,
+    "xxl": $layout-spacing--xxl,
+);

--- a/portal/src/components/Documentation/Spacing/SpacingTable.scss
+++ b/portal/src/components/Documentation/Spacing/SpacingTable.scss
@@ -1,0 +1,86 @@
+@import "~@fremtind/jkl-core/variables/_all.scss";
+
+.jkl-portal-spacing-table {
+    border: 0;
+    width: 100%;
+    max-width: rem(768px);
+
+    &__data,
+    &__header {
+        padding: $component-spacing--small;
+        @include jkl-text-style("desktop/small");
+        text-align: left;
+        vertical-align: top;
+        border-bottom: rem(1px) solid;
+        box-sizing: border-box;
+
+        &:nth-of-type(1) {
+            width: 50%;
+        }
+        &:nth-of-type(2),
+        &:nth-of-type(2) {
+            width: 10%;
+        }
+        &:nth-of-type(4) {
+            width: 30%;
+        }
+    }
+
+    &__header {
+        font-weight: $bold-weight;
+        border-bottom-color: $svart;
+        min-height: rem(40px);
+    }
+
+    &__data {
+        border-bottom-color: $gra-50;
+        padding-bottom: $component-spacing--large;
+        min-height: rem(48px);
+    }
+
+    @include small-device {
+        &__header,
+        &__data {
+            &:nth-of-type(1),
+            &:nth-of-type(2),
+            &:nth-of-type(3),
+            &:nth-of-type(4) {
+                width: initial;
+            }
+        }
+
+        &__header {
+            display: none;
+        }
+
+        &__data {
+            display: flex;
+            align-items: center;
+            text-align: end;
+            justify-content: space-between;
+
+            &::before {
+                content: attr(data-header);
+                margin-right: $layout-spacing--medium;
+            }
+
+            &:first-of-type::before {
+                font-weight: $bold-weight;
+            }
+        }
+
+        &__row {
+            display: block;
+
+            &:not(:last-of-type) {
+                margin-bottom: $layout-spacing--medium;
+            }
+        }
+    }
+
+    *[data-theme="dark"] & {
+        &__header {
+            border-bottom-color: $hvit;
+        }
+    }
+}

--- a/portal/src/components/Documentation/Spacing/SpacingTable.tsx
+++ b/portal/src/components/Documentation/Spacing/SpacingTable.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from "react";
+
+import "./SpacingTable.scss";
+
+function stringLiteralArray<T extends string>(a: T[]) {
+    return a;
+}
+
+const componentSpacings = stringLiteralArray([
+    "component-spacing--xxs",
+    "component-spacing--xs",
+    "component-spacing--small",
+    "component-spacing--medium",
+    "component-spacing--large",
+    "component-spacing--xl",
+    "component-spacing--xxl",
+    "component-spacing--giant",
+]);
+
+const layoutSpacings = stringLiteralArray([
+    "layout-spacing--small",
+    "layout-spacing--medium",
+    "layout-spacing--large",
+    "layout-spacing--xl",
+    "layout-spacing--xxl",
+]);
+
+type spacingClass = typeof componentSpacings[number] | typeof layoutSpacings[number];
+
+const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const getComputed = (cssProperty: string) => {
+        if (ref.current) {
+            return window?.getComputedStyle(ref.current)?.getPropertyValue(cssProperty);
+        }
+        return "N/A";
+    };
+    const pxValue = getComputed("margin-top").replace("px", "");
+    const remValue = pxValue !== "N/A" ? parseInt(pxValue) / 16 : pxValue;
+    return (
+        <tr className="jkl-portal-spacing-table__row">
+            <td data-header="Navn:" className="jkl-portal-spacing-table__data">
+                {spacing}
+            </td>
+            <td data-header="rem:" className="jkl-portal-spacing-table__data">
+                {remValue}
+            </td>
+            <td data-header="px:" className="jkl-portal-spacing-table__data">
+                {pxValue}
+            </td>
+            <td data-header="Eksempel:" className="jkl-portal-spacing-table__data">
+                <div className={`jkl-${spacing}-top`} style={{ display: "none" }} ref={ref} />
+                <div style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }} />
+            </td>
+        </tr>
+    );
+};
+
+const SpacingTable: React.FC<{ values: spacingClass[] }> = ({ values }) => (
+    <table className="jkl-portal-spacing-table">
+        <thead>
+            <tr>
+                <th className="jkl-portal-spacing-table__header">Navn</th>
+                <th className="jkl-portal-spacing-table__header">rem</th>
+                <th className="jkl-portal-spacing-table__header">px</th>
+                <th className="jkl-portal-spacing-table__header">Eksempel</th>
+            </tr>
+        </thead>
+        <tbody>
+            {values.map((value, idx) => (
+                <SpacingTableRow key={idx} spacing={value} />
+            ))}
+        </tbody>
+    </table>
+);
+
+export const ComponentSpacingTable = () => <SpacingTable values={componentSpacings} />;
+export const LayoutSpacingTable = () => <SpacingTable values={layoutSpacings} />;

--- a/portal/src/texts/profile/formdesign.mdx
+++ b/portal/src/texts/profile/formdesign.mdx
@@ -1,7 +1,7 @@
 ---
 title: Skjemadesign
 path: /profil/skjemadesign
-order: 11
+order: 12
 ---
 
 # Skjemadesign

--- a/portal/src/texts/profile/icon.mdx
+++ b/portal/src/texts/profile/icon.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ikoner
 path: /profil/ikoner
-order: 9
+order: 10
 ---
 
 # Ikoner

--- a/portal/src/texts/profile/picture.mdx
+++ b/portal/src/texts/profile/picture.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bildebruk
 path: /profil/bildebruk
-order: 8
+order: 9
 ---
 
 import PictureBox from "../../components/Documentation/Picture/PictureBox";

--- a/portal/src/texts/profile/shadow.mdx
+++ b/portal/src/texts/profile/shadow.mdx
@@ -1,8 +1,9 @@
 ---
 title: Skygger
 path: /profil/skygger
-order: 10
+order: 11
 ---
 
 # Skygger
+
 Vi bruker skygger for å skape inntrykket av elevasjon. Vi har ulike skygger for å skape et hierarki - man skal kunne se hvilket innhold som er på et bestemt nivå, og hva som er over eller under noe annet.

--- a/portal/src/texts/profile/spacing.mdx
+++ b/portal/src/texts/profile/spacing.mdx
@@ -1,0 +1,36 @@
+---
+title: Spacing
+path: /profil/spacing
+order: 8
+---
+
+import { ComponentSpacingTable, LayoutSpacingTable } from "../../components/Documentation/Spacing/SpacingTable";
+
+# Spacing
+
+<Ingress>
+    Spacing er viktig for å skape system, hierarki og god rytme på tvers av løsninger. Ved å etablere gode standarder
+    for avstand blir det enklere og raskere for designere og utviklere å ta gode valg.
+</Ingress>
+
+## Spacingskala
+
+Skalaen består av verdier for to ulike bruksområder; komponenter og layout. Noen av verdiene kan brukes begge steder, mens andre verdier er ment for ett spesifikt bruksområde.
+
+Til design av komponenter har vi behov for mindre verdier, f. eks når vi skal definere avstanden mellom `label` og `text-input`. Når vi zoomer ut og ser på sidens layout og skal definere avstand mellom ulike komponenter og innhold har vi behov for større verdier.
+
+### Komponentskala
+
+<ComponentSpacingTable />
+
+### Layoutskala
+
+<LayoutSpacingTable />
+
+### Praktisk
+
+For å gjøre det lettere å jobbe med skalaen i Figma kan du sette verdien av "big nudge" til 8px. Dette gjør du under Hamburgermeny (øverst til venstre) &rarr; Preferences &rarr; Nudge Amount.
+
+## Hvordan bruke spacingskalaen?
+
+Det er ingen konkret fasit på hvilke verdier i skalaen du skal benytte. Det vil avhenge av løsningen som designes.


### PR DESCRIPTION
## 📥 Proposed changes

- Legger til nye utility-klasser for spacing, som dekker både komponent- og layout-skalaen. De gamle util-klassene beholdes for kompatibilitet.
- Legger til dokumentasjon av spacing-skalaene både under "Profil" og "Komponenter" i portalen.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Closes #1017 
