### PR TITLE
docs: endre issue tittelen og beskrivelsen

### DIFF
--- a/.github/ISSUE_TEMPLATE/funksjonalitets-nske.md
+++ b/.github/ISSUE_TEMPLATE/funksjonalitets-nske.md
@@ -1,6 +1,6 @@
 ---
-name: Funksjonalitetsønske
-about: Ønsket har blitt diskutert og er klart til å jobbes med
+name: Nytt bidrag
+about: Du har diskutert og bekreftet behovet for et bidrag til Jøkul, og skal begynne det praktiske arbeidet
 title: ""
 labels: "✨ enhancement"
 assignees: ""


### PR DESCRIPTION
Veksle fra å snakke om å "_ønske_ ny funksjonalitet" til **komme med nye bidrag**. Dagens ordlyd motstrider målet vårt om at bidragsyterne _selv_ skal sikre kvaliteten i Jøkul, og hverandres bidrag, med _støtte_ fra kjerneteamet—i stedet for godkjenning. I tillegg er premisset for at nye issues opprettes basert på at behovet for ny funksjonalitet allerede bekreftet.