### PR TITLE
Feat/portal menu context

### DIFF
--- a/portal/src/components/Header/Header.tsx
+++ b/portal/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState, useCallback } from "react";
+import React, { useLayoutEffect, useCallback, useRef } from "react";
 import { navigate } from "gatsby";
 import classNames from "classnames";
 
@@ -11,25 +11,21 @@ import { MainMenu, MenuItemList } from "./components/MainMenu";
 import "./header.scss";
 
 export const Header = ({ className }: { className?: string }) => {
-    const [collapsed, setCollapsed] = useState(false);
+    const headerRef = useRef<HTMLElement>(null);
     const collapseMenu = useCallback(() => {
         const shouldCollapse = window.scrollY > 96;
-        if (collapsed !== shouldCollapse) {
-            setCollapsed(shouldCollapse);
+        if (shouldCollapse) {
+            headerRef.current?.classList.add("jkl-portal-header--collapsed");
+        } else {
+            headerRef.current?.classList.remove("jkl-portal-header--collapsed");
         }
-    }, [collapsed, setCollapsed]);
+    }, []);
     useLayoutEffect(() => {
         window && window.addEventListener("scroll", collapseMenu);
         return () => window && window.removeEventListener("scroll", collapseMenu);
     }, [collapseMenu]);
     const { profileDocPages, getStartedDocPages, componentDocPages, blogPages, PageType } = useNavigationLinks();
-    const componentClassName = classNames(
-        {
-            "jkl-portal-header": true,
-            "jkl-portal-header--collapsed": collapsed,
-        },
-        className,
-    );
+    const componentClassName = classNames("jkl-portal-header", className);
 
     const menuItems: MenuItemList = [
         {
@@ -79,7 +75,7 @@ export const Header = ({ className }: { className?: string }) => {
     };
 
     return (
-        <header className={componentClassName}>
+        <header ref={headerRef} className={componentClassName}>
             <JokulLink
                 className="jkl-body jkl-sr-only jkl-sr-only--focusable jkl-portal-header__skip-to-content"
                 href="#innhold"

--- a/portal/src/components/Header/components/FullScreenMenu.tsx
+++ b/portal/src/components/Header/components/FullScreenMenu.tsx
@@ -4,7 +4,7 @@ import CoreToggle from "@nrk/core-toggle/jsx";
 import classNames from "classnames";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 
-import { RootItem, CustomNavigation } from "./MainMenu";
+import { RootItem } from "./MainMenu";
 import { FullScreenMenuItem } from "./FullScreenMenuItem";
 import { useFullscreenMenu } from "../../../contexts/fullscreenMenuContext";
 import { useFullScreenMenuAnimaiton } from "./useFullScreenMenuAnimation";
@@ -16,7 +16,7 @@ interface CoreToggleSelectEvent {
     target: { hidden: boolean; button: HTMLButtonElement; value: { textContent: string } };
 }
 
-interface FullScreenMenuProps extends CustomNavigation {
+interface FullScreenMenuProps {
     className?: string;
     activeClassName?: string;
     baseItem: RootItem;
@@ -31,7 +31,6 @@ export const FullScreenMenu: React.FC<FullScreenMenuProps> = ({
     baseItem,
     customButton,
     isActiveFunction,
-    navigationFunction,
 }) => {
     const CustomButton = customButton; // Need capital letter to please the linter
     const [isOpen, setIsOpen] = useState(false);
@@ -116,7 +115,6 @@ export const FullScreenMenu: React.FC<FullScreenMenuProps> = ({
                         {currentItem.content.map((item, idx) => (
                             <FullScreenMenuItem
                                 forwardFunction={onNavigateForward}
-                                navigationFunction={navigationFunction}
                                 item={item}
                                 key={item.linkText}
                                 controls={controls}

--- a/portal/src/components/Header/components/FullScreenMenuItem.tsx
+++ b/portal/src/components/Header/components/FullScreenMenuItem.tsx
@@ -1,24 +1,20 @@
 import React from "react";
-
-import { MenuItem, isLeafItem, CustomNavigation, defaultNavigationFunction, RootItem } from "./MainMenu";
-import "./FullScreenMenuItem.scss";
 import { motion, AnimationControls } from "framer-motion";
 
-interface Props extends CustomNavigation {
+import { MenuItem, isLeafItem, RootItem } from "./MainMenu";
+import { useMainMenu } from "./mainMenuContext";
+import "./FullScreenMenuItem.scss";
+
+interface Props {
     item: MenuItem;
     forwardFunction: (item: RootItem, evt?: React.MouseEvent) => void;
     idx: number;
     controls: AnimationControls;
 }
 
-export const FullScreenMenuItem: React.FC<Props> = ({
-    item,
-    navigationFunction = defaultNavigationFunction,
-    forwardFunction,
-    idx,
-    controls,
-}) => {
+export const FullScreenMenuItem: React.FC<Props> = ({ item, forwardFunction, idx, controls }) => {
     const isLeaf = isLeafItem(item);
+    const { navigationFunction } = useMainMenu();
     const handleClick = (evt: React.MouseEvent) =>
         isLeafItem(item) ? navigationFunction(item.content) : forwardFunction(item, evt);
     return (

--- a/portal/src/components/Header/components/MainMenuLink.tsx
+++ b/portal/src/components/Header/components/MainMenuLink.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import classNames from "classnames";
+
+import { FullScreenMenu } from "./FullScreenMenu";
+import { MenuItem, isRootItem } from "./MainMenu";
+import { useMainMenu } from "./mainMenuContext";
+
+interface Props {
+    item: MenuItem;
+}
+export const MainMenuLink: React.FC<Props> = ({ item }) => {
+    const path = item.basePath || "";
+    const { navigationFunction, isActiveFunction } = useMainMenu();
+    const className = classNames({
+        "jkl-portal-main-menu__link": true,
+        "jkl-portal-main-menu__link--active": isActiveFunction(path),
+    });
+    return isRootItem(item) ? (
+        <FullScreenMenu
+            isActiveFunction={isActiveFunction}
+            className="jkl-portal-main-menu__link"
+            activeClassName="jkl-portal-main-menu__link--active"
+            baseItem={item}
+        />
+    ) : (
+        <button role="link" onClick={() => navigationFunction(item.content)} className={className}>
+            {item.linkText}
+        </button>
+    );
+};

--- a/portal/src/components/Header/components/mainMenuContext.tsx
+++ b/portal/src/components/Header/components/mainMenuContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+export type NavigationFunction = (path: string) => void;
+export type IsActiveFunction = (path: string) => boolean;
+interface MainMenuContextProps {
+    navigationFunction: NavigationFunction;
+    isActiveFunction: IsActiveFunction;
+}
+
+export const defaultNavigationFunction = (path: string) => {
+    window && window.location.assign(path);
+};
+
+export const mainMenuContext = createContext<MainMenuContextProps>({
+    navigationFunction: defaultNavigationFunction,
+    isActiveFunction: () => false,
+});
+
+export function useMainMenu() {
+    return useContext(mainMenuContext);
+}

--- a/portal/src/components/Header/components/useFullScreenMenuAnimation.tsx
+++ b/portal/src/components/Header/components/useFullScreenMenuAnimation.tsx
@@ -11,19 +11,22 @@ export const useFullScreenMenuAnimaiton = ({ isOpen }: Props) => {
     const exit = {
         opacity: 0,
         clipPath: "inset(0 -3ch 100% 0)",
+        y: "100%",
         transition: { duration: 0 },
     };
 
     const initial = {
         opacity: 1,
         clipPath: "inset(0 -3ch 100% 0)",
-        transition: { duration: 0.25, delay: 0.1 },
+        y: "100%",
+        transition: { duration: 0.15, delay: 0.1 },
     };
 
     const animate = useCallback(
         (idx: number) => ({
             clipPath: "inset(0 -3ch 0% 0)",
-            transition: { duration: 0.35, delay: 0.03 * idx },
+            y: 0,
+            transition: { duration: 0.3, delay: 0.025 * idx },
         }),
         [],
     );


### PR DESCRIPTION
## 📥 Proposed changes

- Flytt navigasjonsfunksjon og funksjon for å avgjøre om menypunktet er aktivt inn i en context for å unngå videresending av props
- Fiks en bug der `Header` rendret på nytt ved scroll
- Justér animasjonen til menypunktene i `FullScreenMenu`

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Closes #1174 
