### PR TITLE
fix: gjenopprett bilder i Bildebruk

### DIFF
--- a/portal/gatsby-config.js
+++ b/portal/gatsby-config.js
@@ -31,6 +31,13 @@ module.exports = {
         {
             resolve: "gatsby-source-filesystem",
             options: {
+                // Det ligger bilder her av historiske årsaker
+                path: "./src/components/Documentation/Picture/Assets",
+            },
+        },
+        {
+            resolve: "gatsby-source-filesystem",
+            options: {
                 name: "components",
                 path: `${__dirname}/../packages`,
                 ignore: ignoreNonMdx,


### PR DESCRIPTION
affects: @fremtind/portal

Oppgraderingen av Gatsby hadde fjernet en source for mye. Det finnes
visst bilder i components-mappa som brukes blant annet på Profil ->
Bildebruk.

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
