### PR TITLE
feat(feedback-react): add support for submit when unmounting the component

### DIFF
--- a/packages/feedback-react/src/BaseFeedback.tsx
+++ b/packages/feedback-react/src/BaseFeedback.tsx
@@ -88,6 +88,7 @@ export const BaseFeedback: FC<Props> = ({
             window.addEventListener("beforeunload", handleSubmit);
         }
         return () => {
+            handleSubmit();
             window.removeEventListener("beforeunload", handleSubmit);
         };
     }, [handleSubmit]);


### PR DESCRIPTION
affects: @fremtind/jkl-feedback-react

## 📥 Proposed changes

Legg til støtte for submit når feedback komponenten unmountes. I dag er det kun et event som håndterer at siden blir lukket, men ved å legge til denne endringen vil man også trigge submit ved feks sidebytte, noe ikke `beforeunload` håndterer. Siden `useEffect()` ikke blir kjørt ved sidelukking går heller ikke disse kallene i beina på hverandre.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
