### PR TITLE
fix: added jkl class to text under photos

### DIFF
--- a/portal/src/components/portal-image/PortalImage.tsx
+++ b/portal/src/components/portal-image/PortalImage.tsx
@@ -43,7 +43,7 @@ export const PortalImage: FC<Props> = ({ className, src, alt, noMargin = false, 
                 >
                     <AnimatedImage src={src} alt={alt} />
                     {!isFullscreen && !noMargin && (
-                        <p className="jkl-small">
+                        <p className="jkl jkl-small">
                             {caption && caption} Klikk for å se større{caption && "."}
                         </p>
                     )}


### PR DESCRIPTION
affects: @fremtind/portal

Ser ut som om tekst under bildet ikke har jkl class og at det må settes manuelt. 

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
