### PR TITLE
chore(ci): ta i bruk riktige filtre ved kjøring av GitHub Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,8 @@ jobs:
               with:
                   token: ${{ secrets.BOT_PUBLISH_TOKEN }}
 
-            - uses: dorny/paths-filter@v2
+            - name: Check for changes
+              uses: dorny/paths-filter@v2
               id: changes
               with:
                   filters: |
@@ -29,12 +30,12 @@ jobs:
                         - "yarn.lock"
 
             - name: Get yarn cache directory path
-              if: steps.filter.outputs.visual == 'true'
+              if: steps.changes.outputs.visual == 'true'
               id: yarn-cache-dir-path
               run: echo "::set-output name=dir::$(yarn cache dir)"
 
             - name: Cache yarn directory
-              if: steps.filter.outputs.visual == 'true'
+              if: steps.changes.outputs.visual == 'true'
               uses: actions/cache@v2.1.6
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
@@ -45,7 +46,7 @@ jobs:
 
             - name: Cypress run with env
               uses: cypress-io/github-action@v2
-              if: steps.filter.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: steps.changes.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
               with:
                   build: yarn run build
                   start: yarn serve
@@ -55,20 +56,20 @@ jobs:
 
             - name: Upload screenshots
               uses: actions/upload-artifact@v2.2.4
-              if: steps.filter.outputs.visual == 'true' && failure()
+              if: steps.changes.outputs.visual == 'true' && failure()
               with:
                   name: cypress-screenshots
                   path: cypress/screenshots
 
             - name: Upload video
               uses: actions/upload-artifact@v2.2.4
-              if: steps.filter.outputs.visual == 'true' && always()
+              if: steps.changes.outputs.visual == 'true' && always()
               with:
                   name: cypress-videos
                   path: cypress/videos
 
             - name: Update snapshots
-              if: steps.filter.outputs.visual == 'true' && success() && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: steps.changes.outputs.visual == 'true' && success() && !contains(github.event.head_commit.message, '[ci skip cypress]')
               run: |
                   git config user.email "fremtind.designsystem@fremtind.no"
                   git config user.name "fremtind-bot"

--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -12,7 +12,8 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2.3.4
 
-            - uses: dorny/paths-filter@v2
+            - name: Check for changes to portal
+              uses: dorny/paths-filter@v2
               id: changes
               with:
                   filters: |
@@ -26,12 +27,12 @@ jobs:
                         - "yarn.lock"
 
             - name: Get yarn cache directory path
-              if: steps.filter.outputs.portal == 'true'
+              if: steps.changes.outputs.portal == 'true'
               id: yarn-cache-dir-path
               run: echo "::set-output name=dir::$(yarn cache dir)"
 
             - name: Cache yarn directory
-              if: steps.filter.outputs.portal == 'true'
+              if: steps.changes.outputs.portal == 'true'
               uses: actions/cache@v2.1.6
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
@@ -41,7 +42,7 @@ jobs:
                       ${{ runner.os }}-yarn-
 
             - name: Caching Gatsby
-              if: steps.filter.outputs.portal == 'true'
+              if: steps.changes.outputs.portal == 'true'
               id: gatsby-cache-build
               uses: actions/cache@v2
               with:
@@ -53,7 +54,7 @@ jobs:
                       ${{ runner.os }}-gatsby-build-
 
             - name: Build and Deploy
-              if: steps.filter.outputs.portal == 'true' && !contains(github.event.head_commit.message, '[ci skip release]')
+              if: steps.changes.outputs.portal == 'true' && !contains(github.event.head_commit.message, '[ci skip release]')
               env:
                   GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
         steps:
             - uses: actions/checkout@v2.3.4
 
-            - uses: dorny/paths-filter@v2
+            - name: Chack for changes
+              uses: dorny/paths-filter@v2
               id: changes
               with:
                   filters: |
@@ -26,12 +27,12 @@ jobs:
                         - "yarn.lock"
 
             - name: Get yarn cache directory path
-              if: steps.filter.outputs.runtests == 'true'
+              if: steps.changes.outputs.runtests == 'true'
               id: yarn-cache-dir-path
               run: echo "::set-output name=dir::$(yarn cache dir)"
 
             - name: Cache yarn directory
-              if: steps.filter.outputs.runtests == 'true'
+              if: steps.changes.outputs.runtests == 'true'
               uses: actions/cache@v2.1.6
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
@@ -41,7 +42,7 @@ jobs:
                       ${{ runner.os }}-yarn-
 
             - name: Lint and test
-              if: steps.filter.outputs.runtests == 'true' && !contains(github.event.head_commit.message, '[ci skip release]')
+              if: steps.changes.outputs.runtests == 'true' && !contains(github.event.head_commit.message, '[ci skip release]')
               run: |
                   yarn install --frozen-lockfile
                   yarn build


### PR DESCRIPTION
Filtrene i GH Actions var satt opp slik at alle actions med filter alltid ble hoppet over. Dette fikser det (forhåpentligvis)

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
