### PR TITLE
fix: bruk riktig lengde for TextInput

### DIFF
--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -44,7 +44,7 @@ function getWidthAsStyle(width?: string, maxLength?: number): CSSProperties | un
         // adapt to maxLength, but capped at 40ch
         const length = `${Math.min(maxLength, 40)}ch`;
         const padding = "24px"; // left + right padding
-        return { maxWidth: `calc(${length} + ${padding})` };
+        return { width: `calc(${length} + ${padding})` };
     }
 
     return undefined;

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -114,7 +114,7 @@ $text-input-selected-error-color--inverted: transparentize($text-input-error-col
     &__input-wrapper {
         display: inline-flex;
         align-items: center;
-        width: 100%;
+        max-width: 100%;
     }
 
     &__input {


### PR DESCRIPTION
affects: @fremtind/jkl-text-input-react, @fremtind/jkl-text-input

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->
TextInput uten definert maxLength blei like breie som containeren sin, dette var feil og er fiksa i denne PRen.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har skrevet relevant dokumentasjon
