### PR TITLE
chore(ci): ikke feile release-flyt når det ikke er endringer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,11 @@ jobs:
 
             - name: Verify release is needed
               id: lerna_changed
-              run: |
-                  yarn version:check
-                  if [ $? -eq 1 ]
-                  then
-                    echo "::set-output name=has_changes::false"
-                    exit 0
-                  fi
+              continue-on-error: true
+              run: yarn version:check
 
             - name: Publish packages to NPM
-              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }} # only run if there are changes to publish
+              if: steps.lerna_changed.outcome == 'success' # only run if there are changes to publish
               run: yarn release --yes
               env:
                   GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
@@ -56,7 +51,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Switch registry
-              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }}
+              if: steps.lerna_changed.outcome == 'success'
               uses: actions/setup-node@v2
               with:
                   registry-url: "https://npm.pkg.github.com"
@@ -64,7 +59,7 @@ jobs:
                   scope: "@fremtind"
 
             - name: Publish packages to GitHub Packages
-              if: ${{ success() && steps.lerna_changed.has_changes != 'false' }}
+              if: steps.lerna_changed.outcome == 'success'
               run: yarn release-gh --yes
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ikke feile release-flyten når det ikke finnes endringer å publisere. Vanskelig å teste dette uten å merge, men mener at jeg har lest dokumentasjonen av GitHub Actions riktig her:

- [continue-on-error](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)
- [steps context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
