### PR TITLE
fix(toggleslider): improve screenreader experience

### DIFF
--- a/packages/toggle-switch-react/src/ToggleSlider.tsx
+++ b/packages/toggle-switch-react/src/ToggleSlider.tsx
@@ -1,6 +1,7 @@
 import React, { useState, FC } from "react";
 import classNames from "classnames";
 import { nanoid } from "nanoid";
+import { ScreenReaderOnly } from "@fremtind/jkl-core";
 
 interface Props {
     labels: [string, string];
@@ -8,21 +9,38 @@ interface Props {
     defaultValue?: string;
     className?: string;
     inverted?: boolean;
+    screenReaderLabel?: string;
+    screenReaderSelected?: string;
 }
 
-export const ToggleSlider: FC<Props> = ({ labels, className = "", inverted, onToggle, defaultValue, children }) => {
+export const ToggleSlider: FC<Props> = ({
+    labels,
+    className = "",
+    inverted,
+    onToggle,
+    defaultValue,
+    children,
+    screenReaderLabel,
+    screenReaderSelected,
+}) => {
     const [checked, setChecked] = useState(defaultValue !== labels[0]);
+    const [currentLabel, setCurrentLabel] = useState(defaultValue || labels[0]);
     const [id] = useState(nanoid(8));
+
+    const ariaLabel = screenReaderLabel || `${labels[0]} eller ${labels[1]}`;
+    const selectedAriaLabel = screenReaderSelected || `${currentLabel} valgt`;
 
     const handleChange = () => {
         const nextValue = !checked;
+        const nextLabel = nextValue ? labels[1] : labels[0];
         setChecked(nextValue);
-        return onToggle(nextValue ? labels[1] : labels[0]);
+        setCurrentLabel(nextLabel);
+        return onToggle(nextLabel);
     };
 
     return (
         <div className={`jkl-toggle-slider__wrapper ${className}`}>
-            <label htmlFor={id} className="jkl-micro jkl-component-spacing--medium-right">
+            <label htmlFor={id} aria-label={ariaLabel} className="jkl-micro jkl-component-spacing--medium-right">
                 {children}
             </label>
             <button
@@ -38,6 +56,9 @@ export const ToggleSlider: FC<Props> = ({ labels, className = "", inverted, onTo
                     "jkl-toggle-slider--not-checked": !checked,
                 })}
             >
+                <div role="region" aria-live="polite">
+                    <ScreenReaderOnly>{selectedAriaLabel}</ScreenReaderOnly>
+                </div>
                 <span className="jkl-toggle-slider__pill" aria-hidden />
                 <span className="jkl-micro jkl-toggle-slider--left">{labels[0]}</span>
                 <span className="jkl-micro jkl-toggle-slider--right">{labels[1]}</span>


### PR DESCRIPTION
affects: @fremtind/jkl-toggle-switch-react

## 📥 Proposed changes

På min screenreder leser nå eksempelet
"Pris per måned eller år, ToggleButton, not-pressed", 
click -> "Pressed, år"
click -> "Pressed måned"

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
