### PR TITLE
fix(datepicker): fix broken aria reference when no supportlabel

### DIFF
--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -151,7 +151,7 @@ export function DatePicker({
                 <BaseInputField
                     ref={inputRef}
                     id={inputId}
-                    describedBy={supportLabelId}
+                    describedBy={helpLabel || errorLabel ? supportLabelId : undefined}
                     invalid={!!errorLabel}
                     className="jkl-datepicker__input jkl-text-input__input"
                     data-testid="jkl-datepicker__input"


### PR DESCRIPTION
affects: @fremtind/jkl-datepicker-react

## 📥 Proposed changes

Hvis det ikke er supportlabel så settes fortsatt describedby iden til supportlabelen. Det gjør at vi peker screenreaderen til noe som ikke finnes, som er litt uheldig.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
