### PR TITLE
Endre linjehøyde til 28px (line-height-3) på compact/body

### DIFF
--- a/packages/core/variables/_font-size.scss
+++ b/packages/core/variables/_font-size.scss
@@ -94,7 +94,7 @@ $text-styles: (
     ),
     "compact/body": (
         font-size: $font-size-3,
-        line-height: $line-height-2,
+        line-height: $line-height-3,
         font-weight: $normal-weight,
     ),
     "desktop/small": (


### PR DESCRIPTION
## 📥 Proposed changes

I core er linjehøyden feil i forhold til figma. Den er line-height-2 (24px), men i figma er den line-height-3 (28px). Koblet til issue #1479 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

Har ikke testet.
