### PR TITLE
fix(feedback): fiks en bug hvor en allerede lagret tilbakemelding ble lagret på nytt

### DIFF
--- a/packages/feedback-react/src/BaseFeedback.tsx
+++ b/packages/feedback-react/src/BaseFeedback.tsx
@@ -80,16 +80,25 @@ export const BaseFeedback: FC<Props> = ({
     const feedbackValuesRef = useRef({
         onSubmit,
         values: { feedbackValue, message },
+        feedbackSubmitted,
     });
 
+    useEffect(() => {
+        feedbackValuesRef.current.feedbackSubmitted = feedbackSubmitted;
+    }, [feedbackSubmitted]);
+
     const handleSubmit = useCallback(() => {
-        if (!feedbackSubmitted && feedbackValuesRef.current.values.feedbackValue !== undefined) {
+        if (
+            !feedbackValuesRef.current.feedbackSubmitted &&
+            feedbackValuesRef.current.values.feedbackValue !== undefined
+        ) {
             feedbackValuesRef.current.onSubmit(feedbackValuesRef.current.values as FeedbackPayload);
         }
-    }, [feedbackSubmitted]);
+    }, []);
 
     useEffect(() => {
         feedbackValuesRef.current = {
+            ...feedbackValuesRef.current,
             onSubmit,
             values: { feedbackValue, message },
         };

--- a/packages/feedback-react/src/Feedback.test.tsx
+++ b/packages/feedback-react/src/Feedback.test.tsx
@@ -103,6 +103,22 @@ test("should call onSubmit function if the component is unmounted", () => {
     expect(mockFn).toBeCalledTimes(1);
 });
 
+test("should not call onSubmit on unmount if feedback already is submitted", async () => {
+    const { unmount } = render(<Feedback label="feedback" description="some description" onSubmit={mockFn} />);
+
+    userEvent.click(screen.getByTestId("feedback-1"));
+    userEvent.type(screen.getByTestId("feedback-text"), "This is very nice");
+    userEvent.click(screen.getByTestId("submit-button"));
+
+    await screen.findByTestId("feedback-success");
+
+    expect(mockFn).toBeCalledTimes(1);
+
+    unmount();
+
+    expect(mockFn).toBeCalledTimes(1);
+});
+
 test.each([Feedback, SimplifiedFeedback])("Feedback should be a11y compliant", async (Component) => {
     const { container } = render(<Component description="feedback" label="feedback" onSubmit={mockFn} />);
     const inputMode = await axe(container);


### PR DESCRIPTION
affects: @fremtind/jkl-feedback-react

## 📥 Proposed changes

Det var en bug hvor en lagret tilbakemelding ble sendt på nytt når man forlot siden.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

## 💬 Further comments

Jeg prøvde å flytte hele `feedbackSubmitted` inn i `feedbackValuesRef`, men da fikk state oppdateringen problemer. Litt usikker på hvorfor dette skjedde, men det ser ut til å funke fint å representere UI med state og business-logikk med ref.