### PR TITLE
fix(select): remove background color from select wrapper div

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -47,8 +47,6 @@ $select-error-color--inverted: $feil--darkbg;
 
 .jkl-select {
     @include reset-outline;
-    background-color: $select-background-color;
-    background-color: var(--select-background-color);
     display: block;
     position: relative;
 


### PR DESCRIPTION
## 📥 Proposed changes

Fikser en feil der hele wrapper-`<div>`en for Select hadde bakgrunnsfarge.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-select