### PR TITLE
feat(feedback-component): add feedback component

### DIFF
--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -1,0 +1,11 @@
+# `@fremtind/jkl-feedback-react`
+
+> TODO: description
+
+## Usage
+
+```
+const jklFeedbackReact = require('@fremtind/jkl-feedback-react');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/feedback-react/documentation/Example.tsx
+++ b/packages/feedback-react/documentation/Example.tsx
@@ -1,0 +1,38 @@
+import React, { ChangeEvent, useState } from "react";
+import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
+import { Feedback } from "../src";
+
+export const Example = ({ boolValues }: ExampleComponentProps) => {
+    const [feedbackSubmitted, setFeedbackSubmitted] = useState<boolean>(false);
+    const [value, setValue] = useState<string>("");
+
+    const submit = () => {
+        setFeedbackSubmitted(true);
+    };
+
+    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value);
+    };
+
+    return (
+        <Feedback
+            label="Gi oss tilbakemelding!"
+            description="Hvor fornøyd er du med denne siden for å følge saken?"
+            onClick={submit}
+            feedbackSubmitted={feedbackSubmitted}
+            successData={{
+                title: "Takk for tilbakemeldingen!",
+                message: "Det hjelper oss i arbeidet med å forbedre våre skjemaer.",
+            }}
+            textAreaData={{
+                label: "Tips oss gjerne om hva vi kan forbedre",
+                onChange: (e) => onChange(e),
+                value: value,
+            }}
+            simplified={boolValues && boolValues["Uten smilefjes"]}
+            entries={6}
+        />
+    );
+};
+
+export default Example;

--- a/packages/feedback-react/documentation/Feedback.mdx
+++ b/packages/feedback-react/documentation/Feedback.mdx
@@ -1,0 +1,10 @@
+---
+title: Feedback
+scss: feedback
+react: feedback-react
+---
+
+import Example from "./Example";
+import { Feedback } from "../src";
+
+<ComponentExample component={Example} />

--- a/packages/feedback-react/documentation/index.html
+++ b/packages/feedback-react/documentation/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>Jøkul Feedback Example</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body style="background-color: #fafafa;">
+        <div id="app"></div>
+        <script src="index.tsx"></script>
+    </body>
+</html>

--- a/packages/feedback-react/documentation/index.tsx
+++ b/packages/feedback-react/documentation/index.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+// Import core styles, webfonts and tab listener (same for all components):
+import { initTabListener } from "@fremtind/jkl-core";
+import "@fremtind/jkl-core/core.scss";
+import "../../webfonts/documentation/internal.scss";
+
+// Imports required for showing example (same for all components):
+import { DevExample } from "@fremtind/jkl-portal-components";
+import "@fremtind/jkl-portal-components/dev-example.min.css";
+import "@fremtind/jkl-radio-button/radio-button.min.css";
+import "@fremtind/jkl-checkbox/checkbox.min.css";
+import "@fremtind/jkl-icon-button/icon-button.min.css";
+
+// Import actual example and component stylesheet (specific for this component):
+import { Example } from "./Example";
+import "@fremtind/jkl-feedback/feedback.css";
+import "@fremtind/jkl-text-input/text-input.css";
+import "@fremtind/jkl-button/button.css";
+import "@fremtind/jkl-message-box/message-box.css";
+
+initTabListener();
+
+ReactDOM.render(
+    <DevExample
+        component={Example}
+        knobs={{
+            boolProps: ["Uten smilefjes"],
+        }}
+    />,
+    document.getElementById("app"),
+);

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -1,0 +1,59 @@
+{
+    "name": "@fremtind/jkl-feedback-react",
+    "version": "1.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Jøkul react feedback component",
+    "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "feedback",
+        "jøkul",
+        "fremtind"
+    ],
+    "license": "MIT",
+    "types": "./build/index.d.ts",
+    "main": "./build/cjs/index.js",
+    "module": "./build/esm/index.js",
+    "browser": "./build/browser/index.js",
+    "directories": {
+        "lib": "build"
+    },
+    "files": [
+        "build"
+    ],
+    "scripts": {
+        "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
+        "build:types": "tsc -p tsconfig-for-declarations.json",
+        "build:scripts": "rollup --config ../../rollup.config.js",
+        "build": "run-s build:*",
+        "test": "echo \"Error: run tests from root\" && exit 1",
+        "dev:js": "parcel documentation/index.html",
+        "dev:style": "lerna exec --scope=@fremtind/jkl-feedback yarn build:watch",
+        "dev": "run-p dev:*"
+    },
+    "dependencies": {
+        "@babel/runtime": "^7.9.0",
+        "@fremtind/jkl-core": "^4.14.4",
+        "@fremtind/jkl-feedback": "^1.0.0",
+        "@fremtind/jkl-message-box-react": "^1.6.16",
+        "@fremtind/jkl-button-react": "^2.0.2",
+        "@fremtind/jkl-text-input-react": "^3.5.12",
+        "classnames": "^2.2.6",
+        "nanoid": "^3.1.10"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.9.4",
+        "@types/react-dom": "^16.8.4",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
+    "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
+}

--- a/packages/feedback-react/src/Feedback.tsx
+++ b/packages/feedback-react/src/Feedback.tsx
@@ -1,0 +1,175 @@
+import React, { ChangeEventHandler, MouseEventHandler, useState } from "react";
+import { TextArea } from "@fremtind/jkl-text-input-react";
+import { SecondaryButton } from "@fremtind/jkl-button-react";
+import { SuccessMessage } from "@fremtind/jkl-message-box-react";
+import { RadioButtons } from "@fremtind/jkl-radio-button-react";
+import cn from "classnames";
+import { nanoid } from "nanoid";
+
+const strokeColor = "black";
+const strokeWidth = "2";
+
+interface Props {
+    label: string;
+    description: string;
+    successData?: SuccessData;
+    textAreaData: TextAreaData;
+    onClick: MouseEventHandler<HTMLButtonElement>;
+    feedbackSubmitted: boolean;
+    simplified?: boolean;
+    entries?: number;
+}
+
+type SuccessData = {
+    title: string;
+    message: string;
+};
+
+type TextAreaData = {
+    label: string;
+    errorLabel?: string;
+    helpLabel?: string;
+    onChange: ChangeEventHandler<HTMLInputElement>;
+    value: string;
+};
+
+const SmileySwitch = (element: number) => {
+    switch (element) {
+        case 1:
+            return (
+                <path
+                    d="M40 42C40 36.4772 35.0751 32 29 32C22.9249 32 18 36.4772 18 42"
+                    stroke={strokeColor}
+                    strokeWidth={strokeWidth}
+                ></path>
+            );
+        case 2:
+            return (
+                <path
+                    d="M40 39C37.5556 35.4353 33.8529 33 29 33C24.1471 33 20.4444 35.4353 18 39"
+                    stroke={strokeColor}
+                    strokeWidth={strokeWidth}
+                ></path>
+            );
+        case 3:
+            return <line x1="20" y1="37" x2="36" y2="37" stroke={strokeColor} strokeWidth={strokeWidth}></line>;
+        case 4:
+            return (
+                <path
+                    d="M18 35C20.4444 38.5647 24.1471 41 29 41C33.8529 41 37.5556 38.5647 40 35"
+                    stroke={strokeColor}
+                    strokeWidth={strokeWidth}
+                ></path>
+            );
+        case 5:
+            return (
+                <path
+                    d="M29 45C36.5429 45 40.1429 38.3333 41 35L17 35C17.5714 38.3333 21.4571 45 29 45Z"
+                    stroke={strokeColor}
+                    strokeWidth={strokeWidth}
+                ></path>
+            );
+        default:
+            return null;
+    }
+};
+
+export const Feedback = ({
+    label,
+    description,
+    feedbackSubmitted = false,
+    onClick,
+    simplified,
+    entries,
+    successData,
+    textAreaData,
+}: Props) => {
+    const [checked, setChecked] = useState<string>("hidden");
+    const elements = [1, 2, 3, 4, 5];
+    const numberOfEntries = [];
+    if (simplified && entries) {
+        for (let i = 1; i <= entries; i++) {
+            numberOfEntries.push(i.toString());
+        }
+    }
+
+    return (
+        <section className="feedback">
+            <div className="">
+                {feedbackSubmitted && successData ? (
+                    <SuccessMessage className="feedback__messagebox" fullWidth title={successData.title}>
+                        {successData.message}
+                    </SuccessMessage>
+                ) : (
+                    <fieldset className="feedback__fieldset">
+                        <header>
+                            <h2 className="jkl-heading-large">{label}</h2>
+                            {!simplified && <legend className="jkl-lead">{description}</legend>}
+                        </header>
+                        {!simplified &&
+                            elements.map((element) => {
+                                return (
+                                    <span className="feedback__answer" key={nanoid(8)}>
+                                        <input
+                                            className="feedback__answer--smiley"
+                                            type="radio"
+                                            name="feedback"
+                                            id={`feedback--${element}`}
+                                            value={element}
+                                            onChange={(e) => setChecked(e.target.value)}
+                                            checked={checked === element.toString()}
+                                        />
+                                        <label className="feedback__label" htmlFor={`feedback--${element}`}>
+                                            <svg className={`feedback__icon${element}`} viewBox="0 0 57 57">
+                                                <circle
+                                                    cx="28.5"
+                                                    cy="28.5"
+                                                    r="27.5"
+                                                    stroke={strokeColor}
+                                                    strokeWidth={strokeWidth}
+                                                ></circle>
+                                                <circle cx="19" cy="24" r="3" fill="black"></circle>
+                                                <circle cx="38" cy="24" r="3" fill="black"></circle>
+                                                {SmileySwitch(element)}
+                                            </svg>
+                                        </label>
+                                    </span>
+                                );
+                            })}
+                        {simplified && (
+                            <RadioButtons
+                                legend={description}
+                                name="feedback"
+                                choices={numberOfEntries}
+                                inline
+                                onChange={(e) => setChecked(e.target.value)}
+                                selectedValue={checked}
+                            />
+                        )}
+                        <div
+                            className={cn("feedback__input-submit", {
+                                "feedback__input-submit--hidden": checked === "hidden",
+                            })}
+                        >
+                            <TextArea
+                                className="feedback__text-input"
+                                label={textAreaData.label}
+                                variant="small"
+                                rows={3}
+                                onChange={textAreaData.onChange}
+                                helpLabel={textAreaData.helpLabel}
+                                errorLabel={textAreaData.errorLabel}
+                                value={textAreaData.value}
+                            />
+                            <SecondaryButton className="feedback__button" onClick={onClick}>
+                                Send inn tilbakemelding
+                            </SecondaryButton>
+                        </div>
+                    </fieldset>
+                )}
+            </div>
+        </section>
+    );
+};
+
+export default Feedback;

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -1,0 +1,1 @@
+export { Feedback } from "./Feedback";

--- a/packages/feedback-react/tsconfig-for-declarations.json
+++ b/packages/feedback-react/tsconfig-for-declarations.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig-for-declarations.json",
+    "compilerOptions": {
+        "outDir": "./build",
+        "rootDir": "./src"
+    },
+    "include": ["./src"]
+}

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -1,0 +1,102 @@
+@import "~@fremtind/jkl-core/mixins/_all.scss";
+@import "~@fremtind/jkl-core/variables/_all.scss";
+
+$feedback-icons: (
+    "feedback__icon1": #ff7059,
+    "feedback__icon2": #f2994a,
+    "feedback__icon3": #ffc880,
+    "feedback__icon4": #50e68c,
+    "feedback__icon5": #27ae60,
+);
+
+$icon-size: 55px;
+
+.feedback {
+    text-align: center;
+    margin: 0 auto;
+
+    &__fieldset {
+        & .jkl-heading-large {
+            font-weight: $bold-weight;
+        }
+        & legend {
+            margin: 0 auto;
+            margin-top: 1rem;
+        }
+    }
+
+    &__answer {
+        box-sizing: border-box;
+        display: inline-block;
+        margin: 1rem;
+
+        &--smiley {
+            @include reset-outline;
+            height: 0;
+            opacity: 0;
+            width: 0;
+
+            html:not([data-mousenavigation]) &:focus + label {
+                box-shadow: 0 0 0 2px $gra-10, 0 0 0 4px $info;
+            }
+
+            &:checked + label {
+                @each $name, $color in $feedback-icons {
+                    [class*="#{$name}"] {
+                        fill: $color;
+                        transition-property: fill;
+                        @include motion(standard, expressive);
+                    }
+                }
+            }
+        }
+    }
+
+    & [class^="feedback__icon"] {
+        fill: white;
+        width: $icon-size;
+    }
+
+    &__label {
+        border-radius: 50%;
+        box-sizing: border-box;
+        cursor: pointer;
+        display: block;
+        line-height: 0;
+        transition: all 0.2s ease-in-out;
+    }
+
+    &__messagebox {
+        text-align: left;
+    }
+
+    &__text-input {
+        margin: 0 auto;
+        text-align: left;
+        width: 70%;
+
+        & .jkl-label--small {
+            font-weight: $bold-weight;
+        }
+    }
+
+    &__button {
+        margin-top: 2rem;
+    }
+
+    &__input-submit {
+        margin-top: 2rem;
+        max-height: 250px;
+        opacity: 1;
+        transition-property: max-height, opacity;
+        @include motion(standard, expressive);
+
+        &--hidden {
+            display: none;
+        }
+    }
+
+    & .jkl-radio-button--inline {
+        text-align: initial;
+    }
+}

--- a/packages/feedback/gulpfile.js
+++ b/packages/feedback/gulpfile.js
@@ -1,0 +1,3 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+require("../../gulpfile")(require("gulp"));
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@fremtind/jkl-feedback",
+    "version": "1.0.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Jøkul style for feedback",
+    "homepage": "https://fremtind.github.io/jokul",
+    "keywords": [
+        "feedback",
+        "jøkul",
+        "fremtind"
+    ],
+    "files": [
+        "!example",
+        "*.css",
+        "*.scss"
+    ],
+    "license": "MIT",
+    "scripts": {
+        "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
+        "build": "gulp build",
+        "build:watch": "gulp build:watch",
+        "test": "echo \"Error: run tests from root\" && exit 1",
+        "dev": "parcel example/index.html"
+    },
+    "dependencies": {
+        "@fremtind/jkl-core": "^4.14.4"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
+    "bugs": {
+        "url": "https://github.com/fremtind/jokul/issues"
+    },
+    "gitHead": "ffcb2803b73ddd6f1dd37bb0eed345ca801bfebb"
+}

--- a/portal/gatsby-browser.js
+++ b/portal/gatsby-browser.js
@@ -13,6 +13,7 @@ import "@fremtind/jkl-button/button.min.css";
 import "@fremtind/jkl-card/card.min.css";
 import "@fremtind/jkl-checkbox/checkbox.min.css";
 import "@fremtind/jkl-datepicker/datepicker.min.css";
+import "@fremtind/jkl-feedback/feedback.min.css";
 import "@fremtind/jkl-field-group/field-group.min.css";
 import "@fremtind/jkl-hamburger/hamburger.min.css";
 import "@fremtind/jkl-icon-button/icon-button.min.css";


### PR DESCRIPTION
affects: @fremtind/jkl-feedback-react, @fremtind/jkl-feedback, @fremtind/portal

ISSUES CLOSED: #1490

## 📥 Proposed changes

Add feedback component

På SeOpp bruker vi både en variant med smilefjes og en med vanlig radio buttons. Derfor har jeg lagt til muligheten for begge her ved bruk av prop-en `simplified: boolean` og `entries: number`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

- Fix keyboard nav på smilefjes
- Se over stilarket, rydde
- Dokumentasjon
- Test
- Hva enn dere andre finner