### PR TITLE
fix(button): set classname on wrapper for with loader

### DIFF
--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -15,16 +15,11 @@ type ValidButtons = "primary" | "secondary" | "tertiary";
 
 const makeButtonComponent = (buttonType: ValidButtons) => {
     const button = forwardRef<HTMLButtonElement, Props>(
-        ({ children, className, forceCompact, inverted, onClick, onTouchStart, loader, ...rest }, ref) => {
-            const componentClassName = classNames(
-                "jkl-button",
-                "jkl-button--" + buttonType,
-                {
-                    "jkl-button--compact": forceCompact,
-                    "jkl-button--inverted": inverted,
-                },
-                className,
-            );
+        ({ children, className = "", forceCompact, inverted, onClick, onTouchStart, loader, ...rest }, ref) => {
+            const componentClassName = classNames("jkl-button", "jkl-button--" + buttonType, {
+                "jkl-button--compact": forceCompact,
+                "jkl-button--inverted": inverted,
+            });
 
             const handleTouch = (event: TouchEvent<HTMLButtonElement>) => {
                 onTouchStart && onTouchStart(event);
@@ -40,9 +35,9 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
                 }
             };
 
-            const Button = () => (
+            const Button = ({ cn }: { cn?: string }) => (
                 <button
-                    className={componentClassName}
+                    className={cn}
                     onClick={onClick}
                     onTouchStart={handleTouch}
                     disabled={loader?.showLoader}
@@ -54,12 +49,12 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
             );
 
             if (!loader) {
-                return <Button />;
+                return <Button cn={classNames(componentClassName, className)} />;
             }
 
             return (
                 <div
-                    className={classNames("jkl-button-wrapper", {
+                    className={classNames("jkl-button-wrapper", className, {
                         "jkl-button-wrapper--compact": forceCompact,
                     })}
                 >
@@ -68,14 +63,15 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
                             "jkl-button-wrapper__slider--show-loader": !!loader.showLoader,
                         })}
                     >
-                        <Button />
-                        <Loader
-                            className="jkl-button-wrapper__loader jkl-layout-spacing--small-top"
-                            textDescription={loader.textDescription}
-                            negative={inverted}
-                            aria-hidden={!!loader.showLoader}
-                            inline={true}
-                        />
+                        <Button cn={componentClassName} />
+                        <div className="jkl-button-wrapper__loader jkl-layout-spacing--small-top">
+                            <Loader
+                                textDescription={loader.textDescription}
+                                negative={inverted}
+                                aria-hidden={!!loader.showLoader}
+                                inline={true}
+                            />
+                        </div>
                     </div>
                 </div>
             );

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -65,19 +65,27 @@ $button-primary-background-color--inverted: $hvit;
         @include motion("standard", "productive");
         transition-property: transform;
         &--show-loader {
-            transform: translateY(-50%);
+            transform: translateY(-60%);
         }
     }
 
     &__loader {
         display: flex;
-        justify-content: center;
+        padding: 0 $button-padding;
         align-items: center;
         height: $button-height--normal;
+        min-width: $button-min-width--normal;
     }
 
     &--compact {
         height: $button-height--compact;
+        min-width: $button-min-width--compact;
+
+        .jkl-button-wrapper__slider {
+            &--show-loader {
+                transform: translateY(-63%);
+            }
+        }
 
         .jkl-button-wrapper__loader {
             height: $button-height--compact;


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-button

## 📥 Proposed changes
Fikser feil der klassenavn blir satt på feil komponent når man tar i bruk loaderen. Venstrejusterer loaderen, så den ikke havner langt til høyre for der knappen var.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

