### PR TITLE
fix(text-area): remove describedby attr when field has no message

### DIFF
--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -39,6 +39,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
         });
         const [uid] = useState(id || `jkl-text-area-${nanoid(8)}`);
         const [supportId] = useState(`jkl-support-label-${nanoid(8)}`);
+        const hasSupportText = helpLabel || errorLabel;
+        const describedBy = hasSupportText ? supportId : undefined;
 
         const [textAreaFocused, setTextAreaFocused] = useState(false);
         const [baseScrollHeight, setBaseScrollHeight] = useState(0);
@@ -110,7 +112,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
                     onFocus={onFocus}
                     onBlur={onBlur}
                     aria-invalid={!!errorLabel}
-                    aria-describedby={supportId}
+                    aria-describedby={describedBy}
                     placeholder={placeholder}
                     rows={autoExpand ? currentRows : undefined}
                     // Must set overflowX hidden for Firefox https://stackoverflow.com/a/22700700


### PR DESCRIPTION
## 📥 Proposed changes

Fiks for en bug der `TextArea` var `aria-describedby` help-/errorLabel, selv når den ikke ble vist. Har brukt samme pattern her som i `TextInput`.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-text-input-react
