### PR TITLE
chore: fjern historikken fra gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build:docs": "turbo run build:docs --scope=\"@fremtind/portal\" --include-dependencies --cache-dir=\"node_modules/.cache/turbo\"",
         "commit": "git-cz",
         "predeploy:docs": "yarn run build:docs",
-        "deploy:docs": "gh-pages --add --dist portal/public",
+        "deploy:docs": "gh-pages -f --no-history --add --dist portal/public",
         "typecheck": "tsc --noEmit",
         "lint": "run-p lint:eslint lint:stylelint",
         "lint:eslint": "eslint '**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
På grunn av staging blir den branchen etter hvert ganske stor, og blir bare større. Vi er ikke
interessert i historikken.

Fra hvordan jeg leser [stegene i gh-pages](https://github.com/tschaub/gh-pages/blob/main/lib/index.js) så skal den først sjekke ut den eksisterende branchen, så slette den, så legge til alle filene som ligger der fra før pluss de nye. Så dette _bør_ ikke skape noen problemer med staging eller prod.