### PR TITLE
chore(build-config): add a lighter version of the syntax highlighter

### DIFF
--- a/portal/src/components/CodeBlock/CodeBlock.tsx
+++ b/portal/src/components/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import scss from "react-syntax-highlighter/dist/esm/languages/prism/scss";
+
+SyntaxHighlighter.registerLanguage("tsx", tsx);
+SyntaxHighlighter.registerLanguage("scss", scss);
 
 import { useTheme } from "../../contexts/themeContext";
 import fremtindTheme from "./fremtindTheme";


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

After doing an analysis of the js-bundle for the portal I discovered that roughly 30% of the total bundle-size is used by refractor (used for syntax-highlighting code blocks in portal). Refractor supports syntax highlighting of tons of languages but we only use `tsx`, `scss` and `html`.

This PR changes the way we import `react-syntax-highlighter` so that the bundle only includes the languages we use.

Screenshot of the bundle analyse:
![Screenshot 2020-07-29 at 15 55 41](https://user-images.githubusercontent.com/124469/88809487-7d04b380-d1b4-11ea-8c10-2f724cf2506b.png)


## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes

