### PR TITLE
chore: add missing dependency to feedback-react

### DIFF
--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -1,11 +1,31 @@
-# `@fremtind/jkl-feedback-react`
+# [`@fremtind/jkl-feedback-react`](https://fremtind.github.io/jokul/komponenter/feedback)
 
-> TODO: description
+## Beskrivelse
 
-## Usage
+Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/feedback).
 
+## Kom i gang
+
+[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/komigang/utvikling/)
+
+## Bruk av React-pakken
+
+### Installasjon
+
+1. Installér pakken med `yarn add @fremtind/jkl-feedback-react` eller `npm i @fremtind/jkl-feedback-react`. Stil-pakken blir automatisk installert som en avhengighet.
+
+2. Importer _både_ React-pakken og stil-pakken i prosjektet ditt:
+
+```js
+import { Feedback } from "@fremtind/jkl-feedback-react";
+import "@fremtind/jkl-feedback/feedback.min.css";
 ```
-const jklFeedbackReact = require('@fremtind/jkl-feedback-react');
 
-// TODO: DEMONSTRATE API
+Du må også importere stilarkene til komponentene som brukes i mønsteret, hvis du ikke allerede gjør det andre steder i løsningen din:
+
+```js
+import "@fremtind/jkl-radio-button/radio-button.min.css";
+import "@fremtind/jkl-text-input/text-input.min.css";
+import "@fremtind/jkl-button/button.min.css";
+import "@fremtind/jkl-message-box/message-box.min.css";
 ```

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -38,6 +38,7 @@
         "@fremtind/jkl-core": "^4.14.4",
         "@fremtind/jkl-feedback": "^1.1.1",
         "@fremtind/jkl-message-box-react": "^1.6.18",
+        "@fremtind/jkl-radio-button-react": "^1.7.0",
         "@fremtind/jkl-text-input-react": "^3.6.0",
         "classnames": "^2.2.6",
         "nanoid": "^3.1.10"


### PR DESCRIPTION
## 📥 Proposed changes

Adds missing dependency `@fremtind/jkl-radio-button-react` to the `Feedback` component

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

