### PR TITLE
feat(feedback-react): add support for submit when unmounting the component

### DIFF
--- a/packages/feedback-react/src/BaseFeedback.tsx
+++ b/packages/feedback-react/src/BaseFeedback.tsx
@@ -51,6 +51,13 @@ export const FeedbackContext = createContext<{
     setValue: (next: FeedbackValue) => void;
 }>({ description: "", options: [], setValue: () => undefined });
 
+const CustomHeading: React.FC<
+    React.HTMLAttributes<HTMLHeadingElement> & { headingLevel?: "h1" | "h2" | "h3" | "h4" | "h5" | "p" }
+> = ({ headingLevel = "h3", children, ...elProps }) => {
+    const el = React.createElement(headingLevel, { ...elProps }, children);
+    return el;
+};
+
 export class BaseFeedback extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
@@ -102,8 +109,6 @@ export class BaseFeedback extends React.Component<Props, State> {
     }
 
     render() {
-        const H = this.props.headingLevel;
-
         return (
             <div className={cn("jkl-feedback", this.props.className)}>
                 <FeedbackContext.Provider
@@ -135,7 +140,9 @@ export class BaseFeedback extends React.Component<Props, State> {
                             })}
                             onSubmit={this.handleActiveSubmit}
                         >
-                            <H className="jkl-feedback__heading jkl-heading-large">{this.props.label}</H>
+                            <CustomHeading className="jkl-feedback__heading jkl-heading-large">
+                                {this.props.label}
+                            </CustomHeading>
                             {this.props.content}
                             <section
                                 className={cn("jkl-feedback__submit-wrapper", {

--- a/packages/feedback-react/src/BaseFeedback.tsx
+++ b/packages/feedback-react/src/BaseFeedback.tsx
@@ -88,6 +88,7 @@ export const BaseFeedback: FC<Props> = ({
             window.addEventListener("beforeunload", handleSubmit);
         }
         return () => {
+            handleSubmit();
             window.removeEventListener("beforeunload", handleSubmit);
         };
     }, [handleSubmit]);

--- a/packages/feedback-react/src/Feedback.test.tsx
+++ b/packages/feedback-react/src/Feedback.test.tsx
@@ -95,6 +95,15 @@ test("simplified should call onSubmit function with feedback value and message w
     expect(mockFn.mock.calls[0][0]).toStrictEqual({ feedbackValue: 3, message: "This is very nice" });
 });
 
+test("should call onSubmit function if the component is unmounted", () => {
+    const { unmount } = render(<Feedback label="feedback" description="some description" onSubmit={mockFn} />);
+
+    userEvent.click(screen.getByTestId("feedback-1"));
+    unmount();
+
+    expect(mockFn).toBeCalledTimes(1);
+});
+
 test.each([Feedback, SimplifiedFeedback])("Feedback should be a11y compliant", async (Component) => {
     const { container } = render(<Component description="feedback" label="feedback" onSubmit={mockFn} />);
     const inputMode = await axe(container);


### PR DESCRIPTION
affects: @fremtind/jkl-feedback-react## 📥 Proposed changes

Denne fikser i utgangspunktet at komponenten bare kjørte `onSubmit` aktivt, eller når hele fanen lukkes. Med denne fiksen kan komponenten kjøre `onSubmit` når komponenten blir unmountet ved f.eks route-endring.

Nå vil `onSubmit` bli kjørt forutsatt at minimum et smilefjes er satt ved enten trykk på knappen for å sende inn, unmount eller at fanen lukkes.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

## 💬 Further comments

Omskrivingen til en klassekomponent er for å få tilgang på `componentWillUnmount` som fungerer bedre enn å returnere en funksjon fra `useEffect`. Sistnevnte har blitt testet ganske grundig, men så aldri ut til å fungere stabilt nok.