### PR TITLE
fix(summary-table-react): add style pkg as dependency

### DIFF
--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@babel/runtime": "^7.9.0",
         "@fremtind/jkl-core": "^4.18.0",
+        "@fremtind/jkl-summary-table": "^1.1.4",
         "classnames": "^2.2.6"
     },
     "peerDependencies": {


### PR DESCRIPTION
## 📥 Proposed changes

Legger stilpakken til som dependency for `jkl-summary-table-react` slik at den blir automatisk installert ved bruk.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-summary-table-react
