### PR TITLE
DRAFT feat: legg til støtte for addon på hamburger

### DIFF
--- a/packages/content-toggle-react/package.json
+++ b/packages/content-toggle-react/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.9.0",
-        "@fremtind/jkl-content-toggle": "^0.1.1"
+        "@fremtind/jkl-content-toggle": "^1.2.0"
     },
     "devDependencies": {
         "@fremtind/jkl-portal-components": "^0.12.0"

--- a/packages/content-toggle-react/src/ContentToggle.tsx
+++ b/packages/content-toggle-react/src/ContentToggle.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, FC, useState, useEffect } from "react";
+import React, { ReactNode, FC, useState, useEffect, useRef } from "react";
 import cn from "classnames";
 
 export const ContentToggle: FC<{
@@ -11,11 +11,30 @@ export const ContentToggle: FC<{
     // looking for actual change and then enable animating prevents initial blinking and premature animations
     const [initialShowSecondary] = useState(showSecondary);
     const [initial, setInitial] = useState(true);
+    const sliderRef = useRef<HTMLElement>(null);
+
     useEffect(() => {
         if (showSecondary !== initialShowSecondary) {
             setInitial(false);
         }
     }, [showSecondary, initialShowSecondary]);
+
+    useEffect(() => {
+        if (sliderRef.current) {
+            const sliderChildren = sliderRef.current.children;
+
+            let width = 0;
+
+            for (let i = 0; i < sliderChildren.length; i++) {
+                const child = sliderChildren[i];
+                if (child.clientWidth > width) {
+                    width = child.clientWidth;
+                }
+            }
+
+            sliderRef.current.style.width = `${width}px`;
+        }
+    }, [sliderRef]);
 
     return (
         <>
@@ -27,6 +46,7 @@ export const ContentToggle: FC<{
                         "jkl-content-toggle--show-first": !showSecondary,
                         "jkl-content-toggle--show-second": showSecondary,
                     })}
+                    ref={sliderRef}
                 >
                     <span className="jkl-content-toggle__first" aria-hidden={showSecondary}>
                         {children}

--- a/packages/hamburger-react/documentation/Example.tsx
+++ b/packages/hamburger-react/documentation/Example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { ExampleComponentProps } from "@fremtind/jkl-portal-components";
+import { ContentToggle } from "@fremtind/jkl-content-toggle-react";
 import { Hamburger } from "../src";
 
 const Example = ({ boolValues }: ExampleComponentProps) => {
@@ -10,10 +11,20 @@ const Example = ({ boolValues }: ExampleComponentProps) => {
             isOpen={isOpen}
             inverted={boolValues && boolValues["Invertert"]}
             onClick={() => setIsOpen(!isOpen)}
-            actionLabel={{
-                close: "Lukk",
-                open: "Meny",
-            }}
+            addon={
+                boolValues &&
+                boolValues["Addon"] && (
+                    <ContentToggle
+                        secondary="Lukk"
+                        showSecondary={isOpen}
+                        variant="fade"
+                        className="jkl-hamburger-example__addon"
+                    >
+                        Meny
+                    </ContentToggle>
+                )
+            }
+            addonPosition="before"
         />
     );
 };

--- a/packages/hamburger-react/documentation/index.tsx
+++ b/packages/hamburger-react/documentation/index.tsx
@@ -19,6 +19,6 @@ import "@fremtind/jkl-hamburger/hamburger.css";
 initTabListener();
 
 ReactDOM.render(
-    <DevExample knobs={{ boolProps: ["Invertert"] }} component={Example} />,
+    <DevExample knobs={{ boolProps: ["Addon", "Invertert"] }} component={Example} />,
     document.getElementById("app"),
 );

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ContentToggle } from "@fremtind/jkl-content-toggle-react";
 import classnames from "classnames";
 
 interface Props {
@@ -9,10 +8,8 @@ interface Props {
     /** @deprecated use data-theme["dark|light"] where possible in stead. this prop is to support IE11 */
     inverted?: boolean;
     description?: string;
-    actionLabel?: {
-        open: string;
-        close: string;
-    };
+    addon?: React.ReactNode;
+    addonPosition?: "before" | "after";
 }
 
 export const Hamburger = ({
@@ -21,13 +18,16 @@ export const Hamburger = ({
     inverted = false,
     description = "Hovedmeny",
     className = "",
-    actionLabel,
+    addon,
+    addonPosition = "after",
 }: Props) => {
     const componentClassname = classnames(
         "jkl-hamburger",
+        `jkl-hamburger--addon-${addonPosition}`,
         {
             "jkl-hamburger--is-open": isOpen,
             "jkl-hamburger--inverted": inverted,
+            "jkl-hamburger--has-addon": addon,
         },
         className,
     );
@@ -40,17 +40,10 @@ export const Hamburger = ({
             className={componentClassname}
             data-testid="jkl-hamburger"
         >
-            <span className="jkl-hamburger__inner"></span>
-            {actionLabel && (
-                <ContentToggle
-                    className="jkl-hamburger__label"
-                    secondary={actionLabel.close}
-                    showSecondary={isOpen}
-                    variant="fade"
-                >
-                    {actionLabel.open}
-                </ContentToggle>
-            )}
+            <span className="jkl-hamburger__inner-wrapper">
+                <span className="jkl-hamburger__inner"></span>
+            </span>
+            {addon && <span className="jkl-hamburger__addon">{addon}</span>}
         </button>
     );
 };

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -36,6 +36,36 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
     justify-content: center;
     position: relative;
 
+    &--has-addon {
+        width: auto;
+
+        &.jkl-hamburger--addon-before {
+            flex-direction: row-reverse;
+
+            & .jkl-hamburger__addon {
+                justify-content: flex-end;
+                text-align: right;
+                transform-origin: right;
+            }
+        }
+    }
+
+    &__inner-wrapper {
+        width: $bounding-touch-size;
+        display: flex;
+        justify-content: center;
+        height: 100%;
+    }
+
+    &__addon {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        transform: scale(1);
+        @include motion(standard, expressive);
+        transition-property: transform;
+    }
+
     color: $hamburger-color;
     color: var(--hamburger-color);
 
@@ -50,9 +80,8 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
             }
         }
 
-        .jkl-hamburger__label .jkl-content-toggle__slider {
+        .jkl-hamburger__addon {
             transform: scale(1.2);
-            top: 0.4rem;
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,20 +1473,12 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fremtind/jkl-content-toggle@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@fremtind/jkl-content-toggle/-/jkl-content-toggle-0.1.1.tgz#e8f4175411b53bb1815029c17892458b74804ae4"
-  integrity sha512-dwnd31kwFAYsPcRlc3v3qz5YNxeFLUroK26mjHFy+6Y1+OGjJElbLb14o3lXmzsoeRzOTTJEjIxfYAsbWWx0ng==
+"@fremtind/jkl-content-toggle@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@fremtind/jkl-content-toggle/-/jkl-content-toggle-1.2.0.tgz#4fa2e9a13dc713740518c907942b016b4b16df5a"
+  integrity sha512-YjzHFvwWg0JkwYSBgCXWSCROYsLKlEOSHluqMaHIvvUltcUKys/D1hrz+e+CjEcydgoeShTHKZkzSGaELJcSvQ==
   dependencies:
-    "@fremtind/jkl-core" "^6.0.1"
-
-"@fremtind/jkl-core@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@fremtind/jkl-core/-/jkl-core-6.0.1.tgz#766a45d29f9db8e573687fa71611af1e7a42ab9c"
-  integrity sha512-eciTHGB2bfkywLpYdO0IdP14o7ooh2nFg/SO+GTAfg/PNtglIdFGFPjkh5PoHMMdBa+DBBgBA7VEaG0l4aGgdQ==
-  dependencies:
-    "@babel/runtime" "^7.9.0"
-    classnames "^2.2.6"
+    "@fremtind/jkl-core" "^7.0.0"
 
 "@gatsbyjs/reach-router@^1.3.6":
   version "1.3.6"


### PR DESCRIPTION
affects: @fremtind/jkl-content-toggle-react, @fremtind/jkl-hamburger-react, @fremtind/jkl-hamburger

## 📥 Proposed changes

Hamburgeren trenger støtte for å kunne legge tekst på begge sider av seg selv.

Jeg har endret APIet til å ta en react-node som blir lagt på som en addon. Dunno om dette er en bedre løsning enn `actionLabel`. Tanken var at dette gir bedre kontroll over komponenten som ligger ved siden av hamburgeren. Hovedproblemet er dog at jeg ikke klarer å få posisjonert `ContentToggle` på en god måte. Jeg mistenker at dette kommer av bruken av absolute posisjonering og at bredden ikke propagerer oppover treet. Men i `ContentToggle` isolert fungerer dette helt fint...   
Her trenger jeg et sett med øyne til å se på en løsning. Ønsker også feedback på om API-endringen egentlig er nødvendig.

## ☑️ Submission checklist

-   [ ] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

