### PR TITLE
feat(useintersection): allow observing svg elements

### DIFF
--- a/packages/react-hooks/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/react-hooks/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -4,7 +4,7 @@ const hasWindowWithIntersectionObserver = () =>
     typeof window !== "undefined" && typeof IntersectionObserver !== "undefined";
 
 export const useIntersectionObserver = (
-    targetRef: RefObject<HTMLElement>,
+    targetRef: RefObject<HTMLElement | SVGElement>,
     onIntersect: IntersectionObserverCallback,
     fallback: VoidFunction,
     options?: Partial<IntersectionObserverInit>,


### PR DESCRIPTION
## 📥 Proposed changes

Lar `useIntersectionObserver` observere SVG-elementer i tillegg til HTML-elementer. Trenger denne til arbeidet med footer.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-react-hooks
