### PR TITLE
fix(text-input): expose default value prop

### DIFF
--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -26,6 +26,7 @@ export interface BaseProps {
     required?: boolean;
     type?: "text" | "number" | "tel" | "password" | "email" | "year";
     name?: string;
+    defaultValue?: string;
 }
 
 export interface Props extends BaseProps {


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react

## 📥 Proposed changes

Eksponerer prop som er praktisk i en del tilfeller.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
