### PR TITLE
docs: renamed Error/SuccessMessage to Error/SuccessMessageBox in readme

### DIFF
--- a/packages/message-box-react/README.md
+++ b/packages/message-box-react/README.md
@@ -34,13 +34,13 @@ Komponentene tar følgende props:
 En enkel bruk av meldingsboksen kan se slik ut:
 
 ```jsx
-<SuccessMessage title="Opplasting fullført">Filene ble lastet opp uten feil</SuccessMessage>
+<SuccessMessageBox title="Opplasting fullført">Filene ble lastet opp uten feil</SuccessMessageBox>
 ```
 
 Du kan sende mer enn bare ren tekst som innhold. Innholdet blir rendret inne i et `<div>`-element:
 
 ```jsx
-<ErrorMessage title="Feil under innsending av skjema">
+<ErrorMessageBox title="Feil under innsending av skjema">
     <Body>Skjemaet kunne ikke sendes inn på grunn av feil i følgende felter:</Body>
     <UnorderedList>
         <ListItem>Fødselsnummer</ListItem>
@@ -48,7 +48,7 @@ Du kan sende mer enn bare ren tekst som innhold. Innholdet blir rendret inne i e
         <ListItem>Telefonnummer</ListItem>
     </UnorderedList>
     <Body>Rett opp feilene og send deretter inn skjemaet på nytt</Body>
-</ErrorMessage>
+</ErrorMessageBox>
 ```
 
 ### Tilgjengelighet


### PR DESCRIPTION
affects: @fremtind/jkl-message-box-react

Glemte å rename alle steder i readme :( 

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
