### PR TITLE
fix: clean også node_modules på rotnivå

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "1.0.0",
     "scripts": {
-        "clean": "lerna run --parallel clean",
+        "clean": "lerna run --parallel clean && rimraf node_modules/",
         "clean:portal": "lerna run clean:portal --stream",
         "build": "yarn patch-package && lerna run --ignore @fremtind/browserslist-config-jkl --ignore @fremtind/portal build --stream",
         "build:quiet": "yarn patch-package && lerna run --ignore @fremtind/browserslist-config-jkl --ignore @fremtind/portal build",

--- a/portal/src/texts/getstarted/GettingStartedDev.mdx
+++ b/portal/src/texts/getstarted/GettingStartedDev.mdx
@@ -65,7 +65,7 @@ Du kan se på dokumentasjonen for [Tag](/komponenter/tag) og [Alert message](/ko
 
 ## Slik lenker du pakker sammen
 
-Hvis du vil legge til en pakke i en annen, kan du fra hvor som helst i prosjektet kjøre `lerna add <pakke-som-skal-legges-til> --scope=<pakken-den-skal-inn-i>`. For eksempel vil `lerna add @fremtind/jkl-core scope=@fremtind/jkl-button` legge til `jkl-core` som en avhengighet i `jkl-button`-pakken. Når du legger til avhengigheter på denne måten, kan Lerna bruke den lokale versjonen av `jkl-core` i stedet for å laste ned fra NPM, slik at du kan utvikle raskere. Dette fungerer bare for andre pakker i Jøkul.
+Hvis du vil legge til en pakke i en annen, kan du fra hvor som helst i prosjektet kjøre `yarn lerna add <pakke-som-skal-legges-til> --scope=<pakken-den-skal-inn-i>`. For eksempel vil `yarn lerna add @fremtind/jkl-core scope=@fremtind/jkl-button` legge til `jkl-core` som en avhengighet i `jkl-button`-pakken. Når du legger til avhengigheter på denne måten, kan Lerna bruke den lokale versjonen av `jkl-core` i stedet for å laste ned fra NPM, slik at du kan utvikle raskere. Dette fungerer bare for andre pakker i Jøkul.
 
 ## Slik legger du til en avhengighet
 


### PR DESCRIPTION
For å luke ut et opplevd problem etter mixing av npm og yarn

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
