### PR TITLE
Prepare new default branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 ## ☑️ Submission checklist
 
--   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
+-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) doc
 -   [ ] `yarn build` works locally with my changes
 -   [ ] I have added tests that prove my fix is effective or that my feature works
 -   [ ] I have added necessary documentation (if appropriate)

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches:
             - "**"
-            - "!master"
+            - "!main"
 
 jobs:
     cypress-run:

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -2,14 +2,14 @@ name: release-portal
 on:
     push:
         branches:
-            - master
+            - main
 jobs:
     build-and-deploy:
         name: Deploy portal
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@master
+              uses: actions/checkout@main
 
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: publish-packages
 on:
     push:
         branches:
-            - master
+            - main
 
 jobs:
     build-and-publish:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,4 @@ Vi bruker Yarn i stedet for npm, siden Yarn har bedre integrasjon mot monorepo-v
 
 ### Slik organiserer vi branchene
 
-Vi gjør vårt beste for å holde master ren og pen og sørger for at den alltid virker. Master er grunnlaget for pakkene som vi publiserer i npm-registeret. Vi sender normalt pull requester mot master.
+Vi gjør vårt beste for å holde main ren og pen og sørger for at den alltid virker. Master er grunnlaget for pakkene som vi publiserer i npm-registeret. Vi sender normalt pull requester mot main.

--- a/codeql-analysis.yml
+++ b/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 18 * * 3'
 

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
             "registry": "https://registry.npmjs.org/",
             "access": "public",
             "npmClient": "yarn",
-            "allowBranch": ["master", "release"],
+            "allowBranch": ["main", "release"],
             "ignoreChanges": [
                 ".eslintrc",
                 ".prettierrc",

--- a/packages/typography-react/README.md
+++ b/packages/typography-react/README.md
@@ -2,7 +2,7 @@
 
 Denne pakken inneholder komponenter for spesifikke typografiske komponenter, slik som `Label`, `SupportLabel` og `Link`, som brukes av flere av komponentene i Jøkul. Bruk av andre typografiske elementer, som overskrifter og avsnittstiler, se s[iden om typografi](https://fremtind.github.io/jokul/profil/typografi) i portalen.
 
-**NB!** React-komponentene for overskrifter og avsnittstiler i denne pakken er utgående. Se [migrasjonsguiden](https://github.com/fremtind/jokul/blob/master/packages/core/MIGRATION.md#typografielementer) for `jkl-core@3.0.0` for nærmere informasjon.
+**NB!** React-komponentene for overskrifter og avsnittstiler i denne pakken er utgående. Se [migrasjonsguiden](https://github.com/fremtind/jokul/blob/main/packages/core/MIGRATION.md#typografielementer) for `jkl-core@3.0.0` for nærmere informasjon.
 
 ## Beskrivelse
 

--- a/portal/CHANGELOG.md
+++ b/portal/CHANGELOG.md
@@ -567,4 +567,4 @@ TextInput: ActionTextField, InlineTextField, BaseInputField
 
 ### Reverts
 
--   **dropdown:** rebase to master without new dropdown stuff ([3b21e7b](https://github.com/gatsbyjs/gatsby-starter-default/commit/3b21e7b))
+-   **dropdown:** rebase to main without new dropdown stuff ([3b21e7b](https://github.com/gatsbyjs/gatsby-starter-default/commit/3b21e7b))

--- a/portal/package.json
+++ b/portal/package.json
@@ -2,7 +2,7 @@
     "name": "@fremtind/portal",
     "private": true,
     "description": "Documentation portal for Jøkul",
-    "version": "3.18.17",
+    "version": "3.18.18",
     "devDependencies": {
         "@types/downloadjs": "^1.4.2",
         "@types/react-helmet": "^6.0.0",

--- a/portal/src/components/Layout/components/GitHubLinks.tsx
+++ b/portal/src/components/Layout/components/GitHubLinks.tsx
@@ -20,7 +20,7 @@ export function GitHubLinks({ react, scss }: Props) {
     if (!react && !scss) {
         return null;
     }
-    const pkgLink = (pkgName: string) => `https://github.com/fremtind/jokul/tree/master/packages/${pkgName}`;
+    const pkgLink = (pkgName: string) => `https://github.com/fremtind/jokul/tree/main/packages/${pkgName}`;
 
     return (
         <p className="jkl-portal-github-links">

--- a/portal/src/texts/blog/hvordanBlogge/hvordanBlogge.mdx
+++ b/portal/src/texts/blog/hvordanBlogge/hvordanBlogge.mdx
@@ -13,7 +13,7 @@ så er du komfortabel med å lage dokumentasjon der, så er du veldig nære å k
 
 ## Min første blogpost
 
-1. Naviger deg inn til `/portal/src/texts/blog/` i din IDE, eller gå inn på [github her](https://github.com/fremtind/jokul/tree/master/portal/src/texts/blog)
+1. Naviger deg inn til `/portal/src/texts/blog/` i din IDE, eller gå inn på [github her](https://github.com/fremtind/jokul/tree/main/portal/src/texts/blog)
 2. I din IDE, lag en ny fil, gi den et fornuftig navn med filendelsen `.mdx`.<br/>På github kan du trykke på `Create new file`. Det er veldig viktig at fila slutter på _.mdx_, gatsby plukker bare opp filer med denne endelsen.
    ![](/assets/blog/hvordanBlogge/createFile.jpg)
 3. I fila må du legge inn litt metadata om posten din.
@@ -38,7 +38,7 @@ Bare tekst kan jo bli litt kjederlig. Du trenger kanskje et bilde for å forklar
 
 #### Laste opp eget bilde
 
-1. Naviger deg til `/portal/static/assets/blog/` i din IDE,<br/>eller gå inn på [github her](https://github.com/fremtind/jokul/tree/master/portal/static/assets/blog)
+1. Naviger deg til `/portal/static/assets/blog/` i din IDE,<br/>eller gå inn på [github her](https://github.com/fremtind/jokul/tree/main/portal/static/assets/blog)
 2. Legg inn fila di, eller trykk på last opp fil i Github.<br/>Jobber du lokalt må du restarte gatsby før du ser bildet, siden gatsby bare leser statiske assets ved oppstart.
 3. For å få bildet inn i posten din gjør du det med standard markdown,<br/>`![](/assets/blog/ditt-bilde.jpg)`
 
@@ -50,4 +50,4 @@ og `<img src={someAsset} alt="Husk alt tekst, det er vanlig høflighet" />`.
 ## Oppsummering
 
 Så, det er ikke så vanskelig, om du er usikker så kan du se på de eksisterende postene og få inspirasjon av de,
-feks kan du ta en titt på [denne posten](https://github.com/fremtind/jokul/tree/master/portal/src/texts/blog/hvordanBlogge/hvordanBlogge.mdx).
+feks kan du ta en titt på [denne posten](https://github.com/fremtind/jokul/tree/main/portal/src/texts/blog/hvordanBlogge/hvordanBlogge.mdx).

--- a/portal/src/texts/profile/typography.mdx
+++ b/portal/src/texts/profile/typography.mdx
@@ -19,7 +19,7 @@ Vi har vår egen skrifttype: Fremtind Grotesk. Den finnes i snittene Regular, Bo
 hovedsakelig Regular og Bold. Som erstatningsfont bruker vi Calibri Light. Ikke bruk andre skrifttyper når du designer løsninger
 for Fremtind.
 
-[Last ned Fremtind Grotesk ↓](https://github.com/fremtind/jokul/tree/master/packages/webfonts/fonts)
+[Last ned Fremtind Grotesk ↓](https://github.com/fremtind/jokul/tree/main/packages/webfonts/fonts)
 
 ## Typografisk skala
 


### PR DESCRIPTION
Github endrer fra master til main. Jeg ser ingen gode grunner til at ikke vi bare følger opp.

Denne skal ikke merges, er bare er for å kunne vise hva som er endre. Endringen vil skje ved at en maintainer går inn å bytter default branch i Settings. 