### PR TITLE
feat(icons): add title and desc as props

### DIFF
--- a/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
@@ -6,6 +6,7 @@ import { variants } from "../icons/types";
 interface Props {
     isBurger: boolean;
     variant?: variants;
+    title?: [string, string];
 }
 
 interface ShowProps {
@@ -18,16 +19,16 @@ const Show: FC<ShowProps> = ({ when, children }) => (
     </div>
 );
 
-export const HamburgerCloseAnimated: FC<Props> = ({ isBurger, variant = "small" }) => {
+export const HamburgerCloseAnimated: FC<Props> = ({ isBurger, variant = "small", title = ["meny", "lukk"] }) => {
     const iconSize = variant !== "inherit" ? variant : "small";
 
     return (
         <div className={`jkl-icon--${iconSize} jkl-icons-animated__burger`}>
             <Show when={isBurger}>
-                <Hamburger variant={iconSize} />
+                <Hamburger variant={iconSize} title={title[0]} />
             </Show>
             <Show when={!isBurger}>
-                <Close variant={iconSize} />
+                <Close variant={iconSize} title={title[1]} />
             </Show>
         </div>
     );

--- a/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/HamburgerCloseAnimated.tsx
@@ -6,7 +6,8 @@ import { variants } from "../icons/types";
 interface Props {
     isBurger: boolean;
     variant?: variants;
-    title?: [string, string];
+    hamburgerTitle?: string;
+    closeTitle?: string;
 }
 
 interface ShowProps {
@@ -19,16 +20,21 @@ const Show: FC<ShowProps> = ({ when, children }) => (
     </div>
 );
 
-export const HamburgerCloseAnimated: FC<Props> = ({ isBurger, variant = "small", title = ["meny", "lukk"] }) => {
+export const HamburgerCloseAnimated: FC<Props> = ({
+    isBurger,
+    variant = "small",
+    hamburgerTitle = "meny",
+    closeTitle = "lukk",
+}) => {
     const iconSize = variant !== "inherit" ? variant : "small";
 
     return (
         <div className={`jkl-icon--${iconSize} jkl-icons-animated__burger`}>
             <Show when={isBurger}>
-                <Hamburger variant={iconSize} title={title[0]} />
+                <Hamburger variant={iconSize} title={hamburgerTitle} />
             </Show>
             <Show when={!isBurger}>
-                <Close variant={iconSize} title={title[1]} />
+                <Close variant={iconSize} title={closeTitle} />
             </Show>
         </div>
     );

--- a/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
@@ -5,9 +5,10 @@ import { variants } from "../icons/types";
 interface Props {
     isPlus: boolean;
     variant?: variants;
+    title?: [string, string];
 }
 
-export const PlusRemoveAnimated: FC<Props> = ({ isPlus, variant = "small" }) => {
+export const PlusRemoveAnimated: FC<Props> = ({ isPlus, variant = "small", title = ["pluss", "lukk"] }) => {
     const iconSize = variant !== "inherit" ? variant : "small";
     return (
         <div
@@ -15,7 +16,11 @@ export const PlusRemoveAnimated: FC<Props> = ({ isPlus, variant = "small" }) => 
                 isPlus ? "plus" : "close"
             }`}
         >
-            <Plus variant={iconSize} />
+            <Plus
+                variant={iconSize}
+                title={isPlus ? title[0] : title[1]}
+                description={`Ikon av ${isPlus ? title[0] : title[1]}tegn`}
+            />
         </div>
     );
 };

--- a/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
@@ -5,10 +5,16 @@ import { variants } from "../icons/types";
 interface Props {
     isPlus: boolean;
     variant?: variants;
-    title?: [string, string];
+    plusTitle?: string;
+    closeTitle?: string;
 }
 
-export const PlusRemoveAnimated: FC<Props> = ({ isPlus, variant = "small", title = ["pluss", "lukk"] }) => {
+export const PlusRemoveAnimated: FC<Props> = ({
+    isPlus,
+    variant = "small",
+    plusTitle = "pluss",
+    closeTitle = "lukk",
+}) => {
     const iconSize = variant !== "inherit" ? variant : "small";
     return (
         <div
@@ -18,8 +24,8 @@ export const PlusRemoveAnimated: FC<Props> = ({ isPlus, variant = "small", title
         >
             <Plus
                 variant={iconSize}
-                title={isPlus ? title[0] : title[1]}
-                description={`Ikon av ${isPlus ? title[0] : title[1]}tegn`}
+                title={isPlus ? plusTitle : closeTitle}
+                description={`Ikon av ${isPlus ? plusTitle : closeTitle}tegn`}
             />
         </div>
     );

--- a/packages/icons-react/src/icons/ArrowDown.tsx
+++ b/packages/icons-react/src/icons/ArrowDown.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const ArrowDown: FC<IconProps> = ({ className, variant }) => (
+export const ArrowDown: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Pil-ned",
+    description = "Ikon av en pil mot ned",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 15 16"
-        title="Pil-ned"
-        description="Ikon av en pil mot ned"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/ArrowLeft.tsx
+++ b/packages/icons-react/src/icons/ArrowLeft.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const ArrowLeft: FC<IconProps> = ({ className, variant }) => (
+export const ArrowLeft: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Pil-venstre",
+    description = "Ikon av en pil mot venstre",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 15 16"
-        title="Pil-venstre"
-        description="Ikon av en pil mot venstre"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/ArrowRight.tsx
+++ b/packages/icons-react/src/icons/ArrowRight.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const ArrowRight: FC<IconProps> = ({ className, variant }) => (
+export const ArrowRight: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Pil-høyre",
+    description = "Ikon av en pil mot høyre",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 15 16"
-        title="Pil-høyre"
-        description="Ikon av en pil mot høyre"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/ArrowUp.tsx
+++ b/packages/icons-react/src/icons/ArrowUp.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const ArrowUp: FC<IconProps> = ({ className, variant }) => (
+export const ArrowUp: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Pil-opp",
+    description = "Ikon av en pil mot opp",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 15 16"
-        title="Pil-opp"
-        description="Ikon av en pil mot opp"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/ArrowUpRight.tsx
+++ b/packages/icons-react/src/icons/ArrowUpRight.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const ArrowUpRight: FC<IconProps> = ({ className, variant }) => (
+export const ArrowUpRight: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Pil-ekstern",
+    description = "Ikon av en pil opp mot høyre",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 15 16"
-        title="Pil-ekstern"
-        description="Ikon av en pil opp mot høyre"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Calendar.tsx
+++ b/packages/icons-react/src/icons/Calendar.tsx
@@ -2,10 +2,15 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Calendar: FC<IconProps> = ({ className, variant }) => (
+export const Calendar: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Kalender",
+    description = "Ikon av en kalender",
+}) => (
     <IconFactory
-        title="Kalender"
-        description="Ikon av en kalender"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/CheckMark.tsx
+++ b/packages/icons-react/src/icons/CheckMark.tsx
@@ -2,10 +2,15 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const CheckMark: FC<IconProps> = ({ className, variant }) => (
+export const CheckMark: FC<IconProps> = ({
+    className,
+    variant,
+    title = "CheckMark",
+    description = "Ikon av en hake",
+}) => (
     <IconFactory
-        title="CheckMark"
-        description="Ikon av en hake"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={<path d="M1 15.2168L5.24264 19.4594L19.3848 5.3173" stroke="currentColor" />}

--- a/packages/icons-react/src/icons/Close.tsx
+++ b/packages/icons-react/src/icons/Close.tsx
@@ -2,10 +2,10 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Close: FC<IconProps> = ({ className, variant }) => (
+export const Close: FC<IconProps> = ({ className, variant, title = "Lukk", description = "Ikon av en x" }) => (
     <IconFactory
-        title="Lukk"
-        description="Ikon av en x"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Error.tsx
+++ b/packages/icons-react/src/icons/Error.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Error: FC<IconProps> = ({ className, variant }) => (
+export const Error: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Error-icon",
+    description = "Sirkel med strek over på tvers",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 24 24"
-        title="Error-icon"
-        description="Sirkel med strek over på tvers"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Hamburger.tsx
+++ b/packages/icons-react/src/icons/Hamburger.tsx
@@ -2,10 +2,15 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Hamburger: FC<IconProps> = ({ className, variant }) => (
+export const Hamburger: FC<IconProps> = ({
+    className,
+    variant,
+    title = "hamburger",
+    description = "Ikon av hamburgermeny",
+}) => (
     <IconFactory
-        title="Hamburger"
-        description="Ikon av hamburgermeny"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Info.tsx
+++ b/packages/icons-react/src/icons/Info.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Info: FC<IconProps> = ({ className, variant }) => (
+export const Info: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Info-icon",
+    description = "Sirkel med 'i' i midten",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 24 24"
-        title="Info-icon"
-        description="Sirkel med 'i' i midten"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Plus.tsx
+++ b/packages/icons-react/src/icons/Plus.tsx
@@ -2,10 +2,10 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Plus: FC<IconProps> = ({ className, variant }) => (
+export const Plus: FC<IconProps> = ({ className, variant, title = "Pluss", description = "Ikon av plusstegn" }) => (
     <IconFactory
-        title="Pluss"
-        description="Ikon av plusstegn"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Search.tsx
+++ b/packages/icons-react/src/icons/Search.tsx
@@ -2,10 +2,15 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Search: FC<IconProps> = ({ className, variant }) => (
+export const Search: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Søk",
+    description = "Ikon av forstørrelsesglass",
+}) => (
     <IconFactory
-        title="Søk"
-        description="Ikon av forstørrelsesglass"
+        title={title}
+        description={description}
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Success.tsx
+++ b/packages/icons-react/src/icons/Success.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Success: FC<IconProps> = ({ className, variant }) => (
+export const Success: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Success-icon",
+    description = "Sirkel med hake i midten",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 24 24"
-        title="Success-icon"
-        description="Sirkel med hake i midten"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/Warning.tsx
+++ b/packages/icons-react/src/icons/Warning.tsx
@@ -2,11 +2,16 @@ import React, { FC } from "react";
 import { IconFactory } from "../IconFactory";
 import { IconProps } from "./types";
 
-export const Warning: FC<IconProps> = ({ className, variant }) => (
+export const Warning: FC<IconProps> = ({
+    className,
+    variant,
+    title = "Warning-icon",
+    description = "Sirkel med utropstegn i midten",
+}) => (
     <IconFactory
+        title={title}
+        description={description}
         viewBox="0 0 24 24"
-        title="Warning-icon"
-        description="Sirkel med utropstegn i midten"
         className={className}
         variant={variant}
         innerSvg={

--- a/packages/icons-react/src/icons/types.ts
+++ b/packages/icons-react/src/icons/types.ts
@@ -3,4 +3,6 @@ export type variants = "inherit" | "small" | "medium" | "large";
 export interface IconProps {
     className?: string;
     variant?: variants;
+    title?: string;
+    description?: string;
 }

--- a/packages/icons/animated-icons.scss
+++ b/packages/icons/animated-icons.scss
@@ -84,6 +84,7 @@
         &--hide {
             transition-delay: 0;
             opacity: 0;
+            z-index: -1;
         }
     }
 }


### PR DESCRIPTION
affects: @fremtind/jkl-icons-react, @fremtind/jkl-icons

ISSUES CLOSED: #1811

## 📥 Proposed changes

Oppfører seg som før, men kan nå ta i mot title og description som props. Fikser også problem med animated plusclose og hamburger hvor tittelfeltet vises for første ikonet uansett.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
