### PR TITLE
fix: changed when withLoader div shows in button

### DIFF
--- a/packages/button-react/documentation/style.scss
+++ b/packages/button-react/documentation/style.scss
@@ -3,7 +3,6 @@
 .jkl-button-example {
     display: flex;
     flex-direction: column;
-    align-items: center;
     justify-content: space-between;
     width: 100%;
 

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -61,14 +61,17 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
                         >
                             {children}
                         </BaseButton>
-                        <div className="jkl-button-wrapper__loader jkl-layout-spacing--small-top">
-                            <Loader
-                                textDescription={loader.textDescription}
-                                negative={inverted}
-                                aria-hidden={!!loader.showLoader}
-                                inline={true}
-                            />
-                        </div>
+
+                        {loader?.showLoader && (
+                            <div className="jkl-button-wrapper__loader jkl-layout-spacing--small-top">
+                                <Loader
+                                    textDescription={loader.textDescription}
+                                    negative={inverted}
+                                    aria-hidden={!!loader.showLoader}
+                                    inline={true}
+                                />
+                            </div>
+                        )}
                     </div>
                 </div>
             );


### PR DESCRIPTION
affects: @fremtind/jkl-button-react

## 📥 Proposed changes

Knappene har en bug i prod der de utvider seg når de starter å loade og muligens flytter innhold på siden. En av internsene fant denne buggen når de skulle ta i bruk dekningsvelgeren som vi bruker i smartforhandler.  Dette er en quick fix for at det ikke skal skje. 

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

## 💬 Further comments

