### PR TITLE
feat(constants): add zero-width space unicode constant

### DIFF
--- a/packages/constants-util/src/unicode.ts
+++ b/packages/constants-util/src/unicode.ts
@@ -11,3 +11,4 @@ export const LEFTWARDS_ARROW = "\u2190";
 export const UPWARDS_ARROW = "\u2191";
 export const RIGHTWARDS_ARROW = "\u2192";
 export const DOWNWARDS_ARROW = "\u2193";
+export const ZERO_WIDTH_SPACE = "\u200B";


### PR DESCRIPTION
affects: @fremtind/jkl-constants-util

La til ZERO_WIDTH_SPACE konstant for å kunne kontrollere ordbrytning

## 🎯 Sjekkliste

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
