### PR TITLE
feat(core): add keyboard mixin

### DIFF
--- a/packages/core/documentation/Example.tsx
+++ b/packages/core/documentation/Example.tsx
@@ -12,6 +12,7 @@ import { LinkExample } from "./Link/LinkExample";
 import { NavLinkExample } from "./Link/NavLinkExample";
 import { ComponentSpacingTable, LayoutSpacingTable } from "./Spacing/Spacing";
 import { DesktopExample, CompactExample } from "./Typography/Typography";
+import { Keyboard } from "./Mixins/Keyboard";
 
 interface BoxProps {
     type: "color" | "component" | "layout";
@@ -64,6 +65,7 @@ const Example = () => (
         <LayoutSpacingTable />
         <CompactExample />
         <DesktopExample />
+        <Keyboard />
     </section>
 );
 

--- a/packages/core/documentation/Mixins/Keyboard.tsx
+++ b/packages/core/documentation/Mixins/Keyboard.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import "./keyboard.scss";
+import { initTabListener } from "../../src";
+
+initTabListener();
+
+export const Keyboard = () => (
+    <div>
+        <p className="jkl-body">
+            Sjekk hover state med ved å navigere med tastatur, så klikk på knappen og se hoverstate
+        </p>
+        <button className="keyboard-demo">hest</button>
+    </div>
+);

--- a/packages/core/documentation/Mixins/keyboard.scss
+++ b/packages/core/documentation/Mixins/keyboard.scss
@@ -1,0 +1,15 @@
+@import "../../mixins/navigation";
+@import "../../mixins/helpers";
+@import "../../variables/colors";
+
+.keyboard-demo {
+    @include reset-outline;
+
+    padding: 24px 48px;
+
+    &:hover {
+        @include keyboard-navigation {
+            box-shadow: 0 0 0 2px $info;
+        }
+    }
+}

--- a/packages/core/documentation/mixins.mdx
+++ b/packages/core/documentation/mixins.mdx
@@ -76,3 +76,20 @@ Dette er en snarvei til selektoren for kompakt modus når du skal skrive nye kom
     }
 }
 ```
+
+## Keyboard-navigasjon
+
+Når du setter opp initTabListner fra jkl-core, så settes det noen data-attributter på html-elementet som gjør at man kan sette opp en tydeligere focus state for tastaturbrukere eller egen stil for touchskjermer. Det er en mixin for å gjøre det enklere for klienter og knytte seg på denne funksjonaliteten.
+
+```scss
+@use '@fremtind/jkl-core/mixins/navigation';
+
+.my-component {
+    // pretty component
+    &:focus {
+        @include navigation.keyboard-navigation {
+            box-shadow: 0 0 0 2px $info;
+        }
+    }
+}
+```

--- a/packages/core/mixins/_all.scss
+++ b/packages/core/mixins/_all.scss
@@ -4,3 +4,4 @@
 @import "./motion";
 @import "./screenreader";
 @import "./underline";
+@import "./navigation";

--- a/packages/core/mixins/_navigation.scss
+++ b/packages/core/mixins/_navigation.scss
@@ -1,0 +1,5 @@
+@mixin keyboard-navigation {
+    @at-root html:not([data-mousenavigation]):not([data-touchnavigation]) #{&} {
+        @content;
+    }
+}


### PR DESCRIPTION
affects: @fremtind/jkl-core

## 📥 Proposed changes

I dag så strør vi rundt oss med denne `html:not([data-mousenavigation]):not([data-touchnavigation])` rundt om kring i kode, som i seg selv ikke er et stort problem. Men det gjør at det ikke er spesielt enkelt for klienter å ta ibruk denne funksjonaliteten i sine komponenter uten for jøkul. Ved å tilby dette som en mixin, så fristiller vi klientene fra å ha et forhold til disse funksjonene. Hvis det også skulle dukke opp utvida behov for denne, som det gjorde med touchnavigation, så kan vi oppdatere det et sted, isteden for å distribuere ansvaret. 

1. Er å lage denne og publisere den
2. Erstatte alle interne referanser til `html:not([data-mousenavigation]):not([data-touchnavigation])` med `keyboard-navigation`

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

