### PR TITLE
fix: default variant should be small

### DIFF
--- a/packages/feedback-react/src/Feedback.tsx
+++ b/packages/feedback-react/src/Feedback.tsx
@@ -11,7 +11,7 @@ const FeedbackContent = () => {
     const [id] = useState(nanoid(8));
 
     return (
-        <FieldGroup legend={description} className="jkl-feedback__fieldset">
+        <FieldGroup legend={description} className="jkl-feedback__fieldset" variant="medium">
             {options?.map((option) => {
                 const { label, value: optionValue } = transformToValuePair(option);
                 const radioButtonId = `${id}-feedback--${optionValue}`;

--- a/packages/field-group-react/src/FieldGroup.tsx
+++ b/packages/field-group-react/src/FieldGroup.tsx
@@ -20,7 +20,7 @@ export const FieldGroup = ({
     children,
     helpLabel,
     errorLabel,
-    variant = "medium",
+    variant,
     forceCompact,
     inverted,
 }: Props) => {

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -25,19 +25,7 @@ export interface Props extends BaseProps {
 
 export const TextInput = forwardRef<HTMLInputElement, Props>(
     (
-        {
-            id,
-            className,
-            label,
-            helpLabel,
-            errorLabel,
-            variant = "medium",
-            inline,
-            inverted,
-            forceCompact,
-            action,
-            ...inputProps
-        },
+        { id, className, label, helpLabel, errorLabel, variant, inline, inverted, forceCompact, action, ...inputProps },
         ref,
     ) => {
         const [uid] = useState(id || `jkl-text-input-${nanoid(8)}`);

--- a/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
@@ -27,7 +27,7 @@ function BaseAutosuggest<T>({
     leadText,
     errorLabel,
     helpLabel,
-    variant = "medium",
+    variant = "small",
     noHitsMessage,
     maxNumberOfHits,
     placeholder,


### PR DESCRIPTION
## 📥 Proposed changes

This commit removes default variant value from components
which uses the Label component. This allows the default to be
dictated by Label.
This commit also changes the default variant for BaseAutosuggest
from medium to small to match the default value of Label.

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [ ] `yarn build` works locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)

