### PR TITLE
Lukk kalender når en gyldig dato er skrevet inn

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -183,6 +183,30 @@ describe("Datepicker", () => {
         expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
     });
 
+    it("should close the calendar when a valid date is entered in the field", async () => {
+        jest.useFakeTimers();
+
+        render(<DatePicker label="Some datepicker" />);
+        const inputElement = screen.getByLabelText("Some datepicker");
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
+
+        await act(async () => {
+            userEvent.click(inputElement);
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).not.toHaveClass("jkl-calendar--hidden");
+
+        await act(async () => {
+            // Enter a valid date into the field
+            userEvent.type(inputElement, "14.10.1986");
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByTestId("jkl-calendar__core-datepicker")).toHaveClass("jkl-calendar--hidden");
+    });
+
     it("should keep focus on input field when clicking on the input field", async () => {
         jest.useFakeTimers();
 

--- a/packages/datepicker-react/src/internal/reducer.ts
+++ b/packages/datepicker-react/src/internal/reducer.ts
@@ -51,7 +51,7 @@ export function createReducer(
                 const newDate = parseDateString(action.payload);
 
                 if (newDate && dateHasChanged(state.date, newDate)) {
-                    return { ...state, date: newDate, dateString: action.payload };
+                    return { ...state, date: newDate, dateString: action.payload, calendarHidden: true };
                 } else {
                     return { ...state, date: undefined, dateString: action.payload };
                 }


### PR DESCRIPTION
## 📥 Proposed changes

Legger til funksjonalitet for automatisk å lukke kalenderen dersom en gyldig dato skrives inn i datofeltet i `DatePicker`.

![datepicker](https://user-images.githubusercontent.com/25739615/122557858-9ff2bd00-d03d-11eb-9ad4-029c8cdc06b5.gif)

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

## 💬 Further comments

**Merk**: Vi godtar i dag årstall med to siffer. Bør vi endre det til kun fire siffer, for å være konsekvente? Støtte for to siffer ble lagt inn for fem måneder siden, mener det var etter et ønske/behov fra BM. Har dere noen tanker, @frisol97 og @joms?

affects: @fremtind/jkl-datepicker-react

ISSUES CLOSED: #2033
