### PR TITLE
Fix/datepicker year visibility

### DIFF
--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -121,3 +121,18 @@
         outline: 0;
     }
 }
+
+///
+/// Removes increment and decrement buttons
+/// for number input fields.
+///
+@mixin remove-inner-outer-button {
+    input[type="number"]::-webkit-outer-spin-button,
+    input[type="number"]::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+    }
+
+    input[type="number"] {
+        -moz-appearance: textfield;
+    }
+}

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -208,6 +208,7 @@ $calendar-width: ($date-width * 7) + ($date-spacing * 6) + ($calendar-padding * 
     &__year-selector {
         max-width: 30%;
         margin-right: jkl.$spacing-xl;
+        @include remove-inner-outer-button;
     }
 
     &__month-selector {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fremtind/jkl-image@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@fremtind/jkl-image/-/jkl-image-0.6.0.tgz#8935ffb3ad8a363f9342c6493052b3429895e789"
+  integrity sha512-8nht1yMv+rjZ+RXsENZYVvw8DqgugLsUGiSORmfcQHrLBCtZssk+WGRe+dsKxGfwtYF+0Itl3qnPDkekvAuMcQ==
+  dependencies:
+    "@fremtind/jkl-core" "^9.0.0"
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
Jeg har undersøkt problemet i flere kilder og foreslår at vi bør fjerne inner/outer button i datepicker/year-selector input. Det er to grunner for dette:

1. Cross-browser compatibility er komplisert. For eksempel, se på beskjed i https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-inner-spin-button 
2. Hvis vi prøver å style det, må vi designe det også. Jeg er usikker om dette blir prioritert i dag.

Derfor har jeg skrevet en mixin som fjerner default inner/outer button. Hvis vi trenger å gjøre samme for en andre input[type=number], kan vi bruke samme mixin. 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Minstekrav til dokumentasjon er oppfyllt (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] Testdekningen er god nok (enhetstest, visuell regresjonstest)
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
