### PR TITLE
Remove extraneous builds

### DIFF
--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -16,9 +16,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -11,9 +11,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -20,9 +20,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "scripts": {
         "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
         "build:types": "tsc -p tsconfig-for-declarations.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,9 +16,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/field-group-react/package.json
+++ b/packages/field-group-react/package.json
@@ -11,9 +11,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/hamburger-react/package.json
+++ b/packages/hamburger-react/package.json
@@ -19,9 +19,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "scripts": {
         "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
         "build:types": "tsc -p tsconfig-for-declarations.json",

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -16,9 +16,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -15,9 +15,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/portal-components/package.json
+++ b/packages/portal-components/package.json
@@ -12,9 +12,9 @@
     "homepage": "https://github.com/fremtind/jokul#readme",
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -19,9 +19,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "scripts": {
         "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
         "build:types": "tsc -p tsconfig-for-declarations.json",

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -15,9 +15,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -15,9 +15,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -12,9 +12,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -17,9 +17,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -15,9 +15,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/typography-react/package.json
+++ b/packages/typography-react/package.json
@@ -17,9 +17,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },

--- a/packages/validations-util/package.json
+++ b/packages/validations-util/package.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "types": "./build/index.d.ts",
-    "main": "./build/cjs/index.js",
-    "module": "./build/esm/index.js",
-    "browser": "./build/browser/index.js",
+    "main": "./build/esm/index.min.js",
+    "module": "./build/esm/index.min.js",
+    "browser": "./build/esm/index.min.js",
     "directories": {
         "lib": "build"
     },


### PR DESCRIPTION
## 📥 Proposed changes

Endre bygg av React-pakkene slik at vi kun bygger minifisert kode i ES modules-format med sourcemap. Sørger også for å faktisk bundle Core Components i de pakkene som bruker dem.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

BREAKING CHANGE: React-pakkene kan ikke lenges brukes i Node-prosjekter eller IE11 med mindre de først transpileres til Common JS-format.

Closes: #1243 