### PR TITLE
feat: add onChange event to tabs

### DIFF
--- a/packages/tabs-react/package.json
+++ b/packages/tabs-react/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@babel/runtime": "^7.16.3",
         "@fremtind/jkl-core": "^8.2.1",
+        "@fremtind/jkl-react-hooks": "^6.1.3",
         "@fremtind/jkl-tabs": "^1.2.2",
         "nanoid": "^3.1.30"
     },

--- a/packages/tabs-react/src/Tabs.test.tsx
+++ b/packages/tabs-react/src/Tabs.test.tsx
@@ -3,9 +3,9 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Tabs, Tab, TabList, TabPanel } from ".";
 import { axe } from "jest-axe";
 
-const renderComponent = () =>
+const renderComponent = (onChange?: () => void) =>
     render(
-        <Tabs>
+        <Tabs onChange={onChange}>
             <TabList aria-label="testlist">
                 <Tab>Tab 1</Tab>
                 <Tab>Tab 2</Tab>
@@ -30,6 +30,18 @@ describe("Tabs", () => {
 
         screen.getByText("Tabpanel 2");
         expect(screen.queryByText("Tabpanel 1")).toBeNull();
+    });
+
+    it("triggers onChange when changing tabs", async () => {
+        const onChange = jest.fn();
+
+        renderComponent(onChange);
+
+        expect(onChange).toHaveBeenCalledWith(0);
+
+        fireEvent.click(screen.getByText("Tab 2"));
+
+        expect(onChange).toHaveBeenCalledWith(1);
     });
 });
 

--- a/packages/tabs-react/src/Tabs.test.tsx
+++ b/packages/tabs-react/src/Tabs.test.tsx
@@ -37,7 +37,7 @@ describe("Tabs", () => {
 
         renderComponent(onChange);
 
-        expect(onChange).toHaveBeenCalledWith(0);
+        expect(onChange).not.toHaveBeenCalled();
 
         fireEvent.click(screen.getByText("Tab 2"));
 

--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -14,13 +14,13 @@ interface Props {
  *
  * Docs: https://jokul.fremtind.no/komponenter/tabs
  */
-export const Tabs = (props: Props) => {
+export const Tabs = ({ onChange, ...props }: Props) => {
     const [activeIndex, setActiveIndex] = useState(0);
 
     const [tabIDs, setTabIDs] = useState<string[]>([]);
     const [tabPanelIDs, setTabPanelIds] = useState<string[]>([]);
 
-    useEffect(() => props.onChange?.(activeIndex), [activeIndex, props]);
+    useEffect(() => onChange?.(activeIndex), [activeIndex, onChange]);
 
     const resolveIDs = useCallback(() => {
         const tabList = React.Children.toArray(props.children)[0];

--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, ReactNode } from "react";
 import cx from "classnames";
 import { nanoid } from "nanoid";
+import { usePreviousValue } from "@fremtind/jkl-react-hooks";
 
 interface Props {
     children: ReactNode;
@@ -17,10 +18,16 @@ interface Props {
 export const Tabs = ({ onChange, ...props }: Props) => {
     const [activeIndex, setActiveIndex] = useState(0);
 
+    const previousTabIndex = usePreviousValue(activeIndex);
+
+    useEffect(() => {
+        if (previousTabIndex !== undefined && previousTabIndex !== activeIndex && onChange) {
+            onChange(activeIndex);
+        }
+    }, [onChange, previousTabIndex, activeIndex]);
+
     const [tabIDs, setTabIDs] = useState<string[]>([]);
     const [tabPanelIDs, setTabPanelIds] = useState<string[]>([]);
-
-    useEffect(() => onChange?.(activeIndex), [activeIndex, onChange]);
 
     const resolveIDs = useCallback(() => {
         const tabList = React.Children.toArray(props.children)[0];

--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 interface Props {
     children: ReactNode;
     className?: string;
+    onChange?: (tabIndex: number) => void;
 }
 
 /**
@@ -18,6 +19,8 @@ export const Tabs = (props: Props) => {
 
     const [tabIDs, setTabIDs] = useState<string[]>([]);
     const [tabPanelIDs, setTabPanelIds] = useState<string[]>([]);
+
+    useEffect(() => props.onChange?.(activeIndex), [activeIndex, props]);
 
     const resolveIDs = useCallback(() => {
         const tabList = React.Children.toArray(props.children)[0];


### PR DESCRIPTION
Vi har et behov for å kunne reagere når hvilke tab som er aktiv endrer seg. Dette er for å kunne registrere bruksmønster i Mixpanel. Her har jeg lagt til en onChange funksjon som trigges hver gang den aktive tabIndexen endrer seg.

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [X] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [X] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [X] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [X] Jeg har skrevet relevant dokumentasjon
