### PR TITLE
fix: fix a bug where alert-message would go outside screen bounds

### DIFF
--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -62,6 +62,7 @@ $success-border-color--inverted: $suksess--darkbg;
     background-color: var(--background-color);
     border: rem(1px) solid $border-color;
     border: rem(1px) solid var(--border-color);
+    box-sizing: border-box;
 
     &__icon {
         padding-right: $component-spacing--large;


### PR DESCRIPTION
affects: @fremtind/jkl-alert-message

## 📥 Proposed changes

Fikset en bug som gjorde at alert-message gikk utenfor skjermen og skapte en unødig horisontal scrollbar.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
