### PR TITLE
fix(list): fix display of icon list in IE

### DIFF
--- a/packages/list-react/src/ListItem.tsx
+++ b/packages/list-react/src/ListItem.tsx
@@ -12,7 +12,7 @@ function makeListItem(listItemType: validListItems): FC<Props> {
         return (
             <li
                 className={cn("jkl-list__item", {
-                    "jkl-list__item__iconed": listItemType !== "normal",
+                    "jkl-list__item--iconed": listItemType !== "normal",
                     "jkl-list__item--check": listItemType === "check",
                     "jkl-list__item--cross": listItemType === "cross",
                     className,

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -72,7 +72,7 @@ $jkl-marker-check: url("data:image/svg+xml,%3Csvg width='19' height='19' fill='n
     }
 
     &__item {
-        &__iconed {
+        &--iconed {
             list-style: none;
             position: relative;
             padding-left: 1em;
@@ -81,7 +81,8 @@ $jkl-marker-check: url("data:image/svg+xml,%3Csvg width='19' height='19' fill='n
                 text-indent: -9999px;
                 position: absolute;
                 top: 0.25em;
-                left: clamp(-1em, -1rem ,rem(-23px));
+                left: -1em; // for IE
+                left: clamp(-1em, -1rem, rem(-23px));
                 background-size: contain;
                 display: inline-block;
                 width: 1em;


### PR DESCRIPTION
## 📥 Proposed changes

Fikser en bug der ikonene i ikon-listen dekket over starten av teksten i listepunktet (i IE11).

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-list-react, @fremtind/jkl-list

Closes: #1827
