### PR TITLE
chore: bruk merge i stedet for rebase i syncjobb

### DIFF
--- a/.github/workflows/external-contributions-sync.yml
+++ b/.github/workflows/external-contributions-sync.yml
@@ -18,7 +18,7 @@ jobs:
               run: git switch external-contributions
 
             - name: Rebase
-              run: git rebase main
+              run: git merge main
 
             - name: Push
               run: git push


### PR DESCRIPTION
Dersom det er endringer på external-contributions som ikke er i main vil ikke en rebase kunne pushes
uten --force. Velger å gå for en merge i stedet. Jobben kan fremdeles feile pga merge conflicts, men
de må i så fal håndteres manuelt på external-contributions.
