### PR TITLE
fix: make all button elements respect width constraint

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -60,6 +60,7 @@ a.jkl-button {
 .jkl-button {
     @include reset-outline;
     display: inline-flex;
+    box-sizing: border-box;
     justify-content: center;
     @include jkl.text-style("body/small-screen");
     font-weight: jkl.$typography-weight-bold;


### PR DESCRIPTION
affects: @fremtind/jkl-button

Fikser en bug hvor bruk av .jkl-button ikke blir håndtert likt på alle elementer. Feks `<a href="#" class="jkl-button">`

Close #2585 

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [X] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [X] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [X] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [X] Jeg har skrevet relevant dokumentasjon
