### PR TITLE
Nytt utseende på meldingsbokser

### DIFF
--- a/packages/alert-message-react/documentation/AlertMessage.mdx
+++ b/packages/alert-message-react/documentation/AlertMessage.mdx
@@ -14,7 +14,7 @@ import AlertMessageExample from "./AlertMessageExample";
 <ComponentExample
     component={AlertMessageExample}
     knobs={{
-        boolProps: ["Invertert", "Avvisbar"],
+        boolProps: ["Avvisbar"],
         choiceProps: [
             {
                 name: "Type",

--- a/packages/alert-message-react/documentation/index.tsx
+++ b/packages/alert-message-react/documentation/index.tsx
@@ -11,7 +11,7 @@ renderExample(
     <DevExample
         component={AlertMessageExample}
         knobs={{
-            boolProps: ["Invertert", "Avvisbar"],
+            boolProps: ["Avvisbar"],
             choiceProps: [
                 {
                     name: "Type",

--- a/packages/alert-message-react/src/common/MessageIcon.tsx
+++ b/packages/alert-message-react/src/common/MessageIcon.tsx
@@ -6,42 +6,68 @@ export function MessageIcon({ messageType }: { messageType: messageTypes }) {
     switch (messageType) {
         case "error":
             return (
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
-                    <rect
-                        x="4"
-                        y="4.22168"
-                        width="1"
-                        height="22"
-                        transform="rotate(-45 4 4.22168)"
+                <svg
+                    className="jkl-alert-message__icon"
+                    aria-hidden
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M12 24C18.8503 24 24 18.6274 24 12C24 5.37258 18.8503 0 12 0C5.59548 0 0 5.37258 0 12C0 18.6274 5.59548 24 12 24ZM17.43 8.41421L13.6371 12.2071L17.43 16L16.0158 17.4142L12 13.6213L8.43001 17.4142L7.01579 16L10.8087 12.2071L7.01579 8.41421L8.43001 7L12 10.7929L16.0158 7L17.43 8.41421Z"
                         fill="currentColor"
                     />
                 </svg>
             );
         case "info":
             return (
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
+                <svg
+                    className="jkl-alert-message__icon"
+                    aria-hidden
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
                     <path
-                        d="M11.952 7.328C12.384 7.328 12.688 7.072 12.688 6.624C12.688 6.192 12.384 5.92 11.952 5.92C11.536 5.92 11.248 6.192 11.248 6.624C11.248 7.072 11.536 7.328 11.952 7.328ZM11.504 18H12.512V9.408H11.504V18Z"
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M24 12C24 18.6274 18.8503 24 12 24C5.59548 24 0 18.6274 0 12C0 5.37258 5.59548 0 12 0C18.8503 0 24 5.37258 24 12ZM11 17.4142V10H13.2229V17.4142H11.2229ZM12 8.5C12.9133 8.5 13.4729 7.94036 13.4729 7.25C13.4729 6.55964 12.9133 6 12 6C11.5325 6 10.9729 6.55964 10.9729 7.25C10.9729 7.94036 11.5325 8.5 12 8.5Z"
                         fill="currentColor"
                     />
                 </svg>
             );
         case "success":
             return (
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
-                    <path d="M7 13.5L10 16.5L19.5 7" stroke="currentColor" />
+                <svg
+                    className="jkl-alert-message__icon"
+                    aria-hidden
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M12 24C18.8503 24 24 18.6274 24 12C24 5.37258 18.8503 0 12 0C5.59548 0 0 5.37258 0 12C0 18.6274 5.59548 24 12 24ZM11.5503 16.7071L19.0503 9.20711L17.6361 7.79289L10.8432 14.5858L7.26909 11.0116L5.85486 12.4258L10.1361 16.7071L10.8432 17.4142L11.5503 16.7071Z"
+                        fill="currentColor"
+                    />
                 </svg>
             );
         case "warning":
             return (
-                <svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
+                <svg
+                    className="jkl-alert-message__icon"
+                    aria-hidden
+                    viewBox="0 0 26 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
                     <path
-                        className="jkl-icon-exclamation"
-                        d="M11.112 14.624H11.688L11.896 11.36V6H10.904V11.36L11.112 14.624ZM11.4 18.24C11.784 18.24 12.136 17.952 12.136 17.504C12.136 17.072 11.784 16.784 11.4 16.784C11.016 16.784 10.664 17.072 10.664 17.504C10.664 17.952 11.016 18.24 11.4 18.24Z"
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M22.8058 23L3.19424 23C0.885265 23 -0.558162 20.5008 0.595683 18.5008L10.4015 1.50415C11.5559 -0.496963 14.4441 -0.496963 15.5986 1.50415L25.4043 18.5008C26.5582 20.5008 25.1148 23 22.8058 23ZM14 8.00001L14 15.4142L12 15.4142L12 8.00001L14 8.00001ZM13 17C12.3096 17 11.75 17.5597 11.75 18.25C11.75 18.9404 12.3096 19.5 13 19.5C13.6904 19.5 14.25 18.9404 14.25 18.25C14.25 17.5597 13.6904 17 13 17Z"
                         fill="currentColor"
                     />
                 </svg>

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -1,79 +1,24 @@
 @use "~@fremtind/jkl-core/jkl";
+@use "~@fremtind/jkl-core/variables/colors";
 
 @import "~@fremtind/jkl-core/_functions.scss";
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/mixins/_all.scss";
 
-@function message-bg-light($color) {
-    @return change-color($color, $lightness: 97%);
-}
-@function message-bg-dark($color) {
-    @return change-color($color, $lightness: 5%);
-}
-
 $dismiss-animation-duration: 500ms;
-$dismiss-hover-color: $stein;
-$background-color: $snohvit;
-$text-color: $granitt;
-$border-color: $granitt;
-$info-background-color: message-bg-light($info);
-$info-border-color: $info;
-$warning-background-color: message-bg-light($advarsel);
-$warning-border-color: $advarsel;
-$error-background-color: message-bg-light($feil);
-$error-border-color: $feil;
-$success-background-color: message-bg-light($suksess);
-$success-border-color: $suksess;
+$dismiss-focus-border-color: jkl.$color-granitt;
+$dismiss-hover-color: jkl.$color-stein;
 
-$dismiss-hover-color--inverted: $svaberg;
-$background-color--inverted: $granitt;
-$text-color--inverted: $snohvit;
-$border-color--inverted: $snohvit;
-$info-background-color--inverted: message-bg-dark($info--darkbg);
-$info-border-color--inverted: $info--darkbg;
-$warning-background-color--inverted: message-bg-dark($advarsel--darkbg);
-$warning-border-color--inverted: $advarsel--darkbg;
-$error-background-color--inverted: message-bg-dark($feil--darkbg);
-$error-border-color--inverted: $feil--darkbg;
-$success-background-color--inverted: message-bg-dark($suksess--darkbg);
-$success-border-color--inverted: $suksess--darkbg;
-
-@include jkl.helper-light-mode-variables {
-    --dismiss-hover-color: #{$dismiss-hover-color};
-    --border-color: #{$border-color};
-    --background-color: #{$background-color};
-    --text-color: #{$text-color};
-    --info-border-color: #{$info-border-color};
-    --info-background-color: #{$info-background-color};
-    --warning-border-color: #{$warning-border-color};
-    --warning-background-color: #{$warning-background-color};
-    --error-border-color: #{$error-border-color};
-    --error-background-color: #{$error-background-color};
-    --success-border-color: #{$success-border-color};
-    --success-background-color: #{$success-background-color};
-}
-
-@include jkl.helper-dark-mode-variables {
-    --dismiss-hover-color: #{$dismiss-hover-color--inverted};
-    --border-color: #{$border-color--inverted};
-    --background-color: #{$background-color--inverted};
-    --text-color: #{$text-color--inverted};
-    --info-border-color: #{$info-border-color--inverted};
-    --info-background-color: #{$info-background-color--inverted};
-    --warning-border-color: #{$warning-border-color--inverted};
-    --warning-background-color: #{$warning-background-color--inverted};
-    --error-border-color: #{$error-border-color--inverted};
-    --error-background-color: #{$error-background-color--inverted};
-    --success-border-color: #{$success-border-color--inverted};
-    --success-background-color: #{$success-background-color--inverted};
-}
+$bg-color--default: jkl.$color-snohvit;
+$bg-color--suksess: colors.varslingsfarge("suksess");
+$bg-color--feil: colors.varslingsfarge("feil");
+$bg-color--info: colors.varslingsfarge("info");
+$bg-color--advarsel: colors.varslingsfarge("advarsel");
 
 .jkl-alert-message {
     width: 100%;
-    background-color: $background-color;
-    background-color: var(--background-color);
-    border: rem(1px) solid $border-color;
-    border: rem(1px) solid var(--border-color);
+    background-color: $bg-color--default;
+    color: jkl.$color-granitt;
     box-sizing: border-box;
 
     &__content {
@@ -89,6 +34,7 @@ $success-border-color--inverted: $suksess--darkbg;
         padding-right: $component-spacing--large;
         align-self: flex-start;
         padding-top: $component-spacing--xxs;
+        height: rem(24px);
     }
 
     &__message {
@@ -111,7 +57,6 @@ $success-border-color--inverted: $suksess--darkbg;
 
         &:hover {
             color: $dismiss-hover-color;
-            color: var(--dismiss-hover-color);
         }
 
         &:focus {
@@ -125,8 +70,7 @@ $success-border-color--inverted: $suksess--darkbg;
                     right: rem(-2px);
                     bottom: rem(-2px);
                     left: rem(-2px);
-                    box-shadow: 0 0 0 rem(2px) $border-color;
-                    box-shadow: 0 0 0 rem(2px) var(--border-color);
+                    box-shadow: 0 0 0 rem(2px) $dismiss-focus-border-color;
                 }
             }
         }
@@ -144,99 +88,19 @@ $success-border-color--inverted: $suksess--darkbg;
     }
 
     &--info {
-        border-color: $info-border-color;
-        border-color: var(--info-border-color);
-        background-color: $info-background-color;
-        background-color: var(--info-background-color);
-
-        .jkl-alert-message__icon {
-            color: $info;
-            color: var(--info-border-color);
-        }
+        background-color: $bg-color--info;
     }
 
     &--warning {
-        border-color: $warning-border-color;
-        border-color: var(--warning-border-color);
-        background-color: $warning-background-color;
-        background-color: var(--warning-background-color);
-
-        .jkl-alert-message__icon {
-            color: $warning-border-color;
-            color: var(--warning-border-color);
-
-            .jkl-icon-exclamation {
-                color: $border-color;
-                color: var(--border-color);
-            }
-        }
+        background-color: $bg-color--advarsel;
     }
 
     &--error {
-        border-color: $error-border-color;
-        border-color: var(--error-border-color);
-        background-color: $error-background-color;
-        background-color: var(--error-background-color);
-
-        .jkl-alert-message__icon {
-            color: $error-border-color;
-            color: var(--error-border-color);
-        }
+        background-color: $bg-color--feil;
     }
 
     &--success {
-        border-color: $success-border-color;
-        border-color: var(--success-border-color);
-        background-color: $success-background-color;
-        background-color: var(--success-background-color);
-
-        .jkl-alert-message__icon {
-            color: $success-border-color;
-            color: var(--success-border-color);
-        }
-    }
-
-    &--dark {
-        // TODO fiks inverted dismiss button
-        .jkl-alert-message__message {
-            color: $text-color--inverted;
-        }
-        &.jkl-alert-message--info {
-            border-color: $info-border-color--inverted;
-            background-color: $info-background-color--inverted;
-
-            .jkl-alert-message__icon {
-                color: $info-border-color--inverted;
-            }
-        }
-        &.jkl-alert-message--warning {
-            border-color: $warning-border-color--inverted;
-            background-color: $warning-background-color--inverted;
-
-            .jkl-alert-message__icon {
-                color: $warning-border-color--inverted;
-
-                .jkl-icon-exclamation {
-                    color: $border-color--inverted;
-                }
-            }
-        }
-        &.jkl-alert-message--error {
-            border-color: $error-border-color--inverted;
-            background-color: $error-background-color--inverted;
-
-            .jkl-alert-message__icon {
-                color: $error-border-color--inverted;
-            }
-        }
-        &.jkl-alert-message--success {
-            border-color: $success-border-color--inverted;
-            background-color: $success-background-color--inverted;
-
-            .jkl-alert-message__icon {
-                color: $success-border-color--inverted;
-            }
-        }
+        background-color: $bg-color--suksess;
     }
 }
 

--- a/packages/core/variables/_colors.scss
+++ b/packages/core/variables/_colors.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // Hovedfarger
 $svart: #000;
 $granitt: #1b1917;
@@ -28,3 +30,18 @@ $error-color: $feil;
 $focus-color: $granitt;
 $error-color--darkbg: $feil--darkbg;
 $focus-color--darkbg: $snohvit;
+
+// Varslingsfarger, disse er IKKE en del av profilfargene
+// Kun til bruk i komponenter som gir varslinger til bruker
+$varslingsfarger: (
+    "suksess": #c8ecd2,
+    "feil": #ffc9b2,
+    "info": #d9ddff,
+    "advarsel": #fdeab9,
+    "suksess--alt": #90c49e,
+    "feil--alt": #ff9a7a,
+);
+
+@function varslingsfarge($farge) {
+    @return map.get($varslingsfarger, $farge);
+}

--- a/packages/core/variables/_index.scss
+++ b/packages/core/variables/_index.scss
@@ -1,2 +1,2 @@
-@forward "colors" as color-*;
+@forward "colors" as color-* hide $varslingsfarger, varslingsfarge;
 @forward "typography" as typography-*;

--- a/packages/message-box-react/documentation/MessageBox.mdx
+++ b/packages/message-box-react/documentation/MessageBox.mdx
@@ -14,7 +14,7 @@ import { Example } from "./Example";
 <ComponentExample
     component={Example}
     knobs={{
-        boolProps: ["Full bredde", "Invertert", "Avvisbar"],
+        boolProps: ["Full bredde", "Avvisbar"],
         choiceProps: [
             {
                 name: "Type",

--- a/packages/message-box-react/documentation/index.tsx
+++ b/packages/message-box-react/documentation/index.tsx
@@ -11,7 +11,7 @@ renderExample(
     <DevExample
         component={Example}
         knobs={{
-            boolProps: ["Full bredde", "Invertert", "Avvisbar"],
+            boolProps: ["Full bredde", "Avvisbar"],
             choiceProps: [
                 {
                     name: "Type",

--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -43,21 +43,16 @@ function messageFactory(messageType: messageTypes) {
                 case "error":
                     return (
                         <svg
-                            aria-hidden
                             className="jkl-message-box__icon"
-                            width="24"
-                            height="24"
+                            aria-hidden
                             viewBox="0 0 24 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
                         >
-                            <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
-                            <rect
-                                x="4"
-                                y="4.22168"
-                                width="1"
-                                height="22"
-                                transform="rotate(-45 4 4.22168)"
+                            <path
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                                d="M12 24C18.8503 24 24 18.6274 24 12C24 5.37258 18.8503 0 12 0C5.59548 0 0 5.37258 0 12C0 18.6274 5.59548 24 12 24ZM17.43 8.41421L13.6371 12.2071L17.43 16L16.0158 17.4142L12 13.6213L8.43001 17.4142L7.01579 16L10.8087 12.2071L7.01579 8.41421L8.43001 7L12 10.7929L16.0158 7L17.43 8.41421Z"
                                 fill="currentColor"
                             />
                         </svg>
@@ -65,17 +60,16 @@ function messageFactory(messageType: messageTypes) {
                 case "info":
                     return (
                         <svg
-                            aria-hidden
                             className="jkl-message-box__icon"
-                            width="24"
-                            height="24"
+                            aria-hidden
                             viewBox="0 0 24 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
                         >
-                            <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
                             <path
-                                d="M11.952 7.328C12.384 7.328 12.688 7.072 12.688 6.624C12.688 6.192 12.384 5.92 11.952 5.92C11.536 5.92 11.248 6.192 11.248 6.624C11.248 7.072 11.536 7.328 11.952 7.328ZM11.504 18H12.512V9.408H11.504V18Z"
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                                d="M24 12C24 18.6274 18.8503 24 12 24C5.59548 24 0 18.6274 0 12C0 5.37258 5.59548 0 12 0C18.8503 0 24 5.37258 24 12ZM11 17.4142V10H13.2229V17.4142H11.2229ZM12 8.5C12.9133 8.5 13.4729 7.94036 13.4729 7.25C13.4729 6.55964 12.9133 6 12 6C11.5325 6 10.9729 6.55964 10.9729 7.25C10.9729 7.94036 11.5325 8.5 12 8.5Z"
                                 fill="currentColor"
                             />
                         </svg>
@@ -83,33 +77,33 @@ function messageFactory(messageType: messageTypes) {
                 case "success":
                     return (
                         <svg
-                            aria-hidden
                             className="jkl-message-box__icon"
-                            width="24"
-                            height="24"
+                            aria-hidden
                             viewBox="0 0 24 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
                         >
-                            <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
-                            <path d="M7 13.5L10 16.5L19.5 7" stroke="currentColor" />
+                            <path
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                                d="M12 24C18.8503 24 24 18.6274 24 12C24 5.37258 18.8503 0 12 0C5.59548 0 0 5.37258 0 12C0 18.6274 5.59548 24 12 24ZM11.5503 16.7071L19.0503 9.20711L17.6361 7.79289L10.8432 14.5858L7.26909 11.0116L5.85486 12.4258L10.1361 16.7071L10.8432 17.4142L11.5503 16.7071Z"
+                                fill="currentColor"
+                            />
                         </svg>
                     );
                 case "warning":
                     return (
                         <svg
-                            aria-hidden
                             className="jkl-message-box__icon"
-                            width="24"
-                            height="25"
-                            viewBox="0 0 24 25"
+                            aria-hidden
+                            viewBox="0 0 26 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
                         >
-                            <circle cx="12" cy="12" r="11.5" stroke="currentColor" />
                             <path
-                                className="jkl-icon-exclamation"
-                                d="M11.112 14.624H11.688L11.896 11.36V6H10.904V11.36L11.112 14.624ZM11.4 18.24C11.784 18.24 12.136 17.952 12.136 17.504C12.136 17.072 11.784 16.784 11.4 16.784C11.016 16.784 10.664 17.072 10.664 17.504C10.664 17.952 11.016 18.24 11.4 18.24Z"
+                                fillRule="evenodd"
+                                clipRule="evenodd"
+                                d="M22.8058 23L3.19424 23C0.885265 23 -0.558162 20.5008 0.595683 18.5008L10.4015 1.50415C11.5559 -0.496963 14.4441 -0.496963 15.5986 1.50415L25.4043 18.5008C26.5582 20.5008 25.1148 23 22.8058 23ZM14 8.00001L14 15.4142L12 15.4142L12 8.00001L14 8.00001ZM13 17C12.3096 17 11.75 17.5597 11.75 18.25C11.75 18.9404 12.3096 19.5 13 19.5C13.6904 19.5 14.25 18.9404 14.25 18.25C14.25 17.5597 13.6904 17 13 17Z"
                                 fill="currentColor"
                             />
                         </svg>

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -1,74 +1,22 @@
 @use "~@fremtind/jkl-core/jkl";
+@use "~@fremtind/jkl-core/variables/colors";
 
 @import "~@fremtind/jkl-core/variables/_all.scss";
 @import "~@fremtind/jkl-core/mixins/_all.scss";
 @import "~@fremtind/jkl-core/_functions.scss";
 
-@function message-bg-light($color) {
-    @return change-color($color, $lightness: 97%);
-}
-@function message-bg-dark($color) {
-    @return change-color($color, $lightness: 5%);
-}
-
 $dismiss-animation-duration: 500ms;
 $message-width: rem(560px);
 
-$dismiss-hover-color: $stein;
-$background-color: $snohvit;
-$text-color: $granitt;
-$border-color: $granitt;
-$info-background-color: message-bg-light($info);
-$info-border-color: $info;
-$warning-background-color: message-bg-light($advarsel);
-$warning-border-color: $advarsel;
-$error-background-color: message-bg-light($feil);
-$error-border-color: $feil;
-$success-background-color: message-bg-light($suksess);
-$success-border-color: $suksess;
+$dismiss-focus-border-color: jkl.$color-granitt;
+$dismiss-hover-color: jkl.$color-stein;
 
-$dismiss-hover-color--inverted: $svaberg;
-$background-color--inverted: $granitt;
-$text-color--inverted: $snohvit;
-$border-color--inverted: $snohvit;
-$info-background-color--inverted: message-bg-dark($info--darkbg);
-$info-border-color--inverted: $info--darkbg;
-$warning-background-color--inverted: message-bg-dark($advarsel--darkbg);
-$warning-border-color--inverted: $advarsel--darkbg;
-$error-background-color--inverted: message-bg-dark($feil--darkbg);
-$error-border-color--inverted: $feil--darkbg;
-$success-background-color--inverted: message-bg-dark($suksess--darkbg);
-$success-border-color--inverted: $suksess--darkbg;
-
-@include jkl.helper-light-mode-variables {
-    --dismiss-hover-color: #{$dismiss-hover-color};
-    --text-color: #{$text-color};
-    --border-color: #{$border-color};
-    --background-color: #{$background-color};
-    --info-border-color: #{$info-border-color};
-    --info-background-color: #{$info-background-color};
-    --warning-border-color: #{$warning-border-color};
-    --warning-background-color: #{$warning-background-color};
-    --error-border-color: #{$error-border-color};
-    --error-background-color: #{$error-background-color};
-    --success-border-color: #{$success-border-color};
-    --success-background-color: #{$success-background-color};
-}
-
-@include jkl.helper-dark-mode-variables {
-    --dismiss-hover-color: #{$dismiss-hover-color--inverted};
-    --text-color: #{$text-color--inverted};
-    --border-color: #{$border-color--inverted};
-    --background-color: #{$background-color--inverted};
-    --info-border-color: #{$info-border-color--inverted};
-    --info-background-color: #{$info-background-color--inverted};
-    --warning-border-color: #{$warning-border-color--inverted};
-    --warning-background-color: #{$warning-background-color--inverted};
-    --error-border-color: #{$error-border-color--inverted};
-    --error-background-color: #{$error-background-color--inverted};
-    --success-border-color: #{$success-border-color--inverted};
-    --success-background-color: #{$success-background-color--inverted};
-}
+$text-color: jkl.$color-granitt;
+$bg-color--default: jkl.$color-snohvit;
+$bg-color--suksess: colors.varslingsfarge("suksess");
+$bg-color--feil: colors.varslingsfarge("feil");
+$bg-color--info: colors.varslingsfarge("info");
+$bg-color--advarsel: colors.varslingsfarge("advarsel");
 
 .jkl-message-box {
     position: relative;
@@ -76,8 +24,9 @@ $success-border-color--inverted: $suksess--darkbg;
     max-width: $message-width;
     padding: $component-spacing--xl;
     padding-left: rem(56px);
-    background-color: $background-color;
-    border: rem(1px) solid $border-color;
+    background-color: $bg-color--default;
+    color: $text-color;
+    border-radius: rem(4px);
     box-sizing: border-box;
     display: flex;
     flex-direction: row;
@@ -85,6 +34,7 @@ $success-border-color--inverted: $suksess--darkbg;
     &__icon {
         position: absolute;
         left: $spacing-5;
+        height: rem(24px);
     }
 
     &__content {
@@ -119,7 +69,6 @@ $success-border-color--inverted: $suksess--darkbg;
 
         &:hover {
             color: $dismiss-hover-color;
-            color: var(--dismiss-hover-color);
         }
         &:focus {
             @include keyboard-navigation {
@@ -132,8 +81,7 @@ $success-border-color--inverted: $suksess--darkbg;
                     right: rem(-2px);
                     bottom: rem(-2px);
                     left: rem(-2px);
-                    box-shadow: 0 0 0 rem(2px) $border-color;
-                    box-shadow: 0 0 0 rem(2px) var(--border-color);
+                    box-shadow: 0 0 0 rem(2px) $dismiss-focus-border-color;
                 }
             }
         }
@@ -144,98 +92,19 @@ $success-border-color--inverted: $suksess--darkbg;
     }
 
     &--info {
-        border-color: $info-border-color;
-        border-color: var(--info-border-color);
-        background-color: $info-background-color;
-        background-color: var(--info-background-color);
-
-        .jkl-message-box__icon {
-            color: $info;
-            color: var(--info-border-color);
-        }
+        background-color: $bg-color--info;
     }
 
     &--warning {
-        border-color: $warning-border-color;
-        border-color: var(--warning-border-color);
-        background-color: $warning-background-color;
-        background-color: var(--warning-background-color);
-
-        .jkl-message-box__icon {
-            color: $warning-border-color;
-            color: var(--warning-border-color);
-
-            .jkl-icon-exclamation {
-                color: $border-color;
-                color: var(--border-color);
-            }
-        }
+        background-color: $bg-color--advarsel;
     }
 
     &--error {
-        border-color: $error-border-color;
-        border-color: var(--error-border-color);
-        background-color: $error-background-color;
-        background-color: var(--error-background-color);
-
-        .jkl-message-box__icon {
-            color: $error-border-color;
-            color: var(--error-border-color);
-        }
+        background-color: $bg-color--feil;
     }
 
     &--success {
-        border-color: $success-border-color;
-        border-color: var(--success-border-color);
-        background-color: $success-background-color;
-        background-color: var(--success-background-color);
-
-        .jkl-message-box__icon {
-            color: $success-border-color;
-            color: var(--success-border-color);
-        }
-    }
-
-    &--dark {
-        .jkl-message-box__content {
-            color: $text-color--inverted;
-        }
-        &.jkl-message-box--info {
-            border-color: $info-border-color--inverted;
-            background-color: $info-background-color--inverted;
-
-            .jkl-message-box__icon {
-                color: $info-border-color--inverted;
-            }
-        }
-        &.jkl-message-box--warning {
-            border-color: $warning-border-color--inverted;
-            background-color: $warning-background-color--inverted;
-
-            .jkl-message-box__icon {
-                color: $warning-border-color--inverted;
-
-                .jkl-icon-exclamation {
-                    color: $border-color--inverted;
-                }
-            }
-        }
-        &.jkl-message-box--error {
-            border-color: $error-border-color--inverted;
-            background-color: $error-background-color--inverted;
-
-            .jkl-message-box__icon {
-                color: $error-border-color--inverted;
-            }
-        }
-        &.jkl-message-box--success {
-            border-color: $success-border-color--inverted;
-            background-color: $success-background-color--inverted;
-
-            .jkl-message-box__icon {
-                color: $success-border-color--inverted;
-            }
-        }
+        background-color: $bg-color--suksess;
     }
 
     &--dismissed {


### PR DESCRIPTION
## Endringer

- Nytt utseende på meldingsbokser (`MessageBox` og `AlertMessage`)
- Varslingsfarger (_kun_ til bruk i komponenter) lagt til i core

## Kommentarer

Ikonene som er brukt her bør også inn i enten `Icons`-pakka eller core, slik at de enklere kan brukes i andre komponenter/mønstre. Koden er allerede duplisert i denne PRen, så behovet er der allerede. Jeg har valgt å ikke gjøre endringen her, både for ikke å gjøre PRen for stor, men også fordi `Icons`-pakka og håndteringen av ikoner trenger en generell overhaling.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon

![messagebox](https://user-images.githubusercontent.com/25739615/134339622-0df4b406-c98e-47ab-b4aa-3c5c427efd6b.gif)
![feedback](https://user-images.githubusercontent.com/25739615/134339641-a119ce16-46bd-4f73-b1a5-53da9d55f999.gif)
