### PR TITLE
feat: make parseNumber less naive and including

### DIFF
--- a/packages/formatters-util/src/util/parseNumber.test.ts
+++ b/packages/formatters-util/src/util/parseNumber.test.ts
@@ -9,21 +9,11 @@ describe("parseNumber", () => {
     it("handles valid numbers in a string", () => {
         expect(parseNumber("1234")).toEqual(1234);
         expect(parseNumber("1234,56")).toEqual(1234.56);
-        expect(parseNumber("123.456")).toEqual(123456);
         expect(parseNumber("123.456,78")).toEqual(123456.78);
         expect(parseNumber("1 234,56")).toEqual(1234.56);
         expect(parseNumber("123 456")).toEqual(123456);
         expect(parseNumber("123 456,78")).toEqual(123456.78);
-    });
-
-    it("handles valid numbers with en-US locale in a string", () => {
-        expect(parseNumber("1234.56")).toEqual(1234.56);
-        expect(parseNumber("123,456")).toEqual(123456);
+        expect(parseNumber("23.4453434")).toEqual(23.4453434);
         expect(parseNumber("123,456.78")).toEqual(123456.78);
-    });
-
-    it("strips out characters from input", () => {
-        expect(parseNumber("12s34")).toEqual(1234);
-        expect(parseNumber("kr 1234")).toEqual(1234);
     });
 });

--- a/packages/formatters-util/src/util/parseNumber.ts
+++ b/packages/formatters-util/src/util/parseNumber.ts
@@ -1,8 +1,6 @@
 const replaceAllButLastOccurence = (input: string | string[], search: string) => {
-    // indexOf returns the first index, so flip the input to find the
-    // notator furthest back
-    const arrInput = Array.isArray(input) ? input.reverse() : input.split("").reverse();
-    const indexOfSearch = arrInput.indexOf(search);
+    const arrInput = Array.isArray(input) ? input : input.split("");
+    const indexOfSearch = arrInput.lastIndexOf(search);
 
     return (
         arrInput
@@ -14,8 +12,6 @@ const replaceAllButLastOccurence = (input: string | string[], search: string) =>
 
                 return i === indexOfSearch;
             })
-            // flip back and return as string
-            .reverse()
             .join("")
     );
 };
@@ -26,7 +22,7 @@ export function parseNumber(input: string | number) {
     }
 
     // remove all spaces from number
-    const arrNumber = input.split("").filter((n) => n !== " ");
+    const arrNumber = input.replaceAll(" ", "").split("");
 
     // find what separator is used for decimal notation
     const decimalNotator = arrNumber.reduce<"." | "," | null>((notator, currentItem) => {

--- a/packages/formatters-util/src/util/parseNumber.ts
+++ b/packages/formatters-util/src/util/parseNumber.ts
@@ -1,18 +1,47 @@
+const replaceAllButLastOccurence = (input: string | string[], search: string) => {
+    // indexOf returns the first index, so flip the input to find the
+    // notator furthest back
+    const arrInput = Array.isArray(input) ? input.reverse() : input.split("").reverse();
+    const indexOfSearch = arrInput.indexOf(search);
+
+    return (
+        arrInput
+            // remove all instances of the notator except the last one
+            .filter((f, i) => {
+                if (f !== search) {
+                    return true;
+                }
+
+                return i === indexOfSearch;
+            })
+            // flip back and return as string
+            .reverse()
+            .join("")
+    );
+};
+
 export function parseNumber(input: string | number) {
     if (typeof input === "number") {
         return input;
     }
 
-    // fjern tegn som ikke kan tolkes som tall og erstatt kommadesimal
-    const strippedInput = input
-        .replace(/[^\d.,-]/g, "")
-        .replace(/[.,](\d{3})/g, "$1")
-        .replace(/,/g, ".");
-    const parsedNumber = Number.parseFloat(strippedInput);
+    // remove all spaces from number
+    const arrNumber = input.split("").filter((n) => n !== " ");
 
-    if (Number.isNaN(parsedNumber) || typeof parsedNumber !== "number") {
-        return null;
+    // find what separator is used for decimal notation
+    const decimalNotator = arrNumber.reduce<"." | "," | null>((notator, currentItem) => {
+        if (currentItem === "," || currentItem === ".") {
+            return currentItem;
+        }
+
+        return notator;
+    }, null);
+
+    if (decimalNotator === ".") {
+        return Number(replaceAllButLastOccurence(arrNumber, ".").replace(",", ""));
+    } else if (decimalNotator === ",") {
+        return Number(replaceAllButLastOccurence(arrNumber, ",").replace(".", "").replace(",", "."));
+    } else {
+        return Number(arrNumber.join(""));
     }
-
-    return parsedNumber;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "lib": [                                  /* Specify library files to be included in the compilation. */
             "dom",                                /* We have a browser environment */
             "ESNext.Array",                        /* We like flat arrays */
-            "ES2019.Object"
+            "ES2019.Object",
+            "ES2021"
         ],
         "module": "esnext"                        /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
         // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
affects: @fremtind/jkl-formatters-util

Earlier parseNumber accepted formats way beyond what could be expected
of a legal number. I've now changed it to be closer to the native
functionality of Number, and try to make the assumption that most
numbers will be in a norwegian-ish format

BREAKING CHANGE:
number parsing is more strict

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [X] `yarn build` og `yarn ci:test` gir ingen feil
