### PR TITLE
Endre tidspunktet dependabot sjekker etter nye oppdateringer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-          day: "sunday"
+          day: "monday"
+          time: "06:00"
+          timezone: "Europe/Berlin"
 
     - package-ecosystem: "github-actions"
       # Workflow files stored in the
@@ -12,4 +14,6 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-          day: "sunday"
+          day: "monday"
+          time: "06:00"
+          timezone: "Europe/Berlin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+          day: "sunday"
 
     - package-ecosystem: "github-actions"
       # Workflow files stored in the
@@ -11,3 +12,4 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+          day: "sunday"


### PR DESCRIPTION
Dependabot sjekker by default på et [tilfeldig tidspunkt](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#scheduleday) i løpet av mandag når interval står på "weekly"
I tilfelle den ukentlige assigneen ønsker å få unna oppgavene på mandag kan det kanskje være praktisk å tidspunktet litt frem 😄 


## ☑️ Sjekkliste

-   [ ] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [ ] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
