### PR TITLE
fix(core): add a font stack

### DIFF
--- a/packages/core/core.scss
+++ b/packages/core/core.scss
@@ -11,7 +11,7 @@
 @import "./icons.scss";
 
 :root {
-    font-family: "Fremtind Grotesk";
+    font-family: "Fremtind Grotesk", Calibri, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## 📥 Proposed changes

Per nå har vi bare Fremtind Grotesk satt som font. Det har en rekke problemer ved seg, først så har vi ingen kontroll over hvilken font som vises frem til vår font er lasta, det er opp til standard settingen til nettleseren. Hvis nedlastingen av vår font feiler eller blir blokkert, så blir man stående på feks Times New Roman, som ikke er det vi har lyst til sannsynligvis. Videre så inneholder ikke Fremtind Grotesk alle tegn, så hvis man bruker et tegn fonten ikke har, så skjer det ting. 

Konkret bug oppdaget i ahv: soft-hyphens rendres feil på iOS Safari. Åpne denne på iOS https://it1b7.csb.app/

Kode:
https://codesandbox.io/s/relaxed-sinoussi-it1b7?file=/src/App.tsx

Legg merke til at det legges inn et space som ikke skal være der mellom safari og internett, som også er det når soft hypen dukker opp. Gjelder både unicode og html implementasjonen. Med font stacken satt, så får man ikke space og riktig hyphen.
![Simulator Screen Shot - iPhone 11 Pro - 2020-09-02 at 13 20 41](https://user-images.githubusercontent.com/46530368/91975104-2b08fd80-ed1f-11ea-9697-f3639fe882d0.png)

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

