### PR TITLE
fix: rett feil linjehøyde for kompakte tekstfelt

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -280,8 +280,18 @@ $text-input-selected-error-color--inverted: transparentize($text-input-error-col
     }
 }
 
-.jkl-text-input:not(.jkl-text-area) .jkl-text-input__input {
-    line-height: $text-input-height; // Trengs for å unngå clipping av Å i Chrome, men den ødelegger placeholder i textarea (hvor clippingen ikke skjer)
+.jkl-text-input:not(.jkl-text-area) {
+    .jkl-text-input__input {
+        line-height: $text-input-height; // Trengs for å unngå clipping av Å i Chrome, men den ødelegger placeholder i textarea (hvor clippingen ikke skjer)
+    }
+}
+
+*[data-compactlayout] .jkl-text-input:not(.jkl-text-area),
+.jkl-text-input--compact:not(.jkl-text-area),
+.jkl-text-input--inline:not(.jkl-text-area) {
+    .jkl-text-input__input {
+        line-height: $text-input-height--compact; // Trengs for å unngå clipping av Å i Chrome, men den ødelegger placeholder i textarea (hvor clippingen ikke skjer)
+    }
 }
 
 .jkl-text-area {


### PR DESCRIPTION
affects: @fremtind/jkl-text-input

Fikser en regresjon etter #2509 (bugfix for clipping av Å)

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [ ] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
