### PR TITLE
fix(useAnimatedHeight): ignore bubbling transitions

### DIFF
--- a/packages/react-hooks/src/animation.tsx
+++ b/packages/react-hooks/src/animation.tsx
@@ -20,12 +20,14 @@ export function useAnimatedHeight<T extends HTMLElement>(
     const firstRender = useRef<boolean>(true);
     const prefersReducedMotion = useReducedMotion();
 
-    function handleTransitionEnd() {
+    function handleTransitionEnd(event: TransitionEvent) {
         const element = getElement(elementRef);
-        if (element) {
+
+        // Ignore bubbling transitions from within container
+        if (element && event.target === element) {
             element.removeAttribute("style");
+            options?.onTransitionEnd?.(isOpen);
         }
-        options?.onTransitionEnd?.(isOpen);
     }
 
     const runAnimation = useCallback(() => {


### PR DESCRIPTION
## 📥 Proposed changes

Ignorer `transition`-eventer fra inne i elementet som animeres. Dette hindrer at elementet lukkes for tidlig dersom det brukes CSS-animasjon inne i det, f.eks. ved `TextInput` som mister fokus.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-react-hooks
