### PR TITLE
fix(deps): bruk riktig versjon av stilpakken

### DIFF
--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.16.7",
-        "@fremtind/jkl-image": "^0.6.0",
+        "@fremtind/jkl-image": "^2.0.1",
         "@fremtind/jkl-react-hooks": "^7.1.1",
         "classnames": "^2.2.6"
     },


### PR DESCRIPTION
Den nye bildekomponenten hadde gammel versjon av stilpakken som dependency. Endre dette til den nye versjonen.

## 🎯 Sjekkliste

-   [x] Minstekrav til dokumentasjon er oppfyllt (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] Testdekningen er god nok (enhetstest, visuell regresjonstest)
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
