### PR TITLE
chore(ci): change dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "weekly"
 
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
-    schedule:
-      interval: "daily"
+    - package-ecosystem: "github-actions"
+      # Workflow files stored in the
+      # default location of `.github/workflows`
+      directory: "/"
+      schedule:
+          interval: "weekly"


### PR DESCRIPTION
## 📥 Proposed changes

Endre frekvens på Dependabot-skann fra daglig til ukentlig. Det blir uansett ikke fikset daglig, og det kommer patcher _hele tiden_

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
