### PR TITLE
fix: rett tastaturnavigering, skjermlesing, og CSS-bug i portalmeny

### DIFF
--- a/portal/src/components/Header/components/FullScreenMenuItem.scss
+++ b/portal/src/components/Header/components/FullScreenMenuItem.scss
@@ -10,6 +10,7 @@
 
     &__link {
         position: relative;
+        padding-left: 0;
 
         // static font-sizes for old browsers:
         font-size: rem(30px);
@@ -20,7 +21,6 @@
 
         // button resets:
         background-color: transparent;
-        padding: 0;
         cursor: pointer;
 
         @include medium-device {

--- a/portal/src/components/Header/components/MainMenu.tsx
+++ b/portal/src/components/Header/components/MainMenu.tsx
@@ -4,13 +4,14 @@ import { useAnimatedHeight, useScreen } from "@fremtind/jkl-react-hooks";
 import CoreToggle from "@nrk/core-toggle/jsx";
 import cx from "classnames";
 import { navigate } from "gatsby";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 
 import { isLeafItem, MenuItemList, RootItem, useFullscreenMenuContext } from "../../../contexts/fullscreenMenuContext";
 import { FullScreenMenuItem } from "./FullScreenMenuItem";
 import { useFullScreenMenuAnimaiton } from "./useFullScreenMenuAnimation";
 
 import "./MainMenu.scss";
+import { MainMenuItem } from "./MainMenuItem";
 
 interface MainMenuProps {
     className?: string;
@@ -80,17 +81,58 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                     isOpen={isOpen}
                 />
             )}
+            <CoreToggle
+                forwardRef={menuRef}
+                className={cx("jkl-portal-main-menu__overlay", {
+                    "jkl-portal-main-menu__overlay--open": isOpen,
+                })}
+                popup={true}
+                hidden={!isOpen}
+            >
+                <div className="jkl-portal-main-menu__menu-wrapper">
+                    {isSmallScreen && (
+                        <>
+                            {previousItem && (
+                                <button
+                                    data-text={previousItem.linkText}
+                                    aria-label={`Tilbake til ${previousItem.linkText}`}
+                                    className="jkl-portal-main-menu__back-button"
+                                    onClick={onNavigateBackward}
+                                >
+                                    ←
+                                </button>
+                            )}
+                            <ul className="jkl-portal-main-menu__menu-items" role="menu">
+                                {currentItem &&
+                                    currentItem.content.map((item, idx) => (
+                                        <FullScreenMenuItem
+                                            onClick={(evt) => {
+                                                if (isLeafItem(item)) {
+                                                    navigate(item.content);
+                                                    setIsOpen(false);
+                                                } else {
+                                                    onNavigateForward(item, evt);
+                                                }
+                                            }}
+                                            item={item}
+                                            key={item.linkText}
+                                            controls={controls}
+                                            idx={idx}
+                                        />
+                                    ))}
+                            </ul>
+                        </>
+                    )}
+                </div>
+            </CoreToggle>
             {!isSmallScreen && (
                 <ul className="jkl-portal-main-menu__root-list">
                     {items.map((item) => (
                         <li className="jkl-portal-main-menu__root-item" key={`main-menu-${item.linkText}`}>
-                            <button
-                                data-testid={`full-screen-menu--${item.linkText}`}
-                                className={cx("jkl-portal-main-menu__root-link", {
-                                    "jkl-portal-main-menu__root-link--active": currentItem?.linkText === item.linkText,
-                                })}
-                                aria-haspopup="menu"
-                                aria-expanded={currentItem?.linkText === item.linkText ? "true" : undefined}
+                            <MainMenuItem
+                                isActive={currentItem?.linkText === item.linkText}
+                                isOpen={isOpen && currentItem?.linkText === item.linkText}
+                                label={item.linkText}
                                 onClick={(e) => {
                                     if (!isOpen) {
                                         setIsOpen(true);
@@ -101,52 +143,27 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                                     onNavigateForward(item as RootItem, e);
                                 }}
                             >
-                                {item.linkText}
-                            </button>
+                                {(item as RootItem).content.map((item, idx) => (
+                                    <FullScreenMenuItem
+                                        onClick={(evt) => {
+                                            if (isLeafItem(item)) {
+                                                navigate(item.content);
+                                                setIsOpen(false);
+                                            } else {
+                                                onNavigateForward(item, evt);
+                                            }
+                                        }}
+                                        item={item}
+                                        key={item.linkText}
+                                        controls={controls}
+                                        idx={idx}
+                                    />
+                                ))}
+                            </MainMenuItem>
                         </li>
                     ))}
                 </ul>
             )}
-            <CoreToggle
-                forwardRef={menuRef}
-                className={cx("jkl-portal-main-menu__overlay", {
-                    "jkl-portal-main-menu__overlay--open": isOpen,
-                })}
-                popup={true}
-                hidden={!isOpen}
-            >
-                <div className="jkl-portal-main-menu__menu-wrapper" role="menu">
-                    {isSmallScreen && previousItem && (
-                        <button
-                            data-text={previousItem.linkText}
-                            aria-label={`Tilbake til ${previousItem.linkText}`}
-                            className="jkl-portal-main-menu__back-button"
-                            onClick={onNavigateBackward}
-                        >
-                            ←
-                        </button>
-                    )}
-                    <ul className="jkl-portal-main-menu__menu-items">
-                        {currentItem &&
-                            currentItem.content.map((item, idx) => (
-                                <FullScreenMenuItem
-                                    onClick={(evt) => {
-                                        if (isLeafItem(item)) {
-                                            navigate(item.content);
-                                            setIsOpen(false);
-                                        } else {
-                                            onNavigateForward(item, evt);
-                                        }
-                                    }}
-                                    item={item}
-                                    key={item.linkText}
-                                    controls={controls}
-                                    idx={idx}
-                                />
-                            ))}
-                    </ul>
-                </div>
-            </CoreToggle>
         </nav>
     );
 };

--- a/portal/src/components/Header/components/MainMenu.tsx
+++ b/portal/src/components/Header/components/MainMenu.tsx
@@ -76,6 +76,8 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                                 className={cx("jkl-portal-main-menu__root-link", {
                                     "jkl-portal-main-menu__root-link--active": currentItem?.linkText === item.linkText,
                                 })}
+                                aria-haspopup="menu"
+                                aria-expanded={currentItem?.linkText === item.linkText ? "true" : undefined}
                                 onClick={(e) => {
                                     if (!isOpen) {
                                         setIsOpen(true);
@@ -100,7 +102,7 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                 popup={true}
                 hidden={!isOpen}
             >
-                <div className="jkl-portal-main-menu__menu-wrapper">
+                <div className="jkl-portal-main-menu__menu-wrapper" role="menu">
                     {isSmallScreen && previousItem && (
                         <button
                             data-text={previousItem.linkText}

--- a/portal/src/components/Header/components/MainMenu.tsx
+++ b/portal/src/components/Header/components/MainMenu.tsx
@@ -4,7 +4,7 @@ import { useAnimatedHeight, useScreen } from "@fremtind/jkl-react-hooks";
 import CoreToggle from "@nrk/core-toggle/jsx";
 import cx from "classnames";
 import { navigate } from "gatsby";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 import { isLeafItem, MenuItemList, RootItem, useFullscreenMenuContext } from "../../../contexts/fullscreenMenuContext";
 import { FullScreenMenuItem } from "./FullScreenMenuItem";
@@ -52,6 +52,19 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
             setCurrentItem(rootItem);
         }
     };
+
+    useEffect(() => {
+        const escapeListener = (event: globalThis.KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setIsOpen(false);
+            }
+        };
+        window.addEventListener<"keyup">("keyup", escapeListener);
+
+        return () => {
+            window.removeEventListener<"keyup">("keyup", escapeListener);
+        };
+    }, [setIsOpen]);
 
     return (
         <nav className={cx("jkl-portal-main-menu", className)} aria-label="Hovedmeny">

--- a/portal/src/components/Header/components/MainMenuItem.tsx
+++ b/portal/src/components/Header/components/MainMenuItem.tsx
@@ -1,0 +1,44 @@
+// @ts-ignore: wait for nrk to supply types
+import CoreToggle from "@nrk/core-toggle/jsx";
+import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
+import cx from "classnames";
+import React from "react";
+interface Props {
+    label: string;
+    isOpen: boolean;
+    isActive: boolean;
+    onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+export const MainMenuItem: React.FC<Props> = ({ children, label, isActive, isOpen, onClick }) => {
+    const [menuRef] = useAnimatedHeight(isOpen);
+
+    return (
+        <>
+            <button
+                className={cx("jkl-portal-main-menu__root-link", {
+                    "jkl-portal-main-menu__root-link--active": isActive,
+                })}
+                aria-haspopup="menu"
+                aria-expanded={isOpen ? "true" : undefined}
+                onClick={onClick}
+            >
+                {label}
+            </button>
+            <CoreToggle
+                ref={menuRef}
+                className={cx("jkl-portal-main-menu__overlay", {
+                    "jkl-portal-main-menu__overlay--open": isOpen,
+                })}
+                popup={true}
+                hidden={!isOpen}
+            >
+                <div className="jkl-portal-main-menu__menu-wrapper">
+                    <ul className="jkl-portal-main-menu__menu-items" role="menu">
+                        {children}
+                    </ul>
+                </div>
+            </CoreToggle>
+        </>
+    );
+};


### PR DESCRIPTION
Fikser tastaturnavigasjon og gir et hint til skjermlesere om åpnet/lukket-tilstand til menyen. Retter også et stylingproblem hvor pila i menylenkene ville hoppe frem og tilbake om en holdt pekeren på feil sted.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
