### PR TITLE
fix: <div> cannot appear as a descendant of <p>

### DIFF
--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -46,7 +46,7 @@ function alertFactory(messageType: messageTypes) {
                     <div aria-hidden className="jkl-alert-message__icon">
                         <MessageIcon messageType={messageType} />
                     </div>
-                    <p className="jkl-alert-message__message jkl-body">{children}</p>
+                    <span className="jkl-alert-message__message jkl-body">{children}</span>
                     {dismissAction?.handleDismiss && (
                         <IconButton
                             className="jkl-alert-message__dismiss-button"


### PR DESCRIPTION
Fikser feil der browser gir følgende feilmelding
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    at div
    at div
    at http://localhost:9000/main.js:14249:17
    at p
    at div
    at messageBox (http://localhost:9000/main.js:12651:22)

## 📥 Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
