### PR TITLE
chore(portal): build portal without prefix paths when deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
         "clean:portal": "lerna run clean:portal --stream",
         "build": "yarn patch-package && lerna run --ignore @fremtind/browserslist-config-jkl build --stream",
         "build:style": "lerna run --ignore @fremtind/*-react --ignore @fremtind/jkl-react-hooks build",
-        "build:docs": "lerna run build:docs",
-        "build:docs:local": "lerna run build:local --stream",
+        "build:docs": "lerna run --scope @fremtind/portal build --stream",
         "commit": "git-cz",
         "predeploy:docs": "yarn run build:docs",
         "deploy:docs": "gh-pages -d portal/public",
@@ -27,8 +26,6 @@
         "release": "lerna publish",
         "dev": "lerna run --scope @fremtind/portal dev --stream",
         "start": "yarn run dev",
-        "serve:portal": "lerna run serve --stream",
-        "serve": "run-s clean:portal build:docs:local serve:portal",
         "boot": "yarn install --force && yarn build",
         "reboot": "yarn clean && yarn boot"
     },

--- a/portal/package.json
+++ b/portal/package.json
@@ -45,8 +45,7 @@
     "scripts": {
         "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
         "clean:portal": "gatsby clean",
-        "build:docs": "gatsby build --prefix-paths",
-        "build:local": "gatsby build",
+        "build": "gatsby build",
         "dev": "gatsby develop",
         "start": "yarn dev",
         "serve": "gatsby serve",


### PR DESCRIPTION
## 📥 Proposed changes

Bygg portalen uten `--prefix-paths` siden vi har flyttet portalen til custom domene

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal
