### PR TITLE
docs: gi pakker riktig lenke og overskrift i readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/funksjonalitets-nske.md
+++ b/.github/ISSUE_TEMPLATE/funksjonalitets-nske.md
@@ -1,19 +1,19 @@
 ---
 name: Funksjonalitetsønske
 about: Foreslå en idé til endring eller ny funksjonalitet
-title: ''
+title: ""
 labels: "✨ enhancement"
-assignees: ''
-
+assignees: ""
 ---
 
-Hvilke steg i [prosessen](https://fremtind.github.io/jokul/komigang/prosessen) er utført?
-- [ ] Undersøke
-- [ ] Rapportere
-- [ ] Avklare
-- [ ] Spesifisere krav
-- [ ] Utvikle
-- [ ] Ferdig!
+Hvilke steg i [prosessen](https://jokul.fremtind.no/komigang/prosessen) er utført?
+
+-   [ ] Undersøke
+-   [ ] Rapportere
+-   [ ] Avklare
+-   [ ] Spesifisere krav
+-   [ ] Utvikle
+-   [ ] Ferdig!
 
 **Er ønsket tilknyttet et problem? Fortell oss mer!**
 Gi oss en klar og konsis beskrivelse av problemet. F.eks "Det er dumt at jeg alltid må [...]".

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Jøkul]() av [Fremtind](https://fremtind.no)
+# [Jøkul](https://jokul.fremtind.no) av [Fremtind](https://fremtind.no)
 
 ![lint-test-typecheck](https://img.shields.io/github/workflow/status/fremtind/jokul/lint-test-typecheck)
 ![Visual regression tests](https://img.shields.io/github/workflow/status/fremtind/jokul/Visual%20regression%20tests?label=cypress)
@@ -11,7 +11,7 @@ Jøkul er et [designsystem](https://www.invisionapp.com/inside-design/guide-to-d
 -   **Komponenter**: React-komponentene våre er klare til bruk. Vi har skrevet dem i Typescript, slik at utvikleropplevelsen blir bedre og det blir færre feil.
 -   **Kan utvides**: Jøkul har innebygd støtte for css, scss og React, men er lagt opp til å kunne støtte andre rammeverk og fremtidig teknologi.
 
-## [Kom i gang](https://fremtind.github.io/jokul/komigang/utvikling)
+## [Kom i gang](https://jokul.fremtind.no/komigang/utvikling)
 
 1. Klon repoet til maskinen din og naviger deg til mappen i terminalen
 2. Installer avhengigheter og bygg pakkene med `yarn boot`
@@ -49,9 +49,9 @@ import "@fremtind/jkl-button/button.min.css";
 ...
 ```
 
-## [Dokumentasjon](https://fremtind.github.io/jokul/)
+## [Dokumentasjon](https://jokul.fremtind.no/)
 
-På [https://fremtind.github.io/jokul/](https://fremtind.github.io/jokul/) finner du informasjon om hvordan du bruker Jøkul, om designprinsippene til Fremtind og beskrivelse, bruksområder og kode for hver enkelt komponent.
+På [https://jokul.fremtind.no/](https://jokul.fremtind.no/) finner du informasjon om hvordan du bruker Jøkul, om designprinsippene til Fremtind og beskrivelse, bruksområder og kode for hver enkelt komponent.
 
 ## Bidra
 
@@ -61,7 +61,7 @@ Formålet vårt med Jøkul er at det skal gå raskere å utvikle Fremtind-løsni
 
 Vi setter pris på alle bidrag, enten du [rapporterer feil](https://github.com/fremtind/jokul/issues/new/choose), [har ønsker om ny funksjonalitet](https://github.com/fremtind/jokul/issues/new/choose), [bugfix](https://github.com/fremtind/jokul/labels/bug) eller [vil utvikle noe nytt](https://github.com/fremtind/jokul/labels/enhancement).
 
-Les mer om hvordan du kan bidra i [guiden](https://fremtind.github.io/jokul/komigang/utvikling) vår.
+Les mer om hvordan du kan bidra i [guiden](https://jokul.fremtind.no/komigang/utvikling) vår.
 
 ### Oppførsel
 

--- a/packages/accordion-react/README.md
+++ b/packages/accordion-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-accordion-react`](https://fremtind.github.io/jokul/komponenter/accordion)
+# [`@fremtind/jkl-accordion-react`](https://jokul.fremtind.no/komponenter/accordion)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/accordion).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/accordion).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-accordion`](https://fremtind.github.io/jokul/komponenter/accordion)
+# [`@fremtind/jkl-accordion`](https://jokul.fremtind.no/komponenter/accordion)
 
 # Trekkspillister
 

--- a/packages/alert-message-react/README.md
+++ b/packages/alert-message-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-alert-message-react`](https://fremtind.github.io/jokul/komponenter/alert-message)
+# [`@fremtind/jkl-alert-message-react`](https://jokul.fremtind.no/komponenter/alert-message)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/alert-message).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/alert-message).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/alert-message/README.md
+++ b/packages/alert-message/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-message-box`](https://fremtind.github.io/jokul/komponenter/alert-message)
+# [`@fremtind/jkl-message-box`](https://jokul.fremtind.no/komponenter/alert-message)
 
 # Meldinger
 

--- a/packages/browserslist-config-jkl/README.md
+++ b/packages/browserslist-config-jkl/README.md
@@ -1,4 +1,4 @@
-# [`browserslist-config-jkl`](https://fremtind.github.io/jokul)
+# [`@fremtind/browserslist-config-jkl`](https://jokul.fremtind.no)
 
 Inneholder browserlist konfigurasjonen til Jøkul. Endringer i denne pakke vil påvirke alle andre pakker i Jøkul, så alle endringer her vil kreve regresjonstesting av alle andre pakker i de browsere vi ønsker å støtte.
 

--- a/packages/button-react/README.md
+++ b/packages/button-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-button-react`](https://fremtind.github.io/jokul/komponenter/buttons)
+# [`@fremtind/jkl-button-react`](https://jokul.fremtind.no/komponenter/buttons)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/buttons).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/buttons).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -1,4 +1,4 @@
-#  [`@fremtind/jkl-button`](https://fremtind.github.io/jokul/komponenter/buttons)
+#  [`@fremtind/jkl-button`](https://jokul.fremtind.no/komponenter/buttons)
 
 # Knapper
 

--- a/packages/card-react/README.md
+++ b/packages/card-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-card-react`](https://fremtind.github.io/jokul/komponenter/card)
+# [`@fremtind/jkl-card-react`](https://jokul.fremtind.no/komponenter/card)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/card).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/card).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/card-react/documentation/Example.tsx
+++ b/packages/card-react/documentation/Example.tsx
@@ -15,7 +15,7 @@ const CardDemo = () => (
 
         <br></br>
 
-        <Card title="Basic Card" clickable={{ href: "https://fremtind.github.io/jokul/" }} className="test-class">
+        <Card title="Basic Card" clickable={{ href: "https://jokul.fremtind.no/" }} className="test-class">
             <h2 className="jkl-h4">Clickable</h2>
             <p className="jkl-body">
                 Først ser vi om vi kan behandle saken din automatisk. Da får du svar samme dag. Hvis den ikke kan

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -1,1 +1,1 @@
-# [`@fremtind/jkl-card`](https://fremtind.github.io/jokul/komponenter/card)
+# [`@fremtind/jkl-card`](https://jokul.fremtind.no/komponenter/card)

--- a/packages/checkbox-react/README.md
+++ b/packages/checkbox-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-checkbox-react`](https://fremtind.github.io/jokul/komponenter/checkbox)
+# [`@fremtind/jkl-checkbox-react`](https://jokul.fremtind.no/komponenter/checkbox)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/checkbox).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/checkbox).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 
@@ -22,7 +22,7 @@ import "@fremtind/jkl-checkbox/checkbox.min.css";
 
 ### Bruk
 
-Som regel vil du bruke `Checkbox`-komponenten sammen med `FieldGroup` for å skape en forståelse av konteksten rundt valgene. Se [dokumentasjonen i den pakken](https://fremtind.github.io/jokul/komponenter/FieldGroup) for nærmere forklaring av funksjonaliteten.
+Som regel vil du bruke `Checkbox`-komponenten sammen med `FieldGroup` for å skape en forståelse av konteksten rundt valgene. Se [dokumentasjonen i den pakken](https://jokul.fremtind.no/komponenter/FieldGroup) for nærmere forklaring av funksjonaliteten.
 
 `Checkbox` tar et `name`, som kan være det samme for flere bokser, og en `value` som er unik blandt avmerkingsbokser som deler samme `name`:
 

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-checkbox`](https://fremtind.github.io/jokul/komponenter/checkbox)
+# [`@fremtind/jkl-checkbox`](https://jokul.fremtind.no/komponenter/checkbox)
 
 # Avmerkingsbokser
 

--- a/packages/constants-util/README.md
+++ b/packages/constants-util/README.md
@@ -1,3 +1,3 @@
-# [`@fremtind/jkl-constants-util`](https://fremtind.github.io/jokul/komponenter/constants)
+# [`@fremtind/jkl-constants-util`](https://jokul.fremtind.no/komponenter/constants)
 
 Constant utility files like unicode signs.

--- a/packages/content-toggle-react/README.md
+++ b/packages/content-toggle-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-content-toggle-react`](https://fremtind.github.io/jokul/komponenter/contenttoggle)
+# [`@fremtind/jkl-content-toggle-react`](https://jokul.fremtind.no/komponenter/contenttoggle)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/contenttoggle).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/contenttoggle).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/content-toggle/README.md
+++ b/packages/content-toggle/README.md
@@ -1,1 +1,1 @@
-# [`@fremtind/jkl-content-toggle`](https://fremtind.github.io/jokul/komponenter/contenttoggle)
+# [`@fremtind/jkl-content-toggle`](https://jokul.fremtind.no/komponenter/contenttoggle)

--- a/packages/cookie-consent-react/README.md
+++ b/packages/cookie-consent-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-cookie-consent-react`](https://fremtind.github.io/jokul/komponenter/cookie-consent)
+# [`@fremtind/jkl-cookie-consent-react`](https://jokul.fremtind.no/komponenter/cookie-consent)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/cokie-consent).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/cokie-consent).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -1,4 +1,4 @@
-#  [`@fremtind/jkl-cookie-consent`](https://fremtind.github.io/jokul/komponenter/cookie-consent)
+#  [`@fremtind/jkl-cookie-consent`](https://jokul.fremtind.no/komponenter/cookie-consent)
 
 # Cookie consent
 

--- a/packages/datepicker-react/README.md
+++ b/packages/datepicker-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-datepicker-react`](https://fremtind.github.io/jokul/komponenter/datepicker)
+# [`@fremtind/jkl-datepicker-react`](https://jokul.fremtind.no/komponenter/datepicker)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/datepicker).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/datepicker).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/datepicker/README.md
+++ b/packages/datepicker/README.md
@@ -1,4 +1,4 @@
-# [`datepicker`](https://fremtind.github.io/jokul/komponenter/datepicker)
+# [`@fremtind/jkl-datepicker`](https://jokul.fremtind.no/komponenter/datepicker)
 
 # Datovelger
 

--- a/packages/description-list-react/README.md
+++ b/packages/description-list-react/README.md
@@ -1,12 +1,12 @@
-# `@fremtind/jkl-description-list-react`
+# [`@fremtind/jkl-description-list-react`](https://jokul.fremtind.no/komponenter/descriptionlist)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/descriptionlist).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/descriptionlist).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ### Installasjon
 

--- a/packages/description-list/README.md
+++ b/packages/description-list/README.md
@@ -1,1 +1,1 @@
-# [`DescriptionList`](https://fremtind.github.io/jokul/komponenter/descriptionlist)
+# [`@fremtind/jkl-description-list`](https://jokul.fremtind.no/komponenter/descriptionlist)

--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-feedback-react`](https://fremtind.github.io/jokul/komponenter/feedback)
+# [`@fremtind/jkl-feedback-react`](https://jokul.fremtind.no/komponenter/feedback)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/feedback).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/feedback).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/komigang/utvikling/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/komigang/utvikling/)
 
 ## Bruk av React-pakken
 

--- a/packages/feedback/README.md
+++ b/packages/feedback/README.md
@@ -1,1 +1,1 @@
-# [`Feedback`](https://fremtind.github.io/jokul/komponenter/Feedback)
+# [`@fremtind/jkl-feedback`](https://jokul.fremtind.no/komponenter/Feedback)

--- a/packages/field-group-react/README.md
+++ b/packages/field-group-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/field-group`](https://fremtind.github.io/jokul/komponenter/fieldgroup)
+# [`@fremtind/field-group-react`](https://jokul.fremtind.no/komponenter/fieldgroup)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/fieldgroup).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/fieldgroup).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-komponenten
 

--- a/packages/field-group/README.md
+++ b/packages/field-group/README.md
@@ -1,18 +1,21 @@
-# `@fremtind/field-group`
+# [`@fremtind/field-group`](https://jokul.fremtind.no/komponenter/fieldgroup)
 
 # Feltsett
-Et feltsett er et sett med skjemafelter som hører sammen, for eksempel navn, adresse og postnummer/sted. 
+
+Et feltsett er et sett med skjemafelter som hører sammen, for eksempel navn, adresse og postnummer/sted.
 Feltsettet må ha en overskrift som beskriver innholdet, og kan også ha en hjelpetekst eller en feilmelding.
 
 ## Tekst og validering
+
 Velg størrelse på overskriften til feltsettet etter prinsippene for skjemadesign. Lag en kort og tydelig overskrift, som beskriver hva brukeren skal gjøre. Du kan også legge en forklarende hjelpetekst under feltsettet.
 
-Hvis feltsettet ikke validerer, kan vi enten velge å legge en feilemelding under hele settet, eller under ett eller flere felt, hvis det gir bedre hjelp. 
+Hvis feltsettet ikke validerer, kan vi enten velge å legge en feilemelding under hele settet, eller under ett eller flere felt, hvis det gir bedre hjelp.
 
-Eksempel: 
-I et sett med radioknapper, viser vi feilmeldingen under feltsettet. Merk at feilmeldingen erstatter en eventuell hjelpetekst, slik at den feilmeldingen du lager også må fortelle hva hjelpeteksten var. 
+Eksempel:
+I et sett med radioknapper, viser vi feilmeldingen under feltsettet. Merk at feilmeldingen erstatter en eventuell hjelpetekst, slik at den feilmeldingen du lager også må fortelle hva hjelpeteksten var.
 
 ## Bruk
-- Et sett med radioknapper
-- Et sett med avmerkingsbokser
-- Et feltsett som til sammen utgjør et konsept (for eksempel adressefelter)
+
+-   Et sett med radioknapper
+-   Et sett med avmerkingsbokser
+-   Et feltsett som til sammen utgjør et konsept (for eksempel adressefelter)

--- a/packages/hamburger-react/README.md
+++ b/packages/hamburger-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-hamburger-react`](https://fremtind.github.io/jokul/komponenter/hamburger)
+# [`@fremtind/jkl-hamburger-react`](https://jokul.fremtind.no/komponenter/hamburger)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/hamburger).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/hamburger).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/hamburger/README.md
+++ b/packages/hamburger/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-hamburger`](https://fremtind.github.io/jokul/komponenter/hamburger)
+# [`@fremtind/jkl-hamburger`](https://jokul.fremtind.no/komponenter/hamburger)
 
 ## Om hamburgermenyen
 

--- a/packages/icon-button-react/README.md
+++ b/packages/icon-button-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-icon-button-react`](https://fremtind.github.io/jokul/komponenter/iconbutton)
+# [`@fremtind/jkl-icon-button-react`](https://jokul.fremtind.no/komponenter/iconbutton)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/iconbutton).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/iconbutton).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 
@@ -29,10 +29,8 @@ Komponentene tar følgende props:
 -   `buttonTitle`: Serverer som hjelpetekst. `string`
 -   `onClick`: **Påkrevd**. Klikkhåndtering for knappen. Får en MouseEvent som første argument. `MouseEventHandler<HTMLButtonElement>`
 
-
 En enkel bruk av knapper kan se slik ut:
 
 ```jsx
 <IconButton iconType="calendar" onClick={onClick} buttonTitle="Vis kalendar" />
 ```
-

--- a/packages/icon-button/README.md
+++ b/packages/icon-button/README.md
@@ -1,4 +1,4 @@
-#  [`@fremtind/jkl-button`](https://fremtind.github.io/jokul/komponenter/buttons)
+#  [`@fremtind/jkl-button`](https://jokul.fremtind.no/komponenter/buttons)
 
 # Knapper
 

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-icons-react`](https://fremtind.github.io/jokul/komponenter/icons)
+# [`@fremtind/jkl-icons-react`](https://jokul.fremtind.no/komponenter/icons)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/icons).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/icons).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 
@@ -29,11 +29,9 @@ import { ArrowDown } from "@fremtind/jkl-icons-react";
 
 Ikonene arver farge fra foreldre komponenten, så om man ønsker endring i dark mode, må det styres av komponenten over. Nødvendig stil kommer fra core stil pakka.
 
-
 ```js
 import { ArrowHorizontalAnimated } from "@fremtind/jkl-icons-react";
 import "@fremtind/jkl-icons/animated-icons.min.css";
-
 ```
 
 ### Bruk

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,4 +1,4 @@
-# [`Icons`](https://fremtind.github.io/jokul/komponenter/icons)
+# [`@fremtind/jkl-icons`](https://jokul.fremtind.no/komponenter/icons)
 
 # Ikoner
 

--- a/packages/image-react/README.md
+++ b/packages/image-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-icons-react`](https://fremtind.github.io/jokul/komponenter/image)
+# [`@fremtind/jkl-image-react`](https://jokul.fremtind.no/komponenter/image)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/image).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/image).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -1,4 +1,4 @@
-# [`Image`](https://fremtind.github.io/jokul/komponenter/image)
+# [`@fremtind/jkl-image`](https://jokul.fremtind.no/komponenter/image)
 
 # Image
 

--- a/packages/list-react/README.md
+++ b/packages/list-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-list-react`](https://fremtind.github.io/jokul/komponenter/list)
+# [`@fremtind/jkl-list-react`](https://jokul.fremtind.no/komponenter/list)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/list).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/list).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-list`](https://fremtind.github.io/jokul/komponenter/list)
+# [`@fremtind/jkl-list`](https://jokul.fremtind.no/komponenter/list)
 
 -   **Utgått:** Denne komponenten er utgått, og erstattet av `@fremtind/jkl-list`
 -   **Deprecated:** This component is deprecated, and replaced by `@fremtind/jkl-list`

--- a/packages/loader-react/README.md
+++ b/packages/loader-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-loader-react`](https://fremtind.github.io/jokul/komponenter/loader)
+# [`@fremtind/jkl-loader-react`](https://jokul.fremtind.no/komponenter/loader)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/loader).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/loader).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-komponenten
 

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-loader`](https://fremtind.github.io/jokul/komponenter/loader)
+# [`@fremtind/jkl-loader`](https://jokul.fremtind.no/komponenter/loader)
 
 # Lasteindikator
 

--- a/packages/logo-react/README.md
+++ b/packages/logo-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-logo-react`](https://fremtind.github.io/jokul/komponenter/logo)
+# [`@fremtind/jkl-logo-react`](https://jokul.fremtind.no/komponenter/logo)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/logo).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/logo).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/logo/README.md
+++ b/packages/logo/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-logo`](https://fremtind.github.io/jokul/komponenter/logo)
+# [`@fremtind/jkl-logo`](https://jokul.fremtind.no/komponenter/logo)
 
 # Logo, logosymbol og stempel
 

--- a/packages/message-box-react/README.md
+++ b/packages/message-box-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-message-box-react`](https://fremtind.github.io/jokul/komponenter/messagebox)
+# [`@fremtind/jkl-message-box-react`](https://jokul.fremtind.no/komponenter/messagebox)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/messagebox).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/messagebox).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/message-box/README.md
+++ b/packages/message-box/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-message-box`](https://fremtind.github.io/jokul/komponenter/messagebox)
+# [`@fremtind/jkl-message-box`](https://jokul.fremtind.no/komponenter/messagebox)
 
 # Meldinger
 

--- a/packages/progress-bar-react/README.md
+++ b/packages/progress-bar-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-progress-bar-react`](https://fremtind.github.io/jokul/komponenter/progessbar)
+# [`@fremtind/jkl-progress-bar-react`](https://jokul.fremtind.no/komponenter/progessbar)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/progessbar).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/progessbar).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-progress-bar`](https://fremtind.github.io/jokul/komponenter/progessbar)
+# [`@fremtind/jkl-progress-bar`](https://jokul.fremtind.no/komponenter/progessbar)
 
 ## Om Fremdriftsindikator
 

--- a/packages/radio-button-react/README.md
+++ b/packages/radio-button-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-radio-button-react`](hhttps://fremtind.github.io/jokul/komponenter/radiobutton)
+# [`@fremtind/jkl-radio-button-react`](hhttps://jokul.fremtind.no/komponenter/radiobutton)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](hhttps://fremtind.github.io/jokul/komponenter/radiobutton).
+Se portalen for [bruk og prinsipper](hhttps://jokul.fremtind.no/komponenter/radiobutton).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-komponenten
 

--- a/packages/radio-button/README.md
+++ b/packages/radio-button/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-radio-button`](https://fremtind.github.io/jokul/komponenter/radiobutton)
+# [`@fremtind/jkl-radio-button`](https://jokul.fremtind.no/komponenter/radiobutton)
 
 ## Radioknapper
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-react-hooks`](https://fremtind.github.io/jokul/komponenter/hooks)
+# [`@fremtind/jkl-react-hooks`](https://jokul.fremtind.no/komponenter/hooks)
 
 ## Beskrivelse
 
-[Bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/hooks).
+[Bruk og prinsipper](https://jokul.fremtind.no/komponenter/hooks).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/komigang/utvikling)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/komigang/utvikling)
 
 ## Bruk av React-pakken
 

--- a/packages/select-react/README.md
+++ b/packages/select-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-select-react`](https://fremtind.github.io/jokul/komponenter/select)
+# [`@fremtind/jkl-select-react`](https://jokul.fremtind.no/komponenter/select)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/select).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/select).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-select`](https://fremtind.github.io/jokul/komponenter/select)
+# [`@fremtind/jkl-select`](https://jokul.fremtind.no/komponenter/select)
 
 # Nedtrekksliste
 

--- a/packages/summary-table-react/README.md
+++ b/packages/summary-table-react/README.md
@@ -1,13 +1,12 @@
-# `@fremtind/jkl-summary-table-react`
-
+# [`@fremtind/jkl-summary-table-react`](https://jokul.fremtind.no/komponenter/summarytable)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/summarytable).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/summarytable).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/summary-table/README.md
+++ b/packages/summary-table/README.md
@@ -1,1 +1,1 @@
-# [`SummaryTable`](https://fremtind.github.io/jokul/komponenter/summarytable)
+# [`@fremtind/jkl-summary-table`](https://jokul.fremtind.no/komponenter/summarytable)

--- a/packages/table-react/README.md
+++ b/packages/table-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-table-react`](https://fremtind.github.io/jokul/komponenter/table)
+# [`@fremtind/jkl-table-react`](https://jokul.fremtind.no/komponenter/table)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/table).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/table).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-komponenten
 

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,3 +1,3 @@
-#  [`@fremtind/jkl-table`](https://fremtind.github.io/jokul/komponenter/table)
+#  [`@fremtind/jkl-table`](https://jokul.fremtind.no/komponenter/table)
 
 Vi bruker tabeller for å vise data på en ordnet måte som gjør sammenlikning enkelt. Tabellen består av et sett med navngitte kolonner, og en eller flere rader med data som tilhører de angitte kolonnene. Rader kan være klikkbare, dersom det er naturlig å utføre en handling på eller med informasjonen som vises.

--- a/packages/text-input-react/README.md
+++ b/packages/text-input-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-text-input-react`](https://fremtind.github.io/jokul/komponenter/textinput)
+# [`@fremtind/jkl-text-input-react`](https://jokul.fremtind.no/komponenter/textinput)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/textinput).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/textinput).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 
@@ -53,7 +53,7 @@ Husk å sette `label` til en fornuftig beskrivelse av handlingen (f.eks. "nullst
 #### BaseInputField
 
 Denne er kun eksponert for å dekke spesielle behov og anbefales ikke å brukes.
-Skal denne brukes frittstående må den akkompagneres av en `Label` fra [`@fremtind/jkl-core`](https://fremtind.github.io/jokul/komponenter/Typography) hvor `standAlone` og `htmlFor` skal være spesifisert. Eksempel på hvordan denne kan brukes:
+Skal denne brukes frittstående må den akkompagneres av en `Label` fra [`@fremtind/jkl-core`](https://jokul.fremtind.no/komponenter/Typography) hvor `standAlone` og `htmlFor` skal være spesifisert. Eksempel på hvordan denne kan brukes:
 
 ```tsx
 <Label standAlone htmlFor="complicatedquestion">

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/jkl-text-input`](https://fremtind.github.io/jokul/komponenter/textinput)
+# [`@fremtind/jkl-text-input`](https://jokul.fremtind.no/komponenter/textinput)
 
 # Tekstfelt
 

--- a/packages/toggle-switch-react/README.md
+++ b/packages/toggle-switch-react/README.md
@@ -1,12 +1,12 @@
-# [`@fremtind/jkl-toggle-switch-react`](https://fremtind.github.io/jokul/komponenter/toggleswitch)
+# [`@fremtind/jkl-toggle-switch-react`](https://jokul.fremtind.no/komponenter/toggleswitch)
 
 ## Beskrivelse
 
-Se portalen for [bruk og prinsipper](https://fremtind.github.io/jokul/komponenter/toggleswitch).
+Se portalen for [bruk og prinsipper](https://jokul.fremtind.no/komponenter/toggleswitch).
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/developer/getting-started/)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/developer/getting-started/)
 
 ## Bruk av React-pakken
 

--- a/packages/toggle-switch/README.md
+++ b/packages/toggle-switch/README.md
@@ -1,12 +1,14 @@
-# `@fremtind/jkl-toggle-switch`
+# [`@fremtind/jkl-toggle-switch`](https://jokul.fremtind.no/komponenter/toggleswitch)
 
 # Veksleknapp (toggle switch)
+
 Med veksleknapper kan brukerne bytte mellom to statuser (av eller på) uten at de må bekrefte valget. Ledeteksten forteller hva brukeren slår av og på.
 
-Veksleknapper passer til situasjoner der brukerne selv kan velge å ha en funksjon av eller på, for eksempel automatisk oppdatering eller automatisk lagring. 
+Veksleknapper passer til situasjoner der brukerne selv kan velge å ha en funksjon av eller på, for eksempel automatisk oppdatering eller automatisk lagring.
 
-Ikke bruk veksleknapp hvis brukeren må bekrefte valget sitt. 
+Ikke bruk veksleknapp hvis brukeren må bekrefte valget sitt.
 
 ## Eksempler på bruk
-- Slå innstillinger av eller på i en applikasjon.
-- Bytte mellom lys eller mørk modus i et grensesnitt.
+
+-   Slå innstillinger av eller på i en applikasjon.
+-   Bytte mellom lys eller mørk modus i et grensesnitt.

--- a/packages/validators-util/README.md
+++ b/packages/validators-util/README.md
@@ -1,11 +1,12 @@
-# [`@fremtind/jkl-validators-util`](https://fremtind.github.io/jokul/komponenter/validators)
+# [`@fremtind/jkl-validators-util`](https://jokul.fremtind.no/komponenter/validators)
 
 ## Beskrivelse
-[Bruk og prinsipper](https://fremtind.github.io/jokul/profil/skjemadesign)
+
+[Bruk og prinsipper](https://jokul.fremtind.no/profil/skjemadesign)
 
 ## Kom i gang
 
-[Lær hvordan du kan ta i bruk Jøkul](https://fremtind.github.io/jokul/komigang/utvikling)
+[Lær hvordan du kan ta i bruk Jøkul](https://jokul.fremtind.no/komigang/utvikling)
 
 ## Bruk av React-pakken
 
@@ -18,7 +19,6 @@
 ```js
 import { isValidEpost } from "@fremtind/jkl-validators-util";
 
-const isValidEpost = isValidEpost('foo@bar.com'); //true
-const isNotValidEpost = isValidEpost('foo@bar'); //false
-
+const isValidEpost = isValidEpost("foo@bar.com"); //true
+const isNotValidEpost = isValidEpost("foo@bar"); //false
 ```

--- a/packages/webfonts/README.md
+++ b/packages/webfonts/README.md
@@ -1,4 +1,4 @@
-# [`webfonts`](https://fremtind.github.io/jokul/komponenter/typography)
+# [`@fremtind/jkl-webfonts`](https://jokul.fremtind.no/komponenter/typography)
 
 Denne pakken inneholder skrifttypene våre til bruk i nettløsninger (disse kan ikke installeres lokalt på datamaskinen). Disse må gjøres tilgjengelige i løsningen ved at du legger fontfilene i en mappe som blir eksportert med app-en din, f.eks. `/build`, `/dist` eller lignende.
 
@@ -11,13 +11,13 @@ I tillegg til å distribuere fontfilene sammen med løsningen din må du importe
 Om du bruker Sass-stilark i prosjektet ditt er dette den enkleste måten. I rot-`.scss`-filen din:
 
 Med use syntax:
+
 ```scss
-@use '~@fremtind/jkl-webfonts/webfonts.scss' with (
-    $webfonts-dir: "/relative/path/to/font/files"
-);
+@use "~@fremtind/jkl-webfonts/webfonts.scss" with ($webfonts-dir: "/relative/path/to/font/files");
 ```
 
 Med import syntax:
+
 ```scss
 $webfonts-dir: "/relative/path/to/font/files";
 @import "~@fremtind/jkl-webfonts/webfonts.scss"; // NB! bruk riktig import for din sass-loader


### PR DESCRIPTION
Bruk vårt eget domene i lenker, ikke GitHub Pages. Fiks også noen overskrifter som pekte på feil
pakke eller ikke fulgte formatet.

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->
