### PR TITLE
docs: eradicate "the process" 🤠

### DIFF
--- a/portal/src/texts/getstarted/processGuide.mdx
+++ b/portal/src/texts/getstarted/processGuide.mdx
@@ -1,38 +1,62 @@
 ---
-title: Designsystemprosessen
+title: Bidra til designsystemet
 path: /komigang/prosessen
 order: 1
 ---
 
-# Designsystemprosessen
+import { PrimaryButton, SecondaryButton, TertiaryButton } from "@fremtind/jkl-button-react";
 
-Mange team bruker designsystemet vårt, Jøkul, når de skal utvikle for digitale flater. Noen er godt kjent med det, andre har vært litt innom det, mens noen ikke kjenner til det i det hele tatt. For at Jøkul skal være til nytte, er det avgjørende at alle bidrar til å vedlikeholde systemet og gjøre det best mulig. Det gjelder alle roller, ikke bare utviklere og designere. Under beskriver vi prosessen du skal følge når du har et behov.
+# Bidra til designsystemet
 
-## Undersøke
+Det er mange som bruker designsystemet vårt. Noen er godt kjent med det, andre har vært litt innom det, mens noen ikke kjenner til det i det hele tatt. For å tilrettelegge for godt samarbeid, foregår all utvikling knyttet til Jøkul på GitHub. Hvis ikke du er kjent med GitHub fra før av, anbefaler vi at du [tar kurset vårt](https://www.figma.com/proto/HOmcpKHfjHnS9f8397hfxU/Github-for-Designere?page-id=0%3A1&node-id=1%3A2&viewport=260%2C48%2C0.1&scaling=scale-down-width&starting-point-node-id=1%3A2).
 
-Portalen er en god kilde til å undersøke og avdekke behov. Her har du oversikt over alle komponenter og profilelementer, og du finner beskrivende eksempler. Spør gjerne også andre team om de har hatt samme utfordring.
+<p className="jkl-small jkl-spacing-s--bottom">Vet du allerede hvor du skal? Her er snarveiene.</p>
 
-## Rapportere
+<a
+    className="jkl-button jkl-button--primary jkl-spacing-m--right"
+    href="https://github.com/fremtind/jokul/discussions">
+    Åpne en diskusjon
+</a>
 
-Hvis du ikke finner det du leter etter, kan du opprette et issue på GitHub-siden til Jøkul. Beskriv behovet og ta gjerne med relevante illustrasjoner eller skjermbilder. Du kan også ta kontakt med oss i designsystemteamet direkte. Vi holder til i tredje etasje, ut mot Sentrum scene.
+<a
+    className="jkl-button jkl-button--secondary jkl-spacing-m--right"
+    href="https://github.com/fremtind/jokul/issues/new/choose">
+    Start et issue
+</a>
 
-Designsystemteamet holder hele tiden oversikten over issues som kommer inn, så det vil sjelden ta mer enn et døgn før du får tilbakemelding.
 
-## Avklare
+## Før du begynner
 
-Designsystemteamet og interessenter tydeliggjør behovet og forsikrer seg om at det krever at vi gjør endringer i designsystemet. Kanskje finnes det en eksisterende løsning?
+Sjansen for at behovet ditt har felles-interesser med andre er ganske stor, siden vi er så mange. Det er mulig behovet ditt allerede har blitt løst, eller kan løses med eksisterende komponenter. Derfor er det et par ting som er lurt å spørre seg selv om før du melder inn et nytt forslag:
 
-Vi stiller oss også spørsmålet om dette behovet er unikt for denne løsningen, og noe som ikke kan brukes av andre team. Hvis det er det kaller vi det et snøfnugg og det skal løses av teamet selv.
+-  Ligger det noe i [komponentbiblioteket](https://jokul.fremtind.no/komponenter/accordion) som likner?
+-  Vet du om andre team har samme behov som deg?
+-  Har du tatt en prat med noen fra Designsystem-teamet, eller forumet?
 
-## Spesifisere krav
+## Del behovet ditt
 
-Designsystemteamet og interessenter avtaler et møte for å beskrive kravene. Møtet resulterer i en POC (Proof of Concept).
-Vi dokumenterer kravene og løsningen på GitHub.
+Nesten alt kan bli dobbelt så bra, bare du deler det med et par andre. Det meste som lanseres i Jøkul, starter som en god diskusjon blant likesinnede. Vi deler saker inn i to kategorier, sort sett; **diskusjoner**, og **issues**. Hvis du ikke kjenner disse begrepene fra før, anbefaler vi at du tar [GitHub kurset](https://www.figma.com/proto/HOmcpKHfjHnS9f8397hfxU/Github-for-Designere?page-id=0%3A1&node-id=1%3A2&viewport=260%2C48%2C0.1&scaling=scale-down-width&starting-point-node-id=1%3A2) vårt.
 
-## Utvikle
+#### Hva er forskjellen mellom diskusjoner or issues?
 
-Den som skal utvikle oppretter en pull request på GitHub. Løsningen blir utviklet og godkjennes til slutt av Designsystemteamet. Når løsningen er godkjent, merger vi den inn i hovedbranchen og publiserer den.
+- En god tommelfingerregel for når et bidrag burde starte som en [diskusjon](https://github.com/fremtind/jokul/discussions) kan være at du ønsker flere innspill fra andre, eller at du har et spørsmål eller en utfordring du rett og slett bare trenger å lufte bredt.
+- Du vet som regel at bidraget ditt er godt nok detaljert til å bli et [issue](https://github.com/fremtind/jokul/issues/new/choose) når det er lett å estimere hvor lang tid det tar å lansere bidraget, og det kan knyttes til et behov i et aktivt prosjekt ute hos leveranseteamene.
 
-## Ferdig
+<p className="jkl-small jkl-spacing-s--bottom">PS: Hvis du tør å delegere ansvaret for oppgaven til deg selv, så er den som regel godt nok beskrevet ;)</p>
 
-Når løsningen er publisert, kan den tas i bruk. Kanskje oppdager et annet team et nytt behov når de ser denne løsningen, og prosessen gjentar seg.
+## Tips til et godt beskrevet forslag
+
+Jo mer kontekst du kan dele, jo bedre. Det meste som lanseres i Jøkul er et produkt av godt samarbeid. Da er det viktig å kommunisere godt hva du ønsker. Vi har et par tips til hva du bør tenke på:
+
+- Start for deg selv. Skriv ned kort og enkelt det du tenker, i et par setninger for deg selv, inkluder litt om potensialet og hvilken utfordring du står ovenfor.
+- Lag en skisse! De fleste av oss er visuelle mennesker, lager du en skisse av det du ønsker deg, er det veldig mye greiere å forholde seg til.
+- Oppsummer bidraget ditt og del det på [GitHub](https://github.com/fremtind/jokul/discussions), så kan du trekke på kompetansen til hele design- og teknologimiljøet vårt.
+- Ta opp forslaget ditt på Designsystem-forum, hvis du opplever lite engasjement. Jo lavere terskelen er for andre å hjelpe deg, jo bedre.
+
+#### Unntak er selvfølgelig en greie
+
+Av og til oppdager man bugs, feil, eller veldig åpenbare ting som bare rett og slett burde fikses, da burde det som regel gå ganske greit å hoppe bukk over de fleste stegene og [melder inn et issue](https://github.com/fremtind/jokul/issues/new?assignees=&labels=%F0%9F%90%9D+bug&template=feilmelding.md&title=Feil%3A+) direkte, så lenge du beskriver feilen/bug’en nogenlunde godt, og sjekker med noen andre.
+
+## Vanskelig?
+
+Ikke fortvil, Designsystemet er her for å hjelpe. Hvis du ikke vet hvor du skal starte, har vi gode ambassadører på plass for å sørge for å hjelpe deg i gang. Ta kontakt med kjerneteamet direkte eller via Support Designsystem, hvis du skulle ha noen spørsmål.

--- a/portal/src/texts/getstarted/processGuide.mdx
+++ b/portal/src/texts/getstarted/processGuide.mdx
@@ -4,8 +4,6 @@ path: /komigang/prosessen
 order: 1
 ---
 
-import { PrimaryButton, SecondaryButton, TertiaryButton } from "@fremtind/jkl-button-react";
-
 # Bidra til designsystemet
 
 Det er mange som bruker designsystemet vårt. Noen er godt kjent med det, andre har vært litt innom det, mens noen ikke kjenner til det i det hele tatt. For å tilrettelegge for godt samarbeid, foregår all utvikling knyttet til Jøkul på GitHub. Hvis ikke du er kjent med GitHub fra før av, anbefaler vi at du [tar kurset vårt](https://www.figma.com/proto/HOmcpKHfjHnS9f8397hfxU/Github-for-Designere?page-id=0%3A1&node-id=1%3A2&viewport=260%2C48%2C0.1&scaling=scale-down-width&starting-point-node-id=1%3A2).


### PR DESCRIPTION
## La oss slutte å snakke om "prosessen" og heller snakke om bidrag
I tråd med praten fra forum i dag (16/11) og tidligere diskusjoner, har jeg ett forslag til å "slutte å snakke om prosess" og heller bruke siden som i dag heter "[Designsystemprosessen](https://jokul.fremtind.no/komigang/prosessen)" til å snakke om hvordan man kan bidra til Jøkul i stedet. Siden skal ha innhold, lenker og tips som hjelper bidragsyterne videre på veien til å skape gode bidrag som kan bli en del av Jøkul.

Også er [siden som forklarer](https://jokul.fremtind.no/komigang/prosessen) "prosessen" vår i dag er utdatert og ikke noe vi jobber etter per dags dato. 😄

![image](https://user-images.githubusercontent.com/4263132/141997041-26f65467-e22a-4be7-8659-575c0b7127b4.png)


## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
