### PR TITLE
fix(dark mode): use correct bg-color in dark mode

### DIFF
--- a/packages/cookie-consent/cookie-consent.scss
+++ b/packages/cookie-consent/cookie-consent.scss
@@ -1,3 +1,5 @@
+@use "~@fremtind/jkl-core/jkl";
+
 @import "~@fremtind/jkl-core/variables/all";
 @import "~@fremtind/jkl-core/mixins/all";
 
@@ -37,7 +39,8 @@ $container-width--compact: rem(320px);
     padding: $layout-spacing--medium $layout-spacing--medium rem(30px) $layout-spacing--medium;
     min-width: $container-width--compact;
     max-width: $container-width;
-    background: $hvit;
+    background-color: var(--jkl-background-color);
+    background-color: jkl.$color-snohvit;
     box-shadow: $drop-shadow--large;
     transition: 0.2s;
 


### PR DESCRIPTION
## 📥 Proposed changes

Fiks bakgrunnsfargen til CookieConsent i dark mode

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-cookie-consent