### PR TITLE
chore(portal): handle images in mdx files

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,8 +18,9 @@ Cypress.Commands.add("getComponent", () => {
 
 Cypress.Commands.add("verifyA11y", () => {
     // Cypress misunderstand the animation for lack of contrast
+    // Must wait a bit long to make sure all animations are done, else color contrast is off
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(300).checkA11y({
+    cy.wait(1000).checkA11y({
         exclude: [[".jkl-portal-frontpage__section-contribute", ".jkl-portal-code-block__code"]],
     });
 });

--- a/portal/integration/frontpage.spec.js
+++ b/portal/integration/frontpage.spec.js
@@ -22,7 +22,8 @@ context("Front page", () => {
             .wait(200)
             .url()
             .should("include", "komigang/utvikling")
-            .go("back");
+            .go("back")
+            .wait(200);
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.get(".jkl-portal-card")
@@ -31,7 +32,8 @@ context("Front page", () => {
             .wait(200)
             .url()
             .should("include", "komigang/design")
-            .go("back");
+            .go("back")
+            .wait(200);
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.get(".jkl-portal-card")

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -26,21 +26,17 @@ export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }
                 className={`jkl-portal-image ${isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"}`}
             >
                 <Image imgSrc={imgSrc} />
-                {!isFullscreen && <ClickText />}
+                <div className="jkl-small">Klikk for å se større</div>
             </motion.button>
             {isFullscreen && (
                 <button aria-hidden className="jkl-portal-image jkl-portal-paragraph">
                     <Image imgSrc={imgSrc} />
-                    <ClickText />
+                    <div className="jkl-small">&nbsp;</div>
                 </button>
             )}
         </>
     );
 };
-
-function ClickText() {
-    return <div className="jkl-small">Klikk for å se større</div>;
-}
 
 function Image({ imgSrc }: { imgSrc?: string }) {
     return <motion.img layout className="jkl-portal-image__img" src={imgSrc} alt="illustrasjon" />;

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -1,10 +1,13 @@
-import React, { ImgHTMLAttributes, useState } from "react";
+import React, { ImgHTMLAttributes, useState, useRef } from "react";
 import { withPrefix } from "gatsby";
 import { motion, AnimatePresence } from "framer-motion";
 import "./style.scss";
+import { useKeyListener } from "@fremtind/jkl-react-hooks";
 
 export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }) => {
     const [isFullscreen, setFullscreen] = useState(false);
+    const ref = useRef<HTMLButtonElement>(null);
+    useKeyListener(ref, "Escape", () => setFullscreen(false));
 
     const toggleFullscreen = () => setFullscreen(!isFullscreen);
 
@@ -17,6 +20,7 @@ export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }
         <>
             <BlurredBackground blur={isFullscreen} />
             <motion.button
+                ref={ref}
                 layout
                 onClick={toggleFullscreen}
                 className={`jkl-portal-image ${isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"}`}

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -1,0 +1,58 @@
+import React, { ImgHTMLAttributes, useState } from "react";
+import { withPrefix } from "gatsby";
+import { motion, AnimatePresence } from "framer-motion";
+import "./style.scss";
+
+export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }) => {
+    const [isFullscreen, setFullscreen] = useState(false);
+
+    const toggleFullscreen = () => setFullscreen(!isFullscreen);
+
+    let imgSrc = src;
+    if (src?.startsWith("/")) {
+        imgSrc = withPrefix(src);
+    }
+
+    return (
+        <>
+            <BlurredBackground blur={isFullscreen} />
+            <motion.button
+                layout
+                onClick={toggleFullscreen}
+                className={`jkl-portal-image ${isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"}`}
+            >
+                <Image imgSrc={imgSrc} />
+                {!isFullscreen && <ClickText />}
+            </motion.button>
+            {isFullscreen && (
+                <button aria-hidden className="jkl-portal-image jkl-portal-paragraph">
+                    <Image imgSrc={imgSrc} />
+                    <ClickText />
+                </button>
+            )}
+        </>
+    );
+};
+
+function ClickText() {
+    return <div className="jkl-small">Klikk for å se større</div>;
+}
+
+function Image({ imgSrc }: { imgSrc?: string }) {
+    return <motion.img layout className="jkl-portal-image__img" src={imgSrc} alt="illustrasjon" />;
+}
+
+function BlurredBackground({ blur }: { blur: boolean }) {
+    return (
+        <AnimatePresence>
+            {blur && (
+                <motion.span
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 1 }}
+                    className="portal-bg-blur"
+                />
+            )}
+        </AnimatePresence>
+    );
+}

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -1,0 +1,41 @@
+@import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
+
+.jkl-portal-image {
+    @include reset-outline;
+    background-color: transparent;
+    text-align: left;
+    z-index: 1;
+    cursor: pointer;
+    margin-top: $layout-spacing--medium;
+
+    &__img {
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+    }
+
+    &--fullscreen {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+}
+
+.portal-bg-blur {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: $layout-spacing--large;
+    background-color: rgba(0, 0, 0, 0.7);
+    z-index: 1;
+    display: block;
+}

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -5,9 +5,10 @@
     @include reset-outline;
     background-color: transparent;
     text-align: left;
-    z-index: 1;
+    z-index: $z-index--modal;
     cursor: pointer;
     margin-top: $layout-spacing--medium;
+    display: block;
 
     &__img {
         max-width: 100%;
@@ -36,6 +37,6 @@
     right: 0;
     padding: $layout-spacing--large;
     background-color: rgba(0, 0, 0, 0.7);
-    z-index: 1;
+    z-index: $z-index--modal;
     display: block;
 }

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -5,7 +5,6 @@
     @include reset-outline;
     background-color: transparent;
     text-align: left;
-    z-index: $z-index--modal;
     cursor: pointer;
     margin-top: $layout-spacing--medium;
     display: block;
@@ -26,6 +25,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        z-index: $z-index--modal;
     }
 }
 

--- a/portal/src/components/Typography/FormatProvider.tsx
+++ b/portal/src/components/Typography/FormatProvider.tsx
@@ -28,6 +28,7 @@ const components = {
     ul: UnorderedList,
     ol: OrderedList,
     li: ListItem,
+    img: PortalImg,
     a: Link,
     pre: CodeBlock,
     inlineCode: InlineCode,
@@ -35,7 +36,6 @@ const components = {
     ComponentExample,
     FlowExample,
     DoDontExample,
-    img: PortalImg,
 };
 
 interface Props {

--- a/portal/src/components/Typography/FormatProvider.tsx
+++ b/portal/src/components/Typography/FormatProvider.tsx
@@ -3,6 +3,7 @@ import { MDXProvider } from "@mdx-js/react";
 import { Link } from "@fremtind/jkl-core";
 import { OrderedList, UnorderedList, ListItem } from "@fremtind/jkl-list-react";
 import { ComponentExample, FlowExample } from "@fremtind/jkl-portal-components";
+import { PortalImg } from "../PortalImg/PortalImg";
 
 import { DoDontExample } from "../DoDontExample";
 import {
@@ -34,6 +35,7 @@ const components = {
     ComponentExample,
     FlowExample,
     DoDontExample,
+    img: PortalImg,
 };
 
 interface Props {

--- a/portal/src/pages/index.tsx
+++ b/portal/src/pages/index.tsx
@@ -51,7 +51,11 @@ const IndexPage = () => {
 
     const data = useStaticQuery(graphql`
         {
-            allSitePage(sort: { order: DESC, fields: id }, filter: { path: { regex: "/^/blog/" } }, limit: 1) {
+            allSitePage(
+                sort: { order: DESC, fields: context___frontmatter___publishDate }
+                filter: { path: { regex: "/^/blog/" } }
+                limit: 1
+            ) {
                 edges {
                     node {
                         path


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

Hvordan blogge-posten var ikke heeeelt riktig når det kom til bilder. Vi hadde ikke håntert withPrefix fra img i markdown, så den fant ikke riktig adresse til static når portalen var i PROD.

For å løse dette så lager vi en komponent som erstatter default img komponenten i markdown parseren. Det gjør også at vi kan gjøre litt gøy med bilder, ved at de maks får størrelsen til tekstbredden i portalen, men man kan klikke på bildet for å få det opp i fullskjermsvisning.

Fikset også bug med hvilken post som vises på forsiden.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

