### PR TITLE
fix: add deprecation warning dogid

### DIFF
--- a/packages/validators-util/src/isValidDogId/isValidDogId.ts
+++ b/packages/validators-util/src/isValidDogId/isValidDogId.ts
@@ -1,3 +1,7 @@
 export const DOGID_REGEX = /^5780[0-9]{11}$/;
 
+/**
+ * @deprecated This only validates norwegian id-tags, that is probably more restrictive than you want
+ * expect this function to change, use carefully
+ */
 export const isValidDogId = (value: string) => DOGID_REGEX.test(value);


### PR DESCRIPTION
## 📥 Proposed changes
Denne validerer kun norske nummer, det er sannsynligvis strengere enn man vil ha. Denne kommer nok til å endre seg til å ta med flere gyldige landskoder. Vær klar for at det kommer breaking change på denne om man tar den i bruk.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
