### PR TITLE
docs: add title to spacing example

### DIFF
--- a/packages/core/documentation/Spacing/Spacing.tsx
+++ b/packages/core/documentation/Spacing/Spacing.tsx
@@ -42,7 +42,7 @@ const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
             <td data-header="Spacing:" className="jkl-portal-spacing-example-table__data">
                 <div className={`jkl-${spacing}-top`} style={{ display: "none" }} ref={ref} />
                 <div
-                    aria-label={spacing + ", " + pxValue}
+                    aria-label={`${spacing},  ${pxValue}`}
                     style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }}
                     title={pxValue}
                 />

--- a/packages/core/documentation/Spacing/Spacing.tsx
+++ b/packages/core/documentation/Spacing/Spacing.tsx
@@ -42,8 +42,9 @@ const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
             <td data-header="Spacing:" className="jkl-portal-spacing-example-table__data">
                 <div className={`jkl-${spacing}-top`} style={{ display: "none" }} ref={ref} />
                 <div
-                    aria-label={spacing}
+                    aria-label={spacing + ", " + pxValue}
                     style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }}
+                    title={pxValue}
                 />
             </td>
             <td data-header="Variabel:" className="jkl-portal-spacing-example-table__data">

--- a/portal/src/components/Documentation/Spacing/SpacingTable.tsx
+++ b/portal/src/components/Documentation/Spacing/SpacingTable.tsx
@@ -50,7 +50,10 @@ const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
             </td>
             <td data-header="Eksempel:" className="jkl-portal-spacing-table__data">
                 <div className={`jkl-${spacing}-top`} style={{ display: "none" }} ref={ref} />
-                <div style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }} />
+                <div
+                    style={{ backgroundColor: "currentColor", width: `${remValue}rem`, height: `${remValue}rem` }}
+                    title={pxValue}
+                />
             </td>
         </tr>
     );


### PR DESCRIPTION
Når man ser på spacing skalaen i komponent dokumentasjonen, får man bare scss variabelnavnet, men ikke pixel verdien. Dette er noe jeg savner når jeg ser etter riktig spacing ihht. designet som foreligger.

## 📥 Proposed changes

Lagt til pixelverdien i title for eksemplene. Dette gir meg pixelverdien når jeg hovrer over eksemplene.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

