### PR TITLE
chore(cypress): increase time cypress will wait for portal

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ jobs:
                   build: yarn run build
                   start: yarn serve
                   wait-on: "http://localhost:9000"
-                  wait-on-timeout: 120
+                  wait-on-timeout: 180
 
             - name: Upload screenshots
               uses: actions/upload-artifact@v2.2.0


### PR DESCRIPTION
## 📥 Proposed changes
Byggtiden til portalen har gått noe opp i det siste, som gjør at vi igjen toucher på grensa til at cypress timer ut. 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

