### PR TITLE
Implementer utvidbar tabell-rad

### DIFF
--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -57,7 +57,11 @@ export const ExpandButton = ({
             })}
             {...rest}
         >
-            {children && <ContentWrapper>{children}</ContentWrapper>}
+            {children && (
+                <ContentWrapper>
+                    <span className="jkl-expand-button__text">{children}</span>
+                </ContentWrapper>
+            )}
             <ArrowVerticalAnimated className="jkl-expand-button__arrow" pointingDown={pointingDown} />
         </button>
     );

--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -31,6 +31,7 @@ export interface ExpandButtonProps {
      * @default false
      */
     hideLabel?: boolean;
+    id?: string;
 }
 
 export const ExpandButton = ({

--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -13,6 +13,7 @@ export interface ExpandButtonProps {
     children: ReactNode;
     className?: string;
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
     /**
      * Styrer retningen til pila, som animeres ved endring. Styrer også aria-expanded.
      * @default false

--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -51,10 +51,11 @@ export const ExpandButton = ({
             className={cx("jkl-expand-button", className, {
                 "jkl-expand-button--expanded": isExpanded,
                 "jkl-expand-button--compact": forceCompact,
+                "jkl-expand-button--icon-only": !children,
             })}
             {...rest}
         >
-            <ContentWrapper>{children}</ContentWrapper>
+            {children && <ContentWrapper>{children}</ContentWrapper>}
             <ArrowVerticalAnimated className="jkl-expand-button__arrow" pointingDown={pointingDown} />
         </button>
     );

--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -31,7 +31,6 @@ export interface ExpandButtonProps {
      * @default false
      */
     hideLabel?: boolean;
-    id?: string;
 }
 
 export const ExpandButton = ({

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -88,6 +88,13 @@ $expand-button-focus-color--inverted: jkl.$color-snohvit;
         }
     }
 
+    &--icon-only {
+        .jkl-expand-button__arrow {
+            margin-right: jkl.$spacing-xs;
+            margin-left: jkl.$spacing-xs;
+        }
+    }
+
     &__arrow {
         @include mixins.motion("standard");
 

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -90,8 +90,7 @@ $expand-button-focus-color--inverted: jkl.$color-snohvit;
 
     &--icon-only {
         .jkl-expand-button__arrow {
-            margin-right: jkl.$spacing-xs;
-            margin-left: jkl.$spacing-xs;
+            margin: jkl.$spacing-2xs jkl.$spacing-xs;
         }
     }
 

--- a/packages/react-hooks/documentation/UseIdExample.tsx
+++ b/packages/react-hooks/documentation/UseIdExample.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from "react";
+import { useId } from "../src";
+
+export const UseIdExample = () => {
+    const elId = useId("jkl-useid-example");
+    const [count, setCount] = useState(0);
+
+    return (
+        <div>
+            <p className="jkl-body jkl-spacing-l--bottom" id={elId}>
+                Denne paragrafen har id følgende id: <strong>{elId}</strong>. Selv om elementet rendrer på nytt, vil
+                ikke id endres.
+                <br />
+                <button
+                    className="jkl-button jkl-button--primary jkl-spacing-m--top"
+                    onClick={() => setCount(count + 1)}
+                >
+                    Trigger en re-render
+                </button>
+            </p>
+        </div>
+    );
+};

--- a/packages/react-hooks/documentation/index.tsx
+++ b/packages/react-hooks/documentation/index.tsx
@@ -12,6 +12,7 @@ import KeyListenerExample from "./KeyListenerExample";
 import MutationObserverExample from "./MutationObserverExample";
 import ScrollIntoViewExample from "./ScrollIntoViewExample";
 import ReducedMotionExample from "./ReducedMotionExample";
+import { UseIdExample } from "./UseIdExample";
 import "@fremtind/jkl-button/button.css";
 import "@fremtind/jkl-card/card.css";
 
@@ -25,6 +26,7 @@ renderExample(
         <DevExample component={IntersectionObserverExample} />
         <DevExample component={ScrollIntoViewExample} />
         <DevExample component={ReducedMotionExample} />
+        <DevExample component={UseIdExample} />
     </>,
     document.getElementById("app"),
 );

--- a/packages/react-hooks/documentation/useId.mdx
+++ b/packages/react-hooks/documentation/useId.mdx
@@ -1,0 +1,25 @@
+---
+title: useId
+react: react-hooks
+group: hooks
+---
+
+import { UseIdExample } from "./UseIdExample";
+
+<Ingress>
+    useId lager en unik ID som du kan bruke på elementer. Spesielt er dette nyttig for å for eksempel binde sammen id og
+    labler ol. når man jobber med tilgjengelighet:
+</Ingress>
+
+```jsx
+const elId = useId("jkl-useid-example"); // jkl-useid-example-V1ifIVj1
+
+return (
+    <>
+        <button aria-controls={elId}>Knapp</button>
+        <div id={elId}>{children}</div>
+    </>
+);
+```
+
+<ComponentExample component={UseIdExample} />

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -36,7 +36,8 @@
     "dependencies": {
         "@babel/runtime": "^7.16.7",
         "@fremtind/jkl-core": "^8.3.3",
-        "@fremtind/jkl-react-hooks": "^6.1.7"
+        "@fremtind/jkl-react-hooks": "^6.1.7",
+        "nanoid": "^3.1.30"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0",

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -15,3 +15,4 @@ export { useBrowserPreferences } from ".//useBrowserPreferences/useBrowserPrefer
 export type { ProgressiveImageProps } from "./useProgressiveImg/useProgressiveImg";
 export { useProgressiveImg } from "./useProgressiveImg/useProgressiveImg";
 export { usePreviousValue } from "./usePreviousValue/usePreviousValue";
+export { useId } from "./useId";

--- a/packages/react-hooks/src/useId.ts
+++ b/packages/react-hooks/src/useId.ts
@@ -1,0 +1,8 @@
+import { useState } from "react";
+import { nanoid } from "nanoid";
+
+export const useId = (id: string) => {
+    const [elId] = useState(`${id}-${nanoid(8)}`);
+
+    return elId;
+};

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -1,8 +1,7 @@
 import React, { VFC } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Table, TableCaption, TableHead, TableRow, TableHeader, TableBody, TableCell } from "../src";
-import { ExpandableTableRowCell } from "../src/ExpandableTableRowCell";
-import { ExpandableTableRow } from "../src/ExpandableTableRow";
+import { ExpandableTableRowCell, ExpandableTableRow } from "../src/";
 
 const headings = ["Kravnr", "Kravtype", "Status", "Årsakskode", "Meldt dato"];
 
@@ -70,7 +69,7 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
 
 export default ExpandableTableExample;
 
-export const headlessTableExampleCode = ({ choiceValues }: ExampleComponentProps): string => `
+export const expandableTableExampleCode = ({ choiceValues }: ExampleComponentProps): string => `
 <Table fullWidth collapseToList={${choiceValues?.["Mobilvisning"] === "Liste"}}>
     <TableCaption srOnly>Tabell med ekspanderbare rader</TableCaption>
     <TableHead srOnly={headless}>

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -1,0 +1,55 @@
+import React, { VFC } from "react";
+import { ExampleComponentProps } from "../../../doc-utils";
+import { Table, TableCaption, TableHead, TableRow, TableHeader, TableBody, TableCell } from "../src";
+import { ExpandableTableRowCell } from "../src/ExpandableTableRowCell";
+import { ExpandableTableRow } from "../src/ExpandableTableRow";
+
+const headings = ["Kravnr", "Kravtype", "Status", "Årsakskode", "Meldt dato"];
+
+const rows = [
+    ["11102", "F", "QA", "3.2.2", "22.11.2021"],
+    ["1232", "G", "QA", "3.2.2", "01.12.2021"],
+    ["32312", "H", "PR", "2.2.0", "12.11.2021"],
+];
+
+const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
+    const compact = boolValues?.["Kompakt"];
+    const headless = boolValues?.["Skjul overskrift"];
+    const type = choiceValues?.["Mobilvisning"];
+    const props = type === "Liste" ? { "data-collapse": "true", collapseToList: true, compact: true } : {};
+
+    return (
+        <Table compact={compact} fullWidth {...props}>
+            <TableCaption srOnly>Tabell med ekspanderbare rader</TableCaption>
+            <TableHead srOnly={headless}>
+                <TableRow>
+                    {headings.map((column) => (
+                        <TableHeader key={column} compact bold>
+                            {column}
+                        </TableHeader>
+                    ))}
+                    <TableHeader srOnly>Vis mer</TableHeader>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {rows.map((row, rowIndex) => (
+                    <ExpandableTableRow key={rowIndex} expandedChildren={<>Hello, world!</>}>
+                        {row.map((cell, cellIndex) => (
+                            <TableCell
+                                key={cellIndex}
+                                data-th={headings[cellIndex]}
+                                verticalAlign="center"
+                                align={[0, 3, 5, 7].includes(cellIndex) ? "right" : "left"}
+                            >
+                                {cell}
+                            </TableCell>
+                        ))}
+                        <ExpandableTableRowCell data-th="Mer informasjon" />
+                    </ExpandableTableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+export default ExpandableTableExample;

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -33,7 +33,21 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
             </TableHead>
             <TableBody>
                 {rows.map((row, rowIndex) => (
-                    <ExpandableTableRow key={rowIndex} expandedChildren={<>Hello, world!</>}>
+                    <ExpandableTableRow
+                        key={rowIndex}
+                        expandedChildren={
+                            <Table fullWidth>
+                                <TableBody>
+                                    <TableRow>
+                                        <TableCell>Hello, world!</TableCell>
+                                        <TableCell>Hello, world!</TableCell>
+                                        <TableCell>Hello, world!</TableCell>
+                                        <TableCell>Hello, world!</TableCell>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                        }
+                    >
                         {row.map((cell, cellIndex) => (
                             <TableCell
                                 key={cellIndex}
@@ -44,7 +58,7 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
                                 {cell}
                             </TableCell>
                         ))}
-                        <ExpandableTableRowCell data-th="Mer informasjon" />
+                        <ExpandableTableRowCell data-th="Mer informasjon" verticalAlign="center" compact={compact} />
                     </ExpandableTableRow>
                 ))}
             </TableBody>

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -14,7 +14,7 @@ const rows = [
 const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const compact = boolValues?.["Kompakt"];
     const headless = boolValues?.["Skjul overskrift"];
-    const clickable = boolValues?.["Klikkbar"];
+    const markClickedRows = boolValues?.["Markér v/ klikk"];
     const type = choiceValues?.["Mobilvisning"];
     const props = type === "Liste" ? { "data-collapse": "true", collapseToList: true, compact: true } : {};
 
@@ -35,7 +35,7 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
                 {rows.map((row, rowIndex) => (
                     <ExpandableTableRow
                         key={rowIndex}
-                        clickable={clickable ? { onClick: (e) => console.log(e) } : undefined}
+                        clickable={markClickedRows ? { onClick: (e) => console.log(e), markClickedRows } : undefined}
                         expandedChildren={
                             <Table fullWidth>
                                 <TableHead srOnly>
@@ -81,7 +81,7 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
 
 export default ExpandableTableExample;
 
-export const expandableTableExampleCode = ({ choiceValues }: ExampleComponentProps): string => `
+export const expandableTableExampleCode = ({ choiceValues, boolValues }: ExampleComponentProps): string => `
 <Table fullWidth collapseToList={${choiceValues?.["Mobilvisning"] === "Liste"}}>
     <TableCaption srOnly>Tabell med ekspanderbare rader</TableCaption>
     <TableHead srOnly={headless}>
@@ -97,7 +97,12 @@ export const expandableTableExampleCode = ({ choiceValues }: ExampleComponentPro
     <TableBody>
         {rows.map((row, rowIndex) => (
             <ExpandableTableRow
-                key={rowIndex}
+                key={rowIndex}${
+                    boolValues?.["Markér v/ klikk"] || false
+                        ? `
+                clickable={{ onClick: (e) => console.log(e), markClickedRows }}`
+                        : ``
+                }
                 expandedChildren={
                     <Table fullWidth>
                         <TableBody>

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -69,3 +69,50 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
 };
 
 export default ExpandableTableExample;
+
+export const headlessTableExampleCode = ({ choiceValues }: ExampleComponentProps): string => `
+<Table fullWidth collapseToList={${choiceValues?.["Mobilvisning"] === "Liste"}}>
+    <TableCaption srOnly>Tabell med ekspanderbare rader</TableCaption>
+    <TableHead srOnly={headless}>
+        <TableRow>
+            {headings.map((column) => (
+                <TableHeader key={column} compact bold>
+                    {column}
+                </TableHeader>
+            ))}
+            <TableHeader srOnly>Vis mer</TableHeader>
+        </TableRow>
+    </TableHead>
+    <TableBody>
+        {rows.map((row, rowIndex) => (
+            <ExpandableTableRow
+                key={rowIndex}
+                expandedChildren={
+                    <Table fullWidth>
+                        <TableBody>
+                            <TableRow>
+                                <TableCell>Hello, world!</TableCell>
+                                <TableCell>Hello, world!</TableCell>
+                                <TableCell>Hello, world!</TableCell>
+                                <TableCell>Hello, world!</TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
+                }
+            >
+                {row.map((cell, cellIndex) => (
+                    <TableCell
+                        key={cellIndex}
+                        data-th={headings[cellIndex]}
+                        verticalAlign="center"
+                        align={[0, 3, 5, 7].includes(cellIndex) ? "right" : "left"}
+                    >
+                        {cell}
+                    </TableCell>
+                ))}
+                <ExpandableTableRowCell data-th="Mer informasjon" verticalAlign="center" />
+            </ExpandableTableRow>
+        ))}
+    </TableBody>
+</Table>
+`;

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -38,12 +38,20 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
                         clickable={clickable ? { onClick: (e) => console.log(e) } : undefined}
                         expandedChildren={
                             <Table fullWidth>
+                                <TableHead srOnly>
+                                    <TableRow>
+                                        <TableHeader>Cell 1</TableHeader>
+                                        <TableHeader>Cell 2</TableHeader>
+                                        <TableHeader>Cell 3</TableHeader>
+                                        <TableHeader>Cell 4</TableHeader>
+                                    </TableRow>
+                                </TableHead>
                                 <TableBody>
                                     <TableRow>
-                                        <TableCell>Hello, world!</TableCell>
-                                        <TableCell>Hello, world!</TableCell>
-                                        <TableCell>Hello, world!</TableCell>
-                                        <TableCell>Hello, world!</TableCell>
+                                        <TableCell>Hello, world 1!</TableCell>
+                                        <TableCell>Hello, world 2!</TableCell>
+                                        <TableCell>Hello, world 3!</TableCell>
+                                        <TableCell>Hello, world 4!</TableCell>
                                     </TableRow>
                                 </TableBody>
                             </Table>

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -1,7 +1,7 @@
 import React, { VFC } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Table, TableCaption, TableHead, TableRow, TableHeader, TableBody, TableCell } from "../src";
-import { ExpandableTableRowCell, ExpandableTableRow } from "../src/";
+import { ExpandableTableRowController, ExpandableTableRow } from "../src/";
 
 const headings = ["Kravnr", "Kravtype", "Status", "Årsakskode", "Meldt dato"];
 
@@ -59,7 +59,11 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
                                 {cell}
                             </TableCell>
                         ))}
-                        <ExpandableTableRowCell data-th="Mer informasjon" verticalAlign="center" compact={compact} />
+                        <ExpandableTableRowController
+                            data-th="Mer informasjon"
+                            verticalAlign="center"
+                            compact={compact}
+                        />
                     </ExpandableTableRow>
                 ))}
             </TableBody>
@@ -109,7 +113,7 @@ export const expandableTableExampleCode = ({ choiceValues }: ExampleComponentPro
                         {cell}
                     </TableCell>
                 ))}
-                <ExpandableTableRowCell data-th="Mer informasjon" verticalAlign="center" />
+                <ExpandableTableRowController data-th="Mer informasjon" verticalAlign="center" />
             </ExpandableTableRow>
         ))}
     </TableBody>

--- a/packages/table-react/documentation/ExpandableTableExample.tsx
+++ b/packages/table-react/documentation/ExpandableTableExample.tsx
@@ -15,6 +15,7 @@ const rows = [
 const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const compact = boolValues?.["Kompakt"];
     const headless = boolValues?.["Skjul overskrift"];
+    const clickable = boolValues?.["Klikkbar"];
     const type = choiceValues?.["Mobilvisning"];
     const props = type === "Liste" ? { "data-collapse": "true", collapseToList: true, compact: true } : {};
 
@@ -35,6 +36,7 @@ const ExpandableTableExample: VFC<ExampleComponentProps> = ({ boolValues, choice
                 {rows.map((row, rowIndex) => (
                     <ExpandableTableRow
                         key={rowIndex}
+                        clickable={clickable ? { onClick: (e) => console.log(e) } : undefined}
                         expandedChildren={
                             <Table fullWidth>
                                 <TableBody>

--- a/packages/table-react/documentation/Table.mdx
+++ b/packages/table-react/documentation/Table.mdx
@@ -368,13 +368,13 @@ Hele raden kan gjøres klikkbar om du ønsker, men foretrekk å ha en rad med ha
 
 ### Ekspanderende tabeller
 
-Hele raden gjøres klikkbar, samtidig som man skal sette inn en celle for å vise hvorvidt raden er åpen eller ikke og tilføre informasjon for hjelpemidler. Hvis raden er satt til klikkbar, er det kun knappen som vil kontrollere hvorvidt raden er åpen eller ikke.
+Hele raden blir automatisk klikkbar, samtidig som man skal sette inn en celle for å vise hvorvidt raden er åpen eller ikke og tilføre informasjon for hjelpemidler. Hvis man vil ha en egen klikk-handling på raden og bruker propen `clickable`, er det kun knappen som vil kontrollere hvorvidt raden er åpen eller ikke.
 
 <ComponentExample
     title="Tabell med ekspanderbare rader"
     component={ExpandableTableExample}
     knobs={{
-        boolProps: ["Kompakt", "Klikkbar"],
+        boolProps: ["Kompakt", "Markér v/ klikk"],
         choiceProps: [
             {
                 name: "Mobilvisning",
@@ -383,5 +383,5 @@ Hele raden gjøres klikkbar, samtidig som man skal sette inn en celle for å vis
             },
         ],
     }}
-    codeExample={headlessTableExampleCode}
+    codeExample={expandableTableExampleCode}
 />

--- a/packages/table-react/documentation/Table.mdx
+++ b/packages/table-react/documentation/Table.mdx
@@ -11,6 +11,7 @@ import TableExamples, { tableExamplesCode, tableExamplesProps } from "./TableExa
 import DataTableExample, { dataTableExampleCode } from "./DataTableExample";
 import HeadlessTableExample, { headlessTableExampleCode } from "./HeadlessTableExample";
 import ClickableTableExample, { clickableTableExampleCode } from "./ClickableTableExample";
+import ExpandableTableExample, { expandableTableExampleCode } from "./ExpandableTableExample";
 import ActionTableExample, { actionTableExampleCode } from "./ActionTableExample";
 import MobileScrollTableExample, { mobileScrollTableExampleCode } from "./MobileScrollTableExample";
 import MobileListTableExample, { mobileListTableExampleCode } from "./MobileListTableExample";
@@ -367,12 +368,20 @@ Hele raden kan gjøres klikkbar om du ønsker, men foretrekk å ha en rad med ha
 
 ### Ekspanderende tabeller
 
-Flere av tabellene våre har en eller annen form for ekspandering, det være seg at flere rader blir synlige eller noe annet relatert innhold.
-Jøkul tilbyr per nå ikke noen ferdig komponent for dette, men det er et mål på sikt.
+Hele raden gjøres klikkbar, samtidig som man skal sette inn en celle for å vise hvorvidt raden er åpen eller ikke og tilføre informasjon for hjelpemidler. Hvis raden er satt til klikkbar, er det kun knappen som vil kontrollere hvorvidt raden er åpen eller ikke.
 
-Det vi kan komme med er noen føringer:
-
--   Det skal være en pil på høyre side av tabellraden som ekspanderer og lukker raden (tenk Accordion)
--   Det er denne knappen som gjør ekspandering og lukking. Klikk på raden styrer ikke denne handlingen.
--   Knappen kan ha en tekst som beskriver handlingen, som "Vis mer" og "Skjul". Denne skal stå til venstre for pila.
--   Ekspanderingen bør animeres.
+<ComponentExample
+    title="Tabell med ekspanderbare rader"
+    component={ExpandableTableExample}
+    knobs={{
+        boolProps: ["Kompakt", "Klikkbar"],
+        choiceProps: [
+            {
+                name: "Mobilvisning",
+                values: ["Tabell", "Liste"],
+                defaultValue: 0,
+            },
+        ],
+    }}
+    codeExample={headlessTableExampleCode}
+/>

--- a/packages/table-react/documentation/index.tsx
+++ b/packages/table-react/documentation/index.tsx
@@ -68,7 +68,7 @@ renderExample(
             title="Tabell med ekspanderbare rader"
             component={ExpandableTableExample}
             knobs={{
-                boolProps: ["Kompakt", "Klikkbar"],
+                boolProps: ["Kompakt", "Markér v/ klikk"],
                 choiceProps: [
                     {
                         name: "Mobilvisning",

--- a/packages/table-react/documentation/index.tsx
+++ b/packages/table-react/documentation/index.tsx
@@ -5,12 +5,14 @@ import { renderExample, DevExample } from "../../../doc-utils";
 
 import "../../button/button.css";
 import "../../icons/animated-icons.css";
+import "../../expand-button/expand-button.css";
 // Import actual example and component stylesheet (specific for this component):
 import "@fremtind/jkl-table/table.css";
 import DataTableExample from "./DataTableExample";
 import ClickableTableExample from "./ClickableTableExample";
 import ActionTableExample from "./ActionTableExample";
 import MobileListTableExample from "./MobileListTableExample";
+import ExpandableTableExample from "./ExpandableTableExample";
 
 renderExample(
     <>
@@ -53,6 +55,20 @@ renderExample(
             component={ActionTableExample}
             knobs={{
                 boolProps: ["Compact"],
+                choiceProps: [
+                    {
+                        name: "Mobilvisning",
+                        values: ["Tabell", "Liste"],
+                        defaultValue: 0,
+                    },
+                ],
+            }}
+        />
+        <DevExample
+            title="Tabell med ekspanderbare rader"
+            component={ExpandableTableExample}
+            knobs={{
+                boolProps: ["Kompakt"],
                 choiceProps: [
                     {
                         name: "Mobilvisning",

--- a/packages/table-react/documentation/index.tsx
+++ b/packages/table-react/documentation/index.tsx
@@ -68,7 +68,7 @@ renderExample(
             title="Tabell med ekspanderbare rader"
             component={ExpandableTableExample}
             knobs={{
-                boolProps: ["Kompakt"],
+                boolProps: ["Kompakt", "Klikkbar"],
                 choiceProps: [
                     {
                         name: "Mobilvisning",

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -34,7 +34,8 @@
     "dependencies": {
         "@babel/runtime": "^7.16.7",
         "@fremtind/jkl-core": "^8.3.3",
-        "@fremtind/jkl-table": "^5.1.10"
+        "@fremtind/jkl-expand-button-react": "^1.1.0",
+        "@fremtind/jkl-table": "^5.1.8"
     },
     "devDependencies": {
         "npm-run-all": "^4.1.5"

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -35,6 +35,7 @@
         "@babel/runtime": "^7.16.7",
         "@fremtind/jkl-core": "^8.3.3",
         "@fremtind/jkl-expand-button-react": "^1.1.0",
+        "@fremtind/jkl-react-hooks": "^6.1.4",
         "@fremtind/jkl-table": "^5.1.8"
     },
     "devDependencies": {

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,0 +1,117 @@
+import cx from "classnames";
+import React, { DetailedHTMLProps, FC, HTMLAttributes, useState } from "react";
+import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
+import { useTableContext } from "./tableContext";
+import { useTableSectionContext } from "./tableSectionContext";
+
+export interface ClickableRowProps {
+    markClickedRows?: boolean;
+    /** Lar deg kontrollere radens tilstand untenfra */
+    isClicked?: boolean;
+    onClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent> | React.KeyboardEvent<HTMLTableRowElement>) => void;
+}
+
+export interface ExpandableTableRowProps
+    extends DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> {
+    /**
+     * Gir raden interaktivitet og en click-handler.
+     */
+    clickable?: ClickableRowProps;
+    expandedChildren: React.ReactNode;
+}
+
+export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
+    className,
+    clickable,
+    children,
+    expandedChildren,
+    ...rest
+}) => {
+    const { compact } = useTableContext();
+    const { isTableBody } = useTableSectionContext();
+
+    const [isOpen, setIsOpen] = useState(false);
+    const [clicked, setClicked] = useState(clickable?.isClicked || false);
+
+    if (isTableBody && clickable) {
+        return (
+            <>
+                <tr
+                    onClick={function handleOnClick(e) {
+                        setClicked(!clicked);
+                        clickable.onClick(e);
+                    }}
+                    onKeyPress={function handleKeyPress(e) {
+                        if (e.key === " " || e.key === "Enter") {
+                            e.preventDefault();
+                            setClicked(!clicked);
+                            clickable.onClick(e);
+                        }
+                    }}
+                    className={cx("jkl-table-row", "jkl-table-row--clickable", "jkl-table-row--expandable", className, {
+                        ["jkl-table-row--compact"]: compact,
+                        ["jkl-table-row--clicked"]: clickable?.markClickedRows && clicked,
+                        ["jkl-table-row--expanded"]: isOpen,
+                    })}
+                    aria-label="Klikkbar rad"
+                    aria-pressed={clickable?.markClickedRows ? (clicked ? "true" : "false") : undefined}
+                    tabIndex={0}
+                    {...rest}
+                >
+                    {React.Children.map(children, (child) => {
+                        if (React.isValidElement(child) && child.type == ExpandableTableRowCell) {
+                            return React.cloneElement(child, {
+                                isOpen,
+                                onClick: () => setIsOpen(!isOpen),
+                            });
+                        } else {
+                            return child;
+                        }
+                    })}
+                </tr>
+                {isOpen &&
+                    React.Children.map(expandedChildren, (child) => {
+                        if (React.isValidElement(child)) {
+                            return React.cloneElement(child, {
+                                className: "jkl-expandable-table-row__expanded-row",
+                            });
+                        }
+                        return child;
+                    })}
+            </>
+        );
+    }
+
+    return (
+        <>
+            <tr
+                className={cx("jkl-table-row", "jkl-table-row--expandable", "jkl-table-row--clickable", className, {
+                    ["jkl-table-row--compact"]: compact,
+                    ["jkl-table-row--expanded"]: isOpen,
+                })}
+                onClick={() => setIsOpen(!isOpen)}
+                {...rest}
+            >
+                {React.Children.map(children, (child) => {
+                    if (React.isValidElement(child) && child.type == ExpandableTableRowCell) {
+                        return React.cloneElement(child, {
+                            isOpen,
+                            onClick: () => setIsOpen(!isOpen),
+                        });
+                    } else {
+                        return child;
+                    }
+                })}
+            </tr>
+            {isOpen &&
+                React.Children.map(expandedChildren, (child) => {
+                    if (React.isValidElement(child)) {
+                        return React.cloneElement(child, {
+                            className: "jkl-expandable-table-row__expanded-row",
+                        });
+                    }
+                    return child;
+                })}
+        </>
+    );
+};

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -2,9 +2,8 @@ import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import cx from "classnames";
 import React, { FC, useState } from "react";
 import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
-import { useTableContext } from "./tableContext";
 import { useTableSectionContext } from "./tableSectionContext";
-import { TableRowProps } from "./TableRow";
+import { TableRowProps, TableRow } from "./TableRow";
 export interface ExpandableTableRowProps extends TableRowProps {
     expandedChildren: React.ReactNode;
 }
@@ -16,37 +15,20 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
     expandedChildren,
     ...rest
 }) => {
-    const { compact } = useTableContext();
     const { isTableBody } = useTableSectionContext();
 
     const [isOpen, setIsOpen] = useState(false);
-    const [clicked, setClicked] = useState(clickable?.isClicked || false);
     const [animationRef] = useAnimatedHeight<HTMLDivElement>(isOpen);
 
     if (isTableBody && clickable) {
         return (
             <>
-                <tr
-                    onClick={function handleOnClick(e) {
-                        setClicked(!clicked);
-                        clickable.onClick(e);
-                    }}
-                    onKeyPress={function handleKeyPress(e) {
-                        if (e.key === " " || e.key === "Enter") {
-                            e.preventDefault();
-                            setClicked(!clicked);
-                            clickable.onClick(e);
-                        }
-                    }}
-                    className={cx("jkl-table-row", "jkl-table-row--clickable", "jkl-table-row--expandable", className, {
-                        ["jkl-table-row--compact"]: compact,
-                        ["jkl-table-row--clicked"]: clickable?.markClickedRows && clicked,
+                <TableRow
+                    className={cx("jkl-table-row--expandable", className, {
                         ["jkl-table-row--expanded"]: isOpen,
                     })}
-                    aria-label="Klikkbar rad"
-                    aria-pressed={clickable?.markClickedRows ? (clicked ? "true" : "false") : undefined}
-                    tabIndex={0}
                     {...rest}
+                    clickable={clickable}
                 >
                     {React.Children.map(children, (child) => {
                         if (React.isValidElement(child) && child.type == ExpandableTableRowCell) {
@@ -58,7 +40,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                             return child;
                         }
                     })}
-                </tr>
+                </TableRow>
                 <tr>
                     <td colSpan={100}>
                         <div
@@ -82,12 +64,13 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
 
     return (
         <>
-            <tr
-                className={cx("jkl-table-row", "jkl-table-row--expandable", "jkl-table-row--clickable", className, {
-                    ["jkl-table-row--compact"]: compact,
+            <TableRow
+                className={cx("jkl-table-row--expandable", className, {
                     ["jkl-table-row--expanded"]: isOpen,
                 })}
-                onClick={() => setIsOpen(!isOpen)}
+                clickable={{
+                    onClick: () => setIsOpen(!isOpen),
+                }}
                 {...rest}
             >
                 {React.Children.map(children, (child) => {
@@ -100,7 +83,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                         return child;
                     }
                 })}
-            </tr>
+            </TableRow>
             <tr>
                 <td colSpan={100}>
                     <div

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import cx from "classnames";
-import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
+import { useAnimatedHeight, useId } from "@fremtind/jkl-react-hooks";
 import { ExpandableTableRowController } from "./ExpandableTableRowController";
 import { TableRowProps, TableRow } from "./TableRow";
 
@@ -31,6 +31,8 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
         ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
     });
 
+    const tableRowId = useId("jkl-expandable-table-row");
+
     return (
         <>
             <TableRow
@@ -47,6 +49,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                         return React.cloneElement(child, {
                             isOpen,
                             onClick: () => setIsOpen(!isOpen),
+                            "aria-controls": tableRowId,
                         });
                     } else {
                         return child;
@@ -57,9 +60,9 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                 Use a table row with a single as wide as possible cell to contain content. This allows
                 using useAnimatedHeight to animate the row height.
             */}
-            <tr>
+            <tr aria-hidden={!isOpen}>
                 <td colSpan={colSpan}>
-                    <div ref={animationRef} className={childWrapperClassName}>
+                    <div ref={animationRef} className={childWrapperClassName} id={tableRowId}>
                         {expandedChildren}
                     </div>
                 </td>

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -53,12 +53,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
             <tr>
                 <td colSpan={100}>
                     <div ref={animationRef} className={childWrapperClassName}>
-                        {React.Children.map(expandedChildren, (child) => {
-                            if (React.isValidElement(child)) {
-                                return React.cloneElement(child, {});
-                            }
-                            return child;
-                        })}
+                        {expandedChildren}
                     </div>
                 </td>
             </tr>

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,8 +1,7 @@
-import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
-import cx from "classnames";
 import React, { FC, useState } from "react";
+import cx from "classnames";
+import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
-import { useTableSectionContext } from "./tableSectionContext";
 import { TableRowProps, TableRow } from "./TableRow";
 export interface ExpandableTableRowProps extends TableRowProps {
     expandedChildren: React.ReactNode;
@@ -15,62 +14,25 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
     expandedChildren,
     ...rest
 }) => {
-    const { isTableBody } = useTableSectionContext();
-
     const [isOpen, setIsOpen] = useState(false);
     const [animationRef] = useAnimatedHeight<HTMLDivElement>(isOpen);
 
-    if (isTableBody && clickable) {
-        return (
-            <>
-                <TableRow
-                    className={cx("jkl-table-row--expandable", className, {
-                        ["jkl-table-row--expanded"]: isOpen,
-                    })}
-                    {...rest}
-                    clickable={clickable}
-                >
-                    {React.Children.map(children, (child) => {
-                        if (React.isValidElement(child) && child.type == ExpandableTableRowCell) {
-                            return React.cloneElement(child, {
-                                isOpen,
-                                onClick: () => setIsOpen(!isOpen),
-                            });
-                        } else {
-                            return child;
-                        }
-                    })}
-                </TableRow>
-                <tr>
-                    <td colSpan={100}>
-                        <div
-                            ref={animationRef}
-                            className={cx("jkl-expandable-table-row__expanded-row", {
-                                ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
-                            })}
-                        >
-                            {React.Children.map(expandedChildren, (child) => {
-                                if (React.isValidElement(child)) {
-                                    return React.cloneElement(child, {});
-                                }
-                                return child;
-                            })}
-                        </div>
-                    </td>
-                </tr>
-            </>
-        );
-    }
+    const tableRowClassName = cx("jkl-table-row--expandable", className, {
+        ["jkl-table-row--expanded"]: isOpen,
+    });
+    const childWrapperClassName = cx("jkl-expandable-table-row__expanded-row", {
+        ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
+    });
 
     return (
         <>
             <TableRow
-                className={cx("jkl-table-row--expandable", className, {
-                    ["jkl-table-row--expanded"]: isOpen,
-                })}
-                clickable={{
-                    onClick: () => setIsOpen(!isOpen),
-                }}
+                className={tableRowClassName}
+                clickable={
+                    clickable ?? {
+                        onClick: () => setIsOpen(!isOpen),
+                    }
+                }
                 {...rest}
             >
                 {React.Children.map(children, (child) => {
@@ -86,12 +48,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
             </TableRow>
             <tr>
                 <td colSpan={100}>
-                    <div
-                        ref={animationRef}
-                        className={cx("jkl-expandable-table-row__expanded-row", {
-                            ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
-                        })}
-                    >
+                    <div ref={animationRef} className={childWrapperClassName}>
                         {React.Children.map(expandedChildren, (child) => {
                             if (React.isValidElement(child)) {
                                 return React.cloneElement(child, {});

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,22 +1,11 @@
+import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import cx from "classnames";
-import React, { DetailedHTMLProps, FC, HTMLAttributes, useState } from "react";
+import React, { FC, useState } from "react";
 import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
 import { useTableContext } from "./tableContext";
 import { useTableSectionContext } from "./tableSectionContext";
-
-export interface ClickableRowProps {
-    markClickedRows?: boolean;
-    /** Lar deg kontrollere radens tilstand untenfra */
-    isClicked?: boolean;
-    onClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent> | React.KeyboardEvent<HTMLTableRowElement>) => void;
-}
-
-export interface ExpandableTableRowProps
-    extends DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> {
-    /**
-     * Gir raden interaktivitet og en click-handler.
-     */
-    clickable?: ClickableRowProps;
+import { TableRowProps } from "./TableRow";
+export interface ExpandableTableRowProps extends TableRowProps {
     expandedChildren: React.ReactNode;
 }
 
@@ -32,6 +21,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
 
     const [isOpen, setIsOpen] = useState(false);
     const [clicked, setClicked] = useState(clickable?.isClicked || false);
+    const [animationRef] = useAnimatedHeight<HTMLDivElement>(isOpen);
 
     if (isTableBody && clickable) {
         return (
@@ -69,15 +59,15 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                         }
                     })}
                 </tr>
-                {isOpen &&
-                    React.Children.map(expandedChildren, (child) => {
-                        if (React.isValidElement(child)) {
-                            return React.cloneElement(child, {
-                                className: "jkl-expandable-table-row__expanded-row",
-                            });
-                        }
-                        return child;
-                    })}
+                {React.Children.map(expandedChildren, (child) => {
+                    if (React.isValidElement(child)) {
+                        return React.cloneElement(child, {
+                            className: "jkl-expandable-table-row__expanded-row",
+                            ref: animationRef,
+                        });
+                    }
+                    return child;
+                })}
             </>
         );
     }
@@ -103,15 +93,23 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                     }
                 })}
             </tr>
-            {isOpen &&
-                React.Children.map(expandedChildren, (child) => {
-                    if (React.isValidElement(child)) {
-                        return React.cloneElement(child, {
-                            className: "jkl-expandable-table-row__expanded-row",
-                        });
-                    }
-                    return child;
-                })}
+            <tr>
+                <td colSpan={100}>
+                    <div
+                        ref={animationRef}
+                        className={cx("jkl-expandable-table-row__expanded-row", {
+                            ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
+                        })}
+                    >
+                        {React.Children.map(expandedChildren, (child) => {
+                            if (React.isValidElement(child)) {
+                                return React.cloneElement(child, {});
+                            }
+                            return child;
+                        })}
+                    </div>
+                </td>
+            </tr>
         </>
     );
 };

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -46,6 +46,10 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                     }
                 })}
             </TableRow>
+            {/*
+                Use a table row with a single as wide as possible cell to contain content. This allows
+                using useAnimatedHeight to animate the row height.
+            */}
             <tr>
                 <td colSpan={100}>
                     <div ref={animationRef} className={childWrapperClassName}>

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -59,15 +59,23 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                         }
                     })}
                 </tr>
-                {React.Children.map(expandedChildren, (child) => {
-                    if (React.isValidElement(child)) {
-                        return React.cloneElement(child, {
-                            className: "jkl-expandable-table-row__expanded-row",
-                            ref: animationRef,
-                        });
-                    }
-                    return child;
-                })}
+                <tr>
+                    <td colSpan={100}>
+                        <div
+                            ref={animationRef}
+                            className={cx("jkl-expandable-table-row__expanded-row", {
+                                ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
+                            })}
+                        >
+                            {React.Children.map(expandedChildren, (child) => {
+                                if (React.isValidElement(child)) {
+                                    return React.cloneElement(child, {});
+                                }
+                                return child;
+                            })}
+                        </div>
+                    </td>
+                </tr>
             </>
         );
     }

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -26,6 +26,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
 
     const tableRowClassName = cx("jkl-table-row--expandable", className, {
         ["jkl-table-row--expanded"]: isOpen,
+        ["jkl-expandable-table-row--clickable-external"]: clickable,
     });
     const childWrapperClassName = cx("jkl-expandable-table-row__expanded-row", {
         ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -32,6 +32,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
     });
 
     const tableRowId = useId("jkl-expandable-table-row");
+    const expandableTableRowControllerId = useId("jkl-expandable-table-row-controller");
 
     return (
         <>
@@ -50,6 +51,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                             isOpen,
                             onClick: () => setIsOpen(!isOpen),
                             "aria-controls": tableRowId,
+                            id: expandableTableRowControllerId,
                         });
                     } else {
                         return child;
@@ -62,7 +64,14 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
             */}
             <tr aria-hidden={!isOpen}>
                 <td colSpan={colSpan}>
-                    <div ref={animationRef} className={childWrapperClassName} id={tableRowId}>
+                    <div
+                        ref={animationRef}
+                        className={childWrapperClassName}
+                        id={tableRowId}
+                        aria-labelledby={expandableTableRowControllerId}
+                        hidden={!isOpen}
+                        role="group"
+                    >
                         {expandedChildren}
                     </div>
                 </td>

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -3,8 +3,14 @@ import cx from "classnames";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
 import { TableRowProps, TableRow } from "./TableRow";
+
 export interface ExpandableTableRowProps extends TableRowProps {
     expandedChildren: React.ReactNode;
+    /**
+     * Setter bredden på raden som blir åpnet
+     * @default 100
+     */
+    colSpan?: number;
 }
 
 export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
@@ -12,6 +18,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
     clickable,
     children,
     expandedChildren,
+    colSpan = 100,
     ...rest
 }) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -51,7 +58,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                 using useAnimatedHeight to animate the row height.
             */}
             <tr>
-                <td colSpan={100}>
+                <td colSpan={colSpan}>
                     <div ref={animationRef} className={childWrapperClassName}>
                         {expandedChildren}
                     </div>

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import cx from "classnames";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
-import { ExpandableTableRowCell } from "./ExpandableTableRowCell";
+import { ExpandableTableRowController } from "./ExpandableTableRowController";
 import { TableRowProps, TableRow } from "./TableRow";
 
 export interface ExpandableTableRowProps extends TableRowProps {
@@ -43,7 +43,7 @@ export const ExpandableTableRow: FC<ExpandableTableRowProps> = ({
                 {...rest}
             >
                 {React.Children.map(children, (child) => {
-                    if (React.isValidElement(child) && child.type == ExpandableTableRowCell) {
+                    if (React.isValidElement(child) && child.type == ExpandableTableRowController) {
                         return React.cloneElement(child, {
                             isOpen,
                             onClick: () => setIsOpen(!isOpen),

--- a/packages/table-react/src/ExpandableTableRowCell.tsx
+++ b/packages/table-react/src/ExpandableTableRowCell.tsx
@@ -4,6 +4,7 @@ import { ExpandButton } from "@fremtind/jkl-expand-button-react";
 import { TableCell, TableCellProps } from ".";
 
 export interface ExpandableTableRowCellProps extends TableCellProps {
+    /** Settes automatisk av ExpandableTableRow */
     isOpen?: boolean;
     onClick?: () => void;
     compact?: boolean;

--- a/packages/table-react/src/ExpandableTableRowCell.tsx
+++ b/packages/table-react/src/ExpandableTableRowCell.tsx
@@ -6,6 +6,7 @@ import { TableCell, TableCellProps } from ".";
 interface ExpandableTableRowCellProps extends TableCellProps {
     isOpen?: boolean;
     onClick?: () => void;
+    compact?: boolean;
 }
 
 export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
@@ -13,6 +14,7 @@ export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
     onClick,
     children,
     className,
+    compact,
     ...rest
 }) => {
     if (isOpen === undefined || typeof onClick !== "function") {
@@ -25,6 +27,7 @@ export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
                 className={cx("jkl-table-row-expand-button", {
                     ["jkl-table-row-expand-button--expanded"]: isOpen,
                 })}
+                forceCompact={compact}
                 isExpanded={isOpen}
                 onClick={(e) => {
                     e.stopPropagation();

--- a/packages/table-react/src/ExpandableTableRowCell.tsx
+++ b/packages/table-react/src/ExpandableTableRowCell.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import cx from "classnames";
+import { ExpandButton } from "@fremtind/jkl-expand-button-react";
+import { TableCell, TableCellProps } from ".";
+
+interface ExpandableTableRowCellProps extends TableCellProps {
+    isOpen?: boolean;
+    onClick?: () => void;
+}
+
+export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
+    isOpen,
+    onClick,
+    children,
+    className,
+    ...rest
+}) => {
+    if (isOpen === undefined || typeof onClick !== "function") {
+        throw new Error("ExpandableTableRowCell must have ExpandableTableRow as parent");
+    }
+
+    return (
+        <TableCell className={cx("jkl-table-cell--expand", className)} {...rest}>
+            <ExpandButton
+                className={cx("jkl-table-row-expand-button", {
+                    ["jkl-table-row-expand-button--expanded"]: isOpen,
+                })}
+                isExpanded={isOpen}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onClick();
+                }}
+            >
+                {children}
+            </ExpandButton>
+        </TableCell>
+    );
+};

--- a/packages/table-react/src/ExpandableTableRowCell.tsx
+++ b/packages/table-react/src/ExpandableTableRowCell.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { ExpandButton } from "@fremtind/jkl-expand-button-react";
 import { TableCell, TableCellProps } from ".";
 
-interface ExpandableTableRowCellProps extends TableCellProps {
+export interface ExpandableTableRowCellProps extends TableCellProps {
     isOpen?: boolean;
     onClick?: () => void;
     compact?: boolean;

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -14,6 +14,7 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
     onClick,
     children,
     className,
+    "aria-controls": ariaControls,
     ...rest
 }) => {
     if (isOpen === undefined || typeof onClick !== "function") {
@@ -36,9 +37,16 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
                 })}
                 forceCompact={compact}
                 isExpanded={isOpen}
+                aria-controls={ariaControls}
                 onClick={(e) => {
                     e.stopPropagation();
                     onClick();
+                }}
+                onKeyDown={(e) => {
+                    if (e.key === "enter" || e.key === " ") {
+                        e.stopPropagation();
+                        onClick();
+                    }
                 }}
             >
                 {/* show children. or try to use data-th if children is undefined */}

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -47,6 +47,7 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
                 onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
                         e.stopPropagation();
+                        e.preventDefault();
                         onClick();
                     }
                 }}

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -45,7 +45,7 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
                     onClick();
                 }}
                 onKeyDown={(e) => {
-                    if (e.key === "enter" || e.key === " ") {
+                    if (e.key === "Enter" || e.key === " ") {
                         e.stopPropagation();
                         onClick();
                     }

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -3,14 +3,14 @@ import cx from "classnames";
 import { ExpandButton } from "@fremtind/jkl-expand-button-react";
 import { TableCell, TableCellProps } from ".";
 
-export interface ExpandableTableRowCellProps extends TableCellProps {
+export interface ExpandableTableRowControllerProps extends TableCellProps {
     /** Settes automatisk av ExpandableTableRow */
     isOpen?: boolean;
     onClick?: () => void;
     compact?: boolean;
 }
 
-export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
+export const ExpandableTableRowController: React.FC<ExpandableTableRowControllerProps> = ({
     isOpen,
     onClick,
     children,
@@ -19,7 +19,7 @@ export const ExpandableTableRowCell: React.FC<ExpandableTableRowCellProps> = ({
     ...rest
 }) => {
     if (isOpen === undefined || typeof onClick !== "function") {
-        throw new Error("ExpandableTableRowCell must have ExpandableTableRow as parent");
+        throw new Error("ExpandableTableRowController must have ExpandableTableRow as parent");
     }
 
     return (

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import cx from "classnames";
 import { ExpandButton } from "@fremtind/jkl-expand-button-react";
-import { TableCell, TableCellProps } from ".";
+import { TableCell, TableCellProps, useTableContext } from ".";
 
 export interface ExpandableTableRowControllerProps extends TableCellProps {
     /** Settes automatisk av ExpandableTableRow */
     isOpen?: boolean;
     onClick?: () => void;
-    compact?: boolean;
 }
 
 export const ExpandableTableRowController: React.FC<ExpandableTableRowControllerProps> = ({
@@ -15,15 +14,22 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
     onClick,
     children,
     className,
-    compact,
     ...rest
 }) => {
     if (isOpen === undefined || typeof onClick !== "function") {
         throw new Error("ExpandableTableRowController must have ExpandableTableRow as parent");
     }
 
+    const { compact, collapseToList } = useTableContext();
+
+    // pick text from data-th if possible, but only if it's a list
+    const showTextFromTh: string | undefined = collapseToList ? (rest as Record<string, string>)["data-th"] : undefined;
+
     return (
-        <TableCell className={cx("jkl-table-cell--expand", className)} {...rest}>
+        <TableCell
+            className={cx("jkl-table-cell--expand", { ["jkl-table-cell--expand-without-text"]: !children }, className)}
+            {...rest}
+        >
             <ExpandButton
                 className={cx("jkl-table-row-expand-button", {
                     ["jkl-table-row-expand-button--expanded"]: isOpen,
@@ -35,7 +41,8 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
                     onClick();
                 }}
             >
-                {children}
+                {/* show children. or try to use data-th if children is undefined */}
+                {children ?? showTextFromTh}
             </ExpandButton>
         </TableCell>
     );

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -14,6 +14,7 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
     onClick,
     children,
     className,
+    id,
     "aria-controls": ariaControls,
     ...rest
 }) => {
@@ -35,6 +36,7 @@ export const ExpandableTableRowController: React.FC<ExpandableTableRowController
                 className={cx("jkl-table-row-expand-button", {
                     ["jkl-table-row-expand-button--expanded"]: isOpen,
                 })}
+                id={id}
                 forceCompact={compact}
                 isExpanded={isOpen}
                 aria-controls={ariaControls}

--- a/packages/table-react/src/Table.tsx
+++ b/packages/table-react/src/Table.tsx
@@ -18,7 +18,7 @@ export const Table: FC<TableProps> = ({
     ...rest
 }) => {
     return (
-        <TableContextProvider state={{ compact }}>
+        <TableContextProvider state={{ compact, collapseToList }}>
             <table
                 className={cx("jkl-table", className, {
                     ["jkl-table--full-width"]: fullWidth,

--- a/packages/table-react/src/index.ts
+++ b/packages/table-react/src/index.ts
@@ -12,7 +12,7 @@ export { TableHead } from "./TableHead";
 export { TableHeader } from "./TableHeader";
 export { TableRow } from "./TableRow";
 export { ExpandableTableRow } from "./ExpandableTableRow";
-export { ExpandableTableRowCell } from "./ExpandableTableRowCell";
+export { ExpandableTableRowController } from "./ExpandableTableRowController";
 
 export type { DataTableProps } from "./DataTable";
 export type { TableProps } from "./Table";
@@ -28,4 +28,4 @@ export type { TableHeadProps } from "./TableHead";
 export type { TableHeaderProps } from "./TableHeader";
 export type { TableRowProps } from "./TableRow";
 export type { ExpandableTableRowProps } from "./ExpandableTableRow";
-export type { ExpandableTableRowCellProps } from "./ExpandableTableRowCell";
+export type { ExpandableTableRowControllerProps } from "./ExpandableTableRowController";

--- a/packages/table-react/src/index.ts
+++ b/packages/table-react/src/index.ts
@@ -11,6 +11,8 @@ export { TableFooter } from "./TableFooter";
 export { TableHead } from "./TableHead";
 export { TableHeader } from "./TableHeader";
 export { TableRow } from "./TableRow";
+export { ExpandableTableRow } from "./ExpandableTableRow";
+export { ExpandableTableRowCell } from "./ExpandableTableRowCell";
 
 export type { DataTableProps } from "./DataTable";
 export type { TableProps } from "./Table";
@@ -25,3 +27,5 @@ export type { TableFooterProps } from "./TableFooter";
 export type { TableHeadProps } from "./TableHead";
 export type { TableHeaderProps } from "./TableHeader";
 export type { TableRowProps } from "./TableRow";
+export type { ExpandableTableRowProps } from "./ExpandableTableRow";
+export type { ExpandableTableRowCellProps } from "./ExpandableTableRowCell";

--- a/packages/table-react/src/tableContext.tsx
+++ b/packages/table-react/src/tableContext.tsx
@@ -2,10 +2,12 @@ import React, { createContext, useContext } from "react";
 
 type TableContext = {
     compact: boolean;
+    collapseToList: boolean;
 };
 
 const tableContext = createContext<TableContext>({
     compact: false,
+    collapseToList: false,
 });
 
 export const useTableContext = (): TableContext => useContext(tableContext);

--- a/packages/table/table-cell.scss
+++ b/packages/table/table-cell.scss
@@ -62,6 +62,12 @@
         @include responsive-table-header;
     }
 
+    .jkl-table--collapse-to-list:not([data-collapse]) &--expand-without-text .jkl-expand-button__text {
+        @include mixins.from-medium-device {
+            display: none;
+        }
+    }
+
     .jkl-table-row-expand-button {
         display: flex;
     }

--- a/packages/table/table-cell.scss
+++ b/packages/table/table-cell.scss
@@ -73,7 +73,7 @@
     }
 }
 
-.jkl-table-row--expandable.jkl-table-row--clickable {
+.jkl-table-row--expandable.jkl-table-row--clickable:not(.jkl-expandable-table-row--clickable-external) {
     &:hover,
     html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
         .jkl-table-row-expand-button {

--- a/packages/table/table-cell.scss
+++ b/packages/table/table-cell.scss
@@ -1,16 +1,10 @@
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/mixins/_all.scss" as mixins;
 
-$focus-ring-width: jkl.rem(2px);
-$expand-button-focus-color: jkl.$color-granitt;
-$expand-button-focus-color--inverted: jkl.$color-snohvit;
-
-@include jkl.helper-light-mode-variables {
-    --expand-button-focus-color: #{$expand-button-focus-color};
-}
-
-@include jkl.helper-dark-mode-variables {
-    --expand-button-focus-color: #{$expand-button-focus-color--inverted};
+@mixin _expanded-arrow($px) {
+    .jkl-expand-button__arrow {
+        transform: translateY(jkl.rem($px));
+    }
 }
 
 .jkl-table-cell {
@@ -64,5 +58,19 @@ $expand-button-focus-color--inverted: jkl.$color-snohvit;
 
     .jkl-table--collapse-to-list[data-collapse] &::before {
         @include responsive-table-header;
+    }
+}
+
+.jkl-table-row--expandable {
+    &:hover,
+    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
+        .jkl-table-row-expand-button {
+            @include _expanded-arrow(3px);
+            color: var(--expand-button-focus-color);
+
+            &--expanded {
+                @include _expanded-arrow(0px);
+            }
+        }
     }
 }

--- a/packages/table/table-cell.scss
+++ b/packages/table/table-cell.scss
@@ -48,7 +48,9 @@
         display: block;
     }
 
-    .jkl-table--collapse-to-list &[data-th]::before {
+    // only show inline text if it's not an ExpandController with text inside. if it doesn't
+    // have text inside. the text is moved inside the ExpandButton
+    .jkl-table--collapse-to-list &[data-th]:not(.jkl-table-cell--expand-without-text)::before {
         display: none;
 
         @include mixins.small-device {
@@ -56,7 +58,7 @@
         }
     }
 
-    .jkl-table--collapse-to-list[data-collapse] &::before {
+    .jkl-table--collapse-to-list[data-collapse] &:not(.jkl-table-cell--expand-without-text)::before {
         @include responsive-table-header;
     }
 

--- a/packages/table/table-cell.scss
+++ b/packages/table/table-cell.scss
@@ -59,9 +59,13 @@
     .jkl-table--collapse-to-list[data-collapse] &::before {
         @include responsive-table-header;
     }
+
+    .jkl-table-row-expand-button {
+        display: flex;
+    }
 }
 
-.jkl-table-row--expandable {
+.jkl-table-row--expandable.jkl-table-row--clickable {
     &:hover,
     html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
         .jkl-table-row-expand-button {

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -158,3 +158,12 @@ $table-row-focus-color--inverted: jkl.$color-snohvit;
         }
     }
 }
+
+.jkl-expandable-table-row__expanded-row {
+    display: none;
+    transition: height 0.2s ease-in-out;
+
+    &--expanded {
+        display: table-cell;
+    }
+}

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -164,6 +164,6 @@ $table-row-focus-color--inverted: jkl.$color-snohvit;
     transition: height 0.2s ease-in-out;
 
     &--expanded {
-        display: table-cell;
+        display: block;
     }
 }

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -161,7 +161,8 @@ $table-row-focus-color--inverted: jkl.$color-snohvit;
 
 .jkl-expandable-table-row__expanded-row {
     display: none;
-    transition: height 0.2s ease-in-out;
+    @include mixins.motion("standard", "expressive");
+    transition-property: height;
 
     &--expanded {
         display: block;


### PR DESCRIPTION
Legg til funksjonalitet for utvidbare tabellrader. Se kommentarer for notater om triks og vurderinger.

Endringer: 
- Lagt til ny tabellrad som bruker `TableRow` for å bygge en ekspanderbar tabell
- Utvidet funksjonaliteten i `ExpandButton` for å kun vise pil

## ☑️ Sjekkliste

-   [X] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [X] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
