### PR TITLE
fix(@fremtind/jkl-button): fixes clipped focus-bug in button

### DIFF
--- a/packages/button-react/documentation/Example.tsx
+++ b/packages/button-react/documentation/Example.tsx
@@ -3,6 +3,7 @@ import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
 import { Primary } from "./Primary";
 import { Secondary } from "./Secondary";
 import { Tertiary } from "./Tertiary";
+import "./style.scss";
 
 export const Example: React.FC<ExampleComponentProps> = ({ boolValues }) => {
     return (

--- a/packages/button-react/documentation/style.scss
+++ b/packages/button-react/documentation/style.scss
@@ -3,5 +3,11 @@
 .jkl-button-example {
     display: flex;
     flex-direction: column;
-    padding: $layout-spacing--large;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+
+    > *:not(:last-child) {
+        margin-bottom: 2rem;
+    }
 }

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -34,6 +34,10 @@ $button-focus-color--inverted: $info--darkbg;
 $button-primary-text-color--inverted: $svart;
 $button-primary-background-color--inverted: $hvit;
 
+/* This padding ensures that there is enough space around the button so that it is fully visible during hover and focus inside the wrapper.
+Note that this padding is only necessary for browsers that does not support clip-path. */
+$button-wrapper-animation-safe-area: 7px;
+
 :root,
 [data-theme="light"] {
     --button-border-color: #{$button-border-color};
@@ -56,9 +60,11 @@ $button-primary-background-color--inverted: $hvit;
 .jkl-button-wrapper {
     height: $button-height--normal;
     overflow: hidden;
-    @supports (clip-path: inset(-5% -5% -5% -5%)) {
+    padding: $button-wrapper-animation-safe-area;
+    @supports (clip-path: inset(-12% -12% -12% -12%)) {
         overflow: initial;
-        clip-path: inset(-5% -5% -5% -5%);
+        clip-path: inset(-12% -12% -12% -12%);
+        padding: 0;
     }
 
     &__slider {


### PR DESCRIPTION
affects: @fremtind/jkl-button-react, @fremtind/jkl-button

increases clip-path percentage and adds padding to make the focus outline for button visible

ISSUES CLOSED: #1704

## 📥 Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
