### PR TITLE
Legg til mer snadder på hamburger, og gi den bedre breddekontroll

### DIFF
--- a/packages/content-toggle-react/documentation/ContentToggle.mdx
+++ b/packages/content-toggle-react/documentation/ContentToggle.mdx
@@ -13,7 +13,19 @@ import { Example } from "./Example";
     toggler mellom, så er content-toggle en måte å løse det på en elegant måte.
 </Ingress>
 
-<ComponentExample knobs={{ boolProps: ["Flip", "Fade"] }} component={Example} />
+<ComponentExample
+    knobs={{
+        boolProps: ["Bytt verdi"],
+        choiceProps: [
+            {
+                name: "Variant",
+                values: ["flip", "fade"],
+                defaultValue: 0,
+            },
+        ],
+    }}
+    component={Example}
+/>
 
 Content-toggle komponenten tar inn to ReactNoder, det kan være strenger eller sammensatte komponenter, men bør ikke være store element.
 

--- a/packages/content-toggle-react/documentation/Example.tsx
+++ b/packages/content-toggle-react/documentation/Example.tsx
@@ -2,18 +2,14 @@ import React from "react";
 import { ExampleComponentProps } from "@fremtind/jkl-portal-components/src";
 import { ContentToggle } from "../src";
 
-export const Example: React.FC<ExampleComponentProps> = ({ boolValues }) => (
+export const Example: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => (
     <div className="jkl-body">
-        <ContentToggle showSecondary={!!boolValues?.["Flip"]} secondary="World">
-            Hello
-        </ContentToggle>
         <ContentToggle
-            showSecondary={!!boolValues?.["Fade"]}
-            variant="fade"
-            secondary="out"
-            className="jkl-layout-spacing--medium-top"
+            variant={choiceValues?.["Variant"] as "flip" | "fade"}
+            showSecondary={!!boolValues?.["Bytt verdi"]}
+            secondary="World!"
         >
-            Fade
+            Hello
         </ContentToggle>
     </div>
 );

--- a/packages/content-toggle-react/documentation/index.tsx
+++ b/packages/content-toggle-react/documentation/index.tsx
@@ -18,6 +18,18 @@ import "@fremtind/jkl-content-toggle/content-toggle.css";
 initTabListener();
 
 ReactDOM.render(
-    <DevExample knobs={{ boolProps: ["Flip", "Fade"] }} component={Example} />,
+    <DevExample
+        knobs={{
+            boolProps: ["Bytt verdi"],
+            choiceProps: [
+                {
+                    name: "Variant",
+                    values: ["flip", "fade"],
+                    defaultValue: 0,
+                },
+            ],
+        }}
+        component={Example}
+    />,
     document.getElementById("app"),
 );

--- a/packages/content-toggle-react/src/ContentToggle.tsx
+++ b/packages/content-toggle-react/src/ContentToggle.tsx
@@ -18,24 +18,19 @@ export const ContentToggle: FC<{
     }, [showSecondary, initialShowSecondary]);
 
     return (
-        <>
-            <span className={`jkl-content-toggle jkl-content-toggle--${variant} ${className}`}>
-                <span
-                    className={cn("jkl-content-toggle__slider", {
-                        "jkl-content-toggle__slider--initial": initial,
-                        "jkl-content-toggle__slider--animate": !initial,
-                        "jkl-content-toggle--show-first": !showSecondary,
-                        "jkl-content-toggle--show-second": showSecondary,
-                    })}
-                >
-                    <span className="jkl-content-toggle__first" aria-hidden={showSecondary}>
-                        {children}
-                    </span>
-                    <span className="jkl-content-toggle__secondary" aria-hidden={!showSecondary}>
-                        {secondary}
-                    </span>
+        <span className={cn("jkl-content-toggle", `jkl-content-toggle--${variant}`, className)}>
+            <span
+                className="jkl-content-toggle__slider"
+                data-show={showSecondary ? "second" : "first"}
+                data-initial={initial}
+            >
+                <span className="jkl-content-toggle__first" aria-hidden={showSecondary}>
+                    {children}
+                </span>
+                <span className="jkl-content-toggle__second" aria-hidden={!showSecondary}>
+                    {secondary}
                 </span>
             </span>
-        </>
+        </span>
     );
 };

--- a/packages/content-toggle/content-toggle.scss
+++ b/packages/content-toggle/content-toggle.scss
@@ -30,79 +30,69 @@ $half-animation-duration: calc(#{$animation-duration} / 2);
     overflow: hidden;
     display: block;
 
-    &--flip {
-        .jkl-content-toggle {
-            &--show-first {
+    &__slider {
+        .jkl-content-toggle--flip > & {
+            display: flex;
+            flex-direction: column;
+            @include motion(standard, expressive);
+            transition-property: transform;
+
+            &[data-show="first"] {
                 transform: translateY(0);
             }
 
-            &--show-second {
+            &[data-show="second"] {
                 transform: translateY(-50%);
             }
+        }
 
-            &__slider {
-                display: flex;
-                flex-direction: column;
-                transition-property: transform;
-                @include motion(standard, expressive);
-                @media (prefers-reduced-motion) {
-                    transition-property: none;
+        .jkl-content-toggle--fade > & {
+            animation-duration: $half-animation-duration;
+
+            &[data-initial="true"] {
+                animation-duration: 0ms;
+                & > .jkl-content-toggle__first,
+                & > .jkl-content-toggle__second {
+                    animation-delay: 0ms !important;
                 }
             }
         }
     }
 
-    &--fade {
-        .jkl-content-toggle {
-            &__first,
-            &__secondary {
-                animation-fill-mode: both;
-                position: absolute;
-                animation-duration: inherit;
-                transition-property: opacity;
-            }
+    &__first,
+    &__second {
+        .jkl-content-toggle--fade & {
+            display: block;
+            animation-fill-mode: both;
+            animation-duration: inherit;
+            transition-property: opacity;
+        }
+    }
 
-            &__slider {
-                animation-duration: $half-animation-duration;
+    &__first {
+        .jkl-content-toggle--fade [data-show="first"] & {
+            animation-name: fadeIn;
+            animation-delay: $half-animation-duration;
+            visibility: hidden;
+        }
+        .jkl-content-toggle--fade [data-show="second"] & {
+            animation-name: fadeOut;
+            animation-delay: 0ms;
+        }
+    }
 
-                &--initial {
-                    animation-duration: 0ms;
-                    .jkl-content-toggle__first,
-                    .jkl-content-toggle__secondary {
-                        animation-delay: 0ms !important;
-                    }
-                }
-
-                &--animate {
-                    animation-duration: $half-animation-duration;
-                }
-            }
-
-            &--show-first {
-                .jkl-content-toggle__first {
-                    animation-name: fadeIn;
-                    animation-delay: $half-animation-duration;
-                    visibility: hidden;
-                }
-
-                .jkl-content-toggle__secondary {
-                    animation-name: fadeOut;
-                    animation-delay: 0ms;
-                    visibility: visible;
-                }
-            }
-
-            &--show-second {
-                .jkl-content-toggle__first {
-                    animation-delay: 0ms;
-                    animation-name: fadeOut;
-                }
-
-                .jkl-content-toggle__secondary {
-                    animation-delay: $half-animation-duration;
-                    animation-name: fadeIn;
-                }
-            }
+    &__second {
+        .jkl-content-toggle--fade & {
+            transform: translateY(-100%);
+        }
+        .jkl-content-toggle--fade [data-show="first"] & {
+            animation-name: fadeOut;
+            animation-delay: 0ms;
+            visibility: visible;
+        }
+        .jkl-content-toggle--fade [data-show="second"] & {
+            animation-name: fadeIn;
+            animation-delay: $half-animation-duration;
         }
     }
 }

--- a/packages/hamburger-react/documentation/Example.tsx
+++ b/packages/hamburger-react/documentation/Example.tsx
@@ -10,10 +10,14 @@ const Example = ({ boolValues }: ExampleComponentProps) => {
             isOpen={isOpen}
             inverted={boolValues && boolValues["Invertert"]}
             onClick={() => setIsOpen(!isOpen)}
-            actionLabel={{
-                close: "Lukk",
-                open: "Meny",
-            }}
+            actionLabel={
+                boolValues && boolValues["Med tekst"]
+                    ? {
+                          close: "Lukk",
+                          open: "Meny",
+                      }
+                    : undefined
+            }
         />
     );
 };

--- a/packages/hamburger-react/documentation/Example.tsx
+++ b/packages/hamburger-react/documentation/Example.tsx
@@ -15,6 +15,7 @@ const Example = ({ boolValues }: ExampleComponentProps) => {
                     ? {
                           close: "Lukk",
                           open: "Meny",
+                          position: boolValues["Tekst før knapp"] ? "before" : "after",
                       }
                     : undefined
             }

--- a/packages/hamburger-react/documentation/Example.tsx
+++ b/packages/hamburger-react/documentation/Example.tsx
@@ -16,6 +16,7 @@ const Example = ({ boolValues }: ExampleComponentProps) => {
                           close: "Lukk",
                           open: "Meny",
                           position: boolValues["Tekst før knapp"] ? "before" : "after",
+                          animated: boolValues["Skaler tekst ved hover"],
                       }
                     : undefined
             }

--- a/packages/hamburger-react/documentation/Hamburger.mdx
+++ b/packages/hamburger-react/documentation/Hamburger.mdx
@@ -7,4 +7,7 @@ group: layout
 
 import Example from "./Example";
 
-<ComponentExample knobs={{ boolProps: ["Invertert"] }} component={Example} />
+<ComponentExample
+    knobs={{ boolProps: ["Invertert", "Med tekst", "Tekst før knapp", "Skaler tekst ved hover"] }}
+    component={Example}
+/>

--- a/packages/hamburger-react/documentation/index.tsx
+++ b/packages/hamburger-react/documentation/index.tsx
@@ -19,6 +19,9 @@ import "@fremtind/jkl-hamburger/hamburger.css";
 initTabListener();
 
 ReactDOM.render(
-    <DevExample knobs={{ boolProps: ["Invertert", "Med tekst", "Tekst før knapp"] }} component={Example} />,
+    <DevExample
+        knobs={{ boolProps: ["Invertert", "Med tekst", "Tekst før knapp", "Skaler tekst ved hover"] }}
+        component={Example}
+    />,
     document.getElementById("app"),
 );

--- a/packages/hamburger-react/documentation/index.tsx
+++ b/packages/hamburger-react/documentation/index.tsx
@@ -19,6 +19,6 @@ import "@fremtind/jkl-hamburger/hamburger.css";
 initTabListener();
 
 ReactDOM.render(
-    <DevExample knobs={{ boolProps: ["Invertert", "Med tekst"] }} component={Example} />,
+    <DevExample knobs={{ boolProps: ["Invertert", "Med tekst", "Tekst før knapp"] }} component={Example} />,
     document.getElementById("app"),
 );

--- a/packages/hamburger-react/documentation/index.tsx
+++ b/packages/hamburger-react/documentation/index.tsx
@@ -19,6 +19,6 @@ import "@fremtind/jkl-hamburger/hamburger.css";
 initTabListener();
 
 ReactDOM.render(
-    <DevExample knobs={{ boolProps: ["Invertert"] }} component={Example} />,
+    <DevExample knobs={{ boolProps: ["Invertert", "Med tekst"] }} component={Example} />,
     document.getElementById("app"),
 );

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -12,6 +12,8 @@ interface Props {
     actionLabel?: {
         open: string;
         close: string;
+        animated?: boolean;
+        position?: "before" | "after";
     };
 }
 
@@ -28,9 +30,15 @@ export const Hamburger = ({
         {
             "jkl-hamburger--is-open": isOpen,
             "jkl-hamburger--inverted": inverted,
+            "jkl-hamburger--label-before": actionLabel?.position === "before",
+            "jkl-hamburger--label-after": actionLabel && actionLabel.position !== "before",
         },
         className,
     );
+
+    const labelClassname = classnames("jkl-hamburger__label", {
+        "jkl-hamburger__label--animated": actionLabel?.animated,
+    });
 
     return (
         <button
@@ -43,7 +51,7 @@ export const Hamburger = ({
             <span className="jkl-hamburger__inner"></span>
             {actionLabel && (
                 <ContentToggle
-                    className="jkl-hamburger__label"
+                    className={labelClassname}
                     secondary={actionLabel.close}
                     showSecondary={isOpen}
                     variant="fade"

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { ContentToggle } from "@fremtind/jkl-content-toggle-react";
 import classnames from "classnames";
 
@@ -22,7 +22,7 @@ export const Hamburger = ({
     onClick,
     inverted = false,
     description = "Hovedmeny",
-    className = "",
+    className,
     actionLabel,
 }: Props) => {
     const componentClassname = classnames(
@@ -30,24 +30,11 @@ export const Hamburger = ({
         {
             "jkl-hamburger--is-open": isOpen,
             "jkl-hamburger--inverted": inverted,
-            "jkl-hamburger--label-before": actionLabel?.position === "before",
-            "jkl-hamburger--label-after": actionLabel && actionLabel.position !== "before",
+            "jkl-hamburger--label-before": actionLabel && actionLabel.position !== "after",
+            "jkl-hamburger--label-after": actionLabel?.position === "after",
         },
         className,
     );
-
-    const longestLabelLength = useMemo(() => {
-        if (!actionLabel) {
-            return undefined;
-        }
-
-        let length = actionLabel.open.length;
-        if (actionLabel.close.length > length) {
-            length = actionLabel.close.length;
-        }
-
-        return length;
-    }, [actionLabel]);
 
     const labelClassname = classnames("jkl-hamburger__label", {
         "jkl-hamburger__label--animated": actionLabel?.animated,
@@ -60,16 +47,8 @@ export const Hamburger = ({
             onClick={onClick}
             className={componentClassname}
             data-testid="jkl-hamburger"
-            style={
-                actionLabel
-                    ? {
-                          //  style calculated off touch size and label length with multiplier to account for uppercase letters
-                          width: `calc(3rem + ${(longestLabelLength ?? 0) * 1.75}ch`,
-                      }
-                    : undefined
-            }
         >
-            <span className="jkl-hamburger__inner"></span>
+            <span className="jkl-hamburger__lines"></span>
             {actionLabel && (
                 <ContentToggle
                     className={labelClassname}

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { ContentToggle } from "@fremtind/jkl-content-toggle-react";
 import classnames from "classnames";
 
@@ -36,6 +36,19 @@ export const Hamburger = ({
         className,
     );
 
+    const longestLabelLength = useMemo(() => {
+        if (!actionLabel) {
+            return undefined;
+        }
+
+        let length = actionLabel.open.length;
+        if (actionLabel.close.length > length) {
+            length = actionLabel.close.length;
+        }
+
+        return length;
+    }, [actionLabel]);
+
     const labelClassname = classnames("jkl-hamburger__label", {
         "jkl-hamburger__label--animated": actionLabel?.animated,
     });
@@ -47,6 +60,14 @@ export const Hamburger = ({
             onClick={onClick}
             className={componentClassname}
             data-testid="jkl-hamburger"
+            style={
+                actionLabel
+                    ? {
+                          //  style calculated off touch size and label length with multiplier to account for uppercase letters
+                          width: `calc(3rem + ${(longestLabelLength ?? 0) * 1.75}ch`,
+                      }
+                    : undefined
+            }
         >
             <span className="jkl-hamburger__inner"></span>
             {actionLabel && (

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -30,8 +30,8 @@ export const Hamburger = ({
         {
             "jkl-hamburger--is-open": isOpen,
             "jkl-hamburger--inverted": inverted,
-            "jkl-hamburger--label-before": actionLabel && actionLabel.position !== "after",
-            "jkl-hamburger--label-after": actionLabel?.position === "after",
+            "jkl-hamburger--label-before": actionLabel?.position === "before",
+            "jkl-hamburger--label-after": actionLabel && actionLabel.position !== "before",
         },
         className,
     );

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -27,7 +27,6 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
     @include reset-outline;
     border: none;
     outline: none;
-    display: flex;
     cursor: pointer;
     background-color: transparent;
     height: $bounding-touch-size;
@@ -38,6 +37,15 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
 
     color: $hamburger-color;
     color: var(--hamburger-color);
+
+    &--label-before {
+        transform: rotate(180deg);
+
+        .jkl-content-toggle__first,
+        .jkl-content-toggle__secondary {
+            transform: rotate(180deg);
+        }
+    }
 
     &:hover {
         .jkl-hamburger__inner {
@@ -81,14 +89,14 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
         position: absolute;
         display: block;
         top: 50%;
-        transform: translateY(-50%);
-        transition-timing-function: ease;
+        transform: translateX(20%);
 
         &::before,
         &::after {
             content: "";
             display: block;
             transition-property: transform;
+            transition-timing-function: ease;
             transition-timing-function: ease;
         }
 
@@ -135,7 +143,7 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
 
         & .jkl-hamburger__inner {
             margin: auto;
-            transform: rotate(-180deg);
+            transform: rotate(-180deg) translateX(-25%);
             background-color: transparent;
         }
         & .jkl-hamburger__inner::before {

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -50,7 +50,7 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
             }
         }
 
-        .jkl-hamburger__label .jkl-content-toggle__slider {
+        .jkl-hamburger__label.jkl-hamburger__label--animated .jkl-content-toggle__slider {
             transform: scale(1.2);
             top: 0.4rem;
         }
@@ -66,7 +66,7 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
     &__label {
         .jkl-content-toggle__slider {
             position: absolute;
-            left: calc(#{$hamburger-icon-width} * 1.5);
+            left: calc(#{$hamburger-icon-width} * 0.9);
             top: 0.5rem;
             transition-property: transform top;
             transform-origin: center;

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -1,5 +1,6 @@
 @use "~@fremtind/jkl-core/jkl";
 @import "~@fremtind/jkl-core/mixins/all.scss";
+@import "~@fremtind/jkl-core/variables/all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
 $bounding-touch-size: rem(48px);
@@ -30,74 +31,35 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
     cursor: pointer;
     background-color: transparent;
     height: $bounding-touch-size;
-    width: $bounding-touch-size;
-    padding: 0;
+    min-width: $bounding-touch-size;
+    display: flex;
+    flex-direction: row;
+    padding: $component-spacing--small;
     justify-content: center;
+    align-items: center;
     position: relative;
 
     color: $hamburger-color;
     color: var(--hamburger-color);
 
-    &--label-before {
-        transform: rotate(180deg);
+    @include jkl.text-style("body");
 
-        .jkl-content-toggle__first,
-        .jkl-content-toggle__secondary {
-            transform: rotate(180deg);
-        }
+    &__label.jkl-content-toggle {
+        height: rem(32px);
+        @include motion(standard, expressive);
+        transform-origin: left;
     }
 
-    &:hover {
-        .jkl-hamburger__inner {
-            &::before {
-                top: calc(#{$hamburger-line-spacing} * 1.5);
-            }
-
-            &::after {
-                bottom: calc(#{$hamburger-line-spacing} * 1.5);
-            }
-        }
-
-        .jkl-hamburger__label.jkl-hamburger__label--animated .jkl-content-toggle__slider {
-            transform: scale(1.2);
-            top: 0.4rem;
-        }
-    }
-
-    @include keyboard-navigation {
-        &:focus {
-            box-shadow: 0 0 0 rem(2px) $hamburger-focus-color;
-            box-shadow: 0 0 0 rem(2px) var(--hamburger-focus-color);
-        }
-    }
-
-    &__label {
-        .jkl-content-toggle__slider {
-            position: absolute;
-            left: calc(#{$hamburger-icon-width} * 0.9);
-            top: 0.5rem;
-            transition-property: transform top;
-            transform-origin: center;
-            transform: scale(1);
-
-            @include jkl.text-style("body");
-            @include motion(standard, expressive);
-        }
-    }
-
-    &__inner {
-        position: absolute;
-        display: block;
-        top: 50%;
-        transform: translateX(20%);
+    &__lines {
+        position: relative;
+        transform-origin: center;
 
         &::before,
         &::after {
             content: "";
             display: block;
-            transition-property: transform;
-            transition-timing-function: ease;
-            transition-timing-function: ease;
+            position: absolute;
+            transform-origin: center;
         }
 
         &::before {
@@ -108,49 +70,90 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
         }
     }
 
-    &__inner,
-    &__inner::before,
-    &__inner::after {
+    &__lines,
+    &__lines::before,
+    &__lines::after {
         width: $hamburger-icon-width;
         height: $hamburger-line-height;
         background-color: currentColor;
-        position: absolute;
 
         transition-property: background-color, transform, top, bottom;
 
         @include motion(standard, expressive);
     }
 
+    &:hover {
+        .jkl-hamburger__lines {
+            &::before {
+                top: calc(#{$hamburger-line-spacing} * 1.5);
+            }
+
+            &::after {
+                bottom: calc(#{$hamburger-line-spacing} * 1.5);
+            }
+        }
+
+        .jkl-hamburger__label.jkl-hamburger__label--animated {
+            transform: scale(1.2);
+        }
+    }
+
+    @include keyboard-navigation {
+        &:focus {
+            box-shadow: 0 0 0 rem(2px) $hamburger-focus-color;
+            box-shadow: 0 0 0 rem(2px) var(--hamburger-focus-color);
+        }
+    }
+
+    &--label-after {
+        text-align: left;
+
+        & .jkl-hamburger__lines {
+            margin-right: $component-spacing--small;
+        }
+    }
+
+    &--label-before {
+        flex-direction: row-reverse;
+        text-align: right;
+
+        & .jkl-hamburger__lines {
+            margin-left: $component-spacing--small;
+        }
+
+        & .jkl-hamburger__label {
+            transform-origin: right;
+        }
+    }
+
     &--is-open {
         &:hover {
-            .jkl-hamburger__inner::before {
+            .jkl-hamburger__lines::before {
                 top: 0;
                 transform: rotate(-45deg) scale3d(1.25, 1, 1);
             }
-            .jkl-hamburger__inner::after {
+            .jkl-hamburger__lines::after {
                 bottom: 0;
                 transform: rotate(45deg) scale3d(1.25, 1, 1);
             }
         }
 
-        & .jkl-hamburger {
-            &__inner,
-            &__inner::before,
-            &__inner::after {
-                width: calc(#{$hamburger-icon-width} - 3px);
-            }
+        &__lines::before,
+        &__lines::after {
+            width: calc(#{$hamburger-icon-width} - 3px);
         }
 
-        & .jkl-hamburger__inner {
-            margin: auto;
-            transform: rotate(-180deg) translateX(-25%);
+        & .jkl-hamburger__lines {
+            transform: rotate(-180deg);
             background-color: transparent;
         }
-        & .jkl-hamburger__inner::before {
+
+        & .jkl-hamburger__lines::before {
             top: 0;
             transform: rotate(-45deg);
         }
-        & .jkl-hamburger__inner::after {
+
+        & .jkl-hamburger__lines::after {
             bottom: 0;
             transform: rotate(45deg);
         }


### PR DESCRIPTION
## 📥 Proposed changes

Den tidligere API-endringen for å legge til `actionLabel` er utvidet med støtte for å kunne slå på animasjon, og muligheten til å plassere teksten til høyre eller venstre for hamburgeren. 

Plassering er løst med å rotere først hele elementet, og så rotere tekstene igjen. Dette var det eneste jeg fikk til å fungere på en god måte. Grunnen til at det har vært trøblete er at children er absolutt posisjonerte, som ikke gir parent et godt forhold til bredde.
Sistnevnte har jeg prøvd å løse ved å kalkulere en gjetning på bredde, men dette fungerer mest for å få hamburgermenyen til å ta en mer riktig plass i DOM-treet. 

Jeg er åpen for forslag på bedre løsninger enn å bruke rotasjon.

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
