### PR TITLE
feat(tabs-react): add optional prop initialActiveIndex to Tabs

### DIFF
--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import { usePreviousValue } from "@fremtind/jkl-react-hooks";
 
 interface Props {
+    initialActiveIndex?: number;
     children: ReactNode;
     className?: string;
     onChange?: (tabIndex: number) => void;
@@ -15,8 +16,8 @@ interface Props {
  *
  * Docs: https://jokul.fremtind.no/komponenter/tabs
  */
-export const Tabs = ({ onChange, ...props }: Props) => {
-    const [activeIndex, setActiveIndex] = useState(0);
+export const Tabs = ({ initialActiveIndex, onChange, ...props }: Props) => {
+    const [activeIndex, setActiveIndex] = useState(initialActiveIndex || 0);
 
     const previousTabIndex = usePreviousValue(activeIndex);
 


### PR DESCRIPTION
Legger til en optional prop for å kunne sette intial active index i Tabs.

Formålet med dette er generelt fleksibilitet, men for min del er behovet egentlig å kunne ha en Tabs der ingen Tab er aktiv default. Dette kan nå gjøres ved å sette `initialActiveIndex={-1}`.

Jeg anså det mer hensiktsmessig med en mer fleksibel løsning, enn å bare lage et flagg, som f.eks. `noActiveInitialTab={true}`.

## ☑️ Sjekkliste

-   [x] Jeg har lest [CONTRIBUTING](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) og dokumentasjon det henvises til
-   [x] Jeg har satt target branch til `main`, eller `external-contributions` dersom pull requesten kommer fra en fork
-   [x] Jeg har kjørt `yarn build` og `yarn ci:test` og disse gir ingen feil
-   [ ] Jeg har lagt til tester som demonstrerer at feilen er rettet eller featuren fungerer
-   [x] Jeg har skrevet relevant dokumentasjon
