### PR TITLE
Bedre semantikk og tilgjengelighet i Hamburger

### DIFF
--- a/packages/hamburger-react/README.md
+++ b/packages/hamburger-react/README.md
@@ -22,11 +22,15 @@ import "@fremtind/jkl-hamburger/hamburger.min.css";
 
 ### Bruk
 
+Vi anbefaler at du refererer til elementet som åpnes/lukkes av hamburgermenyen ved hjelp av `aria-controls`-attributten:
+
 ```jsx
-const [isMenuOpen, setIsMenuOpen] = useState(false);
+const [menuIsOpen, setMenuIsOpen] = useState(false);
+const toggleMenu = () => setMenuIsOpen((prevState) => !prevState);
 
-<div>
-    <Hamburger onClick={() => setIsMenuOpen(!isMenuOpen)} isOpen={isMenuOpen} />
-</div>
+<Hamburger onClick={toggleMenu} isOpen={menuIsOpen} aria-controls="min-meny" />
+
+<ul id="min-meny" hidden={!menuIsOpen}>
+    // ...menyobjekter
+</ul>
 ```
-

--- a/packages/hamburger-react/src/Hamburger.test.tsx
+++ b/packages/hamburger-react/src/Hamburger.test.tsx
@@ -8,12 +8,12 @@ describe("Hamburger", () => {
         render(<Hamburger isOpen={false} onClick={() => {}} />);
     });
 
-    it("should get class jkl-hamburger--is-open when isOpen is true", () => {
+    it("should have attribute aria-expanded when isOpen is true", () => {
         render(<Hamburger isOpen onClick={() => {}} />);
 
         const burger = screen.getByTestId("jkl-hamburger");
 
-        expect(burger).toHaveClass("jkl-hamburger--is-open");
+        expect(burger).toHaveAttribute("aria-expanded");
     });
 
     it("should get class jkl-hamburger--inverted when specified", () => {
@@ -21,6 +21,14 @@ describe("Hamburger", () => {
 
         const component = screen.getByTestId("jkl-hamburger");
         expect(component).toHaveClass("jkl-hamburger--inverted");
+    });
+
+    it("sets correct value for aria-controls", () => {
+        const menuid = "hgsf8w4kjDH";
+        render(<Hamburger isOpen={false} aria-controls={menuid} onClick={() => {}} />);
+
+        const component = screen.getByTestId("jkl-hamburger");
+        expect(component).toHaveAttribute("aria-controls", menuid);
     });
 
     it("should render call onClick", () => {
@@ -32,14 +40,14 @@ describe("Hamburger", () => {
         expect(fn).toHaveBeenCalledTimes(1);
     });
 
-    it("should set class to jkl-hamburger--is-open when changing isOpen state", () => {
+    it("should set attribute aria-expanded when changing isOpen state", () => {
         const { rerender } = render(<Hamburger isOpen={false} onClick={() => {}} />);
         const burger = screen.getByTestId("jkl-hamburger");
 
-        expect(burger).not.toHaveClass("jkl-hamburger--is-open");
+        expect(burger).not.toHaveAttribute("aria-expanded");
 
         rerender(<Hamburger isOpen={true} onClick={() => {}} />);
-        expect(burger).toHaveClass("jkl-hamburger--is-open");
+        expect(burger).toHaveAttribute("aria-expanded");
     });
 
     it("should render have correct description", () => {

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -15,6 +15,7 @@ interface Props {
         animated?: boolean;
         position?: "before" | "after";
     };
+    "aria-controls"?: string;
 }
 
 export const Hamburger = ({
@@ -24,11 +25,11 @@ export const Hamburger = ({
     description = "Hovedmeny",
     className,
     actionLabel,
+    "aria-controls": ariaControls,
 }: Props) => {
     const componentClassname = classnames(
         "jkl-hamburger",
         {
-            "jkl-hamburger--is-open": isOpen,
             "jkl-hamburger--inverted": inverted,
             "jkl-hamburger--label-before": actionLabel?.position === "before",
             "jkl-hamburger--label-after": actionLabel && actionLabel.position !== "before",
@@ -46,7 +47,10 @@ export const Hamburger = ({
             aria-label={description}
             onClick={onClick}
             className={componentClassname}
+            aria-expanded={isOpen || undefined}
+            aria-haspopup="menu"
             data-testid="jkl-hamburger"
+            aria-controls={ariaControls}
         >
             <span className="jkl-hamburger__lines"></span>
             {actionLabel && (

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -126,26 +126,15 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
         }
     }
 
-    &--is-open {
-        &:hover {
-            .jkl-hamburger__lines::before {
-                top: 0;
-                transform: rotate(-45deg) scale3d(1.25, 1, 1);
-            }
-            .jkl-hamburger__lines::after {
-                bottom: 0;
-                transform: rotate(45deg) scale3d(1.25, 1, 1);
-            }
-        }
-
-        &__lines::before,
-        &__lines::after {
-            width: calc(#{$hamburger-icon-width} - 3px);
-        }
-
+    &[aria-expanded="true"] {
         & .jkl-hamburger__lines {
             transform: rotate(-180deg);
             background-color: transparent;
+        }
+
+        & .jkl-hamburger__lines::before,
+        & .jkl-hamburger__lines::after {
+            width: calc(#{$hamburger-icon-width} - 3px);
         }
 
         & .jkl-hamburger__lines::before {
@@ -156,6 +145,17 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
         & .jkl-hamburger__lines::after {
             bottom: 0;
             transform: rotate(45deg);
+        }
+
+        &:hover {
+            .jkl-hamburger__lines::before {
+                top: 0;
+                transform: rotate(-45deg) scale3d(1.25, 1, 1);
+            }
+            .jkl-hamburger__lines::after {
+                bottom: 0;
+                transform: rotate(45deg) scale3d(1.25, 1, 1);
+            }
         }
     }
 


### PR DESCRIPTION
Legger til `aria-haspopup` og `aria-expanded` som egenskaper på Hamburger, for å bedree kommunisere egenskapene dens til f.eks. skjermlesere. Jeg valgte foreløpig å _ikke_ la disse endres, da hamburgeren alltid skal brukes til å styre en meny og derfor alltid vil trenge disse egenskapene.

Legger også til støtte for valgfri prop `aria-controls` som kan peke på `id`en til elementet som inneholder menyen og åpnes/lukkes av knappen.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
