### PR TITLE
fix(react-hooks): fix small device check in useScreen

### DIFF
--- a/packages/react-hooks/src/useScreen/state.ts
+++ b/packages/react-hooks/src/useScreen/state.ts
@@ -28,7 +28,7 @@ export const actionTypes = {
 };
 
 const setDeviceSize = (width: number, height: number) => ({
-    isSmallDevice: width < breakpoints.small,
+    isSmallDevice: width <= breakpoints.small,
     isMediumDevice: width > breakpoints.small && width < breakpoints.medium,
     isLargeDevice: width > breakpoints.medium && width < breakpoints.large,
     isXlDevice: width > breakpoints.large,


### PR DESCRIPTION
affects: @fremtind/jkl-react-hooks

Hvis skjermbredden er 768, faller alle sjekker igjennom siden breakpointet er 768 for small og det ikke sjekkes som bredden er lik.

## 📥 Proposed changes

Legger til sjekk om skjermbredden er lik breakpointet for small.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
