### PR TITLE
chore: creates a weekly issue to upgrade dependencies

### DIFF
--- a/.github/workflows/weekly-tasks.yml
+++ b/.github/workflows/weekly-tasks.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Weekly tasks
+on:
+  schedule:
+    - cron: 00 05 * * 0
+
+jobs:
+  create_issue:
+    name: Create weekly issue to upgrade dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name:  Create weekly issue to upgrade dependencies
+        uses: imjohnbo/issue-bot@v3.3.3
+        with:
+          assignees: "espkva, henrikhermansen, joms, kennidenni, mikaila94, piofinn, saegrov, sercansercan, wkillerud"
+          rotate-assignees: true
+          labels: "dependencies"
+          projects: 'Kjerneteamet'
+          title: "Weekly dependency update"
+          body: |
+            ### Agenda
+
+            - [ ] Use the command ```yarn upgrade-interactive``` to evaluate and upgrade packages.
+            - [ ] For major upgrades that requires more work, create a separate issue.
+                    
+          pinned: true
+          close-previous: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
creates a weekly issue to upgrade dependencies with rotation among the assignees

## 📥 Proposed changes

Denne action-en vil lage en issue ukentlig for oppgradering av avhengigheter.
Det er også rotasjon blant assignees.
 
Fulgte denne guiden:  https://docs.github.com/en/actions/guides/scheduling-issue-creation

Denne bruker en tredjepartsbot som heter Issue Bot Action: https://github.com/marketplace/actions/issue-bot-action

## ☑️ Submission checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) doc
-   [x] `yarn build` works locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)

## 💬 Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc...

