### PR TITLE
fix(portal): riktig bakgrunn på menykort

### DIFF
--- a/portal/src/components/Card/card.scss
+++ b/portal/src/components/Card/card.scss
@@ -18,7 +18,7 @@
     max-width: rem(400px);
 
     @include small-device {
-        background-color: jkl.$color-snohvit;
+        background-color: var(--jkl-background-color);
     }
 
     &__heading {


### PR DESCRIPTION
affects: @fremtind/portal

Sørg for at menykortene på forsiden av portalen har riktig bakgrunnsfarge, også på små skjermer.

ISSUES CLOSED: 2421

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
