### PR TITLE
docs: dokumenter Autosuggest, deprecate leadText

### DIFF
--- a/packages/text-input-react/documentation/Autosuggest.mdx
+++ b/packages/text-input-react/documentation/Autosuggest.mdx
@@ -7,16 +7,11 @@ displayTypes: |
     - Autosuggest
 ---
 
-import AutosuggestExample from "./AutosuggestExample";
+import AutosuggestExample, { autosuggestExampleCode } from "./AutosuggestExample";
 
 <Ingress>
-    Autosuggest er en del av{" "}
-    <a className="jkl-link" href="/komponenter/textinput">
-        text-input
-    </a>{" "}
-    pakken, og kan brukes til å gi brukerene forslag basert på det man legger inn. Den er spesielt nyttig når brukeren
-    må/kan velge fra en veldig lang liste med potensielle resultat. Komponenten kan også brukes async, hvor resultatene
-    hentes etter at brukeren har tastet inn x antall tegn.
+    Autosuggest kan brukes til å gi brukerene forhåndsdefinerte forslag basert på det de skriver, men også godta
+    brukerens tekst som gyldig input uavhengig av treff.
 </Ingress>
 
 <Experimental>
@@ -37,16 +32,7 @@ import AutosuggestExample from "./AutosuggestExample";
 <ComponentExample
     component={AutosuggestExample}
     knobs={{
-        boolProps: [
-            "Invertert",
-            "Hjelpetekst",
-            "Feiltekst",
-            "Leadtekst",
-            "Ingen treff",
-            "Max antall treff",
-            "Placeholder",
-            "Vis kontroller",
-        ],
+        boolProps: ["Hjelpetekst", "Feiltekst", "Ingen treff", "Mis maks 3 treff", "Placeholder", "Vis ikoner"],
         choiceProps: [
             {
                 name: "Variant",
@@ -55,4 +41,11 @@ import AutosuggestExample from "./AutosuggestExample";
             },
         ],
     }}
+    codeExample={autosuggestExampleCode}
 />
+
+## Bruk
+
+Autosuggest har noen likhetstrekk med en [Select](/komponenter/select) med søk. En nyanseforskjell er at en nedtrekksliste ikke lar brukeren velge noe annet enn de forhåndsbestemte alternativene. Autosuggest lar deg derimot godta brukerens input uansett om det er treff eller ei – fritekst. Om brukeren alltid skal velge ett av de gitte alternativene er det sannsynligvis Select som er riktig komponent å bruke.
+
+For å skille Autosuggest visuelt fra [Text input](/komponenter/textinput) kan du bruke ikonene som er innebygget.

--- a/packages/text-input-react/documentation/Autosuggest.mdx
+++ b/packages/text-input-react/documentation/Autosuggest.mdx
@@ -3,6 +3,8 @@ title: ­Autosuggest 🧪
 react: text-input-react
 scss: text-input
 group: skjema
+displayTypes: |
+    - Autosuggest
 ---
 
 import AutosuggestExample from "./AutosuggestExample";
@@ -12,9 +14,9 @@ import AutosuggestExample from "./AutosuggestExample";
     <a className="jkl-link" href="/komponenter/textinput">
         text-input
     </a>{" "}
-    pakken, og kan brukes til å gi brukerene forslag basert på det man legger inn. Den er spesielt nyttig når brukeren må/kan
-    velge fra en veldig lang liste med potensielle resultat. Komponenten kan også brukes async, hvor resultatene hentes etter at
-    brukeren har tastet inn x antall tegn.
+    pakken, og kan brukes til å gi brukerene forslag basert på det man legger inn. Den er spesielt nyttig når brukeren
+    må/kan velge fra en veldig lang liste med potensielle resultat. Komponenten kan også brukes async, hvor resultatene
+    hentes etter at brukeren har tastet inn x antall tegn.
 </Ingress>
 
 <Experimental>

--- a/packages/text-input-react/documentation/AutosuggestExample.tsx
+++ b/packages/text-input-react/documentation/AutosuggestExample.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
-import { ExampleComponentProps } from "../../../doc-utils";
+import { CodeExample, ExampleComponentProps } from "../../../doc-utils";
 import { Autosuggest } from "../src";
 
 export const AutosuggestExample: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [value, setValue] = useState("");
-    const [value2, setValue2] = useState("");
 
     const allItems = [
         "Afghanistan",
@@ -19,47 +18,56 @@ export const AutosuggestExample: React.FC<ExampleComponentProps> = ({ boolValues
         "Bhutan",
     ];
 
-    const filteredItems = allItems.filter((item) => item.toLowerCase().includes(value2.toLowerCase()));
+    const filteredItems = allItems.filter((item) => item.toLowerCase().includes(value.toLowerCase()));
 
     return (
         <div style={{ maxWidth: "400px", width: "100%" }}>
             <Autosuggest
+                className="jkl-spacing-l--top"
                 label="Velg land"
+                onInputValueChange={setValue}
                 onChange={setValue}
                 value={value}
                 onConfirm={() => console.log("onConfirm")}
-                allItems={allItems}
-                helpLabel={boolValues?.Hjelpetekst ? "Velg et land" : undefined}
-                errorLabel={boolValues?.Feiltekst ? "Du må velge et land" : undefined}
-                leadText={boolValues?.Leadtekst ? "Velg det beste landet" : undefined}
-                placeholder={boolValues?.Placeholder ? "Velg et land" : undefined}
-                showDropdownControllerButton={boolValues && boolValues["Vis kontroller"]}
-                noHitsMessage={boolValues && boolValues["Ingen treff"] ? "Tror ikke det er et land" : undefined}
-                maxNumberOfHits={boolValues && boolValues["Max antall treff"] ? 3 : undefined}
-                variant={(choiceValues?.Variant as "small" | "medium" | "large") || "medium"}
-                inverted={boolValues?.Invertert}
-            />
-
-            <Autosuggest
-                className="jkl-spacing-l--top"
-                label="Velg land med fritekst"
-                onInputValueChange={setValue2}
-                onChange={setValue2}
-                value={value2}
-                onConfirm={() => console.log("onConfirm")}
                 allItems={filteredItems}
-                helpLabel={boolValues?.Hjelpetekst ? "Velg et land" : undefined}
+                helpLabel={boolValues?.Hjelpetekst ? "Velg et land fra listen eller skriv inn landet selv" : undefined}
                 errorLabel={boolValues?.Feiltekst ? "Du må velge et land" : undefined}
-                leadText={boolValues?.Leadtekst ? "Velg det beste landet" : undefined}
                 placeholder={boolValues?.Placeholder ? "Velg et land" : undefined}
-                showDropdownControllerButton={boolValues && boolValues["Vis kontroller"]}
-                noHitsMessage={boolValues && boolValues["Ingen treff"] ? "Tror ikke det er et land" : undefined}
-                maxNumberOfHits={boolValues && boolValues["Max antall treff"] ? 3 : undefined}
+                showDropdownControllerButton={boolValues?.["Vis ikoner"]}
+                noHitsMessage={boolValues?.["Ingen treff"] ? "Fant ingen land, men du kan skrive ferdig" : undefined}
+                maxNumberOfHits={boolValues?.["Mis maks 3 treff"] ? 3 : undefined}
                 variant={(choiceValues?.Variant as "small" | "medium" | "large") || "medium"}
                 inverted={boolValues?.Invertert}
             />
+            <p className="jkl-body jkl-spacing-m--top">Du har valgt: {value}</p>
         </div>
     );
 };
 
 export default AutosuggestExample;
+
+export const autosuggestExampleCode: CodeExample = ({ boolValues, choiceValues }) => `
+const allItems = ["Afghanistan", "Aland Islands", /* etc... */];
+const [value, setValue] = useState("");
+return (
+    <div style={{ maxWidth: "400px", width: "100%" }}>
+        <Autosuggest
+            className="jkl-spacing-l--top"
+            label="Velg land med fritekst"
+            onInputValueChange={setValue}
+            onChange={setValue}
+            value={value}
+            allItems={allItems.filter((item) => item.toLowerCase().includes(value.toLowerCase()))}
+            helpLabel=${
+                boolValues?.Hjelpetekst ? `"Velg et land fra listen eller skriv inn landet selv"` : "{undefined}"
+            }
+            errorLabel=${boolValues?.Feiltekst ? `"Du må velge et land"` : "{undefined}"}
+            placeholder=${boolValues?.Placeholder ? `"Velg et land"` : "{undefined}"}
+            showDropdownControllerButton={${boolValues?.["Vis ikoner"]}}
+            noHitsMessage=${boolValues?.["Ingen treff"] ? `"Fant ingen land, men du kan skrive ferdig"` : "{undefined}"}
+            maxNumberOfHits=${boolValues?.["Mis maks 3 treff"] ? 3 : "{undefined}"}
+            variant=${choiceValues?.Variant}
+        />
+    </div>
+);
+`;

--- a/packages/text-input-react/documentation/TextInput.mdx
+++ b/packages/text-input-react/documentation/TextInput.mdx
@@ -3,6 +3,10 @@ title: Text input
 react: text-input-react
 scss: text-input
 group: skjema
+displayTypes: |
+    - TextInput
+    - TextArea
+    - BaseInputField
 ---
 
 import { TextInput, TextArea } from "../src";

--- a/packages/text-input-react/src/autosuggest/Autosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.tsx
@@ -17,6 +17,7 @@ export type CommonProps = (
 ) & {
     className?: string;
     isOpen?: boolean;
+    /** @deprecated Bruk helpLabel eller flytt denne teksten ovenfor skjemafeltets label */
     leadText?: string;
     errorLabel?: string;
     helpLabel?: string;

--- a/packages/text-input-react/src/autosuggest/Autosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.tsx
@@ -1,6 +1,5 @@
 import { StateChangeOptions } from "downshift";
-import React, { ReactNode, useEffect, useState, VFC } from "react";
-
+import React, { ReactNode, useEffect, useState } from "react";
 import BaseAutosuggest from "./BaseAutosuggest";
 import { filter } from "./utils";
 
@@ -39,9 +38,9 @@ export interface AutosuggestStringItemProps {
     onConfirm?: () => void;
 }
 
-type Props = CommonProps & AutosuggestStringItemProps;
+export type AutosuggestProps = CommonProps & AutosuggestStringItemProps;
 
-export const Autosuggest: VFC<Props> = ({
+export const Autosuggest = ({
     allItems,
     onChange = () => {
         /* default noop */
@@ -54,7 +53,7 @@ export const Autosuggest: VFC<Props> = ({
     value,
     isOpen,
     ...rest
-}) => {
+}: AutosuggestProps): JSX.Element => {
     const [hits, setHits] = useState(allItems);
 
     useEffect(() => setHits(allItems), [allItems]);

--- a/packages/text-input-react/src/autosuggest/index.ts
+++ b/packages/text-input-react/src/autosuggest/index.ts
@@ -1,1 +1,2 @@
+export type { AutosuggestProps } from "./Autosuggest";
 export { Autosuggest } from "./Autosuggest";

--- a/packages/text-input-react/src/index.ts
+++ b/packages/text-input-react/src/index.ts
@@ -1,6 +1,7 @@
 import { TextArea, Props as TextAreaPropsInterface } from "./TextArea";
 import { TextInput, Props as TextInputPropsInterface } from "./TextInput";
 import { BaseInputField, Props as BaseInputPropsInterface } from "./BaseInputField";
+export type { AutosuggestProps } from "./autosuggest";
 import { Autosuggest } from "./autosuggest";
 
 interface BaseInputProps extends BaseInputPropsInterface {}

--- a/portal/src/components/Experimental/Experimental.tsx
+++ b/portal/src/components/Experimental/Experimental.tsx
@@ -3,7 +3,10 @@ import { WarningMessageBox } from "@fremtind/jkl-message-box-react";
 
 export const Experimental: React.FC = ({ children }) => {
     return (
-        <WarningMessageBox className="jkl-spacing-xl--top jkl-spacing-xl--bottom" title="Eksperimentell komponent">
+        <WarningMessageBox
+            className="jkl-portal-paragraph jkl-spacing-xl--top jkl-spacing-xl--bottom"
+            title="Eksperimentell komponent"
+        >
             {children}
         </WarningMessageBox>
     );


### PR DESCRIPTION
Rendyrk Autosuggest som en komponent hvor formålet er å tillate fritekst, men komme med kjente forslag der vi har dem. Dette tydeliggjør rollene til denne komponenten og en søkbar Select. Ingen kodeendringer, bare dokumentasjon.

Om `leadText`: dette er ikke et mønster vi bruker i skjemaene våre. Det skal ikke være et avsnitt med tekst mellom
en label og skjemafeltet. Bruk helpLabel eller flytt denne teksten ovenfor skjemafeltets label i et selvstendig avsnitt.

ISSUES CLOSED: #2575 

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
