### PR TITLE
chore: fixes typo in weekyl-tasks.yml

### DIFF
--- a/.github/workflows/weekly-tasks.yml
+++ b/.github/workflows/weekly-tasks.yml
@@ -6,7 +6,7 @@
 name: Weekly tasks
 on:
   schedule:
-    - cron: 00 05 * * 0
+    - cron: 00 05 * * 1
 
 jobs:
   create_issue:
@@ -21,7 +21,7 @@ jobs:
           assignees: "espkva, henrikhermansen, joms, kennidenni, mikaila94, piofinn, saegrov, sercansercan, wkillerud"
           rotate-assignees: true
           labels: "dependencies"
-          projects: 'Kjerneteamet'
+          project: "Kjerneteamet"
           title: "Weekly dependency update"
           body: |
             ### Agenda


### PR DESCRIPTION
Fikser typo i project-feltet for weekly-tasks.yml og endrer fra tidpsunkt for ukentlig oppgradering fra søndag kl5 til mandag kl5

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
