### PR TITLE
test: update tests to use new testing library syntax

### DIFF
--- a/packages/accordion-react/src/Accordion.test.tsx
+++ b/packages/accordion-react/src/Accordion.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Accordion } from ".";
-
-afterEach(cleanup);
 
 describe("Accordion", () => {
     it("should render without exploding", () => {

--- a/packages/accordion-react/src/Accordion.test.tsx
+++ b/packages/accordion-react/src/Accordion.test.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Accordion } from ".";
 
 afterEach(cleanup);
 
 describe("Accordion", () => {
     it("should render without exploding", () => {
-        const { getByTestId } = render(<Accordion>Hello</Accordion>);
+        render(<Accordion>Hello</Accordion>);
 
-        expect(getByTestId("jkl-accordion")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-accordion")).toBeInTheDocument();
     });
     it("should render its children", () => {
-        const { getByText } = render(<Accordion>Hello</Accordion>);
+        render(<Accordion>Hello</Accordion>);
 
-        expect(getByText("Hello")).toBeInTheDocument();
+        expect(screen.getByText("Hello")).toBeInTheDocument();
     });
 });

--- a/packages/accordion-react/src/AccordionItem.test.tsx
+++ b/packages/accordion-react/src/AccordionItem.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { AccordionItem } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("AccordionItem", () => {
     it("should render without exploding", () => {

--- a/packages/accordion-react/src/AccordionItem.test.tsx
+++ b/packages/accordion-react/src/AccordionItem.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { AccordionItem } from ".";
 import { axe } from "jest-axe";
 
@@ -7,38 +7,38 @@ afterEach(cleanup);
 
 describe("AccordionItem", () => {
     it("should render without exploding", () => {
-        const { getByTestId } = render(<AccordionItem title="Hello">Something</AccordionItem>);
+        render(<AccordionItem title="Hello">Something</AccordionItem>);
 
-        expect(getByTestId("jkl-accordion-item")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-accordion-item")).toBeInTheDocument();
     });
     it("should apply custom classnames", () => {
-        const { getByTestId } = render(
+        render(
             <AccordionItem title="Hello" className="custom-class">
                 Something
             </AccordionItem>,
         );
 
-        expect(getByTestId("jkl-accordion-item")).toHaveClass("custom-class");
+        expect(screen.getByTestId("jkl-accordion-item")).toHaveClass("custom-class");
     });
     it("should render its children", () => {
-        const { getByText } = render(<AccordionItem title="Hello">Something</AccordionItem>);
-        const child = getByText("Something");
+        render(<AccordionItem title="Hello">Something</AccordionItem>);
+        const child = screen.getByText("Something");
 
         expect(child).toBeInTheDocument();
     });
     it("should start closed as default", () => {
-        const { getByTestId } = render(<AccordionItem title="Hello">Something</AccordionItem>);
-        const wrapper = getByTestId("jkl-accordion-item__content-wrapper");
+        render(<AccordionItem title="Hello">Something</AccordionItem>);
+        const wrapper = screen.getByTestId("jkl-accordion-item__content-wrapper");
 
         expect(wrapper).toHaveProperty("hidden", true);
     });
     it("should start open if told to", () => {
-        const { getByTestId } = render(
+        render(
             <AccordionItem startExpanded={true} title="Hello">
                 Something
             </AccordionItem>,
         );
-        const wrapper = getByTestId("jkl-accordion-item__content-wrapper");
+        const wrapper = screen.getByTestId("jkl-accordion-item__content-wrapper");
 
         expect(wrapper).toHaveProperty("hidden", false);
     });

--- a/packages/alert-message-react/src/AlertMessage.test.tsx
+++ b/packages/alert-message-react/src/AlertMessage.test.tsx
@@ -25,8 +25,8 @@ describe("Alert messages", () => {
     [messageWithStyles, messageWitoutStyles].forEach((messageStyleProps) => {
         types.map(([name, E]) => {
             it(name + " should render message content", () => {
-                const { getByText } = render(<E {...messageStyleProps}>content</E>);
-                getByText("content");
+                render(<E {...messageStyleProps}>content</E>);
+                screen.getByText("content");
             });
         });
     });

--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from ".";
 import { axe } from "jest-axe";
 
@@ -14,17 +14,17 @@ describe("Button", () => {
     ].map((buttonVariant) => {
         it(`renders the ${buttonVariant.name} button correctly`, () => {
             const { name, component: Button } = buttonVariant;
-            const { getByText } = render(<Button onClick={() => {}}>{name}</Button>);
+            render(<Button onClick={() => {}}>{name}</Button>);
 
-            expect(getByText(name)).toHaveClass(`jkl-button--${name}`);
+            expect(screen.getByText(name)).toHaveClass(`jkl-button--${name}`);
         });
     });
 
     it("calls the onClick handler when clicked", () => {
         const clickHandler = jest.fn();
-        const { getByText } = render(<PrimaryButton onClick={clickHandler}>I am groot!</PrimaryButton>);
+        render(<PrimaryButton onClick={clickHandler}>I am groot!</PrimaryButton>);
 
-        const button = getByText("I am groot!");
+        const button = screen.getByText("I am groot!");
 
         button.click();
 
@@ -32,23 +32,23 @@ describe("Button", () => {
     });
 
     it("applies passed classNames", () => {
-        const { getByText } = render(
+        render(
             <PrimaryButton className="test-class" onClick={() => {}}>
                 test
             </PrimaryButton>,
         );
 
-        expect(getByText("test")).toHaveClass("test-class");
+        expect(screen.getByText("test")).toHaveClass("test-class");
     });
 
     it("applies compact mode when forced to", () => {
-        const { getByText } = render(
+        render(
             <PrimaryButton forceCompact onClick={() => {}}>
                 test
             </PrimaryButton>,
         );
 
-        expect(getByText("test")).toHaveClass("jkl-button--compact");
+        expect(screen.getByText("test")).toHaveClass("jkl-button--compact");
     });
 });
 

--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from ".";
 import { axe } from "jest-axe";
 
@@ -24,7 +24,7 @@ describe("Button", () => {
 
         const button = screen.getByText("I am groot!");
 
-        button.click();
+        fireEvent.click(button);
 
         expect(clickHandler).toHaveBeenCalled();
     });

--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { PrimaryButton, SecondaryButton, TertiaryButton } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Button", () => {
     // Test all button variants:

--- a/packages/card-react/src/Card.test.tsx
+++ b/packages/card-react/src/Card.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Card } from ".";
 import { axe } from "jest-axe";
 
@@ -70,7 +70,7 @@ describe("Card", () => {
 
         const button = screen.getByText("Click me");
 
-        button.click();
+        fireEvent.click(button);
 
         expect(clickHandler).toHaveBeenCalled();
     });

--- a/packages/card-react/src/Card.test.tsx
+++ b/packages/card-react/src/Card.test.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Card } from ".";
 import { axe } from "jest-axe";
 
 describe("Card", () => {
-    afterAll(cleanup);
-
     it("renders without exploding", () => {
         render(
             <Card title="Hello">

--- a/packages/card-react/src/Card.test.tsx
+++ b/packages/card-react/src/Card.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Card } from ".";
 import { axe } from "jest-axe";
 
@@ -7,18 +7,18 @@ describe("Card", () => {
     afterAll(cleanup);
 
     it("renders without exploding", () => {
-        const { getByText } = render(
+        render(
             <Card title="Hello">
                 <p>Hello world</p>
             </Card>,
         );
 
-        expect(getByText("Hello world")).toBeInTheDocument();
+        expect(screen.getByText("Hello world")).toBeInTheDocument();
     });
 
     it("renders the given title", () => {
-        const { getByText } = render(<Card title="Fremtind" />);
-        expect(getByText("Fremtind")).toBeInTheDocument();
+        render(<Card title="Fremtind" />);
+        expect(screen.getByText("Fremtind")).toBeInTheDocument();
     });
 
     it("renders without title", () => {
@@ -27,56 +27,50 @@ describe("Card", () => {
     });
 
     it("has an image", () => {
-        const { getByRole } = render(<Card title="Test" media={{ src: "image.jpg", alt: "Image" }} />);
+        render(<Card title="Test" media={{ src: "image.jpg", alt: "Image" }} />);
 
-        const component = getByRole("img");
+        const component = screen.getByRole("img");
         expect(component).toBeInTheDocument();
     });
 
     it("renders image with label", () => {
-        const { getByAltText } = render(<Card title="Test" media={{ src: "image.jpg", alt: "Man with dog" }} />);
-        expect(getByAltText("Man with dog")).toBeInTheDocument();
+        render(<Card title="Test" media={{ src: "image.jpg", alt: "Man with dog" }} />);
+        expect(screen.getByAltText("Man with dog")).toBeInTheDocument();
     });
 
     it("renders with darkmode", () => {
-        const { getByTestId } = render(<Card title="Test" dark />);
+        render(<Card title="Test" dark />);
 
-        const component = getByTestId("jkl-card");
+        const component = screen.getByTestId("jkl-card");
         expect(component).toHaveClass("jkl-card--dark");
     });
 
     it("uses the passed class name", () => {
-        const { getByTestId } = render(<Card title="Test" className="test-class" />);
+        render(<Card title="Test" className="test-class" />);
 
-        const component = getByTestId("jkl-card");
+        const component = screen.getByTestId("jkl-card");
         expect(component).toHaveClass("test-class");
     });
 
     it("has a button", () => {
-        const { getByRole } = render(
-            <Card title="Test" action={{ type: "secondary", name: "Test", onClick: () => {} }} />,
-        );
+        render(<Card title="Test" action={{ type: "secondary", name: "Test", onClick: () => {} }} />);
 
-        const component = getByRole("button");
+        const component = screen.getByRole("button");
         expect(component).toBeInTheDocument();
     });
 
     it("renders the given button", () => {
-        const { getByRole } = render(
-            <Card title="Test" action={{ type: "tertiary", name: "Click me", onClick: () => {} }}></Card>,
-        );
+        render(<Card title="Test" action={{ type: "tertiary", name: "Click me", onClick: () => {} }}></Card>);
 
-        const component = getByRole("button");
+        const component = screen.getByRole("button");
         expect(component).toHaveClass("jkl-button--tertiary");
     });
 
     it("executes the onclick function on button", () => {
         const clickHandler = jest.fn();
-        const { getByText } = render(
-            <Card title="Test" action={{ type: "primary", name: "Click me", onClick: clickHandler }} />,
-        );
+        render(<Card title="Test" action={{ type: "primary", name: "Click me", onClick: clickHandler }} />);
 
-        const button = getByText("Click me");
+        const button = screen.getByText("Click me");
 
         button.click();
 

--- a/packages/checkbox-react/src/Checkbox.test.tsx
+++ b/packages/checkbox-react/src/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Checkbox } from ".";
 import { axe } from "jest-axe";
 
@@ -16,7 +16,7 @@ describe("checkbox", () => {
 
         expect(input).toHaveProperty("checked", false);
 
-        label.click();
+        fireEvent.click(label);
 
         expect(input).toHaveProperty("checked", true);
     });
@@ -32,7 +32,7 @@ describe("checkbox", () => {
 
         expect(input).toHaveProperty("checked", false);
 
-        input.click();
+        fireEvent.click(input);
 
         expect(input).toHaveProperty("checked", true);
     });
@@ -65,7 +65,7 @@ describe("checkbox", () => {
 
         expect(input).toHaveProperty("checked", true);
 
-        input.click();
+        fireEvent.click(input);
 
         expect(input).toHaveProperty("checked", false);
     });
@@ -79,7 +79,7 @@ describe("checkbox", () => {
         );
 
         const input = screen.getByLabelText("Switch me!");
-        input.click();
+        fireEvent.click(input);
 
         expect(onChange).toHaveBeenCalled();
     });

--- a/packages/checkbox-react/src/Checkbox.test.tsx
+++ b/packages/checkbox-react/src/Checkbox.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Checkbox } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("checkbox", () => {
     it("should be checked after clicking the label", () => {

--- a/packages/checkbox-react/src/Checkbox.test.tsx
+++ b/packages/checkbox-react/src/Checkbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Checkbox } from ".";
 import { axe } from "jest-axe";
 
@@ -7,14 +7,14 @@ afterEach(cleanup);
 
 describe("checkbox", () => {
     it("should be checked after clicking the label", () => {
-        const { getByText, getByTestId } = render(
+        render(
             <Checkbox value="iamgroot" name="iamgroot">
                 I am groot!
             </Checkbox>,
         );
 
-        const label = getByText("I am groot!");
-        const input = getByTestId("jkl-checkbox-input");
+        const label = screen.getByText("I am groot!");
+        const input = screen.getByTestId("jkl-checkbox-input");
 
         expect(input).toHaveProperty("checked", false);
 
@@ -24,13 +24,13 @@ describe("checkbox", () => {
     });
 
     it("should be checked after clicking the input ", function () {
-        const { getByTestId } = render(
+        render(
             <Checkbox value="iamgroot" name="iamgroot">
                 I am groot!
             </Checkbox>,
         );
 
-        const input = getByTestId("jkl-checkbox-input");
+        const input = screen.getByTestId("jkl-checkbox-input");
 
         expect(input).toHaveProperty("checked", false);
 
@@ -40,13 +40,13 @@ describe("checkbox", () => {
     });
 
     it("should be checked if checked is true", function () {
-        const { getByTestId } = render(
+        render(
             <Checkbox value="iamgroot" name="iamgroot" checked={true} onChange={() => {}}>
                 I am groot!
             </Checkbox>,
         );
 
-        const input = getByTestId("jkl-checkbox-input");
+        const input = screen.getByTestId("jkl-checkbox-input");
 
         expect(input).toHaveProperty("checked", true);
     });
@@ -61,9 +61,9 @@ describe("checkbox", () => {
             );
         };
 
-        const { getByTestId } = render(<TestCheckbox />);
+        render(<TestCheckbox />);
 
-        const input = getByTestId("jkl-checkbox-input");
+        const input = screen.getByTestId("jkl-checkbox-input");
 
         expect(input).toHaveProperty("checked", true);
 
@@ -74,13 +74,13 @@ describe("checkbox", () => {
 
     it("should call the passed onChange method when clicked", () => {
         const onChange = jest.fn();
-        const { getByLabelText } = render(
+        render(
             <Checkbox value="switchme" name="switchme" onChange={onChange}>
                 Switch me!
             </Checkbox>,
         );
 
-        const input = getByLabelText("Switch me!");
+        const input = screen.getByLabelText("Switch me!");
         input.click();
 
         expect(onChange).toHaveBeenCalled();

--- a/packages/core/src/components/ScreenReaderOnly.test.tsx
+++ b/packages/core/src/components/ScreenReaderOnly.test.tsx
@@ -1,19 +1,19 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ScreenReaderOnly } from "./ScreenReaderOnly";
 
 test("should show content with correct className", () => {
-    const { getByText } = render(<ScreenReaderOnly>invisible for normal people</ScreenReaderOnly>);
+    render(<ScreenReaderOnly>invisible for normal people</ScreenReaderOnly>);
 
-    const hiddenText = getByText("invisible for normal people");
+    const hiddenText = screen.getByText("invisible for normal people");
 
     expect(hiddenText).toHaveAttribute("class", "jkl-sr-only ");
 });
 
 test("should show content with correct className", () => {
-    const { getByText } = render(<ScreenReaderOnly showOnFocus>invisible for normal people</ScreenReaderOnly>);
+    render(<ScreenReaderOnly showOnFocus>invisible for normal people</ScreenReaderOnly>);
 
-    const hiddenText = getByText("invisible for normal people");
+    const hiddenText = screen.getByText("invisible for normal people");
 
     expect(hiddenText).toHaveAttribute("class", "jkl-sr-only jkl-sr-only--focusable");
 });

--- a/packages/core/src/components/SupportLabel.test.tsx
+++ b/packages/core/src/components/SupportLabel.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { SupportLabel } from "./SupportLabel";
 
 describe("SupportLabel", () => {
-    afterEach(cleanup);
-
     const helpLabel = "helpfull text";
     const errorLabel = "error error error, read in a computer voice";
 

--- a/packages/core/src/components/SupportLabel.test.tsx
+++ b/packages/core/src/components/SupportLabel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { SupportLabel } from "./SupportLabel";
 
 describe("SupportLabel", () => {
@@ -9,28 +9,26 @@ describe("SupportLabel", () => {
     const errorLabel = "error error error, read in a computer voice";
 
     it("renders with help text when valid", () => {
-        const { getByText } = render(
-            <SupportLabel errorLabel={false ? errorLabel : undefined} helpLabel={helpLabel} />,
-        );
+        render(<SupportLabel errorLabel={false ? errorLabel : undefined} helpLabel={helpLabel} />);
 
-        expect(getByText(helpLabel)).toBeInTheDocument();
+        expect(screen.getByText(helpLabel)).toBeInTheDocument();
     });
 
     it("renders with error text when invalid", () => {
-        const { getByText } = render(<SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} />);
+        render(<SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} />);
 
-        expect(getByText(errorLabel)).toBeInTheDocument();
+        expect(screen.getByText(errorLabel)).toBeInTheDocument();
     });
 
     it("renders with error text when invalid without help text", () => {
-        const { getByText } = render(<SupportLabel errorLabel={errorLabel} />);
+        render(<SupportLabel errorLabel={errorLabel} />);
 
-        expect(getByText(errorLabel)).toBeInTheDocument();
+        expect(screen.getByText(errorLabel)).toBeInTheDocument();
     });
 
     it("renders with help text when valid without error text", () => {
-        const { getByText } = render(<SupportLabel helpLabel={helpLabel} />);
+        render(<SupportLabel helpLabel={helpLabel} />);
 
-        expect(getByText(helpLabel)).toBeInTheDocument();
+        expect(screen.getByText(helpLabel)).toBeInTheDocument();
     });
 });

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { DatePicker } from ".";
 import { axe } from "jest-axe";
-
-beforeEach(cleanup);
 
 describe("Datepicker", () => {
     it("renders with the correct format", () => {

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 import { DatePicker } from ".";
 import { axe } from "jest-axe";
 
@@ -8,16 +8,16 @@ beforeEach(cleanup);
 describe("Datepicker", () => {
     it("renders with the correct format", () => {
         const thePast = new Date(2019, 11, 24);
-        const { getByTestId } = render(<DatePicker initialDate={thePast} />);
+        render(<DatePicker initialDate={thePast} />);
 
-        const date = getByTestId("jkl-datepicker__input");
+        const date = screen.getByTestId("jkl-datepicker__input");
         expect(date).toHaveProperty("value", "24.12.2019");
     });
 
     it("fires onChange method on edit input with valid date", () => {
         const changeHandler = jest.fn();
-        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
-        const input = getByTestId("jkl-datepicker__input");
+        render(<DatePicker onChange={changeHandler} />);
+        const input = screen.getByTestId("jkl-datepicker__input");
         expect(input).toHaveProperty("value", "");
         fireEvent.change(input, { target: { value: "01.12.2019" } });
         expect(input).toHaveProperty("value", "01.12.2019");
@@ -26,8 +26,8 @@ describe("Datepicker", () => {
 
     it("fires onChange method with undefined when text input is cleared", () => {
         const changeHandler = jest.fn();
-        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
-        const input = getByTestId("jkl-datepicker__input");
+        render(<DatePicker onChange={changeHandler} />);
+        const input = screen.getByTestId("jkl-datepicker__input");
         expect(input).toHaveProperty("value", "");
         fireEvent.change(input, { target: { value: "some value to be cleared" } });
         fireEvent.change(input, { target: { value: "" } });
@@ -37,8 +37,8 @@ describe("Datepicker", () => {
 
     it("does not fire onChange on edit input with invalid date", () => {
         const changeHandler = jest.fn();
-        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
-        const input = getByTestId("jkl-datepicker__input");
+        render(<DatePicker onChange={changeHandler} />);
+        const input = screen.getByTestId("jkl-datepicker__input");
         expect(input).toHaveProperty("value", "");
         fireEvent.change(input, { target: { value: "a random string" } });
         expect(input).toHaveProperty("value", "a random string");
@@ -47,10 +47,10 @@ describe("Datepicker", () => {
 
     it("should change date on new props", () => {
         // New date takes MM.DD.YYYY values
-        const { container, getByTestId } = render(<DatePicker initialDate={new Date("02.02.2019")} />);
+        const { container } = render(<DatePicker initialDate={new Date("02.02.2019")} />);
         render(<DatePicker initialDate={new Date("09.12.2019")} />, { container });
 
-        const input = getByTestId("jkl-datepicker__input");
+        const input = screen.getByTestId("jkl-datepicker__input");
 
         // Check for date formatted as DD.MM.YYYY
         expect(input).toHaveProperty("value", "12.09.2019");

--- a/packages/field-group-react/src/FieldGroup.test.tsx
+++ b/packages/field-group-react/src/FieldGroup.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { FieldGroup } from "./FieldGroup";
 import { axe } from "jest-axe";
 
@@ -7,19 +7,19 @@ afterEach(cleanup);
 
 describe("FieldGroup", () => {
     it("should render the correct legend", () => {
-        const { getByText } = render(<FieldGroup legend="Hello"></FieldGroup>);
+        render(<FieldGroup legend="Hello"></FieldGroup>);
 
-        expect(getByText("Hello")).toBeInTheDocument;
+        expect(screen.getByText("Hello")).toBeInTheDocument;
     });
     it("should render the correct help text", () => {
-        const { getByText } = render(<FieldGroup legend="Hello" helpLabel="Helpful text"></FieldGroup>);
+        render(<FieldGroup legend="Hello" helpLabel="Helpful text"></FieldGroup>);
 
-        expect(getByText("Helpful text")).toBeInTheDocument;
+        expect(screen.getByText("Helpful text")).toBeInTheDocument;
     });
     it("should render the correct error text", () => {
-        const { getByText } = render(<FieldGroup legend="Hello" errorLabel="Helpful suggestion"></FieldGroup>);
+        render(<FieldGroup legend="Hello" errorLabel="Helpful suggestion"></FieldGroup>);
 
-        expect(getByText("Helpful suggestion")).toBeInTheDocument;
+        expect(screen.getByText("Helpful suggestion")).toBeInTheDocument;
     });
     it("should not render help text when there is an error text", () => {
         const { queryByText } = render(

--- a/packages/field-group-react/src/FieldGroup.test.tsx
+++ b/packages/field-group-react/src/FieldGroup.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { FieldGroup } from "./FieldGroup";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("FieldGroup", () => {
     it("should render the correct legend", () => {

--- a/packages/hamburger-react/src/Hamburger.test.tsx
+++ b/packages/hamburger-react/src/Hamburger.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Hamburger } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Hamburger", () => {
     it("should render to document", () => {

--- a/packages/hamburger-react/src/Hamburger.test.tsx
+++ b/packages/hamburger-react/src/Hamburger.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Hamburger } from ".";
 import { axe } from "jest-axe";
 
@@ -12,7 +12,7 @@ describe("Hamburger", () => {
         render(<Hamburger />);
 
         const burger = screen.getByTestId("jkl-hamburger");
-        burger.click();
+        fireEvent.click(burger);
 
         expect(burger).toHaveClass("jkl-hamburger--is-active");
     });
@@ -35,7 +35,7 @@ describe("Hamburger", () => {
         const fn = jest.fn();
         render(<Hamburger onClick={fn} />);
         const burger = screen.getByTestId("jkl-hamburger");
-        burger.click();
+        fireEvent.click(burger);
 
         expect(fn).toHaveBeenCalledTimes(1);
 

--- a/packages/hamburger-react/src/Hamburger.test.tsx
+++ b/packages/hamburger-react/src/Hamburger.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Hamburger } from ".";
 import { axe } from "jest-axe";
 
@@ -11,32 +11,32 @@ describe("Hamburger", () => {
     });
 
     it("should get class jkl-hamburger--is-active on click", () => {
-        const { getByTestId } = render(<Hamburger />);
+        render(<Hamburger />);
 
-        const burger = getByTestId("jkl-hamburger");
+        const burger = screen.getByTestId("jkl-hamburger");
         burger.click();
 
         expect(burger).toHaveClass("jkl-hamburger--is-active");
     });
 
     it("should get class jkl-hamburger--negative when specified", () => {
-        const { getByTestId } = render(<Hamburger negative />);
+        render(<Hamburger negative />);
 
-        const component = getByTestId("jkl-hamburger");
+        const component = screen.getByTestId("jkl-hamburger");
         expect(component).toHaveClass("jkl-hamburger--negative");
     });
 
     it("should have class jkl-hamburger--is-active if initialactive is true", () => {
-        const { getByTestId } = render(<Hamburger initialIsActive />);
+        render(<Hamburger initialIsActive />);
 
-        const component = getByTestId("jkl-hamburger");
+        const component = screen.getByTestId("jkl-hamburger");
         expect(component).toHaveClass("jkl-hamburger--is-active");
     });
 
     it("should render call onClick and set is active", () => {
         const fn = jest.fn();
-        const { getByTestId } = render(<Hamburger onClick={fn} />);
-        const burger = getByTestId("jkl-hamburger");
+        render(<Hamburger onClick={fn} />);
+        const burger = screen.getByTestId("jkl-hamburger");
         burger.click();
 
         expect(fn).toHaveBeenCalledTimes(1);
@@ -45,8 +45,8 @@ describe("Hamburger", () => {
     });
 
     it("should render have correct description", () => {
-        const { getByTestId } = render(<Hamburger description="max is better than micky d" />);
-        const burger = getByTestId("jkl-hamburger");
+        render(<Hamburger description="max is better than micky d" />);
+        const burger = screen.getByTestId("jkl-hamburger");
 
         expect(burger).toHaveAttribute("aria-label", "max is better than micky d");
     });

--- a/packages/icon-button-react/src/IconButton.test.tsx
+++ b/packages/icon-button-react/src/IconButton.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { IconButton } from ".";
-
-afterEach(cleanup);
 
 describe("IconButton", () => {
     it("calls the onClick handler when clicked", () => {

--- a/packages/icon-button-react/src/IconButton.test.tsx
+++ b/packages/icon-button-react/src/IconButton.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { IconButton } from ".";
 
 afterEach(cleanup);
@@ -7,11 +7,9 @@ afterEach(cleanup);
 describe("IconButton", () => {
     it("calls the onClick handler when clicked", () => {
         const clickHandler = jest.fn();
-        const { getByTestId } = render(
-            <IconButton iconType="clear" buttonTitle="I am groot!" onClick={clickHandler} />,
-        );
+        render(<IconButton iconType="clear" buttonTitle="I am groot!" onClick={clickHandler} />);
 
-        const button = getByTestId("jkl-icon-button");
+        const button = screen.getByTestId("jkl-icon-button");
 
         button.click();
 
@@ -20,11 +18,9 @@ describe("IconButton", () => {
 
     it("has search icon", () => {
         const clickHandler = jest.fn();
-        const { getByTestId } = render(
-            <IconButton iconType="search" buttonTitle="I am groot!" onClick={clickHandler} />,
-        );
+        render(<IconButton iconType="search" buttonTitle="I am groot!" onClick={clickHandler} />);
 
-        const svg = getByTestId("jkl-search-icon");
+        const svg = screen.getByTestId("jkl-search-icon");
 
         expect(svg).toBeInTheDocument();
     });

--- a/packages/icon-button-react/src/IconButton.test.tsx
+++ b/packages/icon-button-react/src/IconButton.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { IconButton } from ".";
 
 describe("IconButton", () => {
@@ -9,7 +9,7 @@ describe("IconButton", () => {
 
         const button = screen.getByTestId("jkl-icon-button");
 
-        button.click();
+        fireEvent.click(button);
 
         expect(clickHandler).toHaveBeenCalled();
     });

--- a/packages/list-react/src/List.test.tsx
+++ b/packages/list-react/src/List.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { UnorderedList, OrderedList, ListItem } from "../src";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("List", () => {
     test(`UnorderedList and ListItem should render as expected`, () => {

--- a/packages/list-react/src/List.test.tsx
+++ b/packages/list-react/src/List.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { UnorderedList, OrderedList, ListItem } from "../src";
 import { axe } from "jest-axe";
 
@@ -7,43 +7,43 @@ afterEach(cleanup);
 
 describe("List", () => {
     test(`UnorderedList and ListItem should render as expected`, () => {
-        const { getByText } = render(
+        render(
             <UnorderedList>
                 <ListItem>Kibogiedo</ListItem>
                 <ListItem>Ovoopisow</ListItem>
                 <ListItem>Omocebig</ListItem>
             </UnorderedList>,
         );
-        expect(getByText("Kibogiedo")).toBeInTheDocument();
-        expect(getByText("Ovoopisow")).toBeInTheDocument();
-        expect(getByText("Omocebig")).toBeInTheDocument();
+        expect(screen.getByText("Kibogiedo")).toBeInTheDocument();
+        expect(screen.getByText("Ovoopisow")).toBeInTheDocument();
+        expect(screen.getByText("Omocebig")).toBeInTheDocument();
     });
 
     test(`OrderedList and ListItem should render as expected`, () => {
-        const { getByText } = render(
+        render(
             <OrderedList>
                 <ListItem>Kibogiedo</ListItem>
                 <ListItem>Ovoopisow</ListItem>
                 <ListItem>Omocebig</ListItem>
             </OrderedList>,
         );
-        expect(getByText("Kibogiedo")).toBeInTheDocument();
-        expect(getByText("Ovoopisow")).toBeInTheDocument();
-        expect(getByText("Omocebig")).toBeInTheDocument();
+        expect(screen.getByText("Kibogiedo")).toBeInTheDocument();
+        expect(screen.getByText("Ovoopisow")).toBeInTheDocument();
+        expect(screen.getByText("Omocebig")).toBeInTheDocument();
     });
 
     test(`List gets the passed className`, () => {
-        const { getByTestId } = render(
+        render(
             <UnorderedList className="jkl-lead">
                 <ListItem>Kibogiedo</ListItem>
                 <ListItem>Ovoopisow</ListItem>
             </UnorderedList>,
         );
-        expect(getByTestId("jkl-list")).toHaveClass("jkl-lead");
+        expect(screen.getByTestId("jkl-list")).toHaveClass("jkl-lead");
     });
 
     test(`Nested lists should render all elements as expected`, () => {
-        const { getByText } = render(
+        render(
             <UnorderedList>
                 <ListItem>Kibogiedo</ListItem>
                 <ListItem>Ovoopisow</ListItem>
@@ -55,10 +55,10 @@ describe("List", () => {
                 </ListItem>
             </UnorderedList>,
         );
-        expect(getByText("Kibogiedo")).toBeInTheDocument();
-        expect(getByText("Ovoopisow")).toBeInTheDocument();
-        expect(getByText("Omocebig")).toBeInTheDocument();
-        expect(getByText("Ramzoge")).toBeInTheDocument();
+        expect(screen.getByText("Kibogiedo")).toBeInTheDocument();
+        expect(screen.getByText("Ovoopisow")).toBeInTheDocument();
+        expect(screen.getByText("Omocebig")).toBeInTheDocument();
+        expect(screen.getByText("Ramzoge")).toBeInTheDocument();
     });
 });
 

--- a/packages/loader-react/src/Loader.test.tsx
+++ b/packages/loader-react/src/Loader.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Loader } from ".";
-
-afterEach(cleanup);
 
 describe("Loader", () => {
     it("should render to document", () => {

--- a/packages/loader-react/src/Loader.test.tsx
+++ b/packages/loader-react/src/Loader.test.tsx
@@ -1,39 +1,39 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Loader } from ".";
 
 afterEach(cleanup);
 
 describe("Loader", () => {
     it("should render to document", () => {
-        const { getByTestId } = render(<Loader textDescription="Laster inn" />);
+        render(<Loader textDescription="Laster inn" />);
 
-        expect(getByTestId("jkl-loader")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-loader")).toBeInTheDocument();
     });
     it("should render negative to document", () => {
-        const { getByTestId } = render(<Loader textDescription="Laster inn" negative />);
+        render(<Loader textDescription="Laster inn" negative />);
 
-        expect(getByTestId("jkl-loader")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-loader")).toBeInTheDocument();
     });
     it("should render inline negative to document", () => {
-        const { getByTestId } = render(<Loader textDescription="Laster inn" negative inline />);
+        render(<Loader textDescription="Laster inn" negative inline />);
 
-        expect(getByTestId("jkl-loader")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-loader")).toBeInTheDocument();
     });
     it("should render inline to document", () => {
-        const { getByTestId } = render(<Loader textDescription="Laster inn" inline />);
+        render(<Loader textDescription="Laster inn" inline />);
 
-        expect(getByTestId("jkl-loader")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-loader")).toBeInTheDocument();
     });
     it("should apply passed className prop", () => {
-        const { getByTestId } = render(<Loader textDescription="Laster inn" className="testclass" />);
+        render(<Loader textDescription="Laster inn" className="testclass" />);
 
-        expect(getByTestId("jkl-loader")).toHaveClass("testclass");
+        expect(screen.getByTestId("jkl-loader")).toHaveClass("testclass");
     });
     it("should apply passed aria-label and title", () => {
-        const { getByTestId } = render(<Loader textDescription="Loading" />);
+        render(<Loader textDescription="Loading" />);
 
-        expect(getByTestId("jkl-loader")).toHaveAttribute("aria-label", "Loading");
-        expect(getByTestId("jkl-loader")).toHaveAttribute("title", "Loading");
+        expect(screen.getByTestId("jkl-loader")).toHaveAttribute("aria-label", "Loading");
+        expect(screen.getByTestId("jkl-loader")).toHaveAttribute("title", "Loading");
     });
 });

--- a/packages/message-box-react/src/MessageBox.test.tsx
+++ b/packages/message-box-react/src/MessageBox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { InfoMessage, ErrorMessage, SuccessMessage, WarningMessage } from ".";
 import { axe } from "jest-axe";
 
@@ -9,13 +9,13 @@ describe("Message boxes", () => {
     [true, false].map((fullWidth) => {
         [InfoMessage, ErrorMessage, SuccessMessage, WarningMessage].map((E) => {
             it("should render message title and content", () => {
-                const { getByText } = render(
+                render(
                     <E fullWidth={fullWidth} title="test">
                         content
                     </E>,
                 );
-                getByText("content");
-                getByText("test");
+                screen.getByText("content");
+                screen.getByText("test");
             });
         });
     });

--- a/packages/message-box-react/src/MessageBox.test.tsx
+++ b/packages/message-box-react/src/MessageBox.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { InfoMessage, ErrorMessage, SuccessMessage, WarningMessage } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Message boxes", () => {
     [true, false].map((fullWidth) => {

--- a/packages/progress-bar-react/src/ProgressBar.test.tsx
+++ b/packages/progress-bar-react/src/ProgressBar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { ProgressBar } from ".";
 import { calculatePercentage } from "./ProgressBar";
@@ -15,17 +15,17 @@ const defaultProps = {
 
 describe("ProgressBar", () => {
     test("should render to document", () => {
-        const { getByTestId } = render(<ProgressBar {...defaultProps} />);
+        render(<ProgressBar {...defaultProps} />);
 
-        expect(getByTestId("jkl-progress-bar")).toBeInTheDocument();
-        expect(getByTestId("jkl-progress-bar__tracker")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-progress-bar")).toBeInTheDocument();
+        expect(screen.getByTestId("jkl-progress-bar__tracker")).toBeInTheDocument();
     });
 
     [0, 10, 50, 90, 100].map((current) => {
         test(`should render progress bar at ${current}%`, () => {
-            const { getByTestId } = render(<ProgressBar progress={{ current, total: 100 }} />);
+            render(<ProgressBar progress={{ current, total: 100 }} />);
 
-            const progress = getByTestId("jkl-progress-bar__tracker");
+            const progress = screen.getByTestId("jkl-progress-bar__tracker");
 
             const style = progress.getAttribute("style");
             expect(style).toBe(`width: ${current}%;`);
@@ -34,9 +34,9 @@ describe("ProgressBar", () => {
 
     [0, 1, 5, 9, 10].map((current) => {
         test(`should render progress bar at ${current * 10}% with ${current} of total 10`, () => {
-            const { getByTestId } = render(<ProgressBar progress={{ current, total: 10 }} />);
+            render(<ProgressBar progress={{ current, total: 10 }} />);
 
-            const progress = getByTestId("jkl-progress-bar__tracker");
+            const progress = screen.getByTestId("jkl-progress-bar__tracker");
 
             const style = progress.getAttribute("style");
             expect(style).toBe(`width: ${current * 10}%;`);
@@ -44,21 +44,21 @@ describe("ProgressBar", () => {
     });
 
     test("should show custom className", () => {
-        const { getByTestId } = render(<ProgressBar {...defaultProps} className="customClass" />);
+        render(<ProgressBar {...defaultProps} className="customClass" />);
 
-        expect(getByTestId("jkl-progress-bar")).toHaveClass("customClass");
+        expect(screen.getByTestId("jkl-progress-bar")).toHaveClass("customClass");
     });
 
     test("should have progressbar as role", () => {
-        const { getByRole } = render(<ProgressBar {...defaultProps} />);
+        render(<ProgressBar {...defaultProps} />);
 
-        expect(getByRole("progressbar")).toBeInTheDocument();
+        expect(screen.getByRole("progressbar")).toBeInTheDocument();
     });
 
     test("should have correct aria values", () => {
-        const { getByTestId } = render(<ProgressBar {...defaultProps} />);
+        render(<ProgressBar {...defaultProps} />);
 
-        const progressBar = getByTestId("jkl-progress-bar");
+        const progressBar = screen.getByTestId("jkl-progress-bar");
 
         expect(progressBar).toHaveAttribute("aria-valuenow", "50");
         expect(progressBar).toHaveAttribute("aria-valuemin", "0");
@@ -67,11 +67,9 @@ describe("ProgressBar", () => {
     });
 
     test("should have correct aria values and value text", () => {
-        const { getByTestId } = render(
-            <ProgressBar progress={{ current: 1, total: 2 }} progressTextValue="Almost there" />,
-        );
+        render(<ProgressBar progress={{ current: 1, total: 2 }} progressTextValue="Almost there" />);
 
-        const progressBar = getByTestId("jkl-progress-bar");
+        const progressBar = screen.getByTestId("jkl-progress-bar");
 
         expect(progressBar).toHaveAttribute("aria-valuenow", "1");
         expect(progressBar).toHaveAttribute("aria-valuemin", "0");

--- a/packages/progress-bar-react/src/ProgressBar.test.tsx
+++ b/packages/progress-bar-react/src/ProgressBar.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { ProgressBar } from ".";
 import { calculatePercentage } from "./ProgressBar";
-
-afterEach(cleanup);
 
 const defaultProps = {
     progress: {

--- a/packages/radio-button-react/src/RadioButtonOption.test.tsx
+++ b/packages/radio-button-react/src/RadioButtonOption.test.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { RadioButtonOption } from "./index";
 
 describe("RadioButtonOption", () => {
     afterEach(cleanup);
 
     it("renders with correct label", () => {
-        const { getByText } = render(
+        render(
             <RadioButtonOption
                 value="choice"
                 label="The only choice"
@@ -17,12 +17,12 @@ describe("RadioButtonOption", () => {
             />,
         );
 
-        expect(getByText("The only choice")).toBeInTheDocument();
+        expect(screen.getByText("The only choice")).toBeInTheDocument();
     });
 
     it("executes handleChange when clicked", () => {
         const handleChange = jest.fn();
-        const { getByLabelText } = render(
+        render(
             <RadioButtonOption
                 value="choice"
                 label="The only choice"
@@ -33,7 +33,7 @@ describe("RadioButtonOption", () => {
             />,
         );
 
-        const button = getByLabelText("The only choice");
+        const button = screen.getByLabelText("The only choice");
         button.click();
 
         expect(handleChange).toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe("RadioButtonOption", () => {
 
     it("executes handleChange when label is clicked", () => {
         const handleChange = jest.fn();
-        const { getByTestId } = render(
+        render(
             <RadioButtonOption
                 value="choice"
                 label="The only choice"
@@ -52,7 +52,7 @@ describe("RadioButtonOption", () => {
             />,
         );
 
-        const button = getByTestId("jkl-radio-button__label-tag");
+        const button = screen.getByTestId("jkl-radio-button__label-tag");
         button.click();
 
         expect(handleChange).toHaveBeenCalled();

--- a/packages/radio-button-react/src/RadioButtonOption.test.tsx
+++ b/packages/radio-button-react/src/RadioButtonOption.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { RadioButtonOption } from "./index";
 
 describe("RadioButtonOption", () => {
-    afterEach(cleanup);
-
     it("renders with correct label", () => {
         render(
             <RadioButtonOption

--- a/packages/radio-button-react/src/RadioButtonOption.test.tsx
+++ b/packages/radio-button-react/src/RadioButtonOption.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { RadioButtonOption } from "./index";
 
 describe("RadioButtonOption", () => {
@@ -32,7 +32,7 @@ describe("RadioButtonOption", () => {
         );
 
         const button = screen.getByLabelText("The only choice");
-        button.click();
+        fireEvent.click(button);
 
         expect(handleChange).toHaveBeenCalled();
     });
@@ -51,7 +51,7 @@ describe("RadioButtonOption", () => {
         );
 
         const button = screen.getByTestId("jkl-radio-button__label-tag");
-        button.click();
+        fireEvent.click(button);
 
         expect(handleChange).toHaveBeenCalled();
     });

--- a/packages/radio-button-react/src/RadioButtons.test.tsx
+++ b/packages/radio-button-react/src/RadioButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { RadioButtons } from "./index";
 import { axe } from "jest-axe";
@@ -9,7 +9,7 @@ afterEach(cleanup);
 describe("RadioButtons", () => {
     it("renders a legend with the correct value", () => {
         const choices = ["yes", "no"];
-        const { getByText } = render(
+        render(
             <RadioButtons
                 choices={choices}
                 legend="Does this work?"
@@ -19,12 +19,12 @@ describe("RadioButtons", () => {
             />,
         );
 
-        expect(getByText("Does this work?")).toBeInTheDocument();
+        expect(screen.getByText("Does this work?")).toBeInTheDocument();
     });
 
     it("renders radio buttons for each choice", () => {
         const choices = ["yes", "no"];
-        const { getByText } = render(
+        render(
             <RadioButtons
                 choices={choices}
                 legend="Does this work?"
@@ -34,35 +34,31 @@ describe("RadioButtons", () => {
             />,
         );
 
-        expect(getByText("yes")).toBeInTheDocument();
-        expect(getByText("no")).toBeInTheDocument();
+        expect(screen.getByText("yes")).toBeInTheDocument();
+        expect(screen.getByText("no")).toBeInTheDocument();
     });
 
     it("selects the correct value from given props", () => {
         const choices = ["one", "two"];
-        const { getByLabelText } = render(
-            <RadioButtons choices={choices} legend="Test" name="test" onChange={(f) => f} selectedValue="two" />,
-        );
+        render(<RadioButtons choices={choices} legend="Test" name="test" onChange={(f) => f} selectedValue="two" />);
 
-        const secondButton = getByLabelText("two");
+        const secondButton = screen.getByLabelText("two");
         expect(secondButton).toHaveAttribute("checked");
     });
 
     it("does not preselect a value if empty", () => {
         const choices = ["one", "two"];
-        const { getByLabelText } = render(
-            <RadioButtons choices={choices} legend="Test" name="test" onChange={(f) => f} selectedValue="" />,
-        );
+        render(<RadioButtons choices={choices} legend="Test" name="test" onChange={(f) => f} selectedValue="" />);
 
-        const firstButton = getByLabelText("one");
-        const secondButton = getByLabelText("two");
+        const firstButton = screen.getByLabelText("one");
+        const secondButton = screen.getByLabelText("two");
         expect(firstButton).not.toHaveAttribute("checked");
         expect(secondButton).not.toHaveAttribute("checked");
     });
 
     it("executes handleChange function correctly", () => {
         const handleChange = jest.fn();
-        const { getByLabelText } = render(
+        render(
             <RadioButtons
                 legend="Test"
                 choices={["one", "two"]}
@@ -72,7 +68,7 @@ describe("RadioButtons", () => {
             />,
         );
 
-        const twoButton = getByLabelText("two");
+        const twoButton = screen.getByLabelText("two");
         twoButton.click();
 
         expect(handleChange).toHaveBeenCalled();

--- a/packages/radio-button-react/src/RadioButtons.test.tsx
+++ b/packages/radio-button-react/src/RadioButtons.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { RadioButtons } from "./index";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("RadioButtons", () => {
     it("renders a legend with the correct value", () => {

--- a/packages/radio-button-react/src/RadioButtons.test.tsx
+++ b/packages/radio-button-react/src/RadioButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { RadioButtons } from "./index";
 import { axe } from "jest-axe";
@@ -67,7 +67,7 @@ describe("RadioButtons", () => {
         );
 
         const twoButton = screen.getByLabelText("two");
-        twoButton.click();
+        fireEvent.click(twoButton);
 
         expect(handleChange).toHaveBeenCalled();
     });

--- a/packages/react-hooks/src/useClickOutside.test.tsx
+++ b/packages/react-hooks/src/useClickOutside.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useClickOutside } from "./useClickOutside";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 interface Props {
     fn: () => void;
@@ -24,15 +24,15 @@ afterEach(cleanup);
 describe("useClickOutside", () => {
     test("should not fire function when click is inside the ref", () => {
         const fn = jest.fn();
-        const { getByTestId } = render(<Test fn={fn} />);
-        fireEvent.click(getByTestId("withRef"));
+        render(<Test fn={fn} />);
+        fireEvent.click(screen.getByTestId("withRef"));
 
         expect(fn).toHaveBeenCalledTimes(0);
     });
     test("should fire function when click is outside the ref", () => {
         const fn = jest.fn();
-        const { getByTestId } = render(<Test fn={fn} />);
-        fireEvent.click(getByTestId("withoutRef"));
+        render(<Test fn={fn} />);
+        fireEvent.click(screen.getByTestId("withoutRef"));
 
         expect(fn).toHaveBeenCalledTimes(1);
     });

--- a/packages/react-hooks/src/useClickOutside.test.tsx
+++ b/packages/react-hooks/src/useClickOutside.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useClickOutside } from "./useClickOutside";
-import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 
 interface Props {
     fn: () => void;
@@ -18,8 +18,6 @@ function Test({ fn }: Props) {
         </div>
     );
 }
-
-afterEach(cleanup);
 
 describe("useClickOutside", () => {
     test("should not fire function when click is inside the ref", () => {

--- a/packages/react-hooks/src/useFocusOutside.test.tsx
+++ b/packages/react-hooks/src/useFocusOutside.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useFocusOutside } from "./useFocusOutside";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 interface Props {
     fn: () => void;
@@ -24,15 +24,15 @@ afterEach(cleanup);
 describe("useFocusOutside", () => {
     it("should not fire function when focusing an element inside the ref", () => {
         const fn = jest.fn();
-        const { getByTestId } = render(<Test fn={fn} />);
-        fireEvent.focusIn(getByTestId("withRef"));
+        render(<Test fn={fn} />);
+        fireEvent.focusIn(screen.getByTestId("withRef"));
 
         expect(fn).toHaveBeenCalledTimes(0);
     });
     it("should fire function when focusing an element outside the ref", () => {
         const fn = jest.fn();
-        const { getByTestId } = render(<Test fn={fn} />);
-        fireEvent.focusIn(getByTestId("withoutRef"));
+        render(<Test fn={fn} />);
+        fireEvent.focusIn(screen.getByTestId("withoutRef"));
 
         expect(fn).toHaveBeenCalledTimes(1);
     });

--- a/packages/react-hooks/src/useFocusOutside.test.tsx
+++ b/packages/react-hooks/src/useFocusOutside.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useFocusOutside } from "./useFocusOutside";
-import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 
 interface Props {
     fn: () => void;
@@ -18,8 +18,6 @@ function Test({ fn }: Props) {
         </div>
     );
 }
-
-afterEach(cleanup);
 
 describe("useFocusOutside", () => {
     it("should not fire function when focusing an element inside the ref", () => {

--- a/packages/select-react/src/NativeSelect.test.tsx
+++ b/packages/select-react/src/NativeSelect.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { NativeSelect } from ".";
 import { axe } from "jest-axe";
 
@@ -9,9 +9,9 @@ afterEach(cleanup);
 
 describe("NativeSelect", () => {
     it("should render the correct label", () => {
-        const { getByText } = render(<NativeSelect label="testing" items={["test"]} onChange={dummyFunc} />);
+        render(<NativeSelect label="testing" items={["test"]} onChange={dummyFunc} />);
 
-        expect(getByText("testing")).toBeInTheDocument();
+        expect(screen.getByText("testing")).toBeInTheDocument();
     });
 
     it("should render the correct number of options", () => {
@@ -43,19 +43,15 @@ describe("NativeSelect", () => {
 
     it("should render placeholder when given and field has no value", () => {
         const items = ["item 1", "item 2", "item 3"];
-        const { getByText } = render(
-            <NativeSelect label="testing" items={items} placeholder="Please choose" onChange={dummyFunc} />,
-        );
+        render(<NativeSelect label="testing" items={items} placeholder="Please choose" onChange={dummyFunc} />);
 
-        expect(getByText("Please choose")).toBeInTheDocument();
+        expect(screen.getByText("Please choose")).toBeInTheDocument();
     });
 
     it("can be forced into compact mode", () => {
-        const { getByTestId } = render(
-            <NativeSelect items={["1", "2"]} label="test" onChange={dummyFunc} forceCompact />,
-        );
+        render(<NativeSelect items={["1", "2"]} label="test" onChange={dummyFunc} forceCompact />);
 
-        expect(getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
+        expect(screen.getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });
 });
 

--- a/packages/select-react/src/NativeSelect.test.tsx
+++ b/packages/select-react/src/NativeSelect.test.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { NativeSelect } from ".";
 import { axe } from "jest-axe";
 
 const dummyFunc = () => {};
-
-afterEach(cleanup);
 
 describe("NativeSelect", () => {
     it("should render the correct label", () => {

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { Select } from ".";
 import { axe } from "jest-axe";
 
@@ -15,47 +15,43 @@ describe("Select", () => {
     });
 
     it("should be inline when specified", () => {
-        const { getByTestId } = render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
-        const dropdown = getByTestId("jkl-select");
+        const dropdown = screen.getByTestId("jkl-select");
         expect(dropdown).toHaveClass("jkl-select--inline");
     });
 
     it("should use the specified value", () => {
         const onChange = jest.fn();
         const value = "drop";
-        const { getByTestId } = render(
-            <Select onChange={onChange} items={["drop", "it", "like", "its", "hot"]} label="Snoop" value={value} />,
-        );
+        render(<Select onChange={onChange} items={["drop", "it", "like", "its", "hot"]} label="Snoop" value={value} />);
 
-        const button = getByTestId("jkl-select__button");
+        const button = screen.getByTestId("jkl-select__button");
 
         expect(onChange).toHaveBeenCalledTimes(0);
         expect(button).toHaveTextContent(value);
     });
 
     it("should have default text value in button when no option selected", () => {
-        const { getByTestId } = render(<Select items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        render(<Select items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
-        const button = getByTestId("jkl-select__button");
+        const button = screen.getByTestId("jkl-select__button");
 
         expect(button).toHaveTextContent("Velg");
     });
 
     it("can be forced into compact mode", () => {
-        const { getByTestId } = render(<Select items={["1", "2"]} label="test" forceCompact />);
+        render(<Select items={["1", "2"]} label="test" forceCompact />);
 
-        expect(getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
+        expect(screen.getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });
 
     it("displays the ValuePair label of selected item on first render", () => {
         const valuePairs = [{ value: "datagreier", label: "Fin lesbar tekst" }];
 
-        const { getByTestId } = render(
-            <Select label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />,
-        );
+        render(<Select label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />);
 
-        expect(getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
+        expect(screen.getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
     });
 });
 

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Select } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Select", () => {
     it("should render correct amount of options", () => {

--- a/packages/table-react/src/Table.test.tsx
+++ b/packages/table-react/src/Table.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { Table, TableRowType } from "./index";
 import { axe } from "jest-axe";
@@ -21,20 +21,20 @@ describe("Table", () => {
         const cols = ["Dato", "Saksnummer"];
         const rows = [["24.02.2020", "20-1234567"]];
 
-        const { getByText } = render(<Table columns={cols} rows={rows} />);
+        render(<Table columns={cols} rows={rows} />);
 
-        expect(getByText("Dato")).toBeInTheDocument;
-        expect(getByText("Saksnummer")).toBeInTheDocument;
+        expect(screen.getByText("Dato")).toBeInTheDocument;
+        expect(screen.getByText("Saksnummer")).toBeInTheDocument;
     });
 
     it("renders all row content", () => {
         const cols = ["Dato", "Saksnummer"];
         const rows = [["24.02.2020", "20-1234567"]];
 
-        const { getByText } = render(<Table columns={cols} rows={rows} />);
+        render(<Table columns={cols} rows={rows} />);
 
-        expect(getByText("24.02.2020")).toBeInTheDocument;
-        expect(getByText("20-1234567")).toBeInTheDocument;
+        expect(screen.getByText("24.02.2020")).toBeInTheDocument;
+        expect(screen.getByText("20-1234567")).toBeInTheDocument;
     });
 
     it("renders a link element with correct href in anchor rows", () => {
@@ -48,9 +48,9 @@ describe("Table", () => {
             },
         ];
 
-        const { getByTestId } = render(<Table columns={cols} rows={rows} />);
+        render(<Table columns={cols} rows={rows} />);
 
-        expect(getByTestId("jkl-table__screenreader-link")).toHaveAttribute("href", "/relative/path");
+        expect(screen.getByTestId("jkl-table__screenreader-link")).toHaveAttribute("href", "/relative/path");
     });
 
     it("calls the provided onRowClick function on row click", () => {
@@ -66,8 +66,8 @@ describe("Table", () => {
             },
         ];
 
-        const { getByText } = render(<Table columns={cols} rows={rows} />);
-        getByText("20-1234567").click();
+        render(<Table columns={cols} rows={rows} />);
+        screen.getByText("20-1234567").click();
 
         expect(handleClick).toHaveBeenCalled();
     });

--- a/packages/table-react/src/Table.test.tsx
+++ b/packages/table-react/src/Table.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { Table, TableRowType } from "./index";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Table", () => {
     it("renders to the DOM", () => {

--- a/packages/text-input-react/src/TextArea.test.tsx
+++ b/packages/text-input-react/src/TextArea.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { TextArea } from ".";
 import { axe } from "jest-axe";
 
@@ -7,15 +7,15 @@ afterEach(cleanup);
 
 describe("TextArea", () => {
     it("renders with correct label", () => {
-        const { getByLabelText } = render(<TextArea label="Cool text area" />);
+        render(<TextArea label="Cool text area" />);
 
-        expect(getByLabelText("Cool text area")).toBeInTheDocument();
+        expect(screen.getByLabelText("Cool text area")).toBeInTheDocument();
     });
 
     it("uses the passed class name", () => {
-        const { getByTestId } = render(<TextArea label="testing" className="test-class" />);
+        render(<TextArea label="testing" className="test-class" />);
 
-        const component = getByTestId("jkl-text-area");
+        const component = screen.getByTestId("jkl-text-area");
         expect(component).toHaveClass("test-class");
     });
 });

--- a/packages/text-input-react/src/TextArea.test.tsx
+++ b/packages/text-input-react/src/TextArea.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { TextArea } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("TextArea", () => {
     it("renders with correct label", () => {

--- a/packages/text-input-react/src/TextInput.test.tsx
+++ b/packages/text-input-react/src/TextInput.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { TextInput } from ".";
 import { axe } from "jest-axe";
 
@@ -7,97 +7,95 @@ afterEach(cleanup);
 
 describe("TextInput", () => {
     it("renders with correct label", () => {
-        const { getByLabelText } = render(<TextInput label="Cool text field" />);
+        render(<TextInput label="Cool text field" />);
 
-        expect(getByLabelText("Cool text field")).toBeInTheDocument();
+        expect(screen.getByLabelText("Cool text field")).toBeInTheDocument();
     });
 
     it("uses the passed class name", () => {
-        const { getByTestId } = render(<TextInput label="testing" className="test-class" />);
+        render(<TextInput label="testing" className="test-class" />);
 
-        const component = getByTestId("jkl-text-input");
+        const component = screen.getByTestId("jkl-text-input");
         expect(component).toHaveClass("test-class");
     });
 
     it("has the max-length given", () => {
-        const { getByLabelText } = render(<TextInput label="testing" maxLength={10} />);
+        render(<TextInput label="testing" maxLength={10} />);
 
-        const component = getByLabelText("testing");
+        const component = screen.getByLabelText("testing");
         expect(component).toHaveAttribute("maxlength", "10");
     });
 
     it("renders as compact when specified", () => {
-        const { getByTestId } = render(<TextInput label="testing" forceCompact />);
+        render(<TextInput label="testing" forceCompact />);
 
-        const component = getByTestId("jkl-text-input");
+        const component = screen.getByTestId("jkl-text-input");
         expect(component).toHaveClass("jkl-text-input--compact");
     });
 
     it("has the placeholder given", () => {
-        const { getByLabelText } = render(<TextInput label="testing" placeholder="testingPlaceholder" />);
+        render(<TextInput label="testing" placeholder="testingPlaceholder" />);
 
-        const component = getByLabelText("testing");
+        const component = screen.getByLabelText("testing");
         expect(component).toHaveAttribute("placeholder", "testingPlaceholder");
     });
 
     it("is read-only when specified", () => {
-        const { getByLabelText } = render(<TextInput label="testing" readOnly />);
+        render(<TextInput label="testing" readOnly />);
 
-        const component = getByLabelText("testing");
+        const component = screen.getByLabelText("testing");
         expect(component).toHaveAttribute("readOnly");
     });
 
     it("has the value given", () => {
-        const { getByLabelText } = render(<TextInput label="testing" value="testValue" onChange={() => {}} />);
+        render(<TextInput label="testing" value="testValue" onChange={() => {}} />);
 
-        const component = getByLabelText("testing");
+        const component = screen.getByLabelText("testing");
         expect(component).toHaveValue("testValue");
     });
 
     it("renders errorLabel when given", () => {
-        const { getByText } = render(<TextInput label="testing" errorLabel="det går nok ikke" />);
+        render(<TextInput label="testing" errorLabel="det går nok ikke" />);
 
-        const component = getByText("det går nok ikke");
+        const component = screen.getByText("det går nok ikke");
         expect(component).toBeInTheDocument();
     });
 
     it("renders helpLabel when given", () => {
-        const { getByText } = render(<TextInput label="testing" helpLabel="hjelp" />);
+        render(<TextInput label="testing" helpLabel="hjelp" />);
 
-        const component = getByText("hjelp");
+        const component = screen.getByText("hjelp");
         expect(component).toBeInTheDocument();
     });
 
     it("does not render helpLabel if both helpLabel and errorLabel is given", () => {
-        const { getByText, queryByText } = render(<TextInput label="testing" helpLabel="help" errorLabel="error" />);
+        render(<TextInput label="testing" helpLabel="help" errorLabel="error" />);
 
-        expect(queryByText("help")).not.toBeInTheDocument();
-        expect(getByText("error")).toBeInTheDocument();
+        expect(screen.queryByText("help")).not.toBeInTheDocument();
+        expect(screen.getByText("error")).toBeInTheDocument();
     });
 
     it("has the type specified", () => {
-        const { getByPlaceholderText } = render(<TextInput label="testing" type="password" placeholder="test-ph" />);
+        render(<TextInput label="testing" type="password" placeholder="test-ph" />);
 
-        const component = getByPlaceholderText("test-ph");
+        const component = screen.getByPlaceholderText("test-ph");
         expect(component).toHaveAttribute("type", "password");
     });
 
     describe("with action", () => {
         it("renders the action-icon", () => {
-            const { getByTestId } = render(
-                <TextInput label="testing" action={{ icon: "clear", label: "testing", onClick: () => {} }} />,
-            );
+            render(<TextInput label="testing" action={{ icon: "clear", label: "testing", onClick: () => {} }} />);
 
-            const component = getByTestId("jkl-action-icon");
+            const component = screen.getByTestId("jkl-action-icon");
             expect(component).toBeInTheDocument();
         });
     });
 
     describe("inline", () => {
         it("renders as inline", () => {
-            const { getByTestId } = render(<TextInput inline label="testing" />);
+            render(<TextInput inline label="testing" />);
 
-            const component = getByTestId("jkl-text-input");
+            const component = screen.getByTestId("jkl-text-input");
             expect(component).toHaveClass("jkl-text-input--inline");
         });
     });

--- a/packages/text-input-react/src/TextInput.test.tsx
+++ b/packages/text-input-react/src/TextInput.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { TextInput } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("TextInput", () => {
     it("renders with correct label", () => {

--- a/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { ToggleSwitch } from ".";
 import { axe } from "jest-axe";
 
@@ -15,9 +15,9 @@ describe("Toggle switch", () => {
                 </ToggleSwitch>
             );
         };
-        const { getByText } = render(<TestToggleSwitch />);
+        render(<TestToggleSwitch />);
 
-        const input = getByText("GPS");
+        const input = screen.getByText("GPS");
 
         expect(input).toHaveAttribute("aria-pressed", "false");
 
@@ -27,13 +27,13 @@ describe("Toggle switch", () => {
     });
 
     it("should be pressed if pressed is true", function () {
-        const { getByText } = render(
+        render(
             <ToggleSwitch pressed={true} onClick={() => ""}>
                 I am groot!
             </ToggleSwitch>,
         );
 
-        const input = getByText("I am groot!");
+        const input = screen.getByText("I am groot!");
 
         expect(input).toHaveAttribute("aria-pressed", "true");
     });
@@ -47,18 +47,18 @@ describe("Toggle switch", () => {
                 </ToggleSwitch>
             );
         };
-        const { getByText } = render(<TestToggleSwitch />);
+        render(<TestToggleSwitch />);
 
-        const input = getByText("I am groot!");
+        const input = screen.getByText("I am groot!");
 
         expect(input).toHaveAttribute("aria-pressed", "true");
     });
 
     it("should call the passed onClick method when clicked", () => {
         const onClick = jest.fn();
-        const { getByText } = render(<ToggleSwitch onClick={onClick}>Switch me!</ToggleSwitch>);
+        render(<ToggleSwitch onClick={onClick}>Switch me!</ToggleSwitch>);
 
-        const input = getByText("Switch me!");
+        const input = screen.getByText("Switch me!");
         input.click();
 
         expect(onClick).toHaveBeenCalled();

--- a/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ToggleSwitch } from ".";
 import { axe } from "jest-axe";
-
-afterEach(cleanup);
 
 describe("Toggle switch", () => {
     it("should be pressed after clicking the button", () => {

--- a/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ToggleSwitch } from ".";
 import { axe } from "jest-axe";
 
@@ -19,7 +19,7 @@ describe("Toggle switch", () => {
 
         expect(input).toHaveAttribute("aria-pressed", "false");
 
-        input.click();
+        fireEvent.click(input);
 
         expect(input).toHaveAttribute("aria-pressed", "true");
     });
@@ -57,7 +57,7 @@ describe("Toggle switch", () => {
         render(<ToggleSwitch onClick={onClick}>Switch me!</ToggleSwitch>);
 
         const input = screen.getByText("Switch me!");
-        input.click();
+        fireEvent.click(input);
 
         expect(onClick).toHaveBeenCalled();
     });

--- a/packages/typography-react/src/SupportLabel.test.tsx
+++ b/packages/typography-react/src/SupportLabel.test.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { SupportLabel } from "./SupportLabel";
 
 describe("SupportLabel", () => {
-    afterEach(cleanup);
-
     const helpLabel = "helpfull text";
     const errorLabel = "error error error, read in a computer voice";
 

--- a/packages/typography-react/src/SupportLabel.test.tsx
+++ b/packages/typography-react/src/SupportLabel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { SupportLabel } from "./SupportLabel";
 
 describe("SupportLabel", () => {
@@ -9,28 +9,26 @@ describe("SupportLabel", () => {
     const errorLabel = "error error error, read in a computer voice";
 
     it("renders with help text when valid", () => {
-        const { getByText } = render(
-            <SupportLabel errorLabel={false ? errorLabel : undefined} helpLabel={helpLabel} />,
-        );
+        render(<SupportLabel errorLabel={false ? errorLabel : undefined} helpLabel={helpLabel} />);
 
-        expect(getByText(helpLabel)).toBeInTheDocument();
+        expect(screen.getByText(helpLabel)).toBeInTheDocument();
     });
 
     it("renders with error text when invalid", () => {
-        const { getByText } = render(<SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} />);
+        render(<SupportLabel errorLabel={errorLabel} helpLabel={helpLabel} />);
 
-        expect(getByText(errorLabel)).toBeInTheDocument();
+        expect(screen.getByText(errorLabel)).toBeInTheDocument();
     });
 
     it("renders with error text when invalid without help text", () => {
-        const { getByText } = render(<SupportLabel errorLabel={errorLabel} />);
+        render(<SupportLabel errorLabel={errorLabel} />);
 
-        expect(getByText(errorLabel)).toBeInTheDocument();
+        expect(screen.getByText(errorLabel)).toBeInTheDocument();
     });
 
     it("renders with help text when valid without error text", () => {
-        const { getByText } = render(<SupportLabel helpLabel={helpLabel} />);
+        render(<SupportLabel helpLabel={helpLabel} />);
 
-        expect(getByText(helpLabel)).toBeInTheDocument();
+        expect(screen.getByText(helpLabel)).toBeInTheDocument();
     });
 });

--- a/packages/typography-react/src/Typography.test.tsx
+++ b/packages/typography-react/src/Typography.test.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { H1, H2, H3, H4, H5, Lead, Body, Small, Micro } from ".";
 
 describe("typography", () => {
-    afterEach(cleanup);
     const text = "Hello Mr Universe";
 
     const headings = [

--- a/packages/typography-react/src/Typography.test.tsx
+++ b/packages/typography-react/src/Typography.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { H1, H2, H3, H4, H5, Lead, Body, Small, Micro } from ".";
 
 describe("typography", () => {
@@ -24,8 +24,8 @@ describe("typography", () => {
     [...headings, ...paragraphs].forEach((element) => {
         test(`should render ${element.type} with correct text`, () => {
             const C = element.component;
-            const { getByText } = render(<C>{text}</C>);
-            const res = getByText(text);
+            render(<C>{text}</C>);
+            const res = screen.getByText(text);
             expect(res.tagName).toBe(element.expectedElement);
         });
     });


### PR DESCRIPTION
## 📥 Proposed changes

Endre alle enhetstester til å bruke den nye og mer effektive `screen.getBy`-syntaksen fremfor `const { getBy } = render()`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-accordion-react, @fremtind/jkl-alert-message-react,
@fremtind/jkl-button-react, @fremtind/jkl-card-react, @fremtind/jkl-checkbox-react,
@fremtind/jkl-core, @fremtind/jkl-datepicker-react, @fremtind/jkl-field-group-react,
@fremtind/jkl-hamburger-react, @fremtind/jkl-icon-button-react, @fremtind/jkl-list-react,
@fremtind/jkl-loader-react, @fremtind/jkl-message-box-react, @fremtind/jkl-progress-bar-react,
@fremtind/jkl-radio-button-react, @fremtind/jkl-react-hooks, @fremtind/jkl-select-react,
@fremtind/jkl-table-react, @fremtind/jkl-text-input-react, @fremtind/jkl-toggle-switch-react,
@fremtind/jkl-typography-react
