### PR TITLE
fix(text-styles): use correct weight for heading 2 on small screens

### DIFF
--- a/packages/core/mixins/_text-style.scss
+++ b/packages/core/mixins/_text-style.scss
@@ -32,7 +32,7 @@ $_text-styles: (
         "small-screen": (
             font-size: typography.$font-size-5,
             line-height: typography.$line-height-3,
-            font-weight: typography.$weight-bold,
+            font-weight: typography.$weight-normal,
         ),
         "large-screen": (
             font-size: typography.$font-size-8,


### PR DESCRIPTION
## 📥 Proposed changes

Fikser en bug der tekststilen `heading 2` har fet skrift på små skjermer

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

affects: @fremtind/jkl-core
