### PR TITLE
fix: legg til støtte for Select i Accordion

### DIFF
--- a/packages/accordion-react/src/Accordion.test.tsx
+++ b/packages/accordion-react/src/Accordion.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { Accordion } from ".";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Accordion, AccordionItem } from ".";
+import { Select } from "@fremtind/jkl-select-react";
 
 describe("Accordion", () => {
     it("should render without exploding", () => {
@@ -12,5 +15,21 @@ describe("Accordion", () => {
         render(<Accordion>Hello</Accordion>);
 
         expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+    it("should support toggling a Select inside an AccordionItem without getting stuck in a render-loop (#1466)", () => {
+        render(
+            <Accordion>
+                <AccordionItem title="Velg tingen" startExpanded>
+                    <Select items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                </AccordionItem>
+            </Accordion>,
+        );
+
+        act(() => {
+            const button = screen.getByTestId("jkl-select__button");
+            userEvent.click(button);
+        });
+
+        expect(screen.getByTestId("jkl-select__button")).toBeVisible();
     });
 });

--- a/packages/accordion-react/src/AccordionItem.tsx
+++ b/packages/accordion-react/src/AccordionItem.tsx
@@ -21,7 +21,12 @@ export function AccordionItem({ children, title, className, startExpanded = fals
         "jkl-accordion-item--expanded": isOpen,
     });
 
-    const onToggle = () => setIsOpen(!isOpen);
+    const onToggle = (e: Event) => {
+        if (e.defaultPrevented) {
+            return;
+        }
+        setIsOpen(!isOpen);
+    };
 
     return (
         <div data-testid="jkl-accordion-item" className={componentClassName}>

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
+import { Accordion, AccordionItem } from "@fremtind/jkl-accordion-react";
 import React, { useState } from "react";
 import { Select } from ".";
 
@@ -182,6 +183,23 @@ describe("Select", () => {
         });
 
         expect(onBlur).not.toHaveBeenCalled();
+    });
+
+    it("should support toggling a Select inside an AccordionItem without getting stuck in a render-loop (#1466)", () => {
+        render(
+            <Accordion>
+                <AccordionItem title="Velg tingen" startExpanded>
+                    <Select items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                </AccordionItem>
+            </Accordion>,
+        );
+
+        act(() => {
+            const button = screen.getByTestId("jkl-select__button");
+            userEvent.click(button);
+        });
+
+        expect(screen.getByTestId("jkl-select__button")).toBeVisible();
     });
 });
 
@@ -617,6 +635,23 @@ describe("Searchable select", () => {
         });
 
         expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support toggling a Select inside an AccordionItem without getting stuck in a render-loop (#1466)", () => {
+        render(
+            <Accordion>
+                <AccordionItem title="Velg tingen" startExpanded>
+                    <Select searchable items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                </AccordionItem>
+            </Accordion>,
+        );
+
+        act(() => {
+            const button = screen.getByTestId("jkl-select__button");
+            userEvent.click(button);
+        });
+
+        expect(screen.getByTestId("jkl-select__search-input")).toBeVisible();
     });
 });
 

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -33,9 +33,15 @@ interface Props extends DataTestAutoId {
     onFocus?: SelectEventHandler;
 }
 
-interface CoreToggleSelectEvent {
+interface CoreToggleSelectTarget extends EventTarget {
+    hidden: boolean;
+    button: HTMLButtonElement;
+    value: { textContent: string };
+}
+
+interface CoreToggleSelectEvent extends Event {
     detail: { textContent: string; value: string };
-    target: { hidden: boolean; button: HTMLButtonElement; value: { textContent: string } };
+    target: CoreToggleSelectTarget;
 }
 
 function toLower(str = "") {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -119,7 +119,8 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
             "jkl-select--invalid": !!errorLabel,
         });
 
-        function onToggle() {
+        function onToggle(e: CoreToggleSelectEvent) {
+            e.preventDefault();
             const opening = !dropdownIsShown;
             setShown(!dropdownIsShown);
             if (opening && !searchable) {
@@ -133,6 +134,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
         }
 
         function onToggleSelect(e: CoreToggleSelectEvent) {
+            e.preventDefault();
             const nextValue = e.detail.value;
             setSearchValue("");
             onChange && onChange(nextValue);
@@ -165,6 +167,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
 
         // add support for opening dropdown with arrowkey down as expected from native select
         function handleArrowDown(e: KeyboardEvent<HTMLButtonElement>) {
+            e.preventDefault();
             if (e.key === "ArrowDown" && !dropdownIsShown) {
                 buttonRef.current?.click();
             }
@@ -227,6 +230,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(
                             placeholder="Søk"
                             value={searchValue}
                             onChange={(e) => setSearchValue(e.target.value)}
+                            data-testid="jkl-select__search-input"
                             className="jkl-select__search-input"
                             onBlur={handleBlur}
                             onFocus={handleFocus}

--- a/portal/src/components/Header/components/MainMenu.scss
+++ b/portal/src/components/Header/components/MainMenu.scss
@@ -70,13 +70,14 @@
         left: 0;
         z-index: -1;
         overflow-x: scroll;
+        height: 0vh;
 
         background-color: var(--full-screen-menu-bg-color);
         @include motion("standard", "lazy");
         transition-property: height;
 
         &--open {
-            height: auto;
+            height: 100vh;
             @include motion("entrance", "lazy");
         }
     }

--- a/portal/src/components/Header/components/MainMenu.tsx
+++ b/portal/src/components/Header/components/MainMenu.tsx
@@ -1,7 +1,5 @@
 import { Hamburger } from "@fremtind/jkl-hamburger-react";
 import { useAnimatedHeight, useScreen } from "@fremtind/jkl-react-hooks";
-// @ts-ignore: wait for nrk to supply types
-import CoreToggle from "@nrk/core-toggle/jsx";
 import cx from "classnames";
 import { navigate } from "gatsby";
 import React, { useEffect } from "react";
@@ -25,7 +23,7 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
     const { isOpen, setIsOpen, currentItem, setCurrentItem, peekHistory, popHistory, pushHistory } =
         useFullscreenMenuContext();
 
-    const [menuRef] = useAnimatedHeight(isOpen);
+    const [menuRef] = useAnimatedHeight<HTMLDivElement>(isOpen);
     const [controls] = useFullScreenMenuAnimaiton({ isOpen });
 
     const rootItem: RootItem = {
@@ -81,13 +79,12 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                     isOpen={isOpen}
                 />
             )}
-            <CoreToggle
-                forwardRef={menuRef}
+            <div
+                ref={menuRef}
                 className={cx("jkl-portal-main-menu__overlay", {
                     "jkl-portal-main-menu__overlay--open": isOpen,
                 })}
-                popup={true}
-                hidden={!isOpen}
+                aria-hidden={isOpen ? "false" : "true"}
             >
                 <div className="jkl-portal-main-menu__menu-wrapper">
                     {isSmallScreen && (
@@ -124,7 +121,7 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
                         </>
                     )}
                 </div>
-            </CoreToggle>
+            </div>
             {!isSmallScreen && (
                 <ul className="jkl-portal-main-menu__root-list">
                     {items.map((item) => (


### PR DESCRIPTION
Endringene forhindrer en evig render-loop ved toggling av en CoreToggle inni en Accordion. Loopen
oppstår fordi Select sin toggle-event bobler opp til Accordion. I Accordion endrer event handleren
på hidden-verdien, men en sånn endring trigger et nytt toggle event som trigger en ny onToggle som
trigger en ny toggle-event som trigger...

ISSUES CLOSED: #1466

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
