### PR TITLE
fix: add correct max-height to textarea with counter

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -277,6 +277,7 @@ $text-input-selection-color--inverted: color.scale(
 
         .jkl-text-input__input {
             height: auto;
+            max-height: $text-input-height;
             padding-bottom: jkl.$spacing-xs;
             transition-property: max-height, box-shadow, padding-bottom;
 
@@ -381,6 +382,7 @@ $text-input-selection-color--inverted: color.scale(
 
         &.jkl-text-area--start-open .jkl-text-input__input {
             background: var(--text-input-background-color);
+            max-height: none;
             padding-bottom: jkl.$spacing-xl;
         }
     }


### PR DESCRIPTION
affects: @fremtind/jkl-text-input

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
Eg retta tidligare ein feil som at startOpen ikkje fungerte sammen med counter på TextArea. Dette innførte ein ny feil, TextArea fekk feil høgde (høgden til teksten + høgden til den usynlige counteren). Feilen er fiksa i denne PRen.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
