### PR TITLE
fix(image): fixes issue where loader color were overwitten

### DIFF
--- a/packages/image/image.scss
+++ b/packages/image/image.scss
@@ -3,11 +3,11 @@
 
 :root,
 [data-theme="light"] {
-    --loader-color: #{$gra-20};
+    --jkl-image-loader-color: #{$gra-20};
 }
 
 [data-theme="dark"] {
-    --loader-color: #{$gra-80};
+    --jkl-image-loader-color: #{$gra-80};
 }
 
 .jkl-image {
@@ -40,13 +40,13 @@
 
         &--no-thumbnail {
             background: $gra-20;
-            background: var(--loader-color);
+            background: var(--jkl-image-loader-color);
         }
     }
 
     &--empty {
         background-color: $gra-20;
-        background: var(--loader-color);
+        background: var(--jkl-image-loader-color);
         display: block;
 
         &:before {
@@ -58,7 +58,7 @@
         .jkl-image__blur-container--no-thumbnail,
         .jkl-image--empty {
             background-color: $gra-80;
-            background: var(--loader-color);
+            background: var(--jkl-image-loader-color);
         }
     }
 }


### PR DESCRIPTION
##  📥 Proposed changes

Løser problem er fargen på loader ble satt til grå av image stilen.

affects: @fremtind/jkl-image

ISSUES CLOSED: #1481

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

