### PR TITLE
fix: samling med bugfikser for TextArea

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -393,12 +393,12 @@ $text-input-selection-color--inverted: color.scale(
 
 /* Utility classes for number of rows */
 @for $num from 3 through 10 {
+    $height: $text-input-line-height * $num + jkl.$spacing-xs * 2;
+    $small-height: $text-input-line-height--compact * $num + jkl.$spacing-xs * 2;
+
     .jkl-text-input__input--#{$num}-rows:focus,
     .jkl-text-input__input--#{$num}-rows:not(:placeholder-shown),
     .jkl-text-area--start-open .jkl-text-input__input--#{$num}-rows {
-        $height: $text-input-line-height * $num + jkl.$spacing-xs * 2;
-        $small-height: $text-input-line-height--compact * $num + jkl.$spacing-xs * 2;
-
         /**
          * (#2751) Ekspanderende får inline style med height auto,
          *         som gir et "hopp" dersom det er en teller og vi
@@ -417,5 +417,10 @@ $text-input-selection-color--inverted: color.scale(
             height: $small-height;
             min-height: $small-height; // (#2751)
         }
+    }
+
+    .jkl-text-area--start-open.jkl-text-input--compact .jkl-text-input__input--#{$num}-rows {
+        height: $small-height;
+        min-height: $small-height; // (#2751)
     }
 }

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -253,7 +253,15 @@ $text-input-selection-color--inverted: color.scale(
 
 .jkl-text-area {
     height: auto;
+    min-width: rem(280px); // For å unngå "jank" med ekspanderende textarea med teller på små bredder
     width: 100%;
+
+    &--auto-expand {
+        .jkl-text-input__input,
+        .jkl-text-area__text-area {
+            overflow: hidden; // Skjul scrollbar når høyden autojusteres
+        }
+    }
 
     & .jkl-text-input__input {
         @include motion("standard");
@@ -262,10 +270,6 @@ $text-input-selection-color--inverted: color.scale(
         font-weight: normal;
         width: 100%;
         resize: none; // Disable textarea resize
-    }
-
-    &.jkl-text-input--compact .jkl-text-input__input:empty {
-        overflow: hidden;
     }
 
     &--with-counter {

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -381,7 +381,6 @@ $text-input-selection-color--inverted: color.scale(
         }
 
         &.jkl-text-area--start-open .jkl-text-input__input {
-            background: var(--text-input-background-color);
             max-height: none;
             padding-bottom: jkl.$spacing-xl;
         }

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -392,14 +392,26 @@ $text-input-selection-color--inverted: color.scale(
     .jkl-text-input__input--#{$num}-rows:focus,
     .jkl-text-input__input--#{$num}-rows:not(:placeholder-shown),
     .jkl-text-area--start-open .jkl-text-input__input--#{$num}-rows {
+        $height: $text-input-line-height * $num + jkl.$spacing-xs * 2;
+        $small-height: $text-input-line-height--compact * $num + jkl.$spacing-xs * 2;
+
+        /**
+         * (#2751) Ekspanderende får inline style med height auto,
+         *         som gir et "hopp" dersom det er en teller og vi
+         *         ikke har en minimumshøyde.
+         */
+        min-height: $height; // (#2751)
+        height: $height;
         max-height: 100%;
-        height: $text-input-line-height * $num + jkl.$spacing-xs * 2;
+
         @include small-device {
-            height: $text-input-line-height--compact * $num + jkl.$spacing-xs * 2;
+            height: $small-height;
+            min-height: $small-height; // (#2751)
         }
 
         .jkl-text-input--compact & {
-            height: $text-input-line-height--compact * $num + jkl.$spacing-xs * 2;
+            height: $small-height;
+            min-height: $small-height; // (#2751)
         }
     }
 }


### PR DESCRIPTION
- Setter bakgrunnsfargen først ved fokus når tekstområdet starter utvidet
- Fikser to feil hvor høyden på textarea krympet når man skrev inn tekst (#2751 og urapportert ved forceCompact+startOpen)
- Skriver om logikken som setter høyde på automatisk ekspanderende textarea for å fikse problemer på smale og brede skjemafelter (#2752)

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
