### PR TITLE
feat(datepicker-react): add readOnly prop to DatePicker

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -28,6 +28,13 @@ describe("Datepicker", () => {
         expect(input).toHaveProperty("value", "24.12.2019");
     });
 
+    it("is read-only when specified", async () => {
+        render(<DatePicker readOnly />);
+
+        const input = screen.getByTestId("jkl-datepicker__input-readonly");
+        expect(input).toHaveAttribute("readOnly");
+    });
+
     it("fires onChange method on edit input with valid date", async () => {
         const changeHandler = jest.fn();
         render(<DatePicker onChange={changeHandler} />);

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,7 +1,7 @@
 import { Label, LabelVariant, SupportLabel } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
 import { useAnimatedHeight, useClickOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
-import { BaseInputField } from "@fremtind/jkl-text-input-react";
+import { BaseInputField, TextInput } from "@fremtind/jkl-text-input-react";
 import classNames from "classnames";
 import React, { ChangeEvent, FocusEvent, forwardRef, RefObject, useEffect, useMemo, useReducer, useRef } from "react";
 import { Calendar } from "./Calendar";
@@ -38,6 +38,7 @@ interface Props {
     variant?: LabelVariant;
     forceCompact?: boolean;
     inverted?: boolean;
+    readOnly?: boolean;
     disableBeforeDate?: Date;
     disableAfterDate?: Date;
     width?: string;
@@ -64,6 +65,7 @@ export const DatePicker = forwardRef<HTMLElement, Props>(
             className = "",
             forceCompact,
             inverted,
+            readOnly,
             disableBeforeDate,
             disableAfterDate,
             variant,
@@ -160,6 +162,26 @@ export const DatePicker = forwardRef<HTMLElement, Props>(
         useEffect(() => {
             isFirstRenderRef.current = false;
         }, []);
+
+        if (readOnly) {
+            return (
+                <TextInput
+                    readOnly
+                    name={name}
+                    label={label}
+                    width={width}
+                    variant={variant}
+                    inverted={inverted}
+                    className={className}
+                    helpLabel={helpLabel}
+                    errorLabel={errorLabel}
+                    value={state.dateString}
+                    placeholder={placeholder}
+                    forceCompact={forceCompact}
+                    data-testid="jkl-datepicker__input-readonly"
+                />
+            );
+        }
 
         return (
             <div className={componentClassName}>


### PR DESCRIPTION
Affects @fremtind/jkl-datepicker-react.

## 📥 Proposed changes

Add `readOnly` prop to `DatePicker` component. When set to `true`, a `<TextInput readOnly .../>` is returned. 

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)