### PR TITLE
Make portal code blocks accessible and add dark mode support

### DIFF
--- a/portal/src/components/CodeBlock/CodeBlock.scss
+++ b/portal/src/components/CodeBlock/CodeBlock.scss
@@ -1,0 +1,37 @@
+@import "~@fremtind/jkl-core/_functions.scss";
+@import "~@fremtind/jkl-core/variables/_all.scss";
+
+.jkl-portal-code-block {
+    position: relative;
+    background-color: $gra-20;
+    border-radius: rem(2px);
+    width: 100%;
+    max-width: rem(768px);
+
+    &:before {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: $component-spacing--small;
+        background-color: $svart;
+        color: $gra-10;
+        @include jkl-text-style("desktop/micro");
+        text-transform: uppercase;
+        content: attr(data-language);
+    }
+
+    &__code {
+        display: block;
+        padding: $component-spacing--xl $component-spacing--large;
+        overflow-x: scroll;
+    }
+
+    *[data-theme="dark"] & {
+        background-color: $gra-90;
+
+        &:before {
+            background-color: $gra-50;
+            color: $svart;
+        }
+    }
+}

--- a/portal/src/components/CodeBlock/CodeBlock.tsx
+++ b/portal/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+
+import { useTheme } from "../../contexts/themeContext";
+import fremtindTheme from "./fremtindTheme";
+import fremtindThemeDark from "./fremtindThemeDark";
+
+import "./CodeBlock.scss";
+
+export const CodeBlock: React.FC<{ language: string }> = ({ language, children }) => {
+    const { theme } = useTheme();
+    const style = theme === "dark" ? fremtindThemeDark : fremtindTheme;
+    return (
+        <SyntaxHighlighter
+            className="jkl-portal-code-block"
+            style={style}
+            codeTagProps={{ style: {}, className: "jkl-portal-code-block__code" }}
+            language={language}
+            data-language={language}
+        >
+            {children}
+        </SyntaxHighlighter>
+    );
+};

--- a/portal/src/components/CodeBlock/fremtindTheme.ts
+++ b/portal/src/components/CodeBlock/fremtindTheme.ts
@@ -1,0 +1,171 @@
+export default {
+    'code[class*="language-"]': {
+        color: "black",
+        background: "none",
+        textShadow: "0 1px white",
+        fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+        textAlign: "left",
+        whiteSpace: "pre",
+        wordSpacing: "normal",
+        wordBreak: "normal",
+        wordWrap: "normal",
+        lineHeight: "1.5",
+        MozTabSize: "4",
+        OTabSize: "4",
+        tabSize: "4",
+        WebkitHyphens: "none",
+        MozHyphens: "none",
+        msHyphens: "none",
+        hyphens: "none",
+    },
+    'pre[class*="language-"]': {
+        lineHeight: "1.4",
+    },
+    'pre[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    ':not(pre) > code[class*="language-"]': {
+        background: "#f5f2f0",
+        padding: ".1em",
+        borderRadius: ".3em",
+        whiteSpace: "normal",
+    },
+    comment: {
+        color: "#68563E",
+    },
+    prolog: {
+        color: "#68563E",
+    },
+    doctype: {
+        color: "#68563E",
+    },
+    cdata: {
+        color: "#68563E",
+    },
+    punctuation: {
+        color: "#525252",
+    },
+    ".namespace": {
+        Opacity: ".7",
+    },
+    property: {
+        color: "#AA1F23",
+    },
+    tag: {
+        color: "#AA1F23",
+    },
+    boolean: {
+        color: "#AA1F23",
+    },
+    number: {
+        color: "#AA1F23",
+    },
+    constant: {
+        color: "#AA1F23",
+    },
+    symbol: {
+        color: "#AA1F23",
+    },
+    deleted: {
+        color: "#AA1F23",
+    },
+    selector: {
+        color: "#005F47",
+    },
+    "attr-name": {
+        color: "#005F47",
+    },
+    string: {
+        color: "#005F47",
+    },
+    char: {
+        color: "#005F47",
+    },
+    builtin: {
+        color: "#005F47",
+    },
+    inserted: {
+        color: "#005F47",
+    },
+    operator: {
+        color: "#9a6e3a",
+        background: "transparent",
+    },
+    entity: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+        cursor: "help",
+    },
+    url: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".language-css .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".style .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    atrule: {
+        color: "#000AFA",
+    },
+    "attr-value": {
+        color: "#000AFA",
+    },
+    keyword: {
+        color: "#000AFA",
+    },
+    function: {
+        color: "#cb252b",
+    },
+    "class-name": {
+        color: "#cb252b",
+    },
+    regex: {
+        color: "#9f5704",
+    },
+    important: {
+        color: "#9f5704",
+        fontWeight: "bold",
+    },
+    variable: {
+        color: "#9f5704",
+    },
+    bold: {
+        fontWeight: "bold",
+    },
+    italic: {
+        fontStyle: "italic",
+    },
+};

--- a/portal/src/components/CodeBlock/fremtindThemeDark.ts
+++ b/portal/src/components/CodeBlock/fremtindThemeDark.ts
@@ -1,0 +1,171 @@
+export default {
+    'code[class*="language-"]': {
+        color: "black",
+        background: "none",
+        textShadow: "0 1px white",
+        fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+        textAlign: "left",
+        whiteSpace: "pre",
+        wordSpacing: "normal",
+        wordBreak: "normal",
+        wordWrap: "normal",
+        lineHeight: "1.5",
+        MozTabSize: "4",
+        OTabSize: "4",
+        tabSize: "4",
+        WebkitHyphens: "none",
+        MozHyphens: "none",
+        msHyphens: "none",
+        hyphens: "none",
+    },
+    'pre[class*="language-"]': {
+        lineHeight: "1.4",
+    },
+    'pre[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    ':not(pre) > code[class*="language-"]': {
+        background: "#f5f2f0",
+        padding: ".1em",
+        borderRadius: ".3em",
+        whiteSpace: "normal",
+    },
+    comment: {
+        color: "#999999",
+    },
+    prolog: {
+        color: "#999999",
+    },
+    doctype: {
+        color: "#999999",
+    },
+    cdata: {
+        color: "#999999",
+    },
+    punctuation: {
+        color: "#D6D6D6",
+    },
+    ".namespace": {
+        Opacity: ".7",
+    },
+    property: {
+        color: "#FF8B79",
+    },
+    tag: {
+        color: "#FF8B79",
+    },
+    boolean: {
+        color: "#FF8B79",
+    },
+    number: {
+        color: "#FF8B79",
+    },
+    constant: {
+        color: "#FF8B79",
+    },
+    symbol: {
+        color: "#FF8B79",
+    },
+    deleted: {
+        color: "#FF8B79",
+    },
+    selector: {
+        color: "#5EFFA0",
+    },
+    "attr-name": {
+        color: "#5EFFA0",
+    },
+    string: {
+        color: "#5EFFA0",
+    },
+    char: {
+        color: "#5EFFA0",
+    },
+    builtin: {
+        color: "#5EFFA0",
+    },
+    inserted: {
+        color: "#5EFFA0",
+    },
+    operator: {
+        color: "#9a6e3a",
+        background: "transparent",
+    },
+    entity: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+        cursor: "help",
+    },
+    url: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".language-css .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".style .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    atrule: {
+        color: "#00FAFF",
+    },
+    "attr-value": {
+        color: "#00FAFF",
+    },
+    keyword: {
+        color: "#00FAFF",
+    },
+    function: {
+        color: "#ff644d",
+    },
+    "class-name": {
+        color: "#ff644d",
+    },
+    regex: {
+        color: "#FEC97B",
+    },
+    important: {
+        color: "#FEC97B",
+        fontWeight: "bold",
+    },
+    variable: {
+        color: "#FEC97B",
+    },
+    bold: {
+        fontWeight: "bold",
+    },
+    italic: {
+        fontStyle: "italic",
+    },
+};

--- a/portal/src/components/CodeBlock/index.ts
+++ b/portal/src/components/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export { CodeBlock } from "./CodeBlock";

--- a/portal/src/components/Typography/Typography.tsx
+++ b/portal/src/components/Typography/Typography.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { prism } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+import { CodeBlock as FTCodeBlock } from "../CodeBlock";
 
 export const PageTitle: React.FC = ({ children, ...rest }) => (
     <h1 className="jkl-title-large jkl-portal-page-title" {...rest}>
@@ -60,25 +60,5 @@ export const CodeBlock: React.FC = ({ children, ...rest }) => {
         return <pre {...rest}>{children}</pre>;
     }
     const language = child.props.className?.replace("language-", "");
-    const style = {
-        ...prism,
-        'pre[class*="language-"]': {
-            lineHeight: "1.4",
-        },
-        operator: {
-            ...prism.operator,
-            background: "transparent",
-        },
-    };
-    return (
-        <SyntaxHighlighter
-            className="jkl-portal-code-block"
-            style={style}
-            codeTagProps={{ style: {}, className: "jkl-portal-code-block__code" }}
-            language={language}
-            data-language={language}
-        >
-            {child.props.children}
-        </SyntaxHighlighter>
-    );
+    return <FTCodeBlock language={language}>{child.props.children}</FTCodeBlock>;
 };

--- a/portal/src/components/Typography/typography.scss
+++ b/portal/src/components/Typography/typography.scss
@@ -62,38 +62,3 @@
         background-color: $gra-80;
     }
 }
-
-.jkl-portal-code-block {
-    position: relative;
-    background-color: $gra-20;
-    border-radius: rem(2px);
-    width: 100%;
-    max-width: rem(768px);
-
-    &:before {
-        position: absolute;
-        top: 0;
-        right: 0;
-        padding: $component-spacing--small;
-        background-color: $svart;
-        color: $gra-10;
-        @include jkl-text-style("desktop/micro");
-        text-transform: uppercase;
-        content: attr(data-language);
-    }
-
-    &__code {
-        display: block;
-        padding: $component-spacing--xl $component-spacing--large;
-        overflow-x: scroll;
-    }
-
-    *[data-theme="dark"] & {
-        background-color: $gra-90;
-
-        &:before {
-            background-color: $gra-50;
-            color: $svart;
-        }
-    }
-}


### PR DESCRIPTION
## 📥 Proposed changes

Add support for dark mode, and adjust light theme, for code blocks in the portal. Achieves AA
contrast in both dark and light themes.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal
