### PR TITLE
Oppdater lenke til hjemmeside i package.json-filene

### DIFF
--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react accordion component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "accordion",
         "jøkul",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for accordion menu",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "accordion",
         "jøkul",

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul alert message components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "jøkul",
         "fremtind",

--- a/packages/browserslist-config-jkl/package.json
+++ b/packages/browserslist-config-jkl/package.json
@@ -10,7 +10,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "license": "MIT",
     "main": "index.js",
     "files": [

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react button components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "button",
         "primary button",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for buttons",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "button",
         "primary button",

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react card component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "card"
     ],

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for card",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "card",
         "jøkul",

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react checkbox component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "checkbox",
         "form",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for checkbox",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "checkbox",
         "form",

--- a/packages/content-toggle-react/package.json
+++ b/packages/content-toggle-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react content-toggle component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "content-toggle",
         "animation",

--- a/packages/content-toggle/package.json
+++ b/packages/content-toggle/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for ContentToggle",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "content toggle",
         "jøkul",

--- a/packages/cookie-consent-react/package.json
+++ b/packages/cookie-consent-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react cookie consent component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "cookie consent",
         "jøkul",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for cookie consent solutions",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "cookie consent",
         "jøkul",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul core styles",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "core",
         "typography",

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react datepicker component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "datepicker",
         "jøkul",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for datepicker",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "datepicker",
         "jøkul",

--- a/packages/description-list-react/package.json
+++ b/packages/description-list-react/package.json
@@ -10,7 +10,7 @@
         "jøkul",
         "fremtind"
     ],
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/description-list/package.json
+++ b/packages/description-list/package.json
@@ -10,7 +10,7 @@
         "jøkul",
         "fremtind"
     ],
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "license": "MIT",
     "files": [
         "!example",

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react feedback component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "feedback",
         "jøkul",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for feedback",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "feedback",
         "jøkul",

--- a/packages/field-group-react/package.json
+++ b/packages/field-group-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Used to create a fieldset around groups of inputs",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "form"
     ],

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Style for fieldsets in Jøkul",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "form"
     ],

--- a/packages/hamburger-react/package.json
+++ b/packages/hamburger-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react hamburger component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "hamburger",
         "jøkul",

--- a/packages/hamburger/package.json
+++ b/packages/hamburger/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for hamburger menu",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "dropdown",
         "jøkul",

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react icon-button components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "button",
         "icon button",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for buttons",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "button",
         "icon button",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for icons",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "react",
         "icon",

--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -19,7 +19,7 @@
     "files": [
         "build"
     ],
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -5,7 +5,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "image",
         "images",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for list",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "bullet list",
         "ordered list",

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react loader component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "loader",
         "jøkul",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for loaders",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "loader",
         "jøkul",

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react logo component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "logo",
         "jøkul",

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -10,7 +10,7 @@
         "*.scss"
     ],
     "description": "Jøkul style for Fremtind logo",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "logo",
         "jøkul",

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react message box components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "messagebox",
         "message",

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react progress bar component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "progress bar",
         "jøkul",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for progress bar",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "progress bar",
         "jøkul",

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react radio button components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "radio",
         "form",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for radio button",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "radio",
         "radio button",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react button components",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "hooks",
         "react hooks",

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react select component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "dropdown",
         "select",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for select",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "dropdown",
         "select",

--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "A simple table with two columns.",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "summary-table",
         "jøkul",

--- a/packages/summary-table/package.json
+++ b/packages/summary-table/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "A simple table with two columns",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "summary-table",
         "jøkul",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for tables",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "table",
         "jøkul",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for text input fields",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "text",
         "text field",

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -5,7 +5,7 @@
     },
     "version": "5.0.4",
     "description": "Jøkul react toggle switch component",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "switch",
         "toggle switch",

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -5,7 +5,7 @@
     },
     "version": "5.0.3",
     "description": "Jøkul style for toggle switch",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "switch",
         "toggle switch",

--- a/packages/validators-util/package.json
+++ b/packages/validators-util/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Simple validator-functions to use for validating",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "validators",
         "utils",

--- a/packages/webfonts/package.json
+++ b/packages/webfonts/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Web fonts for Jøkul design system",
-    "homepage": "https://fremtind.github.io/jokul",
+    "homepage": "https://jokul.fremtind.no",
     "keywords": [
         "fremtind",
         "jøkul",


### PR DESCRIPTION
Fikser adressen til hjemmesiden i alle `package.json`-filene, så de ikke lenger peker til github pages-adressen.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
