### PR TITLE
fix: legg til støtte for react-hook-form i select-react

### DIFF
--- a/packages/accordion-react/src/Accordion.test.tsx
+++ b/packages/accordion-react/src/Accordion.test.tsx
@@ -20,7 +20,7 @@ describe("Accordion", () => {
         render(
             <Accordion>
                 <AccordionItem title="Velg tingen" startExpanded>
-                    <Select items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                    <Select name="ting" items={[{ label: "Item 3", value: "3" }]} label="Ting" />
                 </AccordionItem>
             </Accordion>,
         );

--- a/packages/select-react/documentation/SelectExample.tsx
+++ b/packages/select-react/documentation/SelectExample.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent, FocusEvent, useRef, useEffect, VFC } from "react";
+import React, { useState, VFC } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Select, NativeSelect } from "../src";
 import { LabelVariant } from "@fremtind/jkl-core";
@@ -13,44 +13,14 @@ export const SelectExample: VFC<ExampleComponentProps> = ({ boolValues, choiceVa
         { value: "LG", label: "LG" },
     ];
     const [value, setValue] = useState<string>();
-    const universalSetValue = (input: string | ChangeEvent<HTMLSelectElement> | undefined) => {
-        let eventValue;
-        if (typeof input === "string") {
-            eventValue = input;
-        } else if (input) {
-            eventValue = input.target.value;
-        }
-        setValue(eventValue);
-        console.log("Change: ", eventValue);
-    };
 
     const errorLabel = boolValues && boolValues["Med feil"] ? "Beskrivende feilmelding" : undefined;
     const helpLabel = boolValues && boolValues["Med hjelpetekst"] ? "Hjelpsom beskjed" : undefined;
     const variant = choiceValues && (choiceValues["Etikettvariant"] as LabelVariant);
     const searchAble = boolValues && boolValues["Med søk"];
 
-    const selectRef = useRef<HTMLSelectElement>(null);
-    useEffect(() => {
-        const select = selectRef.current;
-        select?.addEventListener("change", (e: unknown) =>
-            console.log("Verdi fra selectRef:", (e as ChangeEvent<HTMLSelectElement>).target.value),
-        );
-        return () => {
-            select?.removeEventListener("change", (e: unknown) =>
-                console.log("Verdi fra selectRef:", (e as ChangeEvent<HTMLSelectElement>).target.value),
-            );
-        };
-    }, [selectRef]);
-    const onFocus = (input: string | FocusEvent<HTMLSelectElement> | undefined) => {
-        console.log("Focus: ", input);
-    };
-    const onBlur = (input: string | FocusEvent<HTMLSelectElement> | undefined) => {
-        console.log("Blur: ", input);
-    };
-
     return (
         <C
-            ref={selectRef}
             id="produsent"
             name="produsent"
             forceCompact={boolValues && boolValues["Kompakt"]}
@@ -61,10 +31,17 @@ export const SelectExample: VFC<ExampleComponentProps> = ({ boolValues, choiceVa
             value={value}
             helpLabel={helpLabel}
             errorLabel={errorLabel}
-            onChange={universalSetValue}
+            onChange={(event) => {
+                setValue(event.target.value);
+                console.log("Change: ", event);
+            }}
             searchable={searchAble}
-            onFocus={onFocus}
-            onBlur={onBlur}
+            onFocus={(event) => {
+                console.log("Focus: ", event);
+            }}
+            onBlur={(event) => {
+                console.log("Blur: ", event);
+            }}
         />
     );
 };

--- a/packages/select-react/src/NativeSelect.test.tsx
+++ b/packages/select-react/src/NativeSelect.test.tsx
@@ -3,26 +3,22 @@ import { render, screen } from "@testing-library/react";
 import { NativeSelect } from ".";
 import { axe } from "jest-axe";
 
-const dummyFunc = () => {};
-
 describe("NativeSelect", () => {
     it("should render the correct label", () => {
-        render(<NativeSelect label="testing" items={["test"]} onChange={dummyFunc} />);
+        render(<NativeSelect label="testing" items={["test"]} />);
 
         expect(screen.getByText("testing")).toBeInTheDocument();
     });
 
     it("should render the correct number of options", () => {
-        const { getAllByTestId } = render(
-            <NativeSelect label="testing" items={["1", "2", "3"]} onChange={dummyFunc} />,
-        );
+        const { getAllByTestId } = render(<NativeSelect label="testing" items={["1", "2", "3"]} />);
 
         expect(getAllByTestId("jkl-select__option")).toHaveLength(3);
     });
 
     it("should render correct label and value when given values as strings", () => {
         const items = ["item 1", "item 2", "item 3"];
-        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} onChange={dummyFunc} />);
+        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} />);
 
         expect(getAllByTestId("jkl-select__option")[0]).toHaveAttribute("value", "item 1");
         expect(getAllByTestId("jkl-select__option")[0]).toHaveTextContent("item 1");
@@ -33,7 +29,7 @@ describe("NativeSelect", () => {
             { value: "item1", label: "Item 1" },
             { value: "item2", label: "Item 2" },
         ];
-        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} onChange={dummyFunc} />);
+        const { getAllByTestId } = render(<NativeSelect label="testing" items={items} />);
 
         expect(getAllByTestId("jkl-select__option")[1]).toHaveAttribute("value", "item2");
         expect(getAllByTestId("jkl-select__option")[1]).toHaveTextContent("Item 2");
@@ -41,13 +37,13 @@ describe("NativeSelect", () => {
 
     it("should render placeholder when given and field has no value", () => {
         const items = ["item 1", "item 2", "item 3"];
-        render(<NativeSelect label="testing" items={items} placeholder="Please choose" onChange={dummyFunc} />);
+        render(<NativeSelect label="testing" items={items} placeholder="Please choose" />);
 
         expect(screen.getByText("Please choose")).toBeInTheDocument();
     });
 
     it("can be forced into compact mode", () => {
-        render(<NativeSelect items={["1", "2"]} label="test" onChange={dummyFunc} forceCompact />);
+        render(<NativeSelect items={["1", "2"]} label="test" forceCompact />);
 
         expect(screen.getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });
@@ -55,8 +51,9 @@ describe("NativeSelect", () => {
 
 describe("a11y", () => {
     test("native select should be a11y compliant", async () => {
+        const onChange = jest.fn();
         const { container } = render(
-            <NativeSelect label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" onChange={dummyFunc} />,
+            <NativeSelect label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" onChange={onChange} />,
         );
         const results = await axe(container);
 
@@ -64,6 +61,7 @@ describe("a11y", () => {
     });
 
     test("compact native select should be a11y compliant", async () => {
+        const onChange = jest.fn();
         const { container } = render(
             <NativeSelect
                 forceCompact
@@ -71,7 +69,7 @@ describe("a11y", () => {
                 items={["1", "2"]}
                 value="1"
                 helpLabel="Velg en av to"
-                onChange={dummyFunc}
+                onChange={onChange}
             />,
         );
         const results = await axe(container);

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -1,13 +1,10 @@
-/* eslint "jsx-a11y/no-onchange": 0 */
-
 import React, { FocusEventHandler, ChangeEventHandler, useState, forwardRef } from "react";
 import { nanoid } from "nanoid";
 import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
-import classNames from "classnames";
-
+import cx from "classnames";
 import { ExpandArrow } from "./ExpandArrow";
 
-interface Props {
+export interface NativeSelectProps {
     id?: string;
     name?: string;
     label: string;
@@ -28,11 +25,10 @@ interface Props {
     onBlur?: FocusEventHandler<HTMLSelectElement>;
 }
 
-export const NativeSelect = forwardRef<HTMLSelectElement, Props>(
+export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
     (
         {
             id,
-            name,
             label,
             items,
             className = "",
@@ -45,32 +41,22 @@ export const NativeSelect = forwardRef<HTMLSelectElement, Props>(
             forceCompact,
             inverted,
             width,
-            onChange,
-            onBlur,
-            onFocus,
+            ...rest
         },
         ref,
     ) => {
-        // If no value is given, set it to first item, or to empty string if there is a placeholder
-        if (!value) {
-            if (!placeholder && items.length) {
-                value = getValuePair(items[0]).value;
-            }
-        }
-
-        const componentClassName = classNames("jkl-select", className, {
-            "jkl-select--inline": inline,
-            "jkl-select--compact": forceCompact,
-            "jkl-select--inverted": inverted,
-            "jkl-select--invalid": !!errorLabel,
-        });
-
-        const defaultValue = value ? undefined : "";
-
         const [uid] = useState(id || `jkl-select-${nanoid(8)}`);
 
         return (
-            <div data-testid="jkl-select" className={componentClassName}>
+            <div
+                data-testid="jkl-select"
+                className={cx("jkl-select", className, {
+                    "jkl-select--inline": inline,
+                    "jkl-select--compact": forceCompact,
+                    "jkl-select--inverted": inverted,
+                    "jkl-select--invalid": !!errorLabel,
+                })}
+            >
                 <Label standAlone htmlFor={uid} variant={variant} forceCompact={forceCompact}>
                     {label}
                 </Label>
@@ -78,13 +64,10 @@ export const NativeSelect = forwardRef<HTMLSelectElement, Props>(
                     <select
                         ref={ref}
                         id={uid}
-                        name={name}
-                        value={value}
-                        defaultValue={defaultValue}
                         className="jkl-select__button"
-                        onChange={onChange}
-                        onBlur={onBlur || onChange}
-                        onFocus={onFocus}
+                        defaultValue={value ? undefined : ""}
+                        value={value}
+                        {...rest}
                     >
                         {placeholder && !value && (
                             <option disabled value="">
@@ -109,3 +92,5 @@ export const NativeSelect = forwardRef<HTMLSelectElement, Props>(
         );
     },
 );
+
+NativeSelect.displayName = "NativeSelect";

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -7,7 +7,9 @@ import { Select } from ".";
 
 describe("Select", () => {
     it("should render correct amount of options", () => {
-        const { getAllByTestId } = render(<Select items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const { getAllByTestId } = render(
+            <Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />,
+        );
 
         const options = getAllByTestId("jkl-select__option");
 
@@ -15,14 +17,14 @@ describe("Select", () => {
     });
 
     it("should be inline when specified", () => {
-        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const dropdown = screen.getByTestId("jkl-select");
         expect(dropdown).toHaveClass("jkl-select--inline");
     });
 
     it("should open when clicked", () => {
-        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -33,7 +35,9 @@ describe("Select", () => {
     });
 
     it("should open when arrow down is pressed", () => {
-        render(<Select inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        // Testen produserer en tom DOMException. Undersøkelser i jsdom ga ikke noe hint om årsak.
+
+        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -46,7 +50,15 @@ describe("Select", () => {
     it("should use the specified value", () => {
         const onChange = jest.fn();
         const value = "drop";
-        render(<Select onChange={onChange} items={["drop", "it", "like", "its", "hot"]} label="Snoop" value={value} />);
+        render(
+            <Select
+                name="snoop"
+                onChange={onChange}
+                items={["drop", "it", "like", "its", "hot"]}
+                label="Snoop"
+                value={value}
+            />,
+        );
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -55,7 +67,7 @@ describe("Select", () => {
     });
 
     it("should have default text value in button when no option selected", () => {
-        render(<Select items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        render(<Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -63,7 +75,7 @@ describe("Select", () => {
     });
 
     it("can be forced into compact mode", () => {
-        render(<Select items={["1", "2"]} label="test" forceCompact />);
+        render(<Select name="count" items={["1", "2"]} label="test" forceCompact />);
 
         expect(screen.getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });
@@ -71,7 +83,7 @@ describe("Select", () => {
     it("displays the ValuePair label of selected item on first render", () => {
         const valuePairs = [{ value: "datagreier", label: "Fin lesbar tekst" }];
 
-        render(<Select label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />);
+        render(<Select name="datagreier" label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />);
 
         expect(screen.getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
     });
@@ -88,10 +100,11 @@ describe("Select", () => {
             ];
             return (
                 <Select
+                    name="items"
                     label="List of items"
                     items={items}
                     value={state}
-                    onChange={(e) => setState(e)}
+                    onChange={(e) => setState(e.target.value)}
                     onFocus={onFocus}
                 />
             );
@@ -121,10 +134,11 @@ describe("Select", () => {
                 <>
                     <button>OUTSIDE BUTTON</button>
                     <Select
+                        name="items"
                         label="List of items"
                         items={items}
                         value={state}
-                        onChange={(e) => setState(e)}
+                        onChange={(e) => setState(e.target.value)}
                         onBlur={onBlur}
                     />
                 </>
@@ -160,10 +174,11 @@ describe("Select", () => {
                 <>
                     <button>OUTSIDE BUTTON</button>
                     <Select
+                        name="items"
                         label="List of items"
                         items={items}
                         value={state}
-                        onChange={(e) => setState(e)}
+                        onChange={(e) => setState(e.target.value)}
                         onBlur={onBlur}
                     />
                 </>
@@ -189,7 +204,7 @@ describe("Select", () => {
         render(
             <Accordion>
                 <AccordionItem title="Velg tingen" startExpanded>
-                    <Select items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                    <Select name="items" items={[{ label: "Item 3", value: "3" }]} label="Ting" />
                 </AccordionItem>
             </Accordion>,
         );
@@ -214,7 +229,14 @@ describe("Searchable select", () => {
                 { label: "Item 3", value: "3" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -232,7 +254,14 @@ describe("Searchable select", () => {
                 { label: "Item 3", value: "3" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -259,7 +288,14 @@ describe("Searchable select", () => {
                 { label: "Item 3", value: "3" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -289,7 +325,14 @@ describe("Searchable select", () => {
                 { label: "Item 6", value: "6" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -323,7 +366,14 @@ describe("Searchable select", () => {
                 { label: "Item 26", value: "F" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -368,7 +418,14 @@ describe("Searchable select", () => {
                 { label: "Item 26", value: "F" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -414,7 +471,14 @@ describe("Searchable select", () => {
                 { label: "Item 6", value: "6" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -461,7 +525,14 @@ describe("Searchable select", () => {
                 { label: "Item 3", value: "3" },
             ];
             return (
-                <Select searchable label="List of items" items={items} value={state} onChange={(e) => setState(e)} />
+                <Select
+                    name="items"
+                    searchable
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
             );
         }
         render(<WrappedSelect />);
@@ -487,11 +558,12 @@ describe("Searchable select", () => {
             ];
             return (
                 <Select
+                    name="items"
                     searchable
                     label="List of items"
                     items={items}
                     value={state}
-                    onChange={(e) => setState(e)}
+                    onChange={(e) => setState(e.target.value)}
                     onFocus={onFocus}
                 />
             );
@@ -519,11 +591,12 @@ describe("Searchable select", () => {
             ];
             return (
                 <Select
+                    name="items"
                     searchable
                     label="List of items"
                     items={items}
                     value={state}
-                    onChange={(e) => setState(e)}
+                    onChange={(e) => setState(e.target.value)}
                     onBlur={onBlur}
                 />
             );
@@ -553,11 +626,12 @@ describe("Searchable select", () => {
                 <>
                     <button>OUTSIDE BUTTON</button>
                     <Select
+                        name="items"
                         searchable
                         label="List of items"
                         items={items}
                         value={state}
-                        onChange={(e) => setState(e)}
+                        onChange={(e) => setState(e.target.value)}
                         onBlur={onBlur}
                     />
                 </>
@@ -595,11 +669,12 @@ describe("Searchable select", () => {
                 <>
                     <button>OUTSIDE BUTTON</button>
                     <Select
+                        name="items"
                         searchable
                         label="List of items"
                         items={items}
                         value={state}
-                        onChange={(e) => setState(e)}
+                        onChange={(e) => setState(e.target.value)}
                         onBlur={onBlur}
                     />
                 </>
@@ -641,7 +716,7 @@ describe("Searchable select", () => {
         render(
             <Accordion>
                 <AccordionItem title="Velg tingen" startExpanded>
-                    <Select searchable items={[{ label: "Item 3", value: "3" }]} label="Ting" />
+                    <Select name="items" searchable items={[{ label: "Item 3", value: "3" }]} label="Ting" />
                 </AccordionItem>
             </Accordion>,
         );
@@ -658,14 +733,16 @@ describe("Searchable select", () => {
 describe("a11y", () => {
     test("searchable select should be a11y compliant", async () => {
         const { container } = render(
-            <Select searchable label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
+            <Select name="items" searchable label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
         );
         const results = await axe(container);
 
         expect(results).toHaveNoViolations();
     });
     test("select should be a11y compliant", async () => {
-        const { container } = render(<Select label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />);
+        const { container } = render(
+            <Select name="items" label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
+        );
         const results = await axe(container);
 
         expect(results).toHaveNoViolations();
@@ -673,7 +750,7 @@ describe("a11y", () => {
 
     test("compact select should be a11y compliant", async () => {
         const { container } = render(
-            <Select forceCompact label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
+            <Select name="items" forceCompact label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
         );
         const results = await axe(container);
 
@@ -694,11 +771,12 @@ describe("a11y", () => {
 
             return (
                 <Select
+                    name="items"
                     label="Hvilket merke er telefonen?"
                     items={items}
                     value={value}
-                    onChange={(value: string | undefined) => {
-                        setValue(value);
+                    onChange={(e) => {
+                        setValue(e.target.value);
                         onChange();
                     }}
                 />

--- a/packages/select-react/src/index.ts
+++ b/packages/select-react/src/index.ts
@@ -1,3 +1,4 @@
+export type { SelectProps } from "./Select";
 export { Select } from "./Select";
 export type { NativeSelectProps } from "./NativeSelect";
 export { NativeSelect } from "./NativeSelect";

--- a/packages/select-react/src/index.ts
+++ b/packages/select-react/src/index.ts
@@ -1,2 +1,3 @@
 export { Select } from "./Select";
+export type { NativeSelectProps } from "./NativeSelect";
 export { NativeSelect } from "./NativeSelect";

--- a/portal/src/components/Examples/SimpleForm/AddressForm.tsx
+++ b/portal/src/components/Examples/SimpleForm/AddressForm.tsx
@@ -110,6 +110,7 @@ const AddressForm: React.FC<Props> = ({ onSubmit }) => {
                 {postnummer?.toString().length === 4 && (
                     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} ref={numberRef}>
                         <Select
+                            name="nummer"
                             className={`jkl-simple-form__postal-group__house-number ${
                                 isCompact ? "jkl-spacing-l--bottom" : "jkl-spacing-xl--bottom"
                             }`}


### PR DESCRIPTION
Skriv om `Select` og `NativeSelect` så begge kan brukes som uncontrolled components (les: med `register`)

Testet OK med react-hook-form på #2489, så rebaset på `main`

ISSUES CLOSED: #2456

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
