### PR TITLE
PoC: forhåndsvisning av brancher med GitHub Pages

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -285,7 +285,7 @@ jobs:
             contents: write
             issues: write
         env:
-            PREVIEW_PATH: preview/${{github.event.number}}
+            PREVIEW_PATH: preview/${{ github.event.pull_request.head.ref }}
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -320,9 +320,9 @@ jobs:
                   git config user.email "fremtind.designsystem@fremtind.no"
                   git config user.name "fremtind-bot"
                   git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/fremtind/jokul.git
-                  yarn gh-pages --add --dist portal/public --dest ${{ env.PREVIEW_PATH }} --message "docs: preview ${{github.event.number}}"
+                  yarn gh-pages --add --dist portal/public --dest ${{ env.PREVIEW_PATH }} --message "docs: preview #${{ github.event.number }}"
 
             - name: Add a comment with a link to the preview
-              run: gh api --method POST /repos/fremtind/jokul/issues/${{github.event.number}}/comments -F body='A preview will be available at https://jokul.fremtind.no/${{ env.PREVIEW_PATH }} within a few minutes'
+              run: gh api --method POST /repos/fremtind/jokul/issues/${{ github.event.number }}/comments -F body='A preview will be available at https://jokul.fremtind.no/${{ env.PREVIEW_PATH }} within a few minutes'
               env:
                   GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -275,3 +275,54 @@ jobs:
                   git add . || echo "No updated snapshots, nothing to add!"
                   git commit -m "chore: update cypress snapshots [ci skip cypress]" --no-verify || echo "No updated snapshots, nothing to commit!"
                   git push
+
+    preview:
+        needs: [build]
+        if: needs.build.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+            contents: write
+            issues: write
+        env:
+            PREVIEW_PATH: preview/${{github.event.number}}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  token: ${{ secrets.BOT_PUBLISH_TOKEN }}
+
+            - name: Setup Node
+              uses: actions/setup-node@v2
+              with:
+                  node-version: "lts/*"
+                  cache: "yarn"
+
+            - name: Install dependencies
+              run: yarn ci:install
+
+            - name: Download built packages
+              uses: actions/download-artifact@v2
+              with:
+                  name: built-packages
+                  path: packages/
+
+            - name: Build site with path prefix
+              env:
+                  PREFIX_PATHS: true
+              run: yarn build:docs
+
+            - name: Deploy preview
+              env:
+                  GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
+              run: |
+                  git config user.email "fremtind.designsystem@fremtind.no"
+                  git config user.name "fremtind-bot"
+                  git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/fremtind/jokul.git
+                  yarn gh-pages --add --dist portal/public --dest ${{ env.PREVIEW_PATH }} --message "docs: preview ${{github.event.number}}"
+
+            - name: Add a comment with a link to the preview
+              run: gh api --method POST /repos/fremtind/jokul/issues/${{github.event.number}}/comments -F body='A preview will be available at https://jokul.fremtind.no/${{ env.PREVIEW_PATH }} within a few minutes'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,11 +31,11 @@ jobs:
             contents: read
         steps:
             - name: Checkout
-              if: "!contains(github.event.head_commit.message, '[ci skip cypress]')"
+              if: "!contains(github.event.pull_request.sender, 'fremtind-bot')"
               uses: actions/checkout@v2
 
             - name: Check for changes that require extra verification
-              if: "!contains(github.event.head_commit.message, '[ci skip cypress]')"
+              if: "!contains(github.event.pull_request.sender, 'fremtind-bot')"
               uses: dorny/paths-filter@1ec7035ff53cbd7a98744bd986f6ca1c7e17d1cb
               id: changes
               with:
@@ -57,22 +57,22 @@ jobs:
 
             - name: Setup Node
               uses: actions/setup-node@v2
-              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.pull_request.sender, 'fremtind-bot')
               with:
                   node-version: "lts/*"
                   cache: "yarn"
 
             - name: Install dependencies
-              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.pull_request.sender, 'fremtind-bot')
               run: yarn ci:install
 
             - name: Build packages
-              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.pull_request.sender, 'fremtind-bot')
               run: yarn build
 
             - name: Upload built packages
               uses: actions/upload-artifact@v2
-              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: (steps.changes.outputs.visual == 'true' || steps.changes.outputs.testlint == 'true') && !contains(github.event.pull_request.sender, 'fremtind-bot')
               with:
                   name: built-packages
                   path: |
@@ -80,7 +80,7 @@ jobs:
                       packages/**/*.css
 
             - name: Caching Gatsby
-              if: steps.changes.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: steps.changes.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
               uses: actions/cache@v2
               with:
                   path: |
@@ -91,11 +91,11 @@ jobs:
                       ${{ runner.os }}-gatsby-build-
 
             - name: Build site
-              if: steps.changes.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: steps.changes.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
               run: yarn build:docs
 
             - name: Upload built site
-              if: steps.changes.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+              if: steps.changes.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
               uses: actions/upload-artifact@v2
               with:
                   name: built-site
@@ -104,7 +104,7 @@ jobs:
 
     testlint:
         needs: [build]
-        if: needs.build.outputs.testlint == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+        if: needs.build.outputs.testlint == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
         runs-on: ubuntu-latest
         permissions:
             actions: read
@@ -133,7 +133,7 @@ jobs:
 
     cypress:
         needs: [build]
-        if: needs.build.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+        if: needs.build.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -223,7 +223,7 @@ jobs:
 
     snapshots:
         needs: [cypress]
-        if: needs.build.outputs.visual == 'true' && !contains(github.event.head_commit.message, '[ci skip cypress]')
+        if: needs.build.outputs.visual == 'true' && !contains(github.event.pull_request.sender, 'fremtind-bot')
         runs-on: ubuntu-latest
         permissions:
             actions: write

--- a/.github/workflows/pull_request_close.yml
+++ b/.github/workflows/pull_request_close.yml
@@ -1,0 +1,29 @@
+name: Pull Request Closed
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    remove-preview:
+        runs-on: ubuntu-20.04
+        permissions:
+            actions: write
+            contents: write
+        env:
+            PREVIEW_PATH: preview/${{github.event.number}}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: gh-pages
+
+            - name: Remove preview from gh-pages branch
+              # Ikke alle pull requests har laget noen preview. Ignorer om det feiler.
+              continue-on-error: true
+              run: |
+                  git config user.email "fremtind.designsystem@fremtind.no"
+                  git config user.name "fremtind-bot"
+                  git rm -r ${{ env.PREVIEW_PATH }}
+                  git commit -m "docs: remove preview ${{github.event.number}}" --no-verify
+                  git push

--- a/.github/workflows/pull_request_close.yml
+++ b/.github/workflows/pull_request_close.yml
@@ -11,7 +11,7 @@ jobs:
             actions: write
             contents: write
         env:
-            PREVIEW_PATH: preview/${{github.event.number}}
+            PREVIEW_PATH: preview/${{ github.event.pull_request.head.ref }}
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -25,5 +25,5 @@ jobs:
                   git config user.email "fremtind.designsystem@fremtind.no"
                   git config user.name "fremtind-bot"
                   git rm -r ${{ env.PREVIEW_PATH }}
-                  git commit -m "docs: remove preview ${{github.event.number}}" --no-verify
+                  git commit -m "docs: remove preview #${{ github.event.number }}" --no-verify
                   git push

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build:docs": "lerna run --scope @fremtind/portal build --stream",
         "commit": "git-cz",
         "predeploy:docs": "yarn run build:docs",
-        "deploy:docs": "gh-pages -d portal/public",
+        "deploy:docs": "gh-pages --add --dist portal/public",
         "typecheck": "tsc --noEmit",
         "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
         "lint:fix": "eslint '**/*.{js,jsx,ts,tsx}' --fix",

--- a/portal/gatsby-config.js
+++ b/portal/gatsby-config.js
@@ -12,7 +12,7 @@ const ignoreNonMdx = [
 ];
 
 module.exports = {
-    pathPrefix: "/jokul",
+    pathPrefix: process.env.PREVIEW_PATH ? `/${process.env.PREVIEW_PATH}` : "/",
     siteMetadata: {
         title: `Jøkul Designsystem`,
         description: `Jøkul er designsystemet til Fremtind`,

--- a/portal/src/pages/hello-world.tsx
+++ b/portal/src/pages/hello-world.tsx
@@ -1,0 +1,24 @@
+import React, { VFC } from "react";
+import { motion } from "framer-motion";
+import { Link as InternalLink } from "gatsby";
+
+const NotFoundPage: VFC = () => (
+    <motion.main
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.35 }}
+        className="jkl-portal__main"
+    >
+        <h1 className="jkl-title jkl-spacing-2xl--bottom jkl-spacing-2xl--top">Hello, World!</h1>
+        <p className="jkl-portal-paragraph">
+            Denne siden er en test. Du vil mest sannsynlig starte fra{" "}
+            <InternalLink to="/" className="jkl-link">
+                forsiden
+            </InternalLink>
+            !
+        </p>
+    </motion.main>
+);
+
+export default NotFoundPage;


### PR DESCRIPTION
Inspirert av [denne bloggposten](https://daiyi.co/blog/pr-previews-for-github-pages/), og det faktum at AWS Amplify (som vi hadde tenkt å gjøre en PoC med) tydeligvis ikke er fans av pull request previews for annet enn private repoer.

Det er for øvrig verdt å [watch this space](https://github.com/github/feedback/discussions/7730) – støtte for previews er på roadmapet (uten ETA, men "medium term").

**Fordeler**
- Løser det umiddelbare problemet for Jøkul med dagens verktøy og infrastruktur
- Veien til GitHub-offisielle previews er forhåpentligvis kort, den dagen det lanseres

**Ulemper**
- Previews havner på samme domene
- Litt _janky_
- Vi må ha på `--all` ved publisering for ikke å slette previews mellom deploys, og prøve å rydde opp etter oss ved lukket PR

Jeg er åpen for at vi bør gå for noe annet enn dette, og uansett må vi tenke nytt om hosting for "Portal 3.0".