### PR TITLE
feat(core): expand layout spacing scale with new value

### DIFF
--- a/packages/core/variables/_spacing.scss
+++ b/packages/core/variables/_spacing.scss
@@ -36,6 +36,7 @@ $component-spacing-new: (
 );
 
 // Layout scale
+$layout-spacing--xs: $spacing-5;
 $layout-spacing--small: $spacing-6;
 $layout-spacing--medium: $spacing-7;
 $layout-spacing--large: $spacing-8;
@@ -46,6 +47,7 @@ $layout-spacing: $layout-spacing--small, $layout-spacing--medium, $layout-spacin
     $layout-spacing--xxl;
 
 $layout-spacing-new: (
+    "xs": $layout-spacing--xs,
     "small": $layout-spacing--small,
     "medium": $layout-spacing--medium,
     "large": $layout-spacing--large,


### PR DESCRIPTION
## 📥 Proposed changes

Legger til et nytt steg i layout-spacing-skalaen (`layout-spacing--xs`) med verdi 1rem/16px. Denne verdien blir ofte brukt i skisser som avstand mellom elementer, men man har til nå måttet bruke en verdi fra component-spacing-skalaen for å få den.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

ISSUES CLOSED: #1043

affects: @fremtind/jkl-core
