### PR TITLE
fix: <div> cannot appear as a descendant of <p>

### DIFF
--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -71,7 +71,7 @@ function messageFactory(messageType: messageTypes) {
             <div className={componentClassName} role="alert">
                 <div className="jkl-message-box__icon">{getIcon(messageType)}</div>
                 {title !== undefined && <div className="jkl-message-box__title jkl-heading-small">{title}</div>}
-                <p className="jkl-message-box__message jkl-body">{children}</p>
+                <span className="jkl-message-box__message jkl-body">{children}</span>
             </div>
         );
     };


### PR DESCRIPTION
Fikser feil der browser gir følgende feilmelding (Oppdaget nå at denne feilen var to steder i Jøkul)
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    at div
    at div
    at http://localhost:9000/main.js:14249:17
    at p
    at div
    at messageBox (http://localhost:9000/main.js:12651:22)

## 📥 Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
