### PR TITLE
fix: oppdater valideringsreglene for chassisnummer

### DIFF
--- a/packages/validators-util/src/isValidChassisnummer/isValidChassisnummer.test.ts
+++ b/packages/validators-util/src/isValidChassisnummer/isValidChassisnummer.test.ts
@@ -1,11 +1,32 @@
 import { isValidChassisnummer } from "./isValidChassisnummer";
 
 describe("isValidChassisnummer", () => {
-    it("should return true for 9-digit numbers", () => {
+    it("should return true for 9-character strings", () => {
         expect(isValidChassisnummer("123456789")).toBe(true);
+        expect(isValidChassisnummer("A23C56U89")).toBe(true);
+        expect(isValidChassisnummer("ABCDEFGHI")).toBe(true);
+        expect(isValidChassisnummer("abcdefghi")).toBe(true);
     });
-
-    it("should return false if any letters", () => {
-        expect(isValidChassisnummer("123A456")).toBe(false);
+    it("should return false for 9-charachter strings containing special characters", () => {
+        expect(isValidChassisnummer("12345678#")).toBe(false);
+        expect(isValidChassisnummer("1234 6789")).toBe(false);
+        expect(isValidChassisnummer("A23[56U89")).toBe(false);
+        expect(isValidChassisnummer("AAA{_}AAA")).toBe(false);
+    });
+    it("should return true for 17-character strings", () => {
+        expect(isValidChassisnummer("12345678901234567")).toBe(true);
+        expect(isValidChassisnummer("ABCDEFG1IJK2MN3P6")).toBe(true);
+        expect(isValidChassisnummer("ABCDEFGHIJKLMNOPQ")).toBe(true);
+        expect(isValidChassisnummer("abcdefghijklmnopq")).toBe(true);
+    });
+    it("should return false for 17-charachter strings containing special characters", () => {
+        expect(isValidChassisnummer("123456789 1234567")).toBe(false);
+        expect(isValidChassisnummer("1234567$901234567")).toBe(false);
+        expect(isValidChassisnummer("ABCDEFG_IJKLMNOPQ")).toBe(false);
+    });
+    it("should return false for strings neither 9 nor 17 characters long", () => {
+        expect(isValidChassisnummer("")).toBe(false);
+        expect(isValidChassisnummer("short")).toBe(false);
+        expect(isValidChassisnummer("longstringisloooooooooooooooooooooooooooooooooooooooooong")).toBe(false);
     });
 });

--- a/packages/validators-util/src/isValidChassisnummer/isValidChassisnummer.ts
+++ b/packages/validators-util/src/isValidChassisnummer/isValidChassisnummer.ts
@@ -1,3 +1,3 @@
-export const CHASSISNR_REGEX = /^\d{9}$/;
+export const CHASSISNR_REGEX = /^[a-zA-Z0-9]{9,17}$/;
 
 export const isValidChassisnummer = (value: string) => CHASSISNR_REGEX.test(value);


### PR DESCRIPTION
affects: @fremtind/jkl-validators-util

Tillat strings med tall og bokstaver, men ikke spesialtegn, på 9 eller 17 tegn

BREAKING CHANGE:
isValidChassisnummer tillater nå ikke-numeriske strings og strings på 17 tegn. Om du parser
resultatet som et tall eller har en lengdebegrensning i databaseskjemaet ditt må du oppdatere
appen din til å støtte den nye regelen.

ISSUES CLOSED: #1662

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
