### PR TITLE
feat: add support for more attributes on RadioButtonOption

### DIFF
--- a/packages/radio-button-react/src/RadioButtonOption.tsx
+++ b/packages/radio-button-react/src/RadioButtonOption.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEventHandler, useState } from "react";
 import classNames from "classnames";
 import { nanoid } from "nanoid";
 
-interface Props {
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
     value: string;
     label: string;
     name: string;
@@ -24,6 +24,7 @@ export const RadioButtonOption = ({
     invalid = false,
     forceCompact,
     inverted,
+    ...radioProps
 }: Props) => {
     const [inputId] = useState(`jkl-radio-button-${nanoid(8)}`);
     const componentClassName = classNames("jkl-radio-button", {
@@ -43,6 +44,7 @@ export const RadioButtonOption = ({
                 value={value}
                 onChange={onChange}
                 checked={checked}
+                {...radioProps}
             />
             <label data-testid="jkl-radio-button__label-tag" htmlFor={inputId} className="jkl-radio-button__label">
                 <span aria-hidden className="jkl-radio-button__dot" />


### PR DESCRIPTION
affects: @fremtind/jkl-radio-button-react

## 📥 Proposed changes

Lagt til støtte for individuelle props på RadioButtonOption. Dette er for å kunne bruke attributter som `aria-describedby` for å legge til help label når man bruker RadioButtonOption selvstendig.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
