### PR TITLE
fix: sett korrekt aria-hidden basert på showLoader

### DIFF
--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -122,5 +122,20 @@ describe("a11y", () => {
 
             expect(results).toHaveNoViolations();
         });
+
+        [false, true].map((showLoader) => {
+            it(`${buttonVariant.name} sets aria-hidden="${String(
+                !showLoader,
+            )}" on loader when showLoader is ${showLoader}`, async () => {
+                const { name, component: Button } = buttonVariant;
+                render(
+                    <Button loader={{ showLoader, textDescription: "Vennligst vent" }} onClick={() => {}}>
+                        {name}
+                    </Button>,
+                );
+                const loader = screen.getByTestId("jkl-loader");
+                expect(loader).toHaveAttribute("aria-hidden", String(!showLoader));
+            });
+        });
     });
 });

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -51,7 +51,7 @@ const makeButtonComponent = (buttonType: ValidButtons) => {
                                 <div className="jkl-button__loader">
                                     <Loader
                                         textDescription={loader.textDescription}
-                                        aria-hidden={!!loader.showLoader}
+                                        aria-hidden={!loader.showLoader}
                                         variant={forceCompact ? "small" : "medium"}
                                     />
                                 </div>


### PR DESCRIPTION
affects: @fremtind/jkl-button-react

Var en logikkfeil som gjorde at loadingtekst ble lest opp umiddelbart, og ikke lest opp når
loadingtilstanden ble startet.

ISSUES CLOSED: #2647

<!--
Forklar formålet med endringene dine og hvorfor de er nødvendige her. Om det er beskrevet allerede i et issue må du lenke til det. Utdyp gjerne hvorfor løsningen din ser ut som den gjør, alternativer du vurderte eller prøvde underveis, og så videre.
-->

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [x] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [ ] Jeg har skrevet relevant dokumentasjon
