### PR TITLE
fix(expand-button): changed to type=button

### DIFF
--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -42,6 +42,7 @@ export const ExpandButton = ({
         <button
             aria-expanded={isExpanded}
             data-testid="jkl-expand-button"
+            type="button"
             className={cx("jkl-expand-button", className, {
                 "jkl-expand-button--expanded": isExpanded,
                 "jkl-expand-button--compact": forceCompact,


### PR DESCRIPTION
affects: @fremtind/jkl-expand-button-react

Form trigget av ExpandButton da den ikke hadde type="button"

## 🎯 Sjekkliste

-   [x] Minstekrav til dokumentasjon er oppfyllt (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] Testdekningen er god nok (enhetstest, visuell regresjonstest)
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
