### PR TITLE
feat(sass): forward functions to new jkl entrypoint

### DIFF
--- a/packages/core/_jkl.scss
+++ b/packages/core/_jkl.scss
@@ -1,2 +1,3 @@
 @forward "variables";
 @forward "mixins";
+@forward "functions";


### PR DESCRIPTION
## 📥 Proposed changes

Eksporter funksjonene i `_functions.scss` gjennom det nye endepunktet `@fremtind/jkl-core/jkl` for enklere bruk.

```scss
@use "@fremtind/jkl-core/jkl";

$border-width: jkl.rem(2px);
```

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments
