### PR TITLE
fix: fjern padding fra hamburger

### DIFF
--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -34,7 +34,7 @@ $hamburger-focus-color--inverted: jkl.$color-svaberg;
     min-width: $bounding-touch-size;
     display: flex;
     flex-direction: row;
-    padding: jkl.$spacing-xs;
+    padding: 0;
     justify-content: center;
     align-items: center;
     position: relative;


### PR DESCRIPTION
affects: @fremtind/jkl-hamburger

dette lar konsumenten selv styre hvordan spacing rundt hamburgeren skal være

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [X] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [ X Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
