### PR TITLE
chore: patch gulp-sass for å bruke sass-embedded

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const sass = require("gulp-sass")(require("sass"));
+const sass = require("gulp-sass/legacy")(require("sass"));
 const importer = require("node-sass-tilde-importer");
 const postcss = require("gulp-postcss");
 const cssnano = require("cssnano");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const sass = require("gulp-sass/legacy")(require("sass"));
-const importer = require("node-sass-tilde-importer");
+const sassEmbedded = require("sass-embedded");
+const sass = require("gulp-sass")(sassEmbedded);
 const postcss = require("gulp-postcss");
 const cssnano = require("cssnano");
 const litePreset = require("cssnano-preset-lite");
 const autoprefixer = require("autoprefixer");
 const rename = require("gulp-rename");
+const path = require("path");
+const { pathToFileURL } = require("url");
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 const scssFiles = ["**/*.scss", "!example/*.scss", "!documentation/*.scss"];
@@ -18,7 +20,22 @@ module.exports = function (gulp) {
     gulp.task("build", function () {
         return gulp
             .src(scssFiles)
-            .pipe(sass.sync({ importer }).on("error", throwSassError))
+            .pipe(
+                sass({
+                    importers: [
+                        {
+                            // An importer that redirects relative URLs starting with "~" to
+                            // the monorepo `node_modules`.
+                            findFileUrl(url) {
+                                if (!url.startsWith("~")) return null;
+                                const base = path.join(__dirname, "node_modules", "/"); // base must end in /, otherwise node_modules/ is discarded from the URL.
+                                const resolved = new URL(url.substring(1), pathToFileURL(base));
+                                return resolved;
+                            },
+                        },
+                    ],
+                }).on("error", throwSassError),
+            )
             .pipe(postcss([autoprefixer()]))
             .pipe(gulp.dest("./"))
             .pipe(postcss([cssnano(litePreset())]))

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "lerna": "^4.0.0",
         "lerna-clean-changelogs-cli": "^2.0.12",
         "lint-staged": "^12.3.4",
-        "node-sass-tilde-importer": "^1.0.2",
         "npm-run-all": "^4.1.5",
         "parcel": "^2.3.1",
         "patch-package": "^6.2.2",
@@ -114,7 +113,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.67.2",
         "rollup-plugin-terser": "^7.0.0",
-        "sass": "^1.49.7",
+        "sass-embedded": "^1.49.8",
         "stylelint": "^14.5.1",
         "typescript": "^4.5.5"
     },

--- a/packages/formatters-util/package.json
+++ b/packages/formatters-util/package.json
@@ -35,7 +35,7 @@
         "@fremtind/jkl-core": "^9.1.1"
     },
     "devDependencies": {
-        "react-hook-form": "^7.22.5"
+        "react-hook-form": "^7.27.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0",

--- a/patches/gulp-sass+5.1.0.patch
+++ b/patches/gulp-sass+5.1.0.patch
@@ -1,0 +1,351 @@
+diff --git a/node_modules/gulp-sass/index.js b/node_modules/gulp-sass/index.js
+index 3a027bc..10182c3 100644
+--- a/node_modules/gulp-sass/index.js
++++ b/node_modules/gulp-sass/index.js
+@@ -24,13 +24,19 @@ const transfob = (transform) => new Transform({ transform, objectMode: true });
+ /**
+  * Handles returning the file to the stream
+  */
+-const filePush = (file, sassObject, callback) => {
++const filePush = (file, compileResult, callback) => {
++  file.contents = Buffer.from(compileResult.css);
++  file.path = replaceExtension(file.path, '.css');
++
+   // Build Source Maps!
+-  if (sassObject.map) {
+-    // Transform map into JSON
+-    const sassMap = JSON.parse(sassObject.map.toString());
+-    // Grab the stdout and transform it into stdin
+-    const sassMapFile = sassMap.file.replace(/^stdout$/, 'stdin');
++  if (compileResult.sourceMap) {
++    const sassMap = compileResult.sourceMap;
++
++    const sassMapFile = file.path;
++    if (!sassMap.file) {
++      sassMap.file = sassMapFile;
++    }
++
+     // Grab the base filename that's being worked on
+     const sassFileSrc = file.relative;
+     // Grab the path portion of the file that's being worked on
+@@ -39,11 +45,9 @@ const filePush = (file, sassObject, callback) => {
+     if (sassFileSrcPath) {
+       const sourceFileIndex = sassMap.sources.indexOf(sassMapFile);
+       // Prepend the path to all files in the sources array except the file that's being worked on
+-      sassMap.sources = sassMap.sources.map((source, index) => (
+-        index === sourceFileIndex
+-          ? source
+-          : path.join(sassFileSrcPath, source)
+-      ));
++      sassMap.sources = sassMap.sources.map((source, index) =>
++        index === sourceFileIndex ? source : path.join(sassFileSrcPath, source)
++      );
+     }
+
+     // Remove 'stdin' from souces and replace with filenames!
+@@ -55,9 +59,6 @@ const filePush = (file, sassObject, callback) => {
+     applySourceMap(file, sassMap);
+   }
+
+-  file.contents = sassObject.css;
+-  file.path = replaceExtension(file.path, '.css');
+-
+   if (file.stat) {
+     file.stat.atime = file.stat.mtime = file.stat.ctime = new Date();
+   }
+@@ -110,52 +111,47 @@ const gulpSass = (options, sync) => {
+     }
+
+     const opts = clonedeep(options || {});
+-    opts.data = file.contents.toString();
+
+-    // We set the file path here so that libsass can correctly resolve import paths
+-    opts.file = file.path;
+-
+-    // Ensure `indentedSyntax` is true if a `.sass` file
++    // Ensure `indented` if a `.sass` file
+     if (path.extname(file.path) === '.sass') {
+-      opts.indentedSyntax = true;
++      opts.syntax = 'indented';
+     }
+
+     // Ensure file's parent directory in the include path
+-    if (opts.includePaths) {
+-      if (typeof opts.includePaths === 'string') {
+-        opts.includePaths = [opts.includePaths];
++    if (opts.loadPaths) {
++      if (typeof opts.loadPaths === 'string') {
++        opts.loadPaths = [opts.loadPaths];
+       }
+     } else {
+-      opts.includePaths = [];
++      opts.loadPaths = [];
+     }
+
+-    opts.includePaths.unshift(path.dirname(file.path));
++    opts.loadPaths.unshift(path.dirname(file.path));
+
+     // Generate Source Maps if the source-map plugin is present
+     if (file.sourceMap) {
+-      opts.sourceMap = file.path;
+-      opts.omitSourceMapUrl = true;
+-      opts.sourceMapContents = true;
++      opts.sourceMap = true;
++      opts.sourceMapIncludeSources = true;
+     }
+
+     if (sync !== true) {
+       /**
+-       * Async Sass render
++       * Async Sass compile
+        */
+-      gulpSass.compiler.render(opts, (error, obj) => {
+-        if (error) {
++      gulpSass.compiler
++        .compileAsync(file.path, opts)
++        .then((compileResult) => {
++          filePush(file, compileResult, callback);
++        })
++        .catch((error) => {
+           handleError(error, file, callback);
+-          return;
+-        }
+-
+-        filePush(file, obj, callback);
+-      });
++        });
+     } else {
+       /**
+-       * Sync Sass render
++       * Sync Sass compile
+        */
+       try {
+-        filePush(file, gulpSass.compiler.renderSync(opts), callback);
++        filePush(file, gulpSass.compiler.compile(opts), callback);
+       } catch (error) {
+         handleError(error, file, callback);
+       }
+@@ -164,7 +160,7 @@ const gulpSass = (options, sync) => {
+ };
+
+ /**
+- * Sync Sass render
++ * Sync Sass compile
+  */
+ gulpSass.sync = (options) => gulpSass(options, true);
+
+@@ -172,13 +168,13 @@ gulpSass.sync = (options) => gulpSass(options, true);
+  * Log errors nicely
+  */
+ gulpSass.logError = function logError(error) {
+-  const message = new PluginError('sass', error.messageFormatted).toString();
++  const message = new PluginError('sass', error).toString();
+   process.stderr.write(`${message}\n`);
+   this.emit('end');
+ };
+
+ module.exports = (compiler) => {
+-  if (!compiler || !compiler.render) {
++  if (!compiler || !compiler.compile) {
+     const message = new PluginError(
+       PLUGIN_NAME,
+       MISSING_COMPILER_MESSAGE,
+diff --git a/node_modules/gulp-sass/legacy.js b/node_modules/gulp-sass/legacy.js
+new file mode 100644
+index 0000000..3a027bc
+--- /dev/null
++++ b/node_modules/gulp-sass/legacy.js
+@@ -0,0 +1,193 @@
++'use strict';
++
++const path = require('path');
++const { Transform } = require('stream');
++const picocolors = require('picocolors');
++const PluginError = require('plugin-error');
++const replaceExtension = require('replace-ext');
++const stripAnsi = require('strip-ansi');
++const clonedeep = require('lodash.clonedeep');
++const applySourceMap = require('vinyl-sourcemaps-apply');
++
++const PLUGIN_NAME = 'gulp-sass';
++
++const MISSING_COMPILER_MESSAGE = `
++gulp-sass no longer has a default Sass compiler; please set one yourself.
++Both the "sass" and "node-sass" packages are permitted.
++For example, in your gulpfile:
++
++  const sass = require('gulp-sass')(require('sass'));
++`;
++
++const transfob = (transform) => new Transform({ transform, objectMode: true });
++
++/**
++ * Handles returning the file to the stream
++ */
++const filePush = (file, sassObject, callback) => {
++  // Build Source Maps!
++  if (sassObject.map) {
++    // Transform map into JSON
++    const sassMap = JSON.parse(sassObject.map.toString());
++    // Grab the stdout and transform it into stdin
++    const sassMapFile = sassMap.file.replace(/^stdout$/, 'stdin');
++    // Grab the base filename that's being worked on
++    const sassFileSrc = file.relative;
++    // Grab the path portion of the file that's being worked on
++    const sassFileSrcPath = path.dirname(sassFileSrc);
++
++    if (sassFileSrcPath) {
++      const sourceFileIndex = sassMap.sources.indexOf(sassMapFile);
++      // Prepend the path to all files in the sources array except the file that's being worked on
++      sassMap.sources = sassMap.sources.map((source, index) => (
++        index === sourceFileIndex
++          ? source
++          : path.join(sassFileSrcPath, source)
++      ));
++    }
++
++    // Remove 'stdin' from souces and replace with filenames!
++    sassMap.sources = sassMap.sources.filter((src) => src !== 'stdin' && src);
++
++    // Replace the map file with the original filename (but new extension)
++    sassMap.file = replaceExtension(sassFileSrc, '.css');
++    // Apply the map
++    applySourceMap(file, sassMap);
++  }
++
++  file.contents = sassObject.css;
++  file.path = replaceExtension(file.path, '.css');
++
++  if (file.stat) {
++    file.stat.atime = file.stat.mtime = file.stat.ctime = new Date();
++  }
++
++  callback(null, file);
++};
++
++/**
++ * Handles error message
++ */
++const handleError = (error, file, callback) => {
++  const filePath = (error.file === 'stdin' ? file.path : error.file) || file.path;
++  const relativePath = path.relative(process.cwd(), filePath);
++  const message = `${picocolors.underline(relativePath)}\n${error.formatted}`;
++
++  error.messageFormatted = message;
++  error.messageOriginal = error.message;
++  error.message = stripAnsi(message);
++  error.relativePath = relativePath;
++
++  return callback(new PluginError(PLUGIN_NAME, error));
++};
++
++/**
++ * Main Gulp Sass function
++ */
++
++// eslint-disable-next-line arrow-body-style
++const gulpSass = (options, sync) => {
++  return transfob((file, encoding, callback) => {
++    if (file.isNull()) {
++      callback(null, file);
++      return;
++    }
++
++    if (file.isStream()) {
++      callback(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
++      return;
++    }
++
++    if (path.basename(file.path).startsWith('_')) {
++      callback();
++      return;
++    }
++
++    if (!file.contents.length) {
++      file.path = replaceExtension(file.path, '.css');
++      callback(null, file);
++      return;
++    }
++
++    const opts = clonedeep(options || {});
++    opts.data = file.contents.toString();
++
++    // We set the file path here so that libsass can correctly resolve import paths
++    opts.file = file.path;
++
++    // Ensure `indentedSyntax` is true if a `.sass` file
++    if (path.extname(file.path) === '.sass') {
++      opts.indentedSyntax = true;
++    }
++
++    // Ensure file's parent directory in the include path
++    if (opts.includePaths) {
++      if (typeof opts.includePaths === 'string') {
++        opts.includePaths = [opts.includePaths];
++      }
++    } else {
++      opts.includePaths = [];
++    }
++
++    opts.includePaths.unshift(path.dirname(file.path));
++
++    // Generate Source Maps if the source-map plugin is present
++    if (file.sourceMap) {
++      opts.sourceMap = file.path;
++      opts.omitSourceMapUrl = true;
++      opts.sourceMapContents = true;
++    }
++
++    if (sync !== true) {
++      /**
++       * Async Sass render
++       */
++      gulpSass.compiler.render(opts, (error, obj) => {
++        if (error) {
++          handleError(error, file, callback);
++          return;
++        }
++
++        filePush(file, obj, callback);
++      });
++    } else {
++      /**
++       * Sync Sass render
++       */
++      try {
++        filePush(file, gulpSass.compiler.renderSync(opts), callback);
++      } catch (error) {
++        handleError(error, file, callback);
++      }
++    }
++  });
++};
++
++/**
++ * Sync Sass render
++ */
++gulpSass.sync = (options) => gulpSass(options, true);
++
++/**
++ * Log errors nicely
++ */
++gulpSass.logError = function logError(error) {
++  const message = new PluginError('sass', error.messageFormatted).toString();
++  process.stderr.write(`${message}\n`);
++  this.emit('end');
++};
++
++module.exports = (compiler) => {
++  if (!compiler || !compiler.render) {
++    const message = new PluginError(
++      PLUGIN_NAME,
++      MISSING_COMPILER_MESSAGE,
++      { showProperties: false },
++    ).toString();
++    process.stderr.write(`${message}\n`);
++    process.exit(1);
++  }
++
++  gulpSass.compiler = compiler;
++  return gulpSass;
++};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,6 +6207,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-builder@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-builder/-/buffer-builder-0.2.0.tgz#3322cd307d8296dab1f604618593b261a3fade8f"
+  integrity sha1-MyLNMH2Cltqx9gRhhZOyYaP63o8=
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -9376,7 +9381,7 @@ extract-files@9.0.0:
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
   integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
 
-extract-zip@2.0.1:
+extract-zip@2.0.1, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -9611,11 +9616,6 @@ find-node-modules@^2.1.2:
   dependencies:
     findup-sync "^4.0.0"
     merge "^2.1.0"
-
-find-parent-dir@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.1.tgz#c5c385b96858c3351f95d446cab866cbf9f11125"
-  integrity sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==
 
 find-root@1.1.0:
   version "1.1.0"
@@ -10925,6 +10925,11 @@ glogg@^1.0.0:
   integrity sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
   dependencies:
     sparkles "^1.0.0"
+
+google-protobuf@^3.11.4:
+  version "3.19.4"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.19.4.tgz#8d32c3e34be9250956f28c0fb90955d13f311888"
+  integrity sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg==
 
 got@^11.8.2, got@^11.8.3:
   version "11.8.3"
@@ -14690,7 +14695,7 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -14754,13 +14759,6 @@ node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
-
-node-sass-tilde-importer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
-  integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==
-  dependencies:
-    find-parent-dir "^0.3.0"
 
 nopt@1.0.10:
   version "1.0.10"
@@ -17750,6 +17748,13 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.4.0:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
+  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
+  dependencies:
+    tslib "^2.1.0"
+
 rxjs@^7.5.1, rxjs@^7.5.2:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
@@ -17786,6 +17791,22 @@ sanitize-filename@^1.6.1:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sass-embedded@^1.49.8:
+  version "1.49.8"
+  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.49.8.tgz#066a9ac5a1abf4e02805c1d1a55ba5c2fb671bb0"
+  integrity sha512-fktiTPZd4VATlNJWXB6XU5xONO4VcCU9c1khvbXaUTRCwfhOMKYfKp3xl7mfhREcupSB8PLoxBGlm33nxngkeg==
+  dependencies:
+    buffer-builder "^0.2.0"
+    extract-zip "^2.0.1"
+    google-protobuf "^3.11.4"
+    immutable "^4.0.0"
+    node-fetch "^2.6.0"
+    rxjs "^7.4.0"
+    semver "^7.3.5"
+    shelljs "^0.8.4"
+    supports-color "^8.1.1"
+    tar "^6.0.5"
+
 sass-loader@^10.1.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.1.tgz#17e51df313f1a7a203889ce8ff91be362651276e"
@@ -17797,7 +17818,7 @@ sass-loader@^10.1.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.38.0, sass@^1.49.7:
+sass@^1.38.0:
   version "1.49.7"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.49.7.tgz#22a86a50552b9b11f71404dfad1b9ff44c6b0c49"
   integrity sha512-13dml55EMIR2rS4d/RDHHP0sXMY3+30e1TKsyXaSz3iLWVoDWEoboY8WzJd5JMnxrRHffKO3wq2mpJ0jxRJiEQ==
@@ -18030,6 +18051,15 @@ shelljs@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.0.tgz#3f6f2e4965cec565f65ff3861d644f879281a576"
   integrity sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shelljs@^0.8.4:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -19182,7 +19212,7 @@ tar@^4.4.12:
     safe-buffer "^5.2.1"
     yallist "^3.1.1"
 
-tar@^6.0.2, tar@^6.1.0:
+tar@^6.0.2, tar@^6.0.5, tar@^6.1.0:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==


### PR DESCRIPTION
Jeg prøver å lande denne patchen upstream, men det er lite respons fra maintainer. Skal følge opp, men er jo ingen grunn til at vi må vente 😄

Med dette kommer vi oss vekk fra et deprecated Sass-API (og får et par sekunders raskere bygg via sass-embedded, ikke at det gjør den største forskjellen 😛)

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
