### PR TITLE
docs(icons): use displayName in portal example

### DIFF
--- a/packages/icons-react/documentation/Example.tsx
+++ b/packages/icons-react/documentation/Example.tsx
@@ -70,7 +70,7 @@ export const Example: React.FC<ExampleComponentProps> = ({ boolValues, choiceVal
                     <IconExample
                         key={Ico.name}
                         renderIcon={() => <Ico variant={variant} />}
-                        name={Ico.name}
+                        name={Ico.displayName}
                         inverted={inverted}
                     />
                 ))}
@@ -84,22 +84,22 @@ export const Example: React.FC<ExampleComponentProps> = ({ boolValues, choiceVal
             <Grid columns="two" color={color}>
                 <AnimatedIcon
                     renderIcon={(isDown) => <ArrowVerticalAnimated pointingDown={isDown} variant={variant} />}
-                    iconName={ArrowVerticalAnimated.name}
+                    iconName={ArrowVerticalAnimated.displayName}
                     inverted={inverted}
                 />
                 <AnimatedIcon
                     renderIcon={(isRight) => <ArrowHorizontalAnimated pointingRight={isRight} variant={variant} />}
-                    iconName={ArrowHorizontalAnimated.name}
+                    iconName={ArrowHorizontalAnimated.displayName}
                     inverted={inverted}
                 />
                 <AnimatedIcon
                     renderIcon={(isPlus) => <PlusRemoveAnimated isPlus={isPlus} variant={variant} />}
-                    iconName={PlusRemoveAnimated.name}
+                    iconName={PlusRemoveAnimated.displayName}
                     inverted={inverted}
                 />
                 <AnimatedIcon
                     renderIcon={(isBurger) => <HamburgerCloseAnimated isBurger={isBurger} variant={variant} />}
-                    iconName={HamburgerCloseAnimated.name}
+                    iconName={HamburgerCloseAnimated.displayName}
                     inverted={inverted}
                 />
             </Grid>

--- a/packages/icons-react/documentation/internal/AnimatedIcon.tsx
+++ b/packages/icons-react/documentation/internal/AnimatedIcon.tsx
@@ -4,7 +4,7 @@ import "@fremtind/jkl-button/button.min.css";
 
 interface AnimatedIconProps {
     renderIcon: (arg0: boolean) => React.ReactNode;
-    iconName: string;
+    iconName?: string;
     inverted: boolean;
 }
 
@@ -15,7 +15,7 @@ export const AnimatedIcon: React.FC<AnimatedIconProps> = ({ renderIcon, iconName
             <div>
                 {renderIcon(state)}
                 <div className={`jkl-micro jkl-component-spacing--small-top jkl-color-${inverted ? "hvit" : "svart"}`}>
-                    {iconName}
+                    {iconName || renderIcon.name}
                 </div>
             </div>
             <SecondaryButton

--- a/packages/icons-react/documentation/internal/IconExample.tsx
+++ b/packages/icons-react/documentation/internal/IconExample.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 
 interface Props {
-    name: string;
+    name?: string;
     renderIcon: () => ReactNode;
     inverted: boolean;
 }
@@ -10,7 +10,7 @@ export const IconExample: React.FC<Props> = ({ name, renderIcon, inverted }) => 
     <div>
         {renderIcon()}
         <div className={`jkl-micro jkl-component-spacing--small-top jkl-color-${inverted ? "hvit" : "svart"}`}>
-            {name}
+            {name || renderIcon.name}
         </div>
     </div>
 );

--- a/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
@@ -23,3 +23,5 @@ export const ArrowHorizontalAnimated: React.FC<Props> = ({ pointingRight, varian
         </div>
     );
 };
+
+ArrowHorizontalAnimated.displayName = "ArrowHorizontalAnimated";

--- a/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
@@ -24,3 +24,5 @@ export const ArrowVerticalAnimated: React.FC<Props> = ({ pointingDown, variant =
         </div>
     );
 };
+
+ArrowVerticalAnimated.displayName = "ArrowVerticalAnimated";

--- a/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
@@ -32,3 +32,5 @@ export const HamburgerCloseAnimated: React.FC<Props> = ({ isBurger, variant = "s
         </div>
     );
 };
+
+HamburgerCloseAnimated.displayName = "HamburgerCloseAnimated";

--- a/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
@@ -19,3 +19,5 @@ export const PlusRemoveAnimated: React.FC<Props> = ({ isPlus, variant = "small" 
         </div>
     );
 };
+
+PlusRemoveAnimated.displayName = "PlusRemoveAnimated";

--- a/packages/icons-react/src/icons/ArrowDown.tsx
+++ b/packages/icons-react/src/icons/ArrowDown.tsx
@@ -17,3 +17,5 @@ export const ArrowDown: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+ArrowDown.displayName = "ArrowDown";

--- a/packages/icons-react/src/icons/ArrowLeft.tsx
+++ b/packages/icons-react/src/icons/ArrowLeft.tsx
@@ -17,3 +17,5 @@ export const ArrowLeft: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+ArrowLeft.displayName = "ArrowLeft";

--- a/packages/icons-react/src/icons/ArrowRight.tsx
+++ b/packages/icons-react/src/icons/ArrowRight.tsx
@@ -17,3 +17,5 @@ export const ArrowRight: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+ArrowRight.displayName = "ArrowRight";

--- a/packages/icons-react/src/icons/ArrowUp.tsx
+++ b/packages/icons-react/src/icons/ArrowUp.tsx
@@ -17,3 +17,5 @@ export const ArrowUp: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+ArrowUp.displayName = "ArrowUp";

--- a/packages/icons-react/src/icons/ArrowUpRight.tsx
+++ b/packages/icons-react/src/icons/ArrowUpRight.tsx
@@ -17,3 +17,5 @@ export const ArrowUpRight: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+ArrowUpRight.displayName = "ArrowUpRight";

--- a/packages/icons-react/src/icons/Calendar.tsx
+++ b/packages/icons-react/src/icons/Calendar.tsx
@@ -18,3 +18,5 @@ export const Calendar: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Calendar.displayName = "Calendar";

--- a/packages/icons-react/src/icons/CheckMark.tsx
+++ b/packages/icons-react/src/icons/CheckMark.tsx
@@ -11,3 +11,5 @@ export const CheckMark: React.FC<IconProps> = ({ className, variant }) => (
         innerSvg={<path d="M1 15.2168L5.24264 19.4594L19.3848 5.3173" stroke="currentColor" />}
     />
 );
+
+CheckMark.displayName = "CheckMark";

--- a/packages/icons-react/src/icons/Close.tsx
+++ b/packages/icons-react/src/icons/Close.tsx
@@ -18,3 +18,5 @@ export const Close: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Close.displayName = "Close";

--- a/packages/icons-react/src/icons/Error.tsx
+++ b/packages/icons-react/src/icons/Error.tsx
@@ -17,3 +17,5 @@ export const Error: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Error.displayName = "Error";

--- a/packages/icons-react/src/icons/Hamburger.tsx
+++ b/packages/icons-react/src/icons/Hamburger.tsx
@@ -18,3 +18,5 @@ export const Hamburger: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Hamburger.displayName = "Hamburger";

--- a/packages/icons-react/src/icons/Info.tsx
+++ b/packages/icons-react/src/icons/Info.tsx
@@ -20,3 +20,5 @@ export const Info: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Info.displayName = "Info";

--- a/packages/icons-react/src/icons/Plus.tsx
+++ b/packages/icons-react/src/icons/Plus.tsx
@@ -18,3 +18,5 @@ export const Plus: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Plus.displayName = "Plus";

--- a/packages/icons-react/src/icons/Search.tsx
+++ b/packages/icons-react/src/icons/Search.tsx
@@ -18,3 +18,5 @@ export const Search: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Search.displayName = "Search";

--- a/packages/icons-react/src/icons/Success.tsx
+++ b/packages/icons-react/src/icons/Success.tsx
@@ -17,3 +17,5 @@ export const Success: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Success.displayName = "Success";

--- a/packages/icons-react/src/icons/Warning.tsx
+++ b/packages/icons-react/src/icons/Warning.tsx
@@ -20,3 +20,5 @@ export const Warning: React.FC<IconProps> = ({ className, variant }) => (
         }
     />
 );
+
+Warning.displayName = "Warning";


### PR DESCRIPTION
## 📥 Proposed changes

Use `displayName` instead of `name` to display icon names in the portal example

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-icons-react

ISSUES CLOSED: #1299
