### PR TITLE
fix: enabled other components as children to messagebox

### DIFF
--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -126,17 +126,9 @@ function messageFactory(messageType: messageTypes) {
             }
         };
 
-        const newChildren = React.Children.map(children, (child) => {
-            if (typeof child === "string") {
-                return <p className="jkl-body">{child}</p>;
-            }
-            if (React.isValidElement(child)) {
-                return React.cloneElement(child, {
-                    className: `jkl-body ${child.props.className}`,
-                });
-            }
-            return child;
-        });
+        const hasStringChild = React.Children.map(children, (child) => typeof child === "string");
+
+        const newChildren = hasStringChild?.[0] ? <p className="jkl-body">{children}</p> : children;
 
         return (
             <div className={componentClassName} role={role || getRole(messageType)} data-theme="light">


### PR DESCRIPTION
affects: @fremtind/jkl-message-box-react

Jeg skal ha et table inne i messagebox, men da får jeg den fine feilen her: `Warning: validateDOMNesting(...): <table> cannot appear as a descendant of <p>.` fordi messageBox alltid hadde `<p>` rundt `children` som blir sendt inn. 

Jeg har derfor lagt til en funksjon som gjør det om til `<p>` dersom det kun er tekst som blir sendt inn, og dersom det er noe annet så setter den `jkl-body` som className som default. 

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
