### PR TITLE
fix(button): add missing types from button

### DIFF
--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef, HTMLAttributes, TouchEvent } from "react";
+import React, { forwardRef, ButtonHTMLAttributes, TouchEvent } from "react";
 import classNames from "classnames";
 import { Loader } from "@fremtind/jkl-loader-react";
 
-export interface Props extends Exclude<HTMLAttributes<HTMLButtonElement>, "disabled"> {
+export interface Props extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
     forceCompact?: boolean;
     inverted?: boolean;
     loader?: {


### PR DESCRIPTION
affects: @fremtind/jkl-button-react

## 📥 Proposed changes

`type` feltet mangler fra typedefinisjonen til buttons fordi den plukket feil element.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

