### PR TITLE
chore: fiks rotering av assignee på weekly

### DIFF
--- a/.github/workflows/weekly-tasks.yml
+++ b/.github/workflows/weekly-tasks.yml
@@ -5,31 +5,39 @@
 
 name: Weekly tasks
 on:
-  schedule:
-    - cron: 00 05 * * 1
+    schedule:
+        - cron: 00 05 * * 1
 
 jobs:
-  create_issue:
-    name: Create weekly issue to upgrade dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name:  Create weekly issue to upgrade dependencies
-        uses: imjohnbo/issue-bot@v3.3.3
-        with:
-          assignees: "espkva, henrikhermansen, joms, kennidenni, mikaila94, piofinn, saegrov, sercansercan, wkillerud"
-          rotate-assignees: true
-          labels: "dependencies"
-          project: "Kjerneteamet"
-          title: "Weekly dependency update"
-          body: |
-            ### Agenda
+    create_issue:
+        name: Create weekly issue to upgrade dependencies
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: Create weekly issue to upgrade dependencies
+              uses: imjohnbo/issue-bot@v3.3.3
+              with:
+                  assignees: "wkillerud, henrikhermansen, joms, kennidenni, mikaila94, piofinn, saegrov, sercansercan, espkva"
+                  rotate-assignees: true
+                  labels: "🔁 round robin, 🔗 dependencies"
+                  pinned: true
+                  close-previous: true
+                  title: "Ukentlig oppdatering av avhengigheter"
+                  body: |
+                      ## Sjekkliste
 
-            - [ ] Use the command ```yarn upgrade-interactive``` to evaluate and upgrade packages.
-            - [ ] For major upgrades that requires more work, create a separate issue.
-                    
-          pinned: true
-          close-previous: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                      - [ ] På toppnivå i Jøkul, kjør `yarn upgrade-interactive` og velg alle patch- og minor-versjoner [^1]
+                      - [ ] Lag issue(s) på Github for å gjøre oppgraderinger som krever mer tid
+                      - [ ] Kjør `yarn build` og `yarn ci:test`
+                      - [ ] Lag en pull request som vanlig
+
+                      Dersom en devDependency har en ny major-versjon må du gjerne sjekke changeloggen og se om vi kan oppgraderes uten større problemer (f. eks. ved fjerning av støtte for utdaterte Node-versjoner).
+
+                      Eksempler på oppgraderinger som krever mer tid er typisk React majorversjoner, eller dersom en oppgradering tar med seg typedefinisjoner som skaper store problemer.
+
+                      ---
+
+                      [1]: Vi har [noen få pakker hvor vi gjør egne patcher](https://github.com/fremtind/jokul/tree/main/patches) i Jøkul. Disse må gjerne oppgraderes, men krever at vi [lager en tilsvarende patch](https://github.com/ds300/patch-package#usage) på den nye versjonen.
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-tasks.yml
+++ b/.github/workflows/weekly-tasks.yml
@@ -16,7 +16,7 @@ jobs:
             issues: write
         steps:
             - name: Create weekly issue to upgrade dependencies
-              uses: imjohnbo/issue-bot@v3.3.3
+              uses: imjohnbo/issue-bot@v3.3.4
               with:
                   assignees: "wkillerud, henrikhermansen, joms, kennidenni, mikaila94, piofinn, saegrov, sercansercan, espkva"
                   rotate-assignees: true


### PR DESCRIPTION
Bruk et sett med labels som er ulikt Dependabot så Issue Bot kan finne igjen forrige assignee.

Skriv om til norsk arbeidsspråk.

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
