### PR TITLE
Mobile portal

### DIFF
--- a/packages/core/documentation/Colors/Colors.tsx
+++ b/packages/core/documentation/Colors/Colors.tsx
@@ -41,8 +41,10 @@ interface Props {
 
 const ColorBox: React.FC<Props> = ({ color, handleClick }) => (
     <button type="button" onClick={() => handleClick(color)} className="jkl-color-box__wrapper">
-        <span className={`jkl-color-box jkl-color-box--left jkl-color-box--${color}`}></span>
-        <span className={`jkl-color-box jkl-color-box--right jkl-color-box--${color}`}></span>
+        <span className="jkl-color-box__multi">
+            <span className={`jkl-color-box jkl-color-box--left jkl-color-box--${color}`}></span>
+            <span className={`jkl-color-box jkl-color-box--right jkl-color-box--${color}`}></span>
+        </span>
         <span className="jkl-color-box__text jkl-body">${color}</span>
     </button>
 );
@@ -54,8 +56,10 @@ interface MultiColorProps {
 
 const MultiColorBox: React.FC<MultiColorProps> = ({ colors, handleClick }) => (
     <button type="button" onClick={() => handleClick(`${colors[0]}, $${colors[1]}`)} className="jkl-color-box__wrapper">
-        <span className={`jkl-color-box jkl-color-box--left jkl-color-box--${colors[0]}`}></span>
-        <span className={`jkl-color-box jkl-color-box--right jkl-color-box--${colors[1]}`}></span>
+        <span className="jkl-color-box__multi">
+            <span className={`jkl-color-box jkl-color-box--left jkl-color-box--${colors[0]}`}></span>
+            <span className={`jkl-color-box jkl-color-box--right jkl-color-box--${colors[1]}`}></span>
+        </span>
         <span className="jkl-color-box__text jkl-body">${colors[0]}</span>
         <span className="jkl-color-box__text jkl-body">${colors[1]}</span>
     </button>

--- a/packages/core/documentation/Colors/colors.scss
+++ b/packages/core/documentation/Colors/colors.scss
@@ -26,6 +26,10 @@
         width: 180px;
     }
 
+    &__multi {
+        display: flex;
+    }
+
     &--left {
         transform: rotate(-90deg);
         .jkl-color-box__text {
@@ -45,6 +49,11 @@
         align-items: center;
         @include reset-outline();
         background-color: transparent;
+
+        @include small-device {
+            flex-direction: column;
+            padding-bottom: $layout-spacing--medium;
+        }
 
         &:hover {
             color: $info;

--- a/packages/portal-components/component-example.scss
+++ b/packages/portal-components/component-example.scss
@@ -59,6 +59,16 @@
         margin-top: $layout-spacing--small;
     }
 
+    @include small-device {
+        width: calc(100% - #{$layout-spacing--medium});
+        max-width: 100%;
+        min-width: initial;
+        flex-direction: column;
+        &__example-wrapper {
+            width: initial;
+        }
+    }
+
     *[data-theme="dark"] & {
         background-color: $gra-100;
     }

--- a/portal/src/components/Card/card.scss
+++ b/portal/src/components/Card/card.scss
@@ -16,6 +16,10 @@
     box-shadow: 0px 10px 25px rgba(0, 0, 0, 0);
     max-width: rem(400px);
 
+    @include small-device {
+        background-color: $hvit;
+    }
+
     &__heading {
         @include jkl-text-style("desktop/heading-medium");
         margin-bottom: $component-spacing--medium;

--- a/portal/src/components/DoDontExample/DoDontExample.scss
+++ b/portal/src/components/DoDontExample/DoDontExample.scss
@@ -53,4 +53,8 @@
             color: $feil--darkbg;
         }
     }
+
+    @include small-device {
+        max-width: 75vw;
+    }
 }

--- a/portal/src/components/DoDontExample/DoDontExample.tsx
+++ b/portal/src/components/DoDontExample/DoDontExample.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from "react";
-import { withPrefix } from "gatsby";
 import classNames from "classnames";
 
 import "./DoDontExample.scss";
+import { PortalImg } from "../PortalImg/PortalImg";
 
 interface Props {
     type: "do" | "dont";
@@ -30,7 +30,9 @@ export const DoDontExample: React.FC<Props> = ({ type, content, image = "", desc
             {content ? (
                 <div>{content}</div>
             ) : (
-                <img className="jkl-portal-do-dont-example__image" src={withPrefix(image)} alt={altText} />
+                <div className="jkl-portal-do-dont-example__image">
+                    <PortalImg src={image} alt={altText} />
+                </div>
             )}
             <p className={headingClass}>{heading}</p>
             <p className="jkl-portal-do-dont-example__description">{description}</p>

--- a/portal/src/components/DoDontExample/DoDontExample.tsx
+++ b/portal/src/components/DoDontExample/DoDontExample.tsx
@@ -31,7 +31,7 @@ export const DoDontExample: React.FC<Props> = ({ type, content, image = "", desc
                 <div>{content}</div>
             ) : (
                 <div className="jkl-portal-do-dont-example__image">
-                    <PortalImg src={image} alt={altText} />
+                    <PortalImg src={image} alt={altText} noMargin />
                 </div>
             )}
             <p className={headingClass}>{heading}</p>

--- a/portal/src/components/Layout/Layout.scss
+++ b/portal/src/components/Layout/Layout.scss
@@ -36,6 +36,15 @@
         }
     }
 
+    @include small-device {
+        &__main {
+            > h1 {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
+
     @include from-large-device {
         display: grid;
         grid-template:

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import "./style.scss";
 import { useKeyListener } from "@fremtind/jkl-react-hooks";
 
-export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }) => {
+export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src, alt }) => {
     const [isFullscreen, setFullscreen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
     useKeyListener(ref, "Escape", () => setFullscreen(false));
@@ -25,8 +25,8 @@ export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }
                 onClick={toggleFullscreen}
                 className={`jkl-portal-image ${isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"}`}
             >
-                <Image imgSrc={imgSrc} />
-                <div className="jkl-small">Klikk for å se større</div>
+                <Image imgSrc={imgSrc} alt={alt} />
+                {!isFullscreen && <div className="jkl-small">Klikk for å se større</div>}
             </motion.button>
             {isFullscreen && (
                 <button aria-hidden className="jkl-portal-image jkl-portal-paragraph">
@@ -38,8 +38,8 @@ export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src }
     );
 };
 
-function Image({ imgSrc }: { imgSrc?: string }) {
-    return <motion.img layout className="jkl-portal-image__img" src={imgSrc} alt="illustrasjon" />;
+function Image({ imgSrc, alt }: { imgSrc?: string; alt?: string }) {
+    return <motion.img layout className="jkl-portal-image__img" src={imgSrc} alt={alt || "illustrasjon"} />;
 }
 
 function BlurredBackground({ blur }: { blur: boolean }) {

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -4,7 +4,11 @@ import { motion, AnimatePresence } from "framer-motion";
 import "./style.scss";
 import { useKeyListener } from "@fremtind/jkl-react-hooks";
 
-export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src, alt }) => {
+interface Props extends ImgHTMLAttributes<HTMLImageElement> {
+    noMargin?: boolean;
+}
+
+export const PortalImg: React.FC<Props> = ({ src, alt, noMargin }) => {
     const [isFullscreen, setFullscreen] = useState(false);
     const ref = useRef<HTMLButtonElement>(null);
     useKeyListener(ref, "Escape", () => setFullscreen(false));
@@ -23,15 +27,20 @@ export const PortalImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({ src, 
                 ref={ref}
                 layout
                 onClick={toggleFullscreen}
-                className={`jkl-portal-image ${isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"}`}
+                className={`jkl-portal-image ${noMargin ? "jkl-portal-image--no-margin" : ""} ${
+                    isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"
+                }`}
             >
                 <Image imgSrc={imgSrc} alt={alt} />
-                {!isFullscreen && <div className="jkl-small">Klikk for å se større</div>}
+                {!isFullscreen && <div className="jkl-micro">Klikk for å se større</div>}
             </motion.button>
             {isFullscreen && (
-                <button aria-hidden className="jkl-portal-image jkl-portal-paragraph">
+                <button
+                    aria-hidden
+                    className={`jkl-portal-image jkl-portal-paragraph ${noMargin ? "jkl-portal-image--no-margin" : ""}`}
+                >
                     <Image imgSrc={imgSrc} />
-                    <div className="jkl-small">&nbsp;</div>
+                    <div className="jkl-micro">&nbsp;</div>
                 </button>
             )}
         </>

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -32,7 +32,7 @@ export const PortalImg: React.FC<Props> = ({ src, alt, noMargin }) => {
                 }`}
             >
                 <Image imgSrc={imgSrc} alt={alt} />
-                {!isFullscreen && <div className="jkl-micro">Klikk for å se større</div>}
+                {!isFullscreen && !noMargin && <div className="jkl-micro">Klikk for å se større</div>}
             </motion.button>
             {isFullscreen && (
                 <button
@@ -40,7 +40,7 @@ export const PortalImg: React.FC<Props> = ({ src, alt, noMargin }) => {
                     className={`jkl-portal-image jkl-portal-paragraph ${noMargin ? "jkl-portal-image--no-margin" : ""}`}
                 >
                     <Image imgSrc={imgSrc} />
-                    <div className="jkl-micro">&nbsp;</div>
+                    {!noMargin && <div className="jkl-micro">&nbsp;</div>}
                 </button>
             )}
         </>

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -4,11 +4,15 @@
 .jkl-portal-image {
     @include reset-outline;
     background-color: transparent;
-    text-align: left;
     cursor: pointer;
     display: block;
     padding: 0;
     margin-top: $layout-spacing--medium;
+    width: 100%;
+
+    > .jkl-micro {
+        text-align: left;
+    }
 
     &--no-margin {
         margin-top: 0;

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -6,8 +6,13 @@
     background-color: transparent;
     text-align: left;
     cursor: pointer;
-    margin-top: $layout-spacing--medium;
     display: block;
+    padding: 0;
+    margin-top: $layout-spacing--medium;
+
+    &--no-margin {
+        margin-top: 0;
+    }
 
     &__img {
         max-width: 100%;

--- a/portal/src/pages/index.scss
+++ b/portal/src/pages/index.scss
@@ -44,6 +44,30 @@
                     }
                 }
             }
+
+            @include small-device {
+                &--image-container {
+                    position: absolute;
+                    height: 100vh;
+                    width: 100vw;
+                }
+                &--image {
+                    background-position: center;
+                }
+
+                &--content {
+                    position: relative;
+                    display: block;
+                    margin-left: -$component-spacing--large;
+
+                    .jkl-portal__card-list {
+                        position: relative;
+                        display: block;
+                        margin-left: $component-spacing--large;
+                        padding-top: $layout-spacing--xxl;
+                    }
+                }
+            }
         }
 
         &--wrapper {


### PR DESCRIPTION
## 📥 Proposed changes

Portalen ser ikke spesielt bra ut på mobil i dag. Så med noen relativt enkle grep fikses de fleste overflyts feilene, så portalen skal bli litt hyggeligere for alle mobilbrukere.

Gjennstående oppgaver:
- Hovedmenyen kan fortsatt flyte over ved lange lenker
- Innholdet bak hovedmenyen bør låses når den er åpen, spesielt iphones har en tendens til å kunne få tak i underliggende innhold og lage en veldig rar scroll opplevelse. (iphones må ha position fixed på underliggende innhold for å sikre oss helt mot dette)

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

