### PR TITLE
chore(ci): use PAT for publishing to github packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
             - name: Publish packages to GitHub Packages
               if: ${{ success() }}
-              run: yarn release-gh --yes
+              run: |
+                echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_PAT }}" >> ~/.npmrc
+                yarn release-gh --yes
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}


### PR DESCRIPTION
Bruk et PAT (fra min bruker) for å publisere til GitHub Packages, inntil vi får på plass en mer permanent løsning (f.eks. via @fremtind-bot )

Jeg er ikke 100 % sikker på at dette vil løse problemet vi har hatt med publisering, men skader ikke å prøve!

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
