### PR TITLE
fix(portal): fix background for transparent portal img

### DIFF
--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -22,6 +22,8 @@
         max-width: 100%;
         max-height: 100%;
         object-fit: contain;
+        background-color: $hvit;
+        padding: $component-spacing--large;
     }
 
     &--fullscreen {


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

Fikser problem der transparrante bilder ser mindre heldig ut i fullskjermsvisning.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments


