### PR TITLE
fix: fjern clip-path på knapper for å vise touch-effekt riktig

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -36,12 +36,6 @@ $button-focus-color--inverted: jkl.$color-snohvit;
 $button-primary-text-color--inverted: jkl.$color-granitt;
 $button-primary-background-color--inverted: jkl.$color-snohvit;
 
-/* This padding ensures that there is enough space around the button so that it
-is fully visible during hover and focus inside the wrapper.
-Note that this padding is only necessary for browsers that does not support
-clip-path. */
-$button-wrapper-animation-safe-area: 10px;
-
 @include jkl.helper-light-mode-variables {
     --button-border-color: #{$button-border-color};
     --button-text-color: #{$button-text-color};
@@ -75,13 +69,7 @@ a.jkl-button {
     line-height: $button-height--normal;
     cursor: pointer;
     user-select: none;
-    overflow: hidden;
-    padding: $button-wrapper-animation-safe-area;
-    @supports (clip-path: inset(-18% -18% -18% -18%)) {
-        overflow: initial;
-        clip-path: inset(-18% -18% -18% -18%);
-        padding: 0;
-    }
+    overflow: visible;
 
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: auto;


### PR DESCRIPTION
affects: @fremtind/jkl-button

ISSUES CLOSED: #2356

Fikser en bug der touch-effet på knappene ble kuttet av.

https://user-images.githubusercontent.com/25739615/136382080-bdc65787-8b9a-4e27-82eb-e8a01a6b7b33.mov

https://user-images.githubusercontent.com/25739615/136382089-4b0e7216-4cec-4161-9bab-886cc0f77b92.mov

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
