### PR TITLE
Fix small bug in spacing/typography docs

### DIFF
--- a/packages/core/documentation/Spacing/Spacing.tsx
+++ b/packages/core/documentation/Spacing/Spacing.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useState } from "react";
 
 import "./Spacing.scss";
 
@@ -28,16 +28,15 @@ const layoutSpacings = stringLiteralArray([
 type spacingClass = typeof componentSpacings[number] | typeof layoutSpacings[number];
 
 const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
-    const ref = useRef<HTMLDivElement>(null);
-    const getComputed = (cssProperty: string) => {
-        if (ref.current) {
-            return window?.getComputedStyle(ref.current)?.getPropertyValue(cssProperty);
-        }
-        return "N/A";
+    const getComputedProperty = (node: HTMLElement | null, cssProperty: string) => {
+        return (node && window?.getComputedStyle(node)?.getPropertyValue(cssProperty)) || "N/A";
+    };
+    const [pxValue, setPxValue] = useState<string>("N/A");
+    const ref = (node: HTMLDivElement | null) => {
+        setPxValue(getComputedProperty(node, "margin-top"));
     };
     const baseFontSize = 16; // 1rem = 16px
-    const pxValue = parseInt(getComputed("margin-top"));
-    const remValue = pxValue ? pxValue / baseFontSize : pxValue;
+    const remValue = pxValue !== "N/A" ? parseInt(pxValue) / baseFontSize : pxValue;
     return (
         <tr className="jkl-portal-spacing-example-table__row">
             <td data-header="Spacing:" className="jkl-portal-spacing-example-table__data">

--- a/portal/src/components/Documentation/Spacing/SpacingTable.tsx
+++ b/portal/src/components/Documentation/Spacing/SpacingTable.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useState } from "react";
 
 import "./SpacingTable.scss";
 
@@ -28,15 +28,15 @@ const layoutSpacings = stringLiteralArray([
 type spacingClass = typeof componentSpacings[number] | typeof layoutSpacings[number];
 
 const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
-    const ref = useRef<HTMLDivElement>(null);
-    const getComputed = (cssProperty: string) => {
-        if (ref.current) {
-            return window?.getComputedStyle(ref.current)?.getPropertyValue(cssProperty);
-        }
-        return "N/A";
+    const getComputedProperty = (node: HTMLElement | null, cssProperty: string) => {
+        return (node && window?.getComputedStyle(node)?.getPropertyValue(cssProperty)) || "N/A";
     };
-    const pxValue = getComputed("margin-top").replace("px", "");
-    const remValue = pxValue !== "N/A" ? parseInt(pxValue) / 16 : pxValue;
+    const [pxValue, setPxValue] = useState<string>("N/A");
+    const ref = (node: HTMLDivElement | null) => {
+        setPxValue(getComputedProperty(node, "margin-top"));
+    };
+    const baseFontSize = 16; // 1rem = 16px
+    const remValue = pxValue !== "N/A" ? parseInt(pxValue) / baseFontSize : pxValue;
     return (
         <tr className="jkl-portal-spacing-table__row">
             <td data-header="Navn:" className="jkl-portal-spacing-table__data">

--- a/portal/src/components/Documentation/Typography/TypograhyTable/ExampleRow.tsx
+++ b/portal/src/components/Documentation/Typography/TypograhyTable/ExampleRow.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useState } from "react";
 import { TableCell } from "./TableCell";
 
 export type TypographyLevels =
@@ -16,13 +16,16 @@ interface Props {
     level: TypographyLevels;
 }
 export const ExampleRow: React.FC<Props> = ({ level }) => {
-    const ref = useRef<HTMLParagraphElement>(null);
-
-    const getComputed = (cssProperty: string) => {
-        if (ref.current) {
-            return window?.getComputedStyle(ref.current)?.getPropertyValue(cssProperty);
-        }
-        return "N/A";
+    const getComputedProperty = (node: HTMLElement | null, cssProperty: string) => {
+        return (node && window?.getComputedStyle(node)?.getPropertyValue(cssProperty)) || "N/A";
+    };
+    const [fontWeight, setFontWeight] = useState("N/A");
+    const [fontSize, setFontSize] = useState("N/A");
+    const [lineHeight, setLineHeight] = useState("N/A");
+    const ref = (node: HTMLParagraphElement | null) => {
+        setFontWeight(getComputedProperty(node, "font-weight"));
+        setFontSize(getComputedProperty(node, "font-size"));
+        setLineHeight(getComputedProperty(node, "line-height"));
     };
     return (
         <tr className={"jkl-typography-table__row"}>
@@ -31,9 +34,9 @@ export const ExampleRow: React.FC<Props> = ({ level }) => {
                     {level}
                 </p>
             </td>
-            <TableCell title="Vekt">{getComputed("font-weight")}</TableCell>
-            <TableCell title="Størrelse">{getComputed("font-size")}</TableCell>
-            <TableCell title="Linjeavstand">{getComputed("line-height")}</TableCell>
+            <TableCell title="Vekt">{fontWeight}</TableCell>
+            <TableCell title="Størrelse">{fontSize}</TableCell>
+            <TableCell title="Linjeavstand">{lineHeight}</TableCell>
         </tr>
     );
 };


### PR DESCRIPTION
## 📥 Proposed changes

Fixes a bug in the typography and spacing doc pages, where calculated values and previews would not load correctly unless the page was reloaded.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

