### PR TITLE
fix: fikser et timingproblem som ga feil aria-label i Select

### DIFF
--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -655,4 +655,46 @@ describe("a11y", () => {
 
         expect(results).toHaveNoViolations();
     });
+
+    test("aria-label should update correctly on change", async () => {
+        const onChange = jest.fn();
+        function WrappedSelect() {
+            const [value, setValue] = useState<string>();
+
+            const items = [
+                { value: "apple", label: "Apple" },
+                { value: "samsung", label: "Samsung" },
+                { value: "huawei", label: "Huawei" },
+                { value: "LG", label: "LG" },
+            ];
+
+            return (
+                <Select
+                    label="Hvilket merke er telefonen?"
+                    items={items}
+                    value={value}
+                    onChange={(value: string | undefined) => {
+                        setValue(value);
+                        onChange();
+                    }}
+                />
+            );
+        }
+
+        const screen = render(<WrappedSelect />);
+
+        const dropdownButtonElement = screen.getByText("Velg");
+        const firstItemButton = screen.getByText("Apple");
+
+        act(() => {
+            userEvent.click(dropdownButtonElement);
+        });
+
+        act(() => {
+            userEvent.click(firstItemButton);
+        });
+
+        expect(onChange).toHaveBeenCalled();
+        expect(screen.getByTestId("jkl-select__button").getAttribute("aria-label")).toContain("Apple");
+    });
 });

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -127,10 +127,10 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
         }
 
         function onToggleSelect(e: CoreToggleSelectEvent) {
-            e.target.value = e.detail;
             const nextValue = e.detail.value;
             setSearchValue("");
             onChange && onChange(nextValue);
+            e.target.value = e.detail;
             selectRef.current && selectRef.current.dispatchEvent(new Event("change", { bubbles: true }));
             e.target.hidden = true;
             e.target.button.focus();

--- a/patches/@nrk+core-toggle+3.0.8.patch
+++ b/patches/@nrk+core-toggle+3.0.8.patch
@@ -1,5 +1,35 @@
+diff --git a/node_modules/@nrk/core-toggle/core-toggle.js b/node_modules/@nrk/core-toggle/core-toggle.js
+index 54c2c73..c7b293d 100644
+--- a/node_modules/@nrk/core-toggle/core-toggle.js
++++ b/node_modules/@nrk/core-toggle/core-toggle.js
+@@ -77,7 +77,8 @@ export default class CoreToggle extends HTMLElement {
+     if (popup === this.popup) {
+       const target = button.querySelector('span') || button // Use span to preserve embedded HTML and SVG
+       button.value = data.value || label
+-      button.setAttribute('aria-label', `${button.textContent},${this.popup}`)
++
++      button.setAttribute('aria-label', `${label},${this.popup}`)
+       target[data.innerHTML ? 'innerHTML' : 'textContent'] = data.innerHTML || label
+     }
+   }
+diff --git a/node_modules/@nrk/core-toggle/core-toggle.jsx.js b/node_modules/@nrk/core-toggle/core-toggle.jsx.js
+index ebf0c09..5735ab1 100644
+--- a/node_modules/@nrk/core-toggle/core-toggle.jsx.js
++++ b/node_modules/@nrk/core-toggle/core-toggle.jsx.js
+@@ -347,9 +347,9 @@
+ 
+         if (popup === this.popup) {
+           var target = button.querySelector('span') || button; // Use span to preserve embedded HTML and SVG
+-
+           button.value = data.value || label;
+-          button.setAttribute('aria-label', "".concat(button.textContent, ",").concat(this.popup));
++
++          button.setAttribute('aria-label', "".concat(label, ",").concat(this.popup));
+           target[data.innerHTML ? 'innerHTML' : 'textContent'] = data.innerHTML || label;
+         }
+       }
 diff --git a/node_modules/@nrk/core-toggle/jsx.js b/node_modules/@nrk/core-toggle/jsx.js
-index b9e52a9..191544f 100644
+index b9e52a9..384b97c 100644
 --- a/node_modules/@nrk/core-toggle/jsx.js
 +++ b/node_modules/@nrk/core-toggle/jsx.js
 @@ -308,7 +308,7 @@ var CoreToggle = /*#__PURE__*/function (_HTMLElement) {
@@ -11,6 +41,15 @@ index b9e52a9..191544f 100644
      } // aria-haspopup triggers forms mode in JAWS, therefore store as custom attr
  
    }, {
+@@ -347,7 +347,7 @@ var CoreToggle = /*#__PURE__*/function (_HTMLElement) {
+         var target = button.querySelector('span') || button; // Use span to preserve embedded HTML and SVG
+ 
+         button.value = data.value || label;
+-        button.setAttribute('aria-label', "".concat(button.textContent, ",").concat(this.popup));
++        button.setAttribute('aria-label', "".concat(label, ",").concat(this.popup));
+         target[data.innerHTML ? 'innerHTML' : 'textContent'] = data.innerHTML || label;
+       }
+     }
 @@ -392,10 +392,10 @@ var closest$1 = function () {
  * @return {Object} A React component
  */


### PR DESCRIPTION
affects: @fremtind/jkl-select-react

ISSUES CLOSED: #1688, #2126

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/master/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

Jeg var først overbevist om at dette var en bug i `@nrk/core-toggle`. Såpass at jeg begynte på en patch og tenkte jeg skulle åpne et issue hos dem. Jeg tenker fortsatt at det kan være lurt, for jeg mener det er noe galt der. Kort fortalt mener jeg denne patchen burde gjøres for å slippe å ha dette timingproblemet i utgangspunktet:

```diff
  set value (data = false) {
    if (!this.button || !this.popup.length) return
    const button = this.button
    const popup = (button.getAttribute('aria-label') || `,${this.popup}`).split(',')[1]
    const label = data.textContent || data || '' // data can be Element, Object or String

    if (popup === this.popup) {
      const target = button.querySelector('span') || button // Use span to preserve embedded HTML and SVG
      button.value = data.value || label
      target[data.innerHTML ? 'innerHTML' : 'textContent'] = data.innerHTML || label
-     button.setAttribute('aria-label', `${button.textContent},${this.popup}`)
+     button.setAttribute('aria-label', `${label},${this.popup}`)
    }
  }
```


https://user-images.githubusercontent.com/1223410/132504195-1c020a67-99e8-4995-b3b6-c0309e45a791.mov

