### PR TITLE
fix: makes header and content props of SummaryTableRow more flexible

### DIFF
--- a/packages/summary-table-react/documentation/SummaryTableExample.tsx
+++ b/packages/summary-table-react/documentation/SummaryTableExample.tsx
@@ -34,7 +34,7 @@ export const summaryTableExampleCode: CodeExample = `
     footer={
         <>
             <SummaryTableRow header="Total sum" content="693,50 kr/mnd" />
-            <SummaryTableRow header="" content="8322,50 kr/mnd" />
+            <SummaryTableRow header={<span className="jkl-sr-only">Total sum per år</span>} content="8322,50 kr/år" />
         </>
     }
 />

--- a/packages/summary-table-react/mocks/index.tsx
+++ b/packages/summary-table-react/mocks/index.tsx
@@ -20,7 +20,7 @@ export const mockBody = (
 export const mockFooter = (
     <>
         <SummaryTableRow header="Total sum" content="693,50 kr/mnd" />
-        <SummaryTableRow header="" content="8322,50 kr/mnd" />
+        <SummaryTableRow header={<span className="jkl-sr-only">Total sum per år</span>} content="8322,50 kr/mnd" />
     </>
 );
 

--- a/packages/summary-table-react/src/SummaryTableRow.tsx
+++ b/packages/summary-table-react/src/SummaryTableRow.tsx
@@ -1,9 +1,9 @@
-import React, { VFC } from "react";
+import React, { VFC, ReactNode } from "react";
 
 export interface SummaryTableRowProps {
     className?: string;
-    header: string;
-    content: string;
+    header: string | ReactNode;
+    content: string | ReactNode;
 }
 
 export const SummaryTableRow: VFC<SummaryTableRowProps> = ({ className, header, content }) => {


### PR DESCRIPTION
allows header and content props of SummaryTableRow to take ReactNode to allow use of jkl-sr-only to
provide better accesibility

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
