### PR TITLE
Button touch animations

### DIFF
--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, HTMLAttributes, TouchEvent } from "react";
 import classNames from "classnames";
 
 export interface Props extends Exclude<HTMLAttributes<HTMLButtonElement>, "disabled"> {
@@ -10,7 +10,7 @@ type ValidButtons = "primary" | "secondary" | "tertiary";
 
 const makeButtonComponent = (buttonType: ValidButtons) => {
     const button = forwardRef<HTMLButtonElement, Props>(
-        ({ children, className, forceCompact, inverted, ...rest }, ref) => {
+        ({ children, className, forceCompact, inverted, onClick, onTouchStart, ...rest }, ref) => {
             const componentClassName = classNames(
                 "jkl-button",
                 "jkl-button--" + buttonType,
@@ -21,8 +21,22 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
                 className,
             );
 
+            const handleTouch = (event: TouchEvent<HTMLButtonElement>) => {
+                onTouchStart && onTouchStart(event);
+
+                const target = event.target as HTMLButtonElement;
+                if (target && event.targetTouches.length) {
+                    const Xcoord = event.targetTouches[0].clientX - target.getBoundingClientRect().x;
+                    const Ycoord = event.targetTouches[0].clientY - target.getBoundingClientRect().y;
+                    target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
+                    target.style.setProperty("--jkl-touch-ycoord", Ycoord.toPrecision(4) + "px");
+                    target.classList.add("jkl-button--pressed");
+                    setTimeout(() => target.classList.remove("jkl-button--pressed"), 400);
+                }
+            };
+
             return (
-                <button className={componentClassName} {...rest} ref={ref}>
+                <button className={componentClassName} onClick={onClick} onTouchStart={handleTouch} {...rest} ref={ref}>
                     {children}
                 </button>
             );

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -22,7 +22,7 @@ $hover-elevation-distance: -0.25rem;
 
 $button-border-color: $svart;
 $button-text-color: $svart;
-$button-background-color: $hvit;
+$button-background-color: transparent;
 $button-focus-color: $info;
 $button-primary-text-color: $hvit;
 $button-primary-background-color: $svart;
@@ -63,9 +63,11 @@ $button-primary-background-color--inverted: $hvit;
     min-width: $button-min-width--normal;
     line-height: $button-height--normal;
     cursor: pointer;
+    user-select: none;
 
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: auto;
+
     border: none;
     outline: none;
     position: relative;
@@ -74,14 +76,20 @@ $button-primary-background-color--inverted: $hvit;
     transform-origin: 50% 90%;
     transition-property: transform, background-color;
 
-    html:not([data-mousenavigation]) &:focus,
-    &:hover {
+    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+    html:not([data-touchnavigation]) &:hover {
         transform: scale(1.05);
     }
 
     html:not([data-mousenavigation]) &:active,
+    html:not([data-touchnavigation]) &:active,
     &:active {
         transform: scale(1);
+    }
+
+    html[data-touchnavigation] &--pressed {
+        transform: scale(0.95);
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     }
 
     // ********* VARIANTS *********
@@ -106,11 +114,25 @@ $button-primary-background-color--inverted: $hvit;
             top: -($button-border-width + $focus-ring-distance);
         }
 
-        html:not([data-mousenavigation]) &:focus {
+        &:before {
+            content: "";
+            position: absolute;
+            border-radius: 999px;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+        }
+
+        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
             &:after {
                 box-shadow: 0 0 0 $focus-ring-width $button-focus-color;
                 box-shadow: 0 0 0 $focus-ring-width var(--button-focus-color);
             }
+        }
+
+        html[data-touchnavigation] &.jkl-button--pressed:before {
+            animation: cubic-bezier(0, 0, 0.3, 1) 400ms flash;
         }
     }
 
@@ -121,7 +143,8 @@ $button-primary-background-color--inverted: $hvit;
         color: var(--button-primary-text-color);
 
         &:hover,
-        html:not([data-mousenavigation]) &:focus {
+        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        html[data-touchnavigation] &.jkl-button--pressed {
             background-color: $button-focus-color;
             background-color: var(--button-focus-color);
             border-color: $button-focus-color;
@@ -136,7 +159,8 @@ $button-primary-background-color--inverted: $hvit;
         color: var(--button-text-color);
 
         &:hover,
-        html:not([data-mousenavigation]) &:focus {
+        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        html[data-touchnavigation] &.jkl-button--pressed {
             color: $button-focus-color;
             color: var(--button-focus-color);
             border-color: $button-focus-color;
@@ -155,8 +179,28 @@ $button-primary-background-color--inverted: $hvit;
         transition: transform $animation-timing, border $animation-timing;
         min-width: unset;
 
+        // Base for touch-effekt
+        &:before {
+            content: "";
+            pointer-events: none;
+            display: block;
+            position: absolute;
+            left: var(--jkl-touch-xcoord, 50%);
+            top: var(--jkl-touch-ycoord, 50%);
+            transform: translate3d(-50%, -50%, 0);
+            border-radius: 100%;
+            width: rem(16px);
+            height: rem(16px);
+            background-color: transparent;
+        }
+
+        html[data-touchnavigation] &.jkl-button--pressed:before {
+            animation: cubic-bezier(0, 0, 0.3, 1) 400ms tertiaryflash;
+        }
+
         &:hover,
-        html:not([data-mousenavigation]) &:focus {
+        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        html[data-touchnavigation] &.jkl-button--pressed {
             border-bottom-color: $button-focus-color;
             border-bottom-color: var(--button-focus-color);
             border-bottom-width: rem(2px);
@@ -166,13 +210,21 @@ $button-primary-background-color--inverted: $hvit;
     }
 
     &--inverted {
+        &.jkl-button--primary,
+        &.jkl-button--secondary {
+            html[data-touchnavigation] &.jkl-button--pressed:before {
+                animation: cubic-bezier(0, 0, 0.3, 1) 400ms invertedflash;
+            }
+        }
+
         &.jkl-button--primary {
             background-color: $button-primary-background-color--inverted;
             border-color: $button-border-color--inverted;
             color: $button-primary-text-color--inverted;
 
             &:hover,
-            html:not([data-mousenavigation]) &:focus {
+            html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+            html[data-touchnavigation] &.jkl-button--pressed {
                 background-color: $button-focus-color--inverted;
                 border-color: $button-focus-color--inverted;
             }
@@ -184,7 +236,8 @@ $button-primary-background-color--inverted: $hvit;
             border-color: $button-text-color--inverted;
 
             &:hover,
-            html:not([data-mousenavigation]) &:focus {
+            html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+            html[data-touchnavigation] &.jkl-button--pressed {
                 color: $button-focus-color--inverted;
                 border-color: $button-focus-color--inverted;
             }
@@ -194,9 +247,14 @@ $button-primary-background-color--inverted: $hvit;
             color: $button-text-color--inverted;
 
             &:hover,
-            html:not([data-mousenavigation]) &:focus {
+            html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+            html[data-touchnavigation] &.jkl-button--pressed {
                 color: $button-focus-color--inverted;
                 border-bottom-color: $button-focus-color--inverted;
+            }
+
+            html[data-touchnavigation] &.jkl-button--pressed:before {
+                animation: cubic-bezier(0, 0, 0.3, 1) 400ms invertedtertiaryflash;
             }
         }
 
@@ -215,5 +273,51 @@ $button-primary-background-color--inverted: $hvit;
         &.jkl-button--tertiary {
             min-width: unset;
         }
+    }
+}
+
+@keyframes flash {
+    0% {
+        box-shadow: 0 0 0 0 var(--button-focus-color);
+        opacity: 0.5;
+    }
+    100% {
+        box-shadow: 0 0 0 #{rem(16px)} var(--button-focus-color);
+        opacity: 0;
+    }
+}
+@keyframes invertedflash {
+    0% {
+        box-shadow: 0 0 0 0 #{$button-focus-color--inverted};
+        opacity: 0.5;
+    }
+    100% {
+        box-shadow: 0 0 0 #{rem(16px)} #{$button-focus-color--inverted};
+        opacity: 0;
+    }
+}
+
+@keyframes tertiaryflash {
+    0% {
+        box-shadow: 0 0 0 0 var(--button-focus-color);
+        background-color: var(--button-focus-color);
+        opacity: 0.5;
+    }
+    100% {
+        box-shadow: 0 0 0 #{rem(40px)} var(--button-focus-color);
+        background-color: var(--button-focus-color);
+        opacity: 0;
+    }
+}
+@keyframes invertedtertiaryflash {
+    0% {
+        box-shadow: 0 0 0 0 #{$button-focus-color--inverted};
+        background-color: #{$button-focus-color--inverted};
+        opacity: 0.5;
+    }
+    100% {
+        box-shadow: 0 0 0 #{rem(40px)} #{$button-focus-color--inverted};
+        background-color: #{$button-focus-color--inverted};
+        opacity: 0;
     }
 }

--- a/packages/core/src/utils/tabListener.ts
+++ b/packages/core/src/utils/tabListener.ts
@@ -1,29 +1,80 @@
 let mousenavigation = false;
+let touchnavigation = false;
+let touchEventFired = false;
+
+const listeners = {
+    mousedown: handleMouseDown as EventListener,
+    keydown: handleKeydown as EventListener,
+    touchstart: handleTouchStart as EventListener,
+};
+
+function removeAllListeners() {
+    (Object.keys(listeners) as Array<keyof typeof listeners>).forEach((listenerType) => {
+        document.removeEventListener(listenerType, listeners[listenerType]);
+    });
+}
+
+function addListener(listenerType: keyof typeof listeners) {
+    document.addEventListener(listenerType, listeners[listenerType]);
+}
 
 function handleMouseDown() {
-    if (!mousenavigation) {
+    if (!mousenavigation && !touchEventFired) {
         mousenavigation = true;
+        touchnavigation = false;
         const htmlElement = document.querySelector("html");
-        htmlElement && htmlElement.setAttribute("data-mousenavigation", "true");
-        document.removeEventListener("mousedown", handleMouseDown);
-        document.addEventListener("keydown", handleKeydown);
+        htmlElement?.setAttribute("data-mousenavigation", "true");
+        htmlElement?.removeAttribute("data-touchnavigation");
+
+        // Reset listeners
+        removeAllListeners();
+        addListener("touchstart");
+        addListener("keydown");
     }
 }
 
 function handleKeydown(event: KeyboardEvent) {
     if (event.key === "Tab") {
-        if (mousenavigation) {
-            mousenavigation = false;
-            const htmlElement = document.querySelector("html");
-            htmlElement && htmlElement.removeAttribute("data-mousenavigation");
-            document.removeEventListener("keydown", handleKeydown);
-            document.addEventListener("mousedown", handleMouseDown);
-        }
+        const htmlElement = document.querySelector("html");
+        removeAllListeners();
+        htmlElement?.removeAttribute("data-mousenavigation");
+        htmlElement?.removeAttribute("data-touchnavigation");
+        mousenavigation = false;
+        touchnavigation = false;
+
+        // Reset listeners
+        addListener("touchstart");
+        addListener("mousedown");
     }
+}
+
+function handleTouchStart() {
+    if (!touchnavigation) {
+        mousenavigation = false;
+        touchnavigation = true;
+        const htmlElement = document.querySelector("html");
+        htmlElement?.setAttribute("data-touchnavigation", "true");
+        htmlElement?.removeAttribute("data-mousenavigation");
+
+        // Reset listeners
+        removeAllListeners();
+        addListener("touchstart");
+        addListener("keydown");
+        addListener("mousedown");
+    }
+
+    // Most touch devices fire both touch and mouse events on touch (in that order)
+    // see https://w3c.github.io/touch-events/#mouse-events
+    // Set a check variable to avoid resetting the data-attribute:
+    touchEventFired = true;
+    setTimeout(() => {
+        touchEventFired = false;
+    }, 150); // Yes, it can take this long between the events
 }
 
 export function initTabListener() {
     if (typeof document !== "undefined") {
-        document.addEventListener("mousedown", handleMouseDown);
+        addListener("touchstart");
+        addListener("mousedown");
     }
 }


### PR DESCRIPTION
## 📥 Proposed changes

Legg til animasjon på knappene ved touch, slik at de ikke skal føles så "døde" på mobile flater.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Denne løsningen bruker CSS custom properties, men alle mobile nettlesere støtter dette. Koden for å oppdatere touch-punktet på knappen er kanskje ikke super-React-aktig, men jeg slet litt med typen til `forwardRef` ifmb dette. Tar gjerne imot tips, så vi kan få flyttet den koden ut i en hook e.l.

![touchknapper](https://user-images.githubusercontent.com/25739615/95720004-f3239d00-0c70-11eb-88ed-f1a8eca77cfe.gif)

Kjørende kode her hvis man vil teste på mobil: https://7gyzm.csb.app