### PR TITLE
feat: make expand row more appealing on mobile

### DIFF
--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -6,12 +6,14 @@ $focus-ring-width: jkl.rem(2px);
 
 @include jkl.helper-light-mode-variables {
     --table-row-border-color: #{jkl.$color-svaberg};
+    --table-row-border-none-color: #{rgba(jkl.$color-svaberg, 0)};
     --table-row-hover-border-color: #{jkl.$color-granitt};
     --table-row-highlight-color: #{jkl.$color-hvit};
 }
 
 @include jkl.helper-dark-mode-variables {
     --table-row-border-color: #{jkl.$color-stein};
+    --table-row-border-none-color: #{rgba(jkl.$color-stein, 0)};
     --table-row-hover-border-color: #{jkl.$color-snohvit};
     --table-row-highlight-color: #{jkl.$color-svart};
 }
@@ -75,6 +77,35 @@ $focus-ring-width: jkl.rem(2px);
         @include responsive-table-row;
     }
 
+    .jkl-table--collapse-to-list[data-collapse] :not(thead) > &.jkl-table-row--expandable {
+        transition-property: border, padding;
+        @include mixins.motion;
+
+        &.jkl-table-row--expanded {
+            border-bottom-color: var(--table-row-border-none-color);
+        }
+
+        .jkl-table-row-expand-button {
+            margin-left: auto;
+        }
+
+        &:hover + tr {
+            background-color: var(--table-row-highlight-color);
+        }
+
+        /* stylelint-disable-next-line selector-max-specificity -- selector needs to nest itself to select sub tables with the same properties */
+        & + tr & {
+            transition-property: border;
+            @include mixins.motion;
+        }
+
+        & + [aria-hidden="false"] {
+            & .jkl-table-row {
+                border-top-color: var(--table-row-border-none-color);
+            }
+        }
+    }
+
     @mixin responsive-table-row--hover {
         /* Tilbakestill hacken som gir riktig border når tabellen ikke har display: block; */
         border-top: solid $border-size var(--table-row-hover-border-color);
@@ -116,6 +147,10 @@ $focus-ring-width: jkl.rem(2px);
 
     &--clicked {
         background-color: var(--table-row-highlight-color);
+
+        &.jkl-table-row--expandable + [aria-hidden="false"] {
+            background-color: var(--table-row-highlight-color);
+        }
     }
 }
 

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -91,6 +91,10 @@ $focus-ring-width: jkl.rem(2px);
 
         &:hover + tr {
             background-color: var(--table-row-highlight-color);
+
+            .jkl-table-row {
+                border-bottom-color: var(--table-row-hover-border-color);
+            }
         }
 
         /* stylelint-disable-next-line selector-max-specificity -- selector needs to nest itself to select sub tables with the same properties */


### PR DESCRIPTION
move expand controller to the right side, and adjust how it influences
the borders

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [X] `yarn build` og `yarn ci:test` gir ingen feil
