### PR TITLE
feat: add focus outline on keyboard nav for clickable card

### DIFF
--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -45,8 +45,10 @@ $card-padding-normal: $component-spacing--xl;
         box-shadow: $drop-shadow--large;
         transform: translateY(-0.125rem);
     }
-    html:not([data-mousenavigation]) &--clickable:focus-within {
-        box-shadow: 0 0px 0 rem(2px) $focus-color;
+    &--clickable:focus-within {
+        @include keyboard-navigation {
+            box-shadow: 0 0px 0 rem(2px) $focus-color;
+        }
     }
     &--clickable:active {
         box-shadow: 0 0 0 0 transparent;

--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -45,6 +45,9 @@ $card-padding-normal: $component-spacing--xl;
         box-shadow: $drop-shadow--large;
         transform: translateY(-0.125rem);
     }
+    html:not([data-mousenavigation]) &--clickable:focus-within {
+        box-shadow: 0 0px 0 rem(2px) $focus-color;
+    }
     &--clickable:active {
         box-shadow: 0 0 0 0 transparent;
     }


### PR DESCRIPTION
affects: @fremtind/jkl-card

ISSUES CLOSED: #1853

## 📥 Proposed changes

Add a focus outline to clickable cards

<img width="852" alt="Skjermbilde 2021-03-02 kl  12 18 00" src="https://user-images.githubusercontent.com/14551408/109642422-3c5a8780-7b53-11eb-8ad7-d9a403adede4.png">


## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)