### PR TITLE
chore: add repository field to package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,6 @@ jobs:
 
             - name: Publish packages to GitHub Packages
               if: ${{ success() }}
-              run: |
-                echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_PAT }}" >> ~/.npmrc
-                yarn release-gh --yes
+              run: yarn release-gh --yes
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -28,6 +28,10 @@
     "dependencies": {
         "@fremtind/jkl-core": "^7.1.0"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/fremtind/jokul.git"
+    },
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     }


### PR DESCRIPTION
- Legger til feltet `repository` i `package.json`-fila til `jkl-image`, slik at pakken kan publiseres til GitHub Packages uten problemer.
- Bruk GITHUB_TOKEN ved release til GitHub Packages

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
