### PR TITLE
fix: add hover color and cursor for select

### DIFF
--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -20,6 +20,24 @@ describe("Select", () => {
         expect(dropdown).toHaveClass("jkl-select--inline");
     });
 
+    it("should open when clicked", () => {
+        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+
+        const button = screen.getByTestId("jkl-select__button");
+
+        userEvent.click(button);
+        expect(screen.getByText("drop")).toBeVisible();
+    });
+
+    it("should open when arrow down is pressed", () => {
+        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+
+        const button = screen.getByTestId("jkl-select__button");
+
+        userEvent.type(button, "{arrowdown}");
+        expect(screen.getByText("drop")).toBeVisible();
+    });
+
     it("should use the specified value", () => {
         const onChange = jest.fn();
         const value = "drop";

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore: wait for core-components to expose types
 import CoreToggle from "@nrk/core-toggle/jsx";
-import React, { FocusEvent, forwardRef, useEffect, useRef, useState } from "react";
+import React, { FocusEvent, forwardRef, useEffect, useRef, useState, KeyboardEvent } from "react";
 import { nanoid } from "nanoid";
 import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair, DataTestAutoId } from "@fremtind/jkl-core";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
@@ -157,6 +157,13 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
             }
         }
 
+        // add support for opening dropdown with arrowkey down as expected from native select
+        function handleArrowDown(e: KeyboardEvent<HTMLButtonElement>) {
+            if (e.key === "ArrowDown" && !dropdownIsShown) {
+                buttonRef.current?.click();
+            }
+        }
+
         // Handle focus and blur of hidden select element
         useEffect(() => {
             const select = selectRef.current;
@@ -228,6 +235,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
                         aria-haspopup="listbox"
                         onBlur={handleBlur}
                         onFocus={handleFocus}
+                        onKeyUp={handleArrowDown}
                     >
                         {selectedValueLabel}
                     </button>
@@ -262,7 +270,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
                                         onBlur={handleBlur}
                                         onFocus={handleFocus}
                                     >
-                                        {item.label}
+                                        <span className="jkl-select__option-label">{item.label}</span>
                                     </button>
                                 </li>
                             ))}

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -22,6 +22,7 @@ $select-background-color: transparent;
 $select-open-background-color: $hvit;
 $select-focus-color: $granitt;
 $select-error-color: $feil;
+$select-hover-option-color: $stein;
 
 $select-border-color--inverted: $svaberg;
 $select-text-color--inverted: $snohvit;
@@ -29,6 +30,7 @@ $select-background-color--inverted: transparent;
 $select-open-background-color--inverted: $svart;
 $select-focus-color--inverted: $snohvit;
 $select-error-color--inverted: $feil--darkbg;
+$select-hover-option-color--inverted: $svaberg;
 
 @include jkl.helper-light-mode-variables {
     --select-border-color: #{$select-border-color};
@@ -37,6 +39,7 @@ $select-error-color--inverted: $feil--darkbg;
     --select-open-background-color: #{$select-open-background-color};
     --select-focus-color: #{$select-focus-color};
     --select-error-color: #{$select-error-color};
+    --select-hover-option-color: #{$select-hover-option-color};
 }
 
 @include jkl.helper-dark-mode-variables {
@@ -46,6 +49,7 @@ $select-error-color--inverted: $feil--darkbg;
     --select-open-background-color: #{$select-open-background-color--inverted};
     --select-focus-color: #{$select-focus-color--inverted};
     --select-error-color: #{$select-error-color--inverted};
+    --select-hover-option-color: #{$select-hover-option-color--inverted};
 }
 
 .jkl-select {
@@ -101,6 +105,7 @@ $select-error-color--inverted: $feil--darkbg;
         background-color: var(--select-background-color);
         color: $select-text-color;
         color: var(--select-text-color);
+        cursor: pointer;
 
         height: rem(48px);
         border-radius: rem(3px);
@@ -192,13 +197,15 @@ $select-error-color--inverted: $feil--darkbg;
         width: 100%;
         background-color: inherit;
         min-height: rem(48px);
-        padding: $component-spacing--small $component-spacing--large;
-        clip-path: inset($component-spacing--small $component-spacing--large);
-        clip: rect();
         text-align: left;
         @include motion("standard");
         transition-property: color, background-color;
         position: relative;
+        cursor: pointer;
+
+        &-label {
+            padding: $component-spacing--small $component-spacing--large;
+        }
 
         &:before {
             content: "";
@@ -214,8 +221,8 @@ $select-error-color--inverted: $feil--darkbg;
         }
 
         &:hover {
-            color: $select-focus-color;
-            color: var(--select-focus-color);
+            color: $select-hover-option-color;
+            color: var(--select-hover-option-color);
         }
 
         &[aria-selected="true"]:not(:focus) {
@@ -224,7 +231,7 @@ $select-error-color--inverted: $feil--darkbg;
                 background-color: $select-focus-color;
                 background-color: var(--select-focus-color);
                 content: "";
-                /* autoprefixer with Browserlist="Chrome >= 70" will not generate 
+                /* autoprefixer with Browserlist="Chrome >= 70" will not generate
                  * a prefix for this even if Chrome 70 doesn't support mask-image
                  */
                 -webkit-mask-image: $mask-image-url;

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -105,7 +105,6 @@ $select-hover-option-color--inverted: $svaberg;
         background-color: var(--select-background-color);
         color: $select-text-color;
         color: var(--select-text-color);
-        cursor: pointer;
 
         height: rem(48px);
         border-radius: rem(3px);
@@ -201,7 +200,6 @@ $select-hover-option-color--inverted: $svaberg;
         @include motion("standard");
         transition-property: color, background-color;
         position: relative;
-        cursor: pointer;
 
         &-label {
             padding: $component-spacing--small $component-spacing--large;


### PR DESCRIPTION
affects: @fremtind/jkl-select## 📥 Proposed changes

Legg til hover farger for innhold i select.

Legg til støtte for å bruke pil ned til å åpne select. Dette ble gjort ved å fremtvinge et klikk-event på knappen, da å bruke `onToggle` eller endre `dropdownIsShown` som brukes av CoreToggle ikke lot seg bruke direkte. CoreToggle feilet med at den satte i gang en evig renderløkke...

## ☑️ Submission checklist

-   [X] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [X] `yarn build` works locally with my changes
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...
