### PR TITLE
docs(autosuggest): move experimental icon to end of title

### DIFF
--- a/packages/text-input-react/documentation/Autosuggest.mdx
+++ b/packages/text-input-react/documentation/Autosuggest.mdx
@@ -1,5 +1,5 @@
 ---
-title: 🧪 Autosuggest
+title: ­Autosuggest 🧪
 react: text-input-react
 scss: text-input
 group: skjema


### PR DESCRIPTION
## 📥 Proposed changes

Move the experimental icon to the end of the title for Autosuggest to improve alignment in menus.
Use a soft hyphen at the start to keep sorting order.

**Before**:
<img width="379" alt="Skjermbilde 2020-08-27 kl  14 45 57" src="https://user-images.githubusercontent.com/25739615/91532050-04f1f080-e90e-11ea-9dec-91170ccf341f.png">
**After**:
<img width="384" alt="Skjermbilde 2020-08-27 kl  14 46 04" src="https://user-images.githubusercontent.com/25739615/91532055-06231d80-e90e-11ea-94ef-ab423add60ac.png">


## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-text-input-react.
