### PR TITLE
fix: exporter type for ImageProps

### DIFF
--- a/packages/image-react/src/index.ts
+++ b/packages/image-react/src/index.ts
@@ -1,1 +1,5 @@
-export { Image } from "./Image";
+import { Image, ImageProps } from "./Image";
+
+export type { ImageProps };
+
+export { Image };


### PR DESCRIPTION
Eksporterer typen ImageProps. Litt usikker om dette er den mest riktige/beste måten å gjøre det på?

## 🎯 Sjekkliste

-   [ x] `yarn build` og `yarn ci:test` gir ingen feil
