### PR TITLE
feat: legg til data-testautoid type og props på Select

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,8 @@ export type ValuePair = {
     value: string;
     label: string;
 };
+
+// Brukes til å extende props for komponenter som skal støtte data-testautoid ifbm. Test Complete
+export interface DataTestAutoId {
+    "data-testautoid"?: string;
+}

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -2,7 +2,7 @@
 import CoreToggle from "@nrk/core-toggle/jsx";
 import React, { useState, useEffect, useCallback } from "react";
 import { nanoid } from "nanoid";
-import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
+import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair, DataTestAutoId } from "@fremtind/jkl-core";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { useListNavigation } from "./useListNavigation";
 import classNames from "classnames";
@@ -11,7 +11,7 @@ import { ExpandArrow } from "./ExpandArrow";
 
 type SelectEventHandler = (value?: string) => void;
 
-interface Props {
+interface Props extends DataTestAutoId {
     id?: string;
     label: string;
     items: Array<string | ValuePair>;
@@ -68,6 +68,7 @@ export function Select({
     forceCompact,
     inverted,
     width,
+    ...selectProps
 }: Props) {
     const [selectedValue, setSelectedValue] = useState(value);
     const [internalFocus, setInternalFocus] = useState(false);
@@ -135,7 +136,7 @@ export function Select({
     const [elementRef] = useAnimatedHeight(dropdownIsShown);
 
     return (
-        <div data-testid="jkl-select" className={componentClassName} style={{ width }}>
+        <div data-testid="jkl-select" className={componentClassName} style={{ width }} {...selectProps}>
             <Label variant={variant} forceCompact={forceCompact} srOnly={inline}>
                 {label}
             </Label>
@@ -167,7 +168,7 @@ export function Select({
                         tabIndex={-1}
                         ref={listRef}
                     >
-                        {items.map(getValuePair).map((item) => (
+                        {items.map(getValuePair).map((item, i) => (
                             <li key={item.value}>
                                 <button
                                     type="button"
@@ -177,6 +178,7 @@ export function Select({
                                     aria-selected={item.value === selectedValue}
                                     role="option"
                                     value={item.value}
+                                    data-testautoid={`jkl-select__option-${i}`}
                                 >
                                     {item.label}
                                 </button>


### PR DESCRIPTION
affects: @fremtind/jkl-core, @fremtind/jkl-select-react

## 📥 Proposed changes

Ifbm. implementering av Test Complete trengs det støtte for `data-testautoid` på `Select`. Denne PRen legger til et interface som kan extendes på komponenter for å legge til dette som en prop.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] `yarn build` works locally with my changes
-   [X] I have added necessary documentation (if appropriate)

## 💬 Further comments

På sikt må vi se på hvordan implementere dette bredere. Foreløpig fungerer dette som en PoC.
