### PR TITLE
feat(datepicker-react): add useFocusOutside to datepicker to close if…

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -171,6 +171,7 @@ describe("Datepicker", () => {
         expect(screen.getByTestId("jkl-calendar__core-datepicker")).not.toHaveClass("jkl-calendar--hidden");
 
         await act(async () => {
+            // Run userEvent.tab() 5 times to navigate out of datepicker. Progresses into the <button> element rendered above.
             userEvent.tab();
             userEvent.tab();
             userEvent.tab();

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -150,6 +150,38 @@ describe("Datepicker", () => {
         expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
     });
 
+    it("should close the datepicker when tab-navigating outside the date picker", async () => {
+        jest.useFakeTimers();
+
+        render(
+            <>
+                <DatePicker label="Some datepicker" />
+                <button>Test</button>
+            </>,
+        );
+        const inputElement = screen.getByLabelText("Some datepicker");
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
+
+        await act(async () => {
+            userEvent.click(inputElement);
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).not.toHaveClass("jkl-calendar--hidden");
+
+        await act(async () => {
+            userEvent.tab();
+            userEvent.tab();
+            userEvent.tab();
+            userEvent.tab();
+            userEvent.tab();
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
+    });
+
     it("should keep focus on input field when clicking on the input field", async () => {
         jest.useFakeTimers();
 

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,6 +1,6 @@
 import { Label, LabelVariant, SupportLabel } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
-import { useAnimatedHeight, useClickOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
+import { useAnimatedHeight, useClickOutside, useFocusOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
 import { BaseInputField } from "@fremtind/jkl-text-input-react";
 import classNames from "classnames";
 import React, { ChangeEvent, FocusEvent, forwardRef, RefObject, useEffect, useMemo, useReducer, useRef } from "react";
@@ -139,6 +139,8 @@ export const DatePicker = forwardRef<HTMLElement, Props>(
         };
 
         useClickOutside(wrapperRef, () => !state.calendarHidden && dispatch({ type: "TOGGLE" }));
+
+        useFocusOutside(wrapperRef, () => !state.calendarHidden && dispatch({ type: "TOGGLE" }));
 
         useKeyListener(calendarRef, ["Escape"], () => {
             !state.calendarHidden && dispatch({ type: "TOGGLE" });


### PR DESCRIPTION
… focus is lost

affects: @fremtind/jkl-datepicker-react

ISSUES CLOSED: #1888

## 📥 Proposed changes

useFocusOutside for å sjekke om fokus er utenfor wrapperen til datovelgeren. Hvis den er det lukkes den på samme måte som useClickOutside som allerede er implementert.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)