### PR TITLE
fix(portal): add focus state and trap to portalimg

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -15,6 +15,7 @@
         "@mdx-js/react": "^1.6.22",
         "classnames": "^2.2.6",
         "downloadjs": "^1.4.7",
+        "focus-trap-react": "^8.4.2",
         "framer-motion": "^3.10.0",
         "gatsby": "^3.0.1",
         "gatsby-image": "^3.0.0",

--- a/portal/src/components/PortalImg/PortalImg.tsx
+++ b/portal/src/components/PortalImg/PortalImg.tsx
@@ -1,8 +1,10 @@
 import React, { ImgHTMLAttributes, useState, useRef } from "react";
+import FocusTrap from "focus-trap-react";
 import { withPrefix } from "gatsby";
 import { motion, AnimatePresence } from "framer-motion";
-import "./style.scss";
 import { useKeyListener } from "@fremtind/jkl-react-hooks";
+import { Close } from "@fremtind/jkl-icons-react";
+import "./style.scss";
 
 interface Props extends ImgHTMLAttributes<HTMLImageElement> {
     noMargin?: boolean;
@@ -21,29 +23,38 @@ export const PortalImg: React.FC<Props> = ({ src, alt, noMargin }) => {
     }
 
     return (
-        <>
-            <BlurredBackground blur={isFullscreen} />
-            <motion.button
-                ref={ref}
-                layout
-                onClick={toggleFullscreen}
-                className={`jkl-portal-image ${noMargin ? "jkl-portal-image--no-margin" : ""} ${
-                    isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"
-                }`}
-            >
-                <Image imgSrc={imgSrc} alt={alt} />
-                {!isFullscreen && !noMargin && <div className="jkl-micro">Klikk for å se større</div>}
-            </motion.button>
-            {isFullscreen && (
-                <button
-                    aria-hidden
-                    className={`jkl-portal-image jkl-portal-paragraph ${noMargin ? "jkl-portal-image--no-margin" : ""}`}
+        <FocusTrap active={isFullscreen}>
+            <div>
+                <BlurredBackground blur={isFullscreen} />
+                <motion.button
+                    ref={ref}
+                    layout
+                    onClick={toggleFullscreen}
+                    className={`jkl-portal-image ${noMargin ? "jkl-portal-image--no-margin" : ""} ${
+                        isFullscreen ? "jkl-portal-image--fullscreen" : "jkl-portal-paragraph"
+                    }`}
                 >
-                    <Image imgSrc={imgSrc} />
-                    {!noMargin && <div className="jkl-micro">&nbsp;</div>}
-                </button>
-            )}
-        </>
+                    <Image imgSrc={imgSrc} alt={alt} />
+                    {!isFullscreen && !noMargin && <div className="jkl-micro">Klikk for å se større</div>}
+                    {
+                        <span className="jkl-portal-image__close">
+                            Lukk
+                            <Close variant="medium" />
+                        </span>
+                    }
+                </motion.button>
+                {isFullscreen && (
+                    <div
+                        className={`jkl-portal-image jkl-portal-paragraph ${
+                            noMargin ? "jkl-portal-image--no-margin" : ""
+                        }`}
+                    >
+                        <Image imgSrc={imgSrc} />
+                        {!noMargin && <div className="jkl-micro">&nbsp;</div>}
+                    </div>
+                )}
+            </div>
+        </FocusTrap>
     );
 };
 

--- a/portal/src/components/PortalImg/style.scss
+++ b/portal/src/components/PortalImg/style.scss
@@ -10,6 +10,12 @@
     margin-top: $layout-spacing--medium;
     width: 100%;
 
+    &:focus {
+        @include keyboard-navigation {
+            box-shadow: 0 0 0 2px $info;
+        }
+    }
+
     > .jkl-micro {
         text-align: left;
     }
@@ -24,6 +30,10 @@
         object-fit: contain;
     }
 
+    &__close {
+        display: none;
+    }
+
     &--fullscreen {
         position: fixed;
         top: 0;
@@ -34,7 +44,31 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        flex-direction: column;
         z-index: $z-index--modal;
+
+        & .jkl-portal-image__close {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: $hvit;
+            background-color: $svart;
+            padding: $component-spacing--small;
+            border-bottom-left-radius: 4px;
+            border-bottom-right-radius: 4px;
+
+            & > svg {
+                margin-left: $component-spacing--large;
+                @include keyboard-navigation {
+                    box-shadow: 0 0 0 2px $info--darkbg;
+                }
+            }
+        }
+        &:focus {
+            @include keyboard-navigation {
+                box-shadow: none;
+            }
+        }
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10881,6 +10881,20 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-react@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.4.2.tgz#5b313605e0789a7beee1467785e455dc63388a98"
+  integrity sha512-yuItOIwgriOBMrbHDqbWMpQjGVs9SbtugYrT0vs0yPjHiPKja3NZ9dBMxDQrV1JhyojGK5d6j7ayqBS7Kcm9xQ==
+  dependencies:
+    focus-trap "^6.3.0"
+
+focus-trap@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.3.0.tgz#31c08f0b6099705f71f6e0a16d88fbcc4c012586"
+  integrity sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==
+  dependencies:
+    tabbable "^5.1.5"
+
 follow-redirects@^1.0.0:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
@@ -22439,6 +22453,11 @@ syntax-error@^1.1.1:
   integrity sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==
   dependencies:
     acorn-node "^1.2.0"
+
+tabbable@^5.1.5:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
affects: @fremtind/portal

## 📥 Proposed changes

Per i dag har ikke bildene noen fokus-state i portalen, så for tastaturbrukere er det veldig vanskelig å se at de er klikkbare. Og enda verre å lukke. Legger til fokus-state på bildet, og en lukk knapp med focustrap.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
