### PR TITLE
Bevegelse i Feedback og custom suksessmelding

### DIFF
--- a/packages/feedback-react/documentation/Example.tsx
+++ b/packages/feedback-react/documentation/Example.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
-import { Feedback, SimplifiedFeedback } from "../src";
+import { SuccessMessage } from "@fremtind/jkl-message-box-react";
+import { Feedback, HAPPY, NEUTRAL, SimplifiedFeedback, UNHAPPY, VERY_HAPPY, VERY_UNHAPPY } from "../src";
 
 export const Example = ({ boolValues }: ExampleComponentProps) => {
     const Component = boolValues?.["Uten smilefjes"] ? SimplifiedFeedback : Feedback;
@@ -12,6 +13,32 @@ export const Example = ({ boolValues }: ExampleComponentProps) => {
                 description="Hvor fornøyd er du med denne siden for å følge saken?"
                 onSubmit={console.info}
                 showTextArea={!boolValues?.["Uten tekst"]}
+                renderCustomSuccess={(props) => (
+                    <div>
+                        <SuccessMessage title="Tilbakemelding sendt!">
+                            {props.value === VERY_UNHAPPY && <>Det var trist!</>}
+                            {props.value === UNHAPPY && (
+                                <>Vi ser på alle tilbakemeldinger, håper vi kan gjøre deg mer fornøyd en annen gang!</>
+                            )}
+                            {props.value === NEUTRAL && (
+                                <>Vi vil gjerne ha fornøyde kunder, så vi skal se på tilbakemeldingen din!</>
+                            )}
+                            {props.value === HAPPY && <>Takk skal du ha!</>}
+                            {props.value === VERY_HAPPY && (
+                                <>
+                                    Det var stas du var fornøyd, vi prøver hele tiden å bli bedre! Takk for
+                                    tilbakemeldingen!
+                                </>
+                            )}
+                        </SuccessMessage>
+                        {props.message && (
+                            <div className="jkl-layout-spacing--small-top">
+                                <span>Kopi av din melding</span>
+                                <pre>{props.message}</pre>
+                            </div>
+                        )}
+                    </div>
+                )}
             />
 
             <Component

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -40,6 +40,7 @@
         "@fremtind/jkl-message-box-react": "^1.7.4",
         "@fremtind/jkl-radio-button-react": "^1.9.3",
         "@fremtind/jkl-text-input-react": "^3.8.5",
+        "@fremtind/jkl-react-hooks": "^1.10.3",
         "classnames": "^2.2.6",
         "nanoid": "^3.1.10"
     },

--- a/packages/feedback-react/src/BaseFeedback.tsx
+++ b/packages/feedback-react/src/BaseFeedback.tsx
@@ -1,19 +1,23 @@
-import React, { createContext, useCallback, useEffect, useState, FC } from "react";
+import React, { createContext, useCallback, useEffect, useState, FC, ReactNode } from "react";
 import cn from "classnames";
 import { TextArea } from "@fremtind/jkl-text-input-react";
 import { SecondaryButton } from "@fremtind/jkl-button-react";
 import { SuccessMessage } from "@fremtind/jkl-message-box-react";
+import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
+import { VERY_UNHAPPY, UNHAPPY, NEUTRAL, HAPPY, VERY_HAPPY } from "./FeedbackValues";
 import { FeedbackValue } from "./types";
 
 export type FeedbackPayload = {
     feedbackValue: FeedbackValue;
     message?: string;
 };
+
 export interface BaseFeedbackProps {
     label: string;
     onSubmit: (data: FeedbackPayload) => void;
     description?: string;
     feedbackOptions?: FeedbackValue[];
+    renderCustomSuccess?: (props: { value: FeedbackValue; message: string }) => ReactNode;
     successTitle?: string;
     successMessage?: string;
     className?: string;
@@ -24,16 +28,21 @@ export interface BaseFeedbackProps {
     headingLevel?: "h1" | "h2" | "h3" | "h4" | "h5" | "p";
 }
 
+interface Props extends BaseFeedbackProps {
+    content: ReactNode;
+}
+
 export const FeedbackContext = createContext<{
     options: FeedbackValue[];
     value?: FeedbackValue;
     setValue: (next: FeedbackValue) => void;
 }>({ options: [], setValue: () => undefined });
 
-export const BaseFeedback: FC<BaseFeedbackProps> = ({
+export const BaseFeedback: FC<Props> = ({
     label,
     onSubmit,
     description,
+    renderCustomSuccess,
     successMessage = "Det hjelper oss i arbeidet med å forbedre våre løsninger",
     successTitle = "Takk for tilbakemeldingen!",
     callToActionText = "Send inn tilbakemelding",
@@ -41,13 +50,15 @@ export const BaseFeedback: FC<BaseFeedbackProps> = ({
     textAreaLabel = "Tips oss gjerne om hva vi kan forbedre",
     textAreaHelpLabel = "",
     className = "",
-    feedbackOptions = [1, 2, 3, 4, 5],
+    feedbackOptions = [VERY_UNHAPPY, UNHAPPY, NEUTRAL, HAPPY, VERY_HAPPY],
     headingLevel = "h3",
-    children,
+    content,
 }) => {
     const [feedbackValue, setFeedbackValue] = useState<FeedbackValue>();
     const [message, setMessage] = useState("");
     const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+    const [feedbackSubmittedAnimation, setFeedbackSubmittedAnimation] = useState(false);
+    const [animationRef] = useAnimatedHeight<HTMLDivElement>(feedbackValue !== undefined);
 
     const handleSubmit = useCallback(() => {
         if (!feedbackSubmitted && feedbackValue) {
@@ -56,8 +67,9 @@ export const BaseFeedback: FC<BaseFeedbackProps> = ({
     }, [feedbackValue, feedbackSubmitted, message, onSubmit]);
 
     const handleActiveSubmit = () => {
-        setFeedbackSubmitted(true);
         handleSubmit();
+        setFeedbackSubmittedAnimation(true);
+        setTimeout(() => setFeedbackSubmitted(true), 250);
     };
 
     useEffect(() => {
@@ -69,49 +81,59 @@ export const BaseFeedback: FC<BaseFeedbackProps> = ({
         };
     }, [handleSubmit]);
 
-    if (feedbackSubmitted) {
-        return <SuccessMessage title={successTitle}>{successMessage}</SuccessMessage>;
-    }
-
     const H = headingLevel;
 
     return (
         <FeedbackContext.Provider
             value={{ options: feedbackOptions, setValue: setFeedbackValue, value: feedbackValue }}
         >
-            <form className={`jkl-feedback ${className}`} onSubmit={(e) => e.preventDefault()}>
-                <div className="jkl-feedback__heading">
-                    <H className="jkl-heading-large">{label}</H>
-                    {description && <p className="jkl-lead">{description}</p>}
-                </div>
-                <fieldset className="jkl-feedback__fieldset">{children}</fieldset>
-                <section
-                    className={cn("jkl-feedback__input-submit", {
-                        "jkl-feedback__input-submit--hidden jkl-layout-spacing--medium-top":
-                            feedbackValue === undefined,
-                    })}
-                >
-                    {showTextArea && (
-                        <TextArea
-                            data-testid="feedback-text"
-                            name="feedback-text"
-                            label={textAreaLabel}
-                            variant="small"
-                            rows={3}
-                            helpLabel={textAreaHelpLabel}
-                            value={message}
-                            onChange={(e) => setMessage(e.currentTarget.value)}
-                        />
-                    )}
-                    <SecondaryButton
-                        data-testid="submit-button"
-                        className="jkl-layout-spacing--medium-top"
-                        onClick={handleActiveSubmit}
-                    >
-                        {callToActionText}
-                    </SecondaryButton>
+            {feedbackSubmitted && (
+                <section className="jkl-feedback__success">
+                    {renderCustomSuccess &&
+                        feedbackValue !== undefined &&
+                        renderCustomSuccess({ value: feedbackValue, message })}
+                    {!renderCustomSuccess && <SuccessMessage title={successTitle}>{successMessage}</SuccessMessage>}
                 </section>
-            </form>
+            )}
+            {!feedbackSubmitted && (
+                <form
+                    className={cn("jkl-feedback", { "jkl-feedback--hidden": feedbackSubmittedAnimation }, className)}
+                    onSubmit={(e) => e.preventDefault()}
+                >
+                    <div className="jkl-feedback__heading">
+                        <H className="jkl-heading-large">{label}</H>
+                        {description && <p className="jkl-lead">{description}</p>}
+                    </div>
+                    <fieldset className="jkl-feedback__fieldset">{content}</fieldset>
+                    <section
+                        ref={animationRef}
+                        className={cn("jkl-feedback__input-submit", {
+                            "jkl-feedback__input-submit--hidden jkl-layout-spacing--medium-top":
+                                feedbackValue === undefined,
+                        })}
+                    >
+                        {showTextArea && (
+                            <TextArea
+                                data-testid="feedback-text"
+                                name="feedback-text"
+                                label={textAreaLabel}
+                                variant="small"
+                                rows={3}
+                                helpLabel={textAreaHelpLabel}
+                                value={message}
+                                onChange={(e) => setMessage(e.currentTarget.value)}
+                            />
+                        )}
+                        <SecondaryButton
+                            data-testid="submit-button"
+                            className="jkl-layout-spacing--medium-top"
+                            onClick={handleActiveSubmit}
+                        >
+                            {callToActionText}
+                        </SecondaryButton>
+                    </section>
+                </form>
+            )}
         </FeedbackContext.Provider>
     );
 };

--- a/packages/feedback-react/src/Feedback.tsx
+++ b/packages/feedback-react/src/Feedback.tsx
@@ -36,9 +36,5 @@ const FeedbackContent = () => {
 };
 
 export const Feedback: FC<BaseFeedbackProps> = (props) => {
-    return (
-        <BaseFeedback {...props}>
-            <FeedbackContent />
-        </BaseFeedback>
-    );
+    return <BaseFeedback {...props} content={<FeedbackContent />} />;
 };

--- a/packages/feedback-react/src/FeedbackValues.tsx
+++ b/packages/feedback-react/src/FeedbackValues.tsx
@@ -1,0 +1,5 @@
+export const VERY_UNHAPPY = 1;
+export const UNHAPPY = 2;
+export const NEUTRAL = 3;
+export const HAPPY = 4;
+export const VERY_HAPPY = 5;

--- a/packages/feedback-react/src/SimplifiedFeedback.tsx
+++ b/packages/feedback-react/src/SimplifiedFeedback.tsx
@@ -23,9 +23,5 @@ export interface SimplifiedFeedbackProps extends Omit<BaseFeedbackProps, "descri
 }
 
 export const SimplifiedFeedback = ({ description, ...rest }: SimplifiedFeedbackProps) => {
-    return (
-        <BaseFeedback {...rest}>
-            <FeedbackContent legend={description} />
-        </BaseFeedback>
-    );
+    return <BaseFeedback {...rest} content={<FeedbackContent legend={description} />} />;
 };

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -1,2 +1,3 @@
 export { Feedback } from "./Feedback";
 export { SimplifiedFeedback } from "./SimplifiedFeedback";
+export { VERY_UNHAPPY, UNHAPPY, NEUTRAL, HAPPY, VERY_HAPPY } from "./FeedbackValues";

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -19,6 +19,20 @@ $icon-size: rem(45px);
     --jkl-feedback-icon--selected: #{$suksess};
 }
 
+@keyframes show {
+    from {
+        transform: translateY(20px);
+        opacity: 0;
+    }
+}
+
+@keyframes hide {
+    to {
+        transform: translateY(-20px);
+        opacity: 0;
+    }
+}
+
 .jkl-feedback__icon {
     &--1 {
         --jkl-feedback-icon--selected: #ff7059;
@@ -41,6 +55,10 @@ $icon-size: rem(45px);
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    &--hidden {
+        animation: hide 0.25s ease-in;
+    }
 
     &__heading {
         text-align: center;
@@ -105,8 +123,7 @@ $icon-size: rem(45px);
     }
 
     &__input-submit {
-        opacity: 1;
-        transition-property: opacity;
+        transition-property: height;
         @include motion(standard, expressive);
         display: flex;
         justify-content: center;
@@ -115,5 +132,9 @@ $icon-size: rem(45px);
         &--hidden {
             display: none;
         }
+    }
+
+    &__success {
+        animation: show 0.25s ease-out;
     }
 }


### PR DESCRIPTION
## 📥 Proposed changes
Bevegelsene var veldig stakato tidligere, nå legges det på en diskret bevegelse ut og inn når ting endrer seg i komponenten.

Legger også til en mye mer dynamisk resultat på fra feedbacken. Dagens funksjonalitet er bevart, men man kan nå ta over ansvaret selv for å generere "success" visningen etter feedbacken er sendt. Der har man tilgengelig svaret og meldingen, så man kan diferensiere hva man sier til kunden om vedkommende var fornøyd eller ikke. Kan også gjøre ting med meldingen om man ønsker det, feks lete etter personopplysinger som ikke burde være der og informere om at de ikke får hjelp her.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
