### PR TITLE
feat: use cursor:pointer style on select

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -105,6 +105,7 @@ $select-hover-option-color--inverted: $svaberg;
         background-color: var(--select-background-color);
         color: $select-text-color;
         color: var(--select-text-color);
+        cursor: pointer;
 
         height: rem(48px);
         border-radius: rem(3px);
@@ -200,6 +201,7 @@ $select-hover-option-color--inverted: $svaberg;
         @include motion("standard");
         transition-property: color, background-color;
         position: relative;
+        cursor: pointer;
 
         &-label {
             padding: $component-spacing--small $component-spacing--large;

--- a/portal/src/texts/blog/cursor-pointer.mdx
+++ b/portal/src/texts/blog/cursor-pointer.mdx
@@ -1,0 +1,38 @@
+---
+title: "Å peke, eller ikke peke"
+author: Jo Emil Holen
+description: Et valg mellom å følge operativsystem eller norm
+publishDate: "2021.09.28"
+---
+
+<Ingress>
+    Operativsystemene og browser defaults tilsier at det kun er linker som skal ha en egen musepeker, men normen på
+    internett er at alle klikkbare elemenenter har dette satt. Hvordan angriper man en sånn problemstilling for å ta et
+    konsekvent valg?
+</Ingress>
+
+Om du trykker rundt i operativsystemet på datamaskinen din vil du se at når du fører musepekeren over en ting er det veldig sjeldent du får en egen musepeker. Dette er stort sett forbeholdt linker, og sånn har det vært ment helt siden vi så den spesielle pekeren i [Apple sitt HyperCard i 1987](https://adamsilver.io/blog/buttons-shouldnt-have-a-hand-cursor-part-2/).
+
+I designretningslinjenene til de forskjellige operativsystemene kan vi lese at en [musepeker av typen "pointer" indikerer en link](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor).
+Det samme ser vi på et ustilet HTML-element. Hverken knapper eller select har en egen musepeker ved hover som standard.
+
+## Men om vi ser på web er saken en helt annen.
+
+```css
+button {
+    pointer: cursor;
+}
+```
+
+Her har knapper, lenker, selects og andre klikkbare elementer mer eller mindre konsekvent en egen peker.
+Både på større og mindre nettsteder ser man dette, det samme med designsystemer som [Carbon](https://www.carbondesignsystem.com/components/select/usage/) og [Material You](https://mui.com/components/buttons/).
+
+Hvorfor det har blitt sånn er vanskelig å si. Kanskje det er en missforståelse om at klikkbare elementer skal ha en egen peker. Eller kanskje man bare har fortsatt med det fordi "alle andre har det" gjennom historien. Kanskje det kommer fra et tredjeparts bibliotek.
+
+Selv er dette noe vi har gjort mindre bevisst. Før denne problemstillingen ble tatt opp kunne man se at f.eks. knapper allerede hadde egen musepeker ved hover.
+
+## I Jøkul har vi tatt en avgjørelse om å konsekvent følge normen.
+
+Etter å ha snakket om dette temaet i Designsystem Forum gjorde vi en avstemning på hva designere og utviklere mente om dette temaet. Noen mente at vi burde ta et sterkt standpunkt å bidra til å redde internett fra denne utingen. Andre mente at vi burde sikre at klikkbare elementer oppførte seg kjent for brukeren.
+
+Med et flertall for å konsekvent bruke egen peker på klikkbare elementer har vi satt brukeren i fokus og sikrer at man unngår forvirring der man kan ha en forventning til hvordan klikkbare elementer oppfører seg.

--- a/portal/src/texts/blog/cursor-pointer.mdx
+++ b/portal/src/texts/blog/cursor-pointer.mdx
@@ -6,17 +6,18 @@ publishDate: "2021.09.28"
 ---
 
 <Ingress>
-    Operativsystemene og browser defaults tilsier at det kun er linker som skal ha en egen musepeker, men normen på
-    internett er at alle klikkbare elemenenter har dette satt. Hvordan angriper man en sånn problemstilling for å ta et
-    konsekvent valg?
+    Operativsystemer og nettleserstandarder sier at det kun er linker som skal ha en egen musepeker, men likevel har
+    normen på internett blitt at alle klikkbare elemenenter har det. Hvordan angriper man en sånn problemstilling for å
+    ta et konsekvent valg?
 </Ingress>
 
-Om du trykker rundt i operativsystemet på datamaskinen din vil du se at når du fører musepekeren over en ting er det veldig sjeldent du får en egen musepeker. Dette er stort sett forbeholdt linker, og sånn har det vært ment helt siden vi så den spesielle pekeren i [Apple sitt HyperCard i 1987](https://adamsilver.io/blog/buttons-shouldnt-have-a-hand-cursor-part-2/).
+Om du trykker rundt i operativsystemet på datamaskinen din vil du se at når du fører musepekeren over en ting er det veldig sjelden du får en egen musepeker. Dette er stort sett forbeholdt linker, og sånn har det vært ment helt siden vi først så den spesielle pekeren i [Apple sitt HyperCard i 1987](https://adamsilver.io/blog/buttons-shouldnt-have-a-hand-cursor-part-2/).
 
 I designretningslinjenene til de forskjellige operativsystemene kan vi lese at en [musepeker av typen "pointer" indikerer en link](https://www.w3.org/TR/CSS21/ui.html#propdef-cursor).
-Det samme ser vi på et ustilet HTML-element. Hverken knapper eller select har en egen musepeker ved hover som standard.
+Det samme ser vi på et ustilet HTML-element: Hverken knapper eller select har en egen musepeker ved hover som standard.
 
-## Men om vi ser på web er saken en helt annen.
+**Men om vi ser på web er saken en helt annen.** Her har knapper, lenker, selects og andre klikkbare elementer mer eller mindre konsekvent en egen peker.
+Både på større og mindre nettsteder ser man dette, også i designsystemer som [Carbon](https://www.carbondesignsystem.com/components/select/usage/) og [Material You](https://mui.com/components/buttons/).
 
 ```css
 button {
@@ -24,15 +25,10 @@ button {
 }
 ```
 
-Her har knapper, lenker, selects og andre klikkbare elementer mer eller mindre konsekvent en egen peker.
-Både på større og mindre nettsteder ser man dette, det samme med designsystemer som [Carbon](https://www.carbondesignsystem.com/components/select/usage/) og [Material You](https://mui.com/components/buttons/).
+Hvorfor det har blitt sånn er vanskelig å si. Kanskje det kommer fra en misforståelse om at klikkbare elementer skal ha en egen peker, eller kanskje man bare har fortsatt med det fordi "alle andre gjør det". Kanskje har det sneket seg inn gjennom tredjeparts biblioteker.
 
-Hvorfor det har blitt sånn er vanskelig å si. Kanskje det er en missforståelse om at klikkbare elementer skal ha en egen peker. Eller kanskje man bare har fortsatt med det fordi "alle andre har det" gjennom historien. Kanskje det kommer fra et tredjeparts bibliotek.
+Selv er dette noe vi har gjort mindre bevisst. Før denne problemstillingen ble tatt opp kunne man se at for eksempel knapper allerede hadde egen musepeker ved hover.
 
-Selv er dette noe vi har gjort mindre bevisst. Før denne problemstillingen ble tatt opp kunne man se at f.eks. knapper allerede hadde egen musepeker ved hover.
+**I Jøkul har vi nå tatt en avgjørelse om konsekvent å følge normen:** Etter å ha snakket om temaet i Designsystemforumet gjorde vi en avstemning på hva designere og utviklere mente om det. Noen mente at vi burde ta et sterkt standpunkt å bidra til å redde internett fra denne utingen. Andre mente at vi burde sikre at klikkbare elementer oppførte seg på en måte som er kjent for brukeren.
 
-## I Jøkul har vi tatt en avgjørelse om å konsekvent følge normen.
-
-Etter å ha snakket om dette temaet i Designsystem Forum gjorde vi en avstemning på hva designere og utviklere mente om dette temaet. Noen mente at vi burde ta et sterkt standpunkt å bidra til å redde internett fra denne utingen. Andre mente at vi burde sikre at klikkbare elementer oppførte seg kjent for brukeren.
-
-Med et flertall for å konsekvent bruke egen peker på klikkbare elementer har vi satt brukeren i fokus og sikrer at man unngår forvirring der man kan ha en forventning til hvordan klikkbare elementer oppfører seg.
+Med et flertall for konsekvent å bruke egen peker på klikkbare elementer har vi satt brukeren i fokus, og ved å gi en klar forventing om hvordan klikkbare elementer oppfører seg unngår man forvirring.


### PR DESCRIPTION
affects: @fremtind/jkl-select, @fremtind/portal

ISSUES CLOSED: #2173

Setter `cursor:pointer` på select. Dette ser ut til å være det eneste klikkbare elementet som ikke brukte denne stilen. Endringen gjøres etter å ha diskutert dette på ds-forum.

Jeg har også skrevet en bloggpost om hvorfor og hvordan vi har tatt denne avgjørelsen. Fint om noen vil lese over og komme med tilbakemeldinger.

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [X] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [X] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [X] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [X] Jeg har skrevet relevant dokumentasjon
