### PR TITLE
chore: dropp videoopptak under Cypress-test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -189,14 +189,8 @@ jobs:
                   name: cypress-screenshots-${{ matrix.group }}
                   path: |
                       cypress/screenshots
-                      packages/**/integration/**/*.png
-
-            - name: Upload video
-              uses: actions/upload-artifact@v2
-              if: failure()
-              with:
-                  name: cypress-videos-${{ matrix.group }}
-                  path: cypress/videos
+                      packages/**/integration/**/*.actual.png
+                      packages/**/integration/**/*.diff.png
 
             - name: Debug
               if: success()

--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
     "viewportWidth": 1920,
     "viewportHeight": 1080,
     "ignoreTestFiles": ["**/__snapshots__/*", "**/__image_snapshots__/*", "**/node_modules/**", "./scripts/**"],
+    "video": false,
     "env": {
         "cypress-plugin-snapshots": {
             "autoCleanUp": false,


### PR DESCRIPTION
Test for å få ned kjøretid av visuelle regresjonstester

Videoene tar tid å laste opp og har en kostnad under opptak også. De
blir sjeldent brukt under feilsøking. Om man opplever å ikke få
reprodusert feilen lokalt kan det eventuelt skrus på igjen etter
behov. I dag er det som oftest tilstrekkelig med screenshots av diff
og actual, som kan sammenlignes med originalene på disk.