### PR TITLE
docs(uu): fix dead links in accessibility pages

### DIFF
--- a/portal/src/texts/uu/dialog.mdx
+++ b/portal/src/texts/uu/dialog.mdx
@@ -6,7 +6,7 @@ wcagRules: ["2.1.1", "2.1.2", "2.2.1", "2.3.1", "2.4.3", "2.4.7", "3.2.1"]
 
 #### Fokus
 
-Det skal være synlig fokus på elementer. Like viktig er det at fokusrekkefølgen ivaretas. Hvis en dialog er tatt i bruk så er det allerede tatt en beslutning på at innholdet som vises er viktig. Derfor skal dialogen være første element i fokusrekkefølgen etter at den er synlig på skjermen. Se [artikkelen om fokushåndtering](http://localhost:8000/komigang/uu/#fokus-handtering).
+Det skal være synlig fokus på elementer. Like viktig er det at fokusrekkefølgen ivaretas. Hvis en dialog er tatt i bruk så er det allerede tatt en beslutning på at innholdet som vises er viktig. Derfor skal dialogen være første element i fokusrekkefølgen etter at den er synlig på skjermen. Se [artikkelen om fokushåndtering](/komigang/uu/#fokus-handtering).
 
 #### Tastaturfelle
 

--- a/portal/src/texts/uu/farger.mdx
+++ b/portal/src/texts/uu/farger.mdx
@@ -12,4 +12,4 @@ Farger kan være en god meningsbærer og kan brukes for å gi bedre oversikt for
     <CheckListItem>Farge er ikke eneste virkemiddel for å formidle funksjonalitet eller viktighet</CheckListItem>
 </List>
 
-For ytterligere info om farger, se [artikkelen om kontrast](http://localhost:8000/komigang/uu/#kontrast).
+For ytterligere info om farger, se [artikkelen om kontrast](/komigang/uu/#kontrast).

--- a/portal/src/texts/uu/liste.mdx
+++ b/portal/src/texts/uu/liste.mdx
@@ -26,4 +26,4 @@ Et konkret eksempel er en liste som definerer hva en forsikring dekker eller ikk
     <CheckListItem>Kulepunktene er testet med skjermleser</CheckListItem>
 </List>
 
-[Jøkuls lister med ikoner](http://localhost:8000/komponenter/list/#lister-med-ikon) har allerede tatt hensyn til dette slik at de kan brukes uten slike overskrifter.
+[Jøkuls lister med ikoner](/komponenter/list/#lister-med-ikon) har allerede tatt hensyn til dette slik at de kan brukes uten slike overskrifter.

--- a/portal/src/texts/uu/lyd-video.mdx
+++ b/portal/src/texts/uu/lyd-video.mdx
@@ -2,7 +2,7 @@
 title: Lyd og video
 tags: ["media"]
 wcagRules: ["1.2.1", "1.4.2"]
-links: [["Vår info om blinkende innhold", "http://localhost:8000/komigang/uu/#blinkende-innhold"]]
+links: [["Vår info om blinkende innhold", "/komigang/uu/#blinkende-innhold"]]
 ---
 
 import { List, CheckListItem } from "@fremtind/jkl-list-react";

--- a/portal/src/texts/uu/skjema.mdx
+++ b/portal/src/texts/uu/skjema.mdx
@@ -52,7 +52,7 @@ For sider med juridiske forpliktelser må det være mulig å kunne angre, kontro
 
 #### Ledetekster eller intruksjoner
 
-Sørg for at ledetekster og overskrifter beskriver emne eller formål. Mer info om ledetekster ved inndatafelter finnes i [artikkelen om inndatafelter](http://localhost:8000/komigang/uu/#inndatafelter).
+Sørg for at ledetekster og overskrifter beskriver emne eller formål. Mer info om ledetekster ved inndatafelter finnes i [artikkelen om inndatafelter](/komigang/uu/#inndatafelter).
 
 <List>
     <CheckListItem>Det skal være beskrivende ledetekster eller instruksjoner</CheckListItem>
@@ -60,7 +60,7 @@ Sørg for at ledetekster og overskrifter beskriver emne eller formål. Mer info 
 
 #### Tastatur
 
-Alle skjemaelementer må være mulig å bruke med kun tastaturnavigasjon. Det er viktig at ingen elementer fungerer som en tastaturfelle – se [artikkelen om tastaturfeller](http://localhost:8000/komigang/uu/#tastaturfeller).
+Alle skjemaelementer må være mulig å bruke med kun tastaturnavigasjon. Det er viktig at ingen elementer fungerer som en tastaturfelle – se [artikkelen om tastaturfeller](/komigang/uu/#tastaturfeller).
 
 #### Fokus
 
@@ -79,4 +79,4 @@ Formålet med en lenke skal kunne fastslås fra selve lenketeksten eller lenkete
     <CheckListItem>Inkluder dokumenttypen i lenketeksten. "Eksempel (PDF)"</CheckListItem>
 </List>
 
-Se [artikkelen om lenker](http://localhost:8000/komigang/uu/#lenker).
+Se [artikkelen om lenker](/komigang/uu/#lenker).


### PR DESCRIPTION


## 📥 Proposed changes

Fikser lenker som pekte til `localhost` på de nye UU-sidene.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/portal
