### PR TITLE
chore: stopp versjonering av portalen

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "packages": ["packages/*", "portal"],
+    "packages": ["packages/*"],
     "version": "independent",
     "useWorkspaces": true,
     "npmClient": "yarn",


### PR DESCRIPTION
Testet endringen på en fork og klonet den til et annet sted på disk. Kjørte `yarn boot`. Portalen fungerte fint med `yarn dev`, og med `yarn build:docs && yarn server`.

ISSUES CLOSED: #2428 

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
