### PR TITLE
chore: begrens hvilke filer som starter en GitHub Action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,6 +5,14 @@ on:
         branches:
             - "**"
             - "!main"
+        paths:
+            - "cypress/*"
+            - "packages/*.mdx"
+            - "packages/*.scss"
+            - "packages/*.ts"
+            - "packages/*.tsx"
+            - "patches/*"
+            - "yarn.lock"
 
 jobs:
     cypress-run:

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -3,6 +3,21 @@ on:
     push:
         branches:
             - main
+        paths:
+            - "packages/*.ts"
+            - "packages/*.tsx"
+            - "packages/*.mdx"
+            - "packages/*.scss"
+            - "patches/*"
+            - "portal/*.ts"
+            - "portal/*.tsx"
+            - "portal/*.mdx"
+            - "portal/*.scss"
+            - "portal/images/*"
+            - "portal/static/*"
+            - "portal/gatsby-*"
+            - "yarn.lock"
+
 jobs:
     build-and-deploy:
         name: Deploy portal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,17 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Verify release is needed
-              run: yarn version:check # will fail (exit with code 1) if there are no changes to release
+              id: lerna_changed
+              run: |
+                  yarn version:check
+                  if [ $? -eq 1 ]
+                  then
+                    echo "::set-output name=has_changes::false"
+                    exit 0
+                  fi
 
             - name: Publish packages to NPM
-              if: ${{ success() }} # only run if there are changes to publish
+              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }} # only run if there are changes to publish
               run: yarn release --yes
               env:
                   GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
@@ -49,7 +56,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Switch registry
-              if: ${{ success() }}
+              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }}
               uses: actions/setup-node@v2
               with:
                   registry-url: "https://npm.pkg.github.com"
@@ -57,7 +64,7 @@ jobs:
                   scope: "@fremtind"
 
             - name: Publish packages to GitHub Packages
-              if: ${{ success() }}
+              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }}
               run: yarn release-gh --yes
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
         branches:
             - "**"
             - "!release"
+        paths:
+            - "jest/*"
+            - "packages/*.ts"
+            - "packages/*.tsx"
+            - "patches/*"
+            - "portal/*.ts"
+            - "portal/*.tsx"
+            - "yarn.lock"
 
 jobs:
     build:

--- a/lerna.json
+++ b/lerna.json
@@ -17,7 +17,10 @@
                 ".npmignore",
                 ".npmrc",
                 "*.md",
+                "*.mdx",
                 "*.test.js",
+                "*.test.ts",
+                "*.test.tsx",
                 "jest/**/*"
             ],
             "message": "chore(release): publish [ci skip release]"


### PR DESCRIPTION
Prøv å begrens bruken av særlig visuelle regresjonstester og byggsteg for endringer som ikke rører
kode.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
