### PR TITLE
revert(cypress): add back bot token to cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2.3.4
+              with:
+                  token: ${{ secrets.BOT_PUBLISH_TOKEN }}
 
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
@@ -34,7 +36,7 @@ jobs:
                   start: yarn serve
                   wait-on: "http://localhost:9000"
                   wait-on-timeout: 280
-                  command-prefix: 'percy exec -- npx'
+                  command-prefix: "percy exec -- npx"
 
             - name: Upload screenshots
               uses: actions/upload-artifact@v2.2.4


### PR DESCRIPTION
## 📥 Proposed changes

The bot access token is required to write snapshots back to the repo

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
