### PR TITLE
feat: prop for å styre role på MessageBox

### DIFF
--- a/packages/alert-message-react/README.md
+++ b/packages/alert-message-react/README.md
@@ -34,6 +34,7 @@ Komponenten tar følgende props:
 -   `maxContentWidth`: Setter maks bredde på innholdet. Innholdet vil søke mot senter av siden `string`
 -   `paddingLeft`: Setter padding på venstre side av innholdet. `string`
 -   `className`: Eventuell(e) css-klassenavn for komponenten. `string`
+-   `role`: Overstyring av `role`-attributtet. For å "skru av" standardrollen kan du bruke verdien `none presentation` ([ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#none)). `string`
 
 En enkel bruk av meldingsboksen kan se slik ut:
 

--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -12,6 +12,7 @@ interface Props {
     inverted?: boolean;
     maxContentWidth?: string;
     paddingLeft?: string;
+    /** Overstyr standardrollen til meldingen. Om du ønsker å "skru av" rollen kan du bruke verdien `none presentation`. */
     role?: string;
     dismissed?: boolean;
     dismissAction?: {

--- a/packages/message-box-react/README.md
+++ b/packages/message-box-react/README.md
@@ -29,6 +29,7 @@ Komponentene tar følgende props:
 -   `title`: Overskriften til meldingsboksen. `string`
 -   `fullWidth`: Angir om meldingsboksen skal ta opp hele bredden av beholderen den er inne i. `boolean`
 -   `className`: Eventuell(e) css-klassenavn for komponenten. `string`
+-   `role`: Overstyring av `role`-attributtet. For å "skru av" standardrollen kan du bruke verdien `none presentation` ([ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#none)). `string`
 
 En enkel bruk av meldingsboksen kan se slik ut:
 

--- a/packages/message-box-react/src/MessageBox.test.tsx
+++ b/packages/message-box-react/src/MessageBox.test.tsx
@@ -27,11 +27,23 @@ describe("a11y", () => {
         expect(results).toHaveNoViolations();
     });
 
+    it("InfoMessage should have role `status` by default", async () => {
+        render(<InfoMessage title="info">Lorem Ipsum</InfoMessage>);
+        const message = screen.getByRole("status");
+        expect(message).toBeTruthy();
+    });
+
     it("ErrorMessage should be a11y compliant", async () => {
         const { container } = render(<ErrorMessage title="error">Lorem Ipsum</ErrorMessage>);
         const results = await axe(container);
 
         expect(results).toHaveNoViolations();
+    });
+
+    it("ErrorMessage should have role `alert` by default", async () => {
+        render(<ErrorMessage title="error">Lorem Ipsum</ErrorMessage>);
+        const message = screen.getByRole("alert");
+        expect(message).toBeTruthy();
     });
 
     it("WarningMessage should be a11y compliant", async () => {
@@ -41,10 +53,32 @@ describe("a11y", () => {
         expect(results).toHaveNoViolations();
     });
 
+    it("WarningMessage should have role `status` by default", async () => {
+        render(<WarningMessage title="warning">Lorem Ipsum</WarningMessage>);
+        const message = screen.getByRole("alert");
+        expect(message).toBeTruthy();
+    });
+
     it("SuccessMessage should be a11y compliant", async () => {
         const { container } = render(<SuccessMessage title="success">Lorem Ipsum</SuccessMessage>);
         const results = await axe(container);
 
         expect(results).toHaveNoViolations();
+    });
+
+    it("SuccessMessage should have role `status` by default", async () => {
+        render(<SuccessMessage title="success">Lorem Ipsum</SuccessMessage>);
+        const message = screen.getByRole("status");
+        expect(message).toBeTruthy();
+    });
+
+    it("should have a role equal to the given prop", async () => {
+        render(
+            <InfoMessage title="info" role="none presentation">
+                Lorem Ipsum
+            </InfoMessage>,
+        );
+        const message = screen.getByRole("none");
+        expect(message).toBeTruthy();
     });
 });

--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { AriaRole, ReactNode } from "react";
 import classNames from "classnames";
 
 import { IconButton } from "@fremtind/jkl-icon-button-react";
@@ -15,6 +15,8 @@ interface Props {
         handleDismiss: () => void;
         buttonTitle?: string;
     };
+    /** Overstyr standardrollen til meldingen. Om du ønsker å "skru av" rollen kan du bruke verdien `none presentation`. */
+    role?: AriaRole;
 }
 
 type messageTypes = "info" | "error" | "success" | "warning";
@@ -28,6 +30,7 @@ function messageFactory(messageType: messageTypes) {
         dismissed,
         dismissAction,
         children,
+        role,
     }: Props) {
         const componentClassName = classNames("jkl-message-box", "jkl-message-box--" + messageType, className, {
             "jkl-message-box--full": fullWidth,
@@ -116,8 +119,21 @@ function messageFactory(messageType: messageTypes) {
             }
         };
 
+        const getRole = (messageType: messageTypes) => {
+            switch (messageType) {
+                case "error":
+                case "warning":
+                    return "alert";
+                case "info":
+                case "success":
+                    return "status";
+                default:
+                    return undefined;
+            }
+        };
+
         return (
-            <div className={componentClassName} role="alert">
+            <div className={componentClassName} role={role || getRole(messageType)}>
                 {getIcon(messageType)}
                 <div className="jkl-message-box__content">
                     {title !== undefined && <p className="jkl-message-box__title">{title}</p>}

--- a/portal/src/texts/getstarted/buildWithJkl.mdx
+++ b/portal/src/texts/getstarted/buildWithJkl.mdx
@@ -11,19 +11,23 @@ Du kan bruke komponentene i Jøkul som rene stilark eller som React-komponenter.
 Dersom du kun bruker stilarkene (f.eks. hvis prosjektet ditt ikke bruker React) må du sørge for å gi komponentene riktig HTML-struktur. Se gjerne på hvordan React-komponentene er implementert, eller sjekk eksemplene i portalen.
 
 ## Kom i gang med React-komponenter
+
 Hvis du vil ta i bruk en Jøkul React-komponent, trenger du å laste inn både stilen og komponenten. Hvis du har satt opp en CSS-loader i pakkesystemet, kan du laste ned stilen direkte i React. Du kan også velge å legge den inn i en av dine `.scss`- eller `.css`-filer.
 
-<InfoMessage>
-    For å normalisere stilen og få tilgang til rotstilen, laster du inn <code>core.min.css</code> fra <code>@fremtind/jkl-core</code>. Det trenger du bare å gjøre én gang i prosjektet ditt.
+<InfoMessage role="none presentation">
+    For å normalisere stilen og få tilgang til rotstilen, laster du inn <code>core.min.css</code> fra{" "}
+    <code>@fremtind/jkl-core</code>. Det trenger du bare å gjøre én gang i prosjektet ditt.
 </InfoMessage>
 
 ## [Installer avhengigheter](#installer-avhengigheter)
+
 Hvis du bruker React-komponenten, installerer du den med `yarn add @fremtind/jkl-accordion-react`. Stilpakken blir automatisk installert som en avhengighet.
 
 Dersom du bare bruker stilpakken, installerer du den med `yarn add @fremtind/jkl-accordion`.
 
-<InfoMessage>
-    Vi bruker Yarn for pakkehåndtering i Jøkul. Hvis ditt prosjekt bruker NPM, kan du selvfølgelig installere pakkene med <code>npm i</code> som vanlig.
+<InfoMessage role="none presentation">
+    Vi bruker Yarn for pakkehåndtering i Jøkul. Hvis ditt prosjekt bruker NPM, kan du selvfølgelig installere pakkene
+    med <code>npm i</code> som vanlig.
 </InfoMessage>
 
 ## Ta i bruk komponenten
@@ -58,16 +62,20 @@ initTabListener();
 
 Jøkul benytter seg av moderne javascript. Det blir transpilert til ES5, men det kan fortsatt være brukt funksjonalitet som ikke støttes i alle nettlesere. Per nå bruker vi bare funksjonalitet som kan transpileres eller polyfilles, men dette vil sannsynligvis forandre seg på sikt. Når det skjer vil vi tydelig merke de komponentene som ikke kan brukes i legacy-systemer.
 
-<InfoMessage>
-    Proxy er et eksempel på moderne javascript som ikke kan polyfilles eller transpileres. Det finnes en ponyfill, men den er ikke et fullgodt alternativ. Framer Motion og React Hook Form er bibliotek som benytter seg av denne typen funksjonalitet, og de vil dermed ikke virke i alle nettlesere. Om man må støtte Internet Explorer 11, finnes det work-arounds for begge inntil videre.
+<InfoMessage role="none presentation">
+    Proxy er et eksempel på moderne javascript som ikke kan polyfilles eller transpileres. Det finnes en ponyfill, men
+    den er ikke et fullgodt alternativ. Framer Motion og React Hook Form er bibliotek som benytter seg av denne typen
+    funksjonalitet, og de vil dermed ikke virke i alle nettlesere. Om man må støtte Internet Explorer 11, finnes det
+    work-arounds for begge inntil videre.
 </InfoMessage>
 
 #### [@webcomponents/webcomponentsjs](https://github.com/webcomponents/webcomponentsjs)
 
 Denne trengs i litt ulike varianter basert på hva du bruker og hva du skal støtte. Moderne nettlesere som ny Chrome, Firefox, Edge og Safari har innebygd støtte, men du skal ikke mer enn tilbake til 2019 før støtten blir mer usikker. Denne må lastes inn så tidlig som overhode mulig i applikasjonen din, gjerne av webpack før ditt entrypoint. Hvis du kun støtter evergreen browsere kan du sløyfe denne.
 
-<InfoMessage>
-    Selv om ikke alle komponentene våre bruker webcomponents, så anbefaler vi fortsatt å sette opp disse polyfillene med en gang du tar i bruk en eller flere av våre React-pakker.
+<InfoMessage role="none presentation">
+    Selv om ikke alle komponentene våre bruker webcomponents, så anbefaler vi fortsatt å sette opp disse polyfillene med
+    en gang du tar i bruk en eller flere av våre React-pakker.
 </InfoMessage>
 
 #### @webcomponents/webcomponentsjs/custom-elements-es5-adapter
@@ -75,24 +83,19 @@ Denne trengs i litt ulike varianter basert på hva du bruker og hva du skal stø
 Denne bør være med uansett hva du ønsker å støtte, den er bare noen få kB. Den gjør det mulig for de aller fleste nettlesere å forstå syntaxen som NRK Core components bygger på, og trengs også sannsynligvis i testoppsettet ditt for at jsdom skal skjønne koden.
 
 webpack.config.js
+
 ```js
-const polyfills = [
-    '@webcomponents/webcomponentsjs',
-    '@webcomponents/webcomponentsjs/custom-elements-es5-adapter',
-];
+const polyfills = ["@webcomponents/webcomponentsjs", "@webcomponents/webcomponentsjs/custom-elements-es5-adapter"];
 
 const config = {
-    entry: [
-        ...polyfills,
-        path.resolve('src', 'index.js'),
-    ]
-}
+    entry: [...polyfills, path.resolve("src", "index.js")],
+};
 ```
 
 Jest setup fil
-```js
-import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter';
 
+```js
+import "@webcomponents/webcomponentsjs/custom-elements-es5-adapter";
 ```
 
 #### Babel runtime
@@ -111,6 +114,7 @@ Du trenger også [babel runtime](https://babeljs.io/docs/en/babel-plugin-transfo
 Flere av våre komponenter bruker nanoid for å generere automatiske ID-er på komponenter som har behov for det, feks radiobuttons. Nanoid er mye lettere enn feks UUID og gir mer enn unike nok ID-er for vårt behov. Men i version 3 droppet de support for IE 11, så for at komponentene som bruker dette skal virke ordentlig hos deg trenger du å transpilere Nanoid med samme settings som din øvrige kode, og du må tilgjengeliggjøre crypto for IE 11. Polyfill.js eller hvor du legger crypto overriden bør være så tidlig i din runtime som mulig. Hvis du ikke må støtte IE 11, kan du trygt sløyfe dette steget.
 
 webpack.js
+
 ```
  module: {
         rules: [
@@ -123,19 +127,20 @@ webpack.js
 ```
 
 polyfill.js
+
 ```
 if (!window.crypto) {
     window.crypto = window.msCrypto;
 }
 ```
 
-#### Testing library 
+#### Testing library
 
 Det er en feil i @testing-library sin webcomponent håndtering hvis en test feiler: Det vil kunne vi en evig løkke som skriver ut stack trace til terminalen helt til terminalen tryner.
 
 ```js
-import { configure } from '@testing-library/react';
-import prettier from 'prettier';
+import { configure } from "@testing-library/react";
+import prettier from "prettier";
 
 configure({
     getElementError: (message, container) => {
@@ -143,12 +148,12 @@ configure({
             [
                 message,
                 prettier.format(container.innerHTML, {
-                    parser: 'html',
-                    htmlWhitespaceSensitivity: 'ignore',
+                    parser: "html",
+                    htmlWhitespaceSensitivity: "ignore",
                 }),
             ]
                 .filter(Boolean)
-                .join('\n\n')
+                .join("\n\n"),
         );
     },
 });


### PR DESCRIPTION
affects: @fremtind/jkl-alert-message-react, @fremtind/jkl-message-box-react, @fremtind/portal

MessageBox og dens varianter lar deg nå overstyre role fra det som har vært standard (alert).
InfoMessage og SuccessMessage får endret standardrolle til status. Med denne endringen kan f. eks.
InfoMessage brukes som et rent presentasjonselement (med \`role="none presentation\`).

ISSUES CLOSED: #1687
