### PR TITLE
fix(list): set className in correct position

### DIFF
--- a/packages/list-react/src/List.test.tsx
+++ b/packages/list-react/src/List.test.tsx
@@ -40,6 +40,15 @@ describe("List", () => {
         expect(screen.getByTestId("jkl-list")).toHaveClass("jkl-lead");
     });
 
+    test(`ListItem gets the passed className`, () => {
+        render(
+            <UnorderedList>
+                <ListItem className="jkl-lead">Kibogiedo</ListItem>
+            </UnorderedList>,
+        );
+        expect(screen.getByTestId("jkl-list-item")).toHaveClass("jkl-lead");
+    });
+
     test(`Nested lists should render all elements as expected`, () => {
         render(
             <UnorderedList>

--- a/packages/list-react/src/ListItem.tsx
+++ b/packages/list-react/src/ListItem.tsx
@@ -11,12 +11,12 @@ function makeListItem(listItemType: validListItems): FC<Props> {
     const ListItem: FC<Props> = ({ className = "", children }) => {
         return (
             <li
-                className={cn("jkl-list__item", {
+                className={cn("jkl-list__item", className, {
                     "jkl-list__item--iconed": listItemType !== "normal",
                     "jkl-list__item--check": listItemType === "check",
                     "jkl-list__item--cross": listItemType === "cross",
-                    className,
                 })}
+                data-testid="jkl-list-item"
             >
                 {children}
             </li>


### PR DESCRIPTION
affects: @fremtind/jkl-list-react

## 📥 Proposed changes

actually set className not className as a string as class

Tidligere `<ListItem className="hest" />` ble `<li class="jkl-list-item className" />`
Nå:  `<ListItem className="hest" />` ble `<li class="jkl-list-item hest" />`

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
