### PR TITLE
Oppdater HTML lang attributt for bedre skjermleser opplevelse

### DIFF
--- a/portal/src/components/Layout/Layout.tsx
+++ b/portal/src/components/Layout/Layout.tsx
@@ -43,7 +43,7 @@ export const Layout: React.FC<Props> = ({ children, location, pathContext, ...re
     return (
         <div className="jkl-portal" data-theme={theme} ref={wrapperRef}>
             <Helmet>
-                <html lang="no-nb" />
+                <html lang="no" />
                 <title>{PageTitle}</title>
             </Helmet>
             <ThemeBG />


### PR DESCRIPTION
På min mac har jeg satt engelsk språk i operativsystemet. Dette gjør at skjermleseren (default macos oppsett for voiceover) stort sett leser på engelsk. Det samme gjaldt portalen, men den leste de norske tekstene med en annen engelsk stemme. Ved å ta vekk "-nb" leser skjermleseren de norske tekstene med den norske stemmen.

Det virker som om VoiceOver ikke takler denne presiseringen når OS-språket er satt til engelsk.

## 📥 Proposed changes

Endret html lang attributten til "no".

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
