### PR TITLE
fix(portal): add prefix to dowload logo

### DIFF
--- a/portal/src/components/DownloadAsset/DownloadAsset.tsx
+++ b/portal/src/components/DownloadAsset/DownloadAsset.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import downloadjs from "downloadjs";
 import classNames from "classnames";
+import { withPrefix } from "gatsby";
 
 import "./DownloadAsset.scss";
 
@@ -38,7 +39,7 @@ export function DownloadAsset({ asset = "", name, type, darkbg = false }: Props)
     return (
         <div className={componentClassName}>
             <button className="jkl-portal-downloadasset__button" onClick={clickDownload}>
-                <img className="jkl-portal-downloadasset__image" src={asset} alt={"Fil " + name} />
+                <img className="jkl-portal-downloadasset__image" src={withPrefix(asset)} alt={"Fil " + name} />
                 <span className={textClassName}>{name}</span>
             </button>
         </div>


### PR DESCRIPTION
affects: @fremtind/portal

ISSUES CLOSED:  #1190

## 📥 Proposed changes

Liten gatsby quirk, fungerer lokalt, siden gatsby der ligger flatt på localhost, men ikke på github pages, siden den der ligger prefixet med jokul. WithPrefix løser biffen.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

