### PR TITLE
Graceful reset av DatePicker om man har gitt en invalid initialDate

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -53,6 +53,13 @@ describe("Datepicker", () => {
         // Check for date formatted as DD.MM.YYYY
         expect(input).toHaveProperty("value", "12.09.2019");
     });
+
+    it("should reset initialDate if it's outside scope", () => {
+        render(<DatePicker initialDate={new Date("10.07.1992")} disableBeforeDate={new Date("09.12.2019")} />);
+
+        const input = screen.getByTestId("jkl-datepicker__input");
+        expect(input).toHaveProperty("value", "");
+    });
 });
 
 describe("a11y", () => {

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -112,10 +112,29 @@ export function DatePicker({
         }
     }, [disableBeforeDate, disableAfterDate]);
 
+    const disableDate = useCallback(
+        (date: Date) => {
+            return (disableAfterDate && date > disableAfterDate) || (disableBeforeDate && date < disableBeforeDate);
+        },
+        [disableAfterDate, disableBeforeDate],
+    );
+
     useEffect(() => {
         setDateString(initialDate ? formatDate(initialDate) : "");
         setDate(initialDate);
     }, [initialDate]);
+
+    useEffect(() => {
+        // if initialdate is outside scope, clear it out. this is to avoid a case in wizard forms
+        // where the initialdate may be based on an invalid value earlier in the form state.
+        if (initialDate && disableDate(initialDate)) {
+            setDateString("");
+            setDate(undefined);
+        }
+        // this check should only have effect at first render. this is to ensure a good user experience, where having
+        // it on every change would clear out the field while the user is typing.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const toggleCalendar = () => {
         const wasHidden = calendarHidden;
@@ -187,10 +206,6 @@ export function DatePicker({
 
         setCalendarHidden(true);
         inputRef.current && inputRef.current.focus();
-    }
-
-    function disableDate(date: Date) {
-        return (disableAfterDate && date > disableAfterDate) || (disableBeforeDate && date < disableBeforeDate);
     }
 
     return (


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react

## 📥 Proposed changes

En problemstilling vi har funnet på BM er at når man bruker DatePicker i wizard forms kan man få et problem om brukeren klarer å sette datoen utenfor den tillatte rangen (ved å skrive i input feltet), og så gå tilbake et hakk. Når brukeren går frem igjen blir `initialDate` satt på basis av verdien som ble skrevet inn sist, og brukeren er låst uten en god mulighet til å komme tilbake til dagens dato uten å skrive manuelt i feltet.

Dette kan nok føles problematisk, spesielt når folk blir stresset over at det står at de har gjort en feil uten å klare å rette opp i det.

Løsningen jeg har lagt inn her er en hook som kjører på initial render og sjekker om `initialDate` er utenfor range. Hvis den er det, vil den bli resatt. Det er da opp til konsumerende applikasjon å vise en fornuftig feilmelding.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
