### PR TITLE
Legg til mulighet for å lukke AlertMessage

### DIFF
--- a/packages/alert-message-react/documentation/AlertMessage.mdx
+++ b/packages/alert-message-react/documentation/AlertMessage.mdx
@@ -14,7 +14,7 @@ import AlertMessageExample from "./AlertMessageExample";
 <ComponentExample
     component={AlertMessageExample}
     knobs={{
-        boolProps: ["Invertert"],
+        boolProps: ["Invertert", "Avvisbar"],
         choiceProps: [
             {
                 name: "Type",
@@ -56,3 +56,7 @@ Vi har fire ulike meldinger, med fargene blå, rød, gul og grønn.
 ### Tilgjengelighet
 
 Når vi bruker meldinger med farge, må vi alltid huske å ha en god og beskrivende tekst, siden farge ikke er et godt nok kjennetegn for alle brukere. Skriv en presis meldingstekst, der du sier det viktigste først.
+
+## Avvisbare meldinger
+
+Dersom meldingen ikke er koblet til en tilstand på siden (som f.eks. en feil i et skjema) kan man la brukeren lukke den. For global informasjon som driftsmeldinger bør man huske valget om å lukke meldingen, så brukeren slipper å se den på nytt.

--- a/packages/alert-message-react/documentation/AlertMessageExample.tsx
+++ b/packages/alert-message-react/documentation/AlertMessageExample.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
 import { InfoAlertMessage, WarningAlertMessage, ErrorAlertMessage, SuccessAlertMessage } from "../src";
 
@@ -19,9 +19,17 @@ const getTypeOfBox = (typeofBox?: string) => {
 
 export const Example: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const C = getTypeOfBox(choiceValues ? choiceValues["Type"] : "");
+    const [dismissed, setDismissed] = useState(false);
+    const dismissAction =
+        boolValues && boolValues["Avvisbar"]
+            ? {
+                  handleDismiss: () => setDismissed(true),
+                  buttonTitle: "Merk som lest",
+              }
+            : undefined;
 
     return (
-        <C inverted={boolValues && boolValues["Invertert"]}>
+        <C inverted={boolValues && boolValues["Invertert"]} dismissed={dismissed} dismissAction={dismissAction}>
             Hei, jeg er en varslingsmelding av typen {choiceValues ? choiceValues["Type"] : "ᕙ(⇀‸↼‶)ᕗ"}
         </C>
     );

--- a/packages/alert-message-react/documentation/index.tsx
+++ b/packages/alert-message-react/documentation/index.tsx
@@ -23,7 +23,7 @@ ReactDOM.render(
         <DevExample
             component={AlertMessageExample}
             knobs={{
-                boolProps: ["Invertert"],
+                boolProps: ["Invertert", "Avvisbar"],
                 choiceProps: [
                     {
                         name: "Type",

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@babel/runtime": "^7.9.0",
         "@fremtind/jkl-alert-message": "^1.2.14",
+        "@fremtind/jkl-icon-button-react": "^0.4.8",
         "classnames": "^2.2.6"
     },
     "devDependencies": {

--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import classNames from "classnames";
 import { MessageIcon } from "./common/MessageIcon";
+import { IconButton } from "@fremtind/jkl-icon-button-react";
 
 type messageTypes = "info" | "error" | "success" | "warning";
 
@@ -11,6 +12,11 @@ interface Props {
     maxContentWidth?: string;
     paddingLeft?: string;
     role?: string;
+    dismissed?: boolean;
+    dismissAction?: {
+        handleDismiss: () => void;
+        buttonTitle?: string;
+    };
 }
 
 function alertFactory(messageType: messageTypes) {
@@ -20,10 +26,13 @@ function alertFactory(messageType: messageTypes) {
         maxContentWidth,
         paddingLeft,
         role = "status",
+        dismissed,
+        dismissAction,
         children,
     }: Props) {
         const componentClassName = classNames("jkl-alert-message", "jkl-alert-message--" + messageType, className, {
             "jkl-alert-message--dark": inverted,
+            "jkl-alert-message--dismissed": dismissed,
         });
 
         const styles = {
@@ -34,10 +43,18 @@ function alertFactory(messageType: messageTypes) {
         return (
             <div className={componentClassName} role={role}>
                 <div className="jkl-alert-message__content" data-testid="alert-message-content" style={{ ...styles }}>
-                    <div className="jkl-alert-message__icon">
+                    <div aria-hidden className="jkl-alert-message__icon">
                         <MessageIcon messageType={messageType} />
                     </div>
                     <p className="jkl-alert-message__message jkl-body">{children}</p>
+                    {dismissAction?.handleDismiss && (
+                        <IconButton
+                            className="jkl-alert-message__dismiss-button"
+                            iconType="clear"
+                            buttonTitle={dismissAction.buttonTitle || "Lukk"}
+                            onClick={dismissAction.handleDismiss}
+                        />
+                    )}
                 </div>
             </div>
         );

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -1,4 +1,6 @@
+@import "~@fremtind/jkl-core/_functions.scss";
 @import "~@fremtind/jkl-core/variables/_all.scss";
+@import "~@fremtind/jkl-core/mixins/_all.scss";
 
 @function message-bg-light($color) {
     @return change-color($color, $lightness: 97%);
@@ -6,6 +8,8 @@
 @function message-bg-dark($color) {
     @return change-color($color, $lightness: 5%);
 }
+
+$dismiss-animation-duration: 500ms;
 
 $background-color: $gra-10;
 $border-color: $svart;
@@ -64,24 +68,70 @@ $success-border-color--inverted: $suksess--darkbg;
     border: rem(1px) solid var(--border-color);
     box-sizing: border-box;
 
+    &__content {
+        box-sizing: border-box;
+        padding: $component-spacing--large $component-spacing--xl;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        margin: 0 auto;
+    }
+
     &__icon {
         padding-right: $component-spacing--large;
         align-self: flex-start;
         padding-top: $component-spacing--xxs;
     }
 
-    &__content {
-        box-sizing: border-box;
-        padding: $component-spacing--large $component-spacing--xl;
-        display: flex;
-        align-items: center;
-        max-width: 100%;
-        margin: 0 auto;
+    &__message {
+        margin-right: $component-spacing--large;
+    }
+
+    &__dismiss-button {
+        @include reset-outline();
+        background-color: transparent;
+        padding: 0;
+        margin-left: auto;
+        margin-top: $component-spacing--xs;
+        color: inherit;
+        cursor: pointer;
+        width: rem(20px);
+        height: rem(20px);
+
+        align-self: flex-start;
+        flex-shrink: 0;
+
+        &:hover,
+        &:focus {
+            color: $info-border-color;
+            color: var(--info-border-color);
+
+            @include keyboard-navigation {
+                position: relative;
+
+                &::after {
+                    content: "";
+                    position: absolute;
+                    top: rem(-2px);
+                    right: rem(-2px);
+                    bottom: rem(-2px);
+                    left: rem(-2px);
+                    box-shadow: 0 0 0 rem(2px) $info-border-color;
+                    box-shadow: 0 0 0 rem(2px) var(--info-border-color);
+                }
+            }
+        }
     }
 
     &__message,
     &__message:last-child {
         margin-bottom: 0;
+    }
+
+    &--dismissed {
+        animation: dismiss-animation $dismiss-animation-duration ease-in-out forwards;
+        transition: visibility 0ms $dismiss-animation-duration;
+        visibility: hidden;
     }
 
     &--info {
@@ -174,5 +224,16 @@ $success-border-color--inverted: $suksess--darkbg;
                 color: $success-border-color--inverted;
             }
         }
+    }
+}
+
+@keyframes dismiss-animation {
+    from {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+    to {
+        opacity: 0;
+        transform: translate3d(0, -50%, 0);
     }
 }


### PR DESCRIPTION
## 📥 Proposed changes

Legger til mulighet for en "lukk"-knapp på AlertMessage for å kunne fjerne meldinger.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Denne dekker et ønske fra Smartforhandler der det nå er en global AlertInfoMessage om at siden er under ombygging. Vi ønsker å la brukeren klikke denne vekk så de slipper å se den hver gang de besøker siden (som ofte brukes hver dag). Det er ikke lagt inn noe logikk her, slik at håndtering av dette kan tilpasses appen den brukes i.
