### PR TITLE
Fix portal menu styling

### DIFF
--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -33,7 +33,7 @@ $link-active-color--inverted: $info--darkbg;
     text-decoration: none;
     color: currentColor;
 
-    &:focus,
+    html:not([data-mousenavigation]) &:focus,
     &:hover {
         color: $link-active-color;
         color: var(--link-active-color);
@@ -58,7 +58,7 @@ $link-active-color--inverted: $info--darkbg;
     }
 
     &--negative {
-        &:focus,
+        html:not([data-mousenavigation]) &:focus,
         &:hover {
             color: $link-active-color--inverted;
             color: var(--link-active-color);
@@ -87,7 +87,7 @@ $link-active-color--inverted: $info--darkbg;
     }
 
     &:hover,
-    &:focus {
+    html:not([data-mousenavigation]) &:focus {
         color: $link-active-color;
         color: var(--link-active-color);
 
@@ -102,7 +102,7 @@ $link-active-color--inverted: $info--darkbg;
 
     &--inverted {
         &:hover,
-        &:focus {
+        html:not([data-mousenavigation]) &:focus {
             color: $link-active-color--inverted;
             color: var(--link-active-color);
         }

--- a/patches/@nrk+core-toggle+3.0.8.patch
+++ b/patches/@nrk+core-toggle+3.0.8.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@nrk/core-toggle/jsx.js b/node_modules/@nrk/core-toggle/jsx.js
-index b9e52a9..76abb6f 100644
+index b9e52a9..dacfa4a 100644
 --- a/node_modules/@nrk/core-toggle/jsx.js
 +++ b/node_modules/@nrk/core-toggle/jsx.js
 @@ -308,7 +308,7 @@ var CoreToggle = /*#__PURE__*/function (_HTMLElement) {
@@ -11,21 +11,7 @@ index b9e52a9..76abb6f 100644
      } // aria-haspopup triggers forms mode in JAWS, therefore store as custom attr
  
    }, {
-@@ -386,16 +386,24 @@ var closest$1 = function () {
-   };
- }();
- /**
-+* getUUID
-+* @return {String} A generated unique ID
-+*/
-+
-+function getUUID() {
-+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 5)
-+}
-+/**
- * customElementToReact
- * @param {Class|Function} elementClass A custom element definition.
- * @param {Array} options Props and custom events
+@@ -392,10 +392,10 @@ var closest$1 = function () {
  * @return {Object} A React component
  */
  
@@ -38,7 +24,7 @@ index b9e52a9..76abb6f 100644
  
    var dashCase = name.replace(/.[A-Z]/g, function (ref) {
      var a = ref[0];
-@@ -514,6 +522,7 @@ function customElementToReact(elementClass, options) {
+@@ -514,6 +514,7 @@ function customElementToReact(elementClass, options) {
  }
  
  var coreToggle = customElementToReact(CoreToggle, {

--- a/portal/src/components/Header/components/FullScreenMenuItem.scss
+++ b/portal/src/components/Header/components/FullScreenMenuItem.scss
@@ -8,7 +8,6 @@
 
     &__link {
         position: relative;
-        @include reset-outline;
         @include jkl-text-style("desktop/title-small");
         // static font-sizes for old browsers:
         font-size: rem(30px);
@@ -16,37 +15,11 @@
         // 30px/40px on iPhone X:
         font-size: relativeSize(30, 375, 812);
         line-height: relativeSize(40, 375, 812);
-        text-decoration: none;
-        color: $svart;
+
+        // button resets:
         background-color: transparent;
         padding: 0;
-        padding-right: 3ch;
         cursor: pointer;
-
-        &:after {
-            position: absolute;
-            content: "\2192";
-            @include motion("standard");
-            transition-property: transform;
-            transform: translateX(0);
-        }
-
-        &:hover,
-        &:focus {
-            color: #000afa;
-            &:after {
-                transform: translateX(60%);
-            }
-        }
-
-        *[data-theme="dark"] & {
-            color: $hvit;
-
-            &:hover,
-            &:focus {
-                color: #00faff;
-            }
-        }
 
         @include medium-device {
             // static font-sizes for old browsers:

--- a/portal/src/components/Header/components/FullScreenMenuItem.tsx
+++ b/portal/src/components/Header/components/FullScreenMenuItem.tsx
@@ -20,7 +20,7 @@ export const FullScreenMenuItem: React.FC<Props> = ({ item, forwardFunction, idx
     return (
         <motion.li custom={idx} animate={controls} className="jkl-portal-full-screen-menu-item" key={item.linkText}>
             <button
-                className="jkl-portal-full-screen-menu-item__link"
+                className="jkl-nav-link jkl-portal-full-screen-menu-item__link"
                 type="button"
                 data-testid={`full-screen-menu-item--${item.linkText.replace(/ /g, "-")}`}
                 aria-expanded={isLeaf ? undefined : "false"}

--- a/portal/src/components/Header/components/MainMenu.scss
+++ b/portal/src/components/Header/components/MainMenu.scss
@@ -40,14 +40,18 @@
         transition-property: box-shadow;
 
         &:hover,
+        html:not([data-mousenavigation]) &:focus {
+            color: #000afa;
+        }
+
+        &:hover,
         html:not([data-mousenavigation]) &:focus,
         &--active {
             box-shadow: inset 0 rem(-4px) 0 0 currentColor;
         }
 
         &--active {
-            font-weight: $bold-weight;
-            color: #000afa;
+            @include no-grow-bold;
         }
 
         *[data-theme="dark"] & {

--- a/portal/src/components/Sidebar/Sidebar.scss
+++ b/portal/src/components/Sidebar/Sidebar.scss
@@ -29,40 +29,7 @@ $animation-timing: 300ms ease-out both;
     position: relative;
 
     &__link {
-        @include reset-outline;
         @include jkl-text-style("desktop/body");
         display: block;
-        text-decoration: none;
-        color: inherit;
-
-        &:after {
-            content: "\2192";
-            position: absolute;
-            @include motion("standard");
-            transition-property: transform;
-        }
-
-        &:hover,
-        &:focus {
-            color: #000afa;
-            &:after {
-                transform: translateX(60%);
-            }
-        }
-
-        &--active {
-            color: #000afa;
-            font-weight: $bold-weight;
-            /* @include jkl-text-style("desktop/lead");
-            margin: $component-spacing--xs 0; */
-        }
-
-        *[data-theme="dark"] & {
-            &--active,
-            &:hover,
-            &:focus {
-                color: #00faff;
-            }
-        }
     }
 }

--- a/portal/src/components/Sidebar/SidebarMenuItem.tsx
+++ b/portal/src/components/Sidebar/SidebarMenuItem.tsx
@@ -11,8 +11,8 @@ export function SidebarMenuItem({ path, title }: SidebarMenuItemProps) {
 
     return (
         <Link
-            activeClassName="jkl-portal-sidebar-menu-item__link--active"
-            className="jkl-portal-sidebar-menu-item__link"
+            className="jkl-nav-link jkl-portal-sidebar-menu-item__link"
+            activeClassName="jkl-nav-link--active"
             to={path}
             state={{ lastPath: currentSection }}
             data-testid={`sidebar-link-${title.replace(/ /g, "-")}`}


### PR DESCRIPTION
## 📥 Proposed changes

- Bruk den nye `jkl-nav-link`-komponenten (kun stilark) i fullskjerm- og sidemenyene i portalen
- Endre hovedmenyen til å følge de nye skissene i Figma (se #1222)
- Fiks en bug i `jkl-link` og `jkl-nav-link` som gjorde at fokus-staten hang igjen etter klikk ved bruk av musen

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Er det bare meg, eller blir det litt fargeløst i portalen nå som vi bare har blå på hover?

<img width="1337" alt="Skjermbilde 2020-08-14 kl  16 29 39" src="https://user-images.githubusercontent.com/25739615/90260129-61074000-de4b-11ea-8a8c-b337e75deb16.png">

