### PR TITLE
WIP: endringer for å støtte forced-colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Jøkul er et [designsystem](https://www.invisionapp.com/inside-design/guide-to-d
 ## [Kom i gang](https://jokul.fremtind.no/komigang/utvikling)
 
 1. Klon repoet til maskinen din og naviger deg til mappen i terminalen
-2. Installer avhengigheter og bygg pakkene med `yarn boot`
+2. Installer avhengigheter og bygg pakkene med `yarn boot` [^windows]
 3. Start portalen lokalt med `yarn dev` og åpne [localhost på port 8000](http://localhost:8000/)
 
 **NB!** Når du sjekker ut en ny branch bør du bygge på nytt for å hindre at gammel bygget kode blir med når du kjører opp eksempler eller portalen. Kommandoen `yarn reboot` sletter alle bygde filer, installerer avhengigheter, og bygger pakkene på nytt.
@@ -148,3 +148,5 @@ Takk for bidrag fra disse flotte menneskene ([emoji-oversikt](https://allcontrib
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 Dette prosjektet følger retningslinjene i spesifikasjonen [all-contributors](https://github.com/all-contributors/all-contributors). Vi setter pris på alle bidrag!
+
+[^windows]: På grunn av en bug i patch-package på Windows vil denne kommandoen feile. Enten må du sjekke ut repoet med _UNIX-style line endings_, eller så må du først gjøre `yarn install` (som vil feile på `postinstall`), så manuelt legge til [denne endringen](https://github.com/ds300/patch-package/pull/301/files) i `node_modules/patch-package/dist/patch/parse.js` på linje 53. Deretter kan du kjøre `yarn postinstall` igjen, og så `yarn build`.

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -196,5 +196,5 @@
         }
     }
 
-    @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+    @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
 }

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -81,11 +81,6 @@
         html:not([data-mousenavigation]) &:focus {
             box-shadow: inset 0 0 0 2px var(--accordion-focus);
         }
-
-        @include jkl.helper-forced-colors-mode {
-            border: unset;
-            outline: unset;
-        }
     }
 
     &--expanded {
@@ -126,6 +121,33 @@
         height: auto;
         padding: jkl.$spacing-m jkl.$spacing-l jkl.$spacing-xl jkl.$spacing-l;
         color: inherit; // Make content same color as rest of page text
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        &:nth-child(n) {
+            border-top: rem(2px) solid ButtonText;
+
+            &:hover {
+                border-top: rem(2px) solid ButtonText;
+
+                + .jkl-accordion-item {
+                    border-top: rem(2px) solid ButtonText;
+                }
+            }
+        }
+
+        &:last-child {
+            border-bottom: rem(2px) solid ButtonText;
+
+            &:hover {
+                border-bottom: rem(2px) solid ButtonText;
+            }
+        }
+
+        &__title {
+            background-color: ButtonFace;
+            outline: revert;
+        }
     }
 }
 

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -168,4 +168,6 @@
             transform: translate(0, -100%);
         }
     }
+
+    @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
 }

--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -81,6 +81,11 @@
         html:not([data-mousenavigation]) &:focus {
             box-shadow: inset 0 0 0 2px var(--accordion-focus);
         }
+
+        @include jkl.helper-forced-colors-mode {
+            border: unset;
+            outline: unset;
+        }
     }
 
     &--expanded {

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -35,7 +35,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         padding-top: jkl.$spacing-3xs;
         height: rem(24px);
 
-        @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
+        @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
     }
 
     &__message {
@@ -53,7 +53,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         height: rem(20px);
 
         color: inherit;
-        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+        @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
         @include jkl.helper-forced-colors-mode {
             background-color: ButtonFace;
             margin-top: rem(-1px);
@@ -67,7 +67,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
 
         &:hover {
             color: $dismiss-hover-color;
-            @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+            @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
         }
 
         &:focus {

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -34,6 +34,8 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         align-self: flex-start;
         padding-top: jkl.$spacing-3xs;
         height: rem(24px);
+
+        @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
     }
 
     &__message {
@@ -46,16 +48,19 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         padding: 0;
         margin-left: auto;
         margin-top: jkl.$spacing-2xs;
-        color: inherit;
         cursor: pointer;
         width: rem(20px);
         height: rem(20px);
+
+        color: inherit;
+        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
 
         align-self: flex-start;
         flex-shrink: 0;
 
         &:hover {
             color: $dismiss-hover-color;
+            @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
         }
 
         &:focus {

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -54,6 +54,13 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
 
         color: inherit;
         @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+        @include jkl.helper-forced-colors-mode {
+            background-color: ButtonFace;
+            margin-top: rem(-1px);
+            width: rem(32px);
+            height: rem(32px);
+            padding: rem(4px);
+        }
 
         align-self: flex-start;
         flex-shrink: 0;
@@ -105,6 +112,22 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
 
     &--success {
         background-color: $bg-color--suksess;
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        border: 4px solid CanvasText;
+
+        &--info {
+            border-style: dotted;
+        }
+
+        &--warning {
+            border-style: dashed;
+        }
+
+        &--error {
+            border-style: double;
+        }
     }
 }
 

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -115,7 +115,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
     }
 
     @include jkl.helper-forced-colors-mode {
-        border: 4px solid CanvasText;
+        border: 2px solid CanvasText;
 
         &--info {
             border-style: dotted;
@@ -127,6 +127,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
 
         &--error {
             border-style: double;
+            border-width: 4px;
         }
     }
 }

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -253,6 +253,38 @@ a.jkl-button {
             min-width: unset;
         }
     }
+
+    @include jkl.helper-forced-colors-mode {
+        &.jkl-button--primary:not(a),
+        &.jkl-button--secondary:not(a),
+        &.jkl-button--primary:hover:not(a),
+        &.jkl-button--secondary:hover:not(a),
+        &.jkl-button--primary:focus:not(a),
+        &.jkl-button--secondary:focus:not(a) {
+            border-color: ButtonText;
+        }
+
+        & .jkl-loader__dot {
+            background-color: ButtonText;
+        }
+
+        &.jkl-button--secondary::after {
+            // Selve knappen har en border, men med to borders er secondary for lik primary uten farger.
+            // Gjør så secondary har _en_ border for å differensiere visuelt i forced-colors-modus.
+            border: none;
+        }
+
+        &.jkl-button--tertiary {
+            outline-offset: jkl.$spacing-3xs;
+        }
+
+        &.jkl-button--tertiary,
+        &.jkl-button--tertiary::after {
+            border-top-style: none;
+            border-right-style: none;
+            border-left-style: none;
+        }
+    }
 }
 
 @keyframes flash {

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -56,13 +56,10 @@ a.jkl-button {
     cursor: pointer;
     user-select: none;
     overflow: visible;
+    position: relative;
 
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: auto;
-
-    border: none;
-    outline: none;
-    position: relative;
 
     @include motion;
     transform-origin: 50% 90%;
@@ -230,6 +227,10 @@ a.jkl-button {
 
             &::after {
                 box-shadow: 0 0 0 $focus-ring-width var(--button-focus-color);
+            }
+
+            @include jkl.helper-forced-colors-mode {
+                border: unset;
             }
         }
 

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -230,7 +230,7 @@ a.jkl-button {
             }
 
             @include jkl.helper-forced-colors-mode {
-                border: unset;
+                border: revert;
             }
         }
 

--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -155,6 +155,11 @@ $card-padding-normal: jkl.$spacing-l;
             outline: func.rem(2px) solid var(--jkl-color);
         }
     }
+
+    @include jkl.helper-forced-colors-mode {
+        outline: unset;
+        border: rem(2px) solid LinkText;
+    }
 }
 
 @include jkl.helper-light-mode-variables {
@@ -207,6 +212,10 @@ $card-padding-normal: jkl.$spacing-l;
     &--with-shadow {
         box-shadow: var(--task-card-shadow);
     }
+
+    @include jkl.helper-forced-colors-mode {
+        border: rem(2px) solid CanvasText;
+    }
 }
 
 .jkl-info-card {
@@ -223,5 +232,9 @@ $card-padding-normal: jkl.$spacing-l;
         display: flex;
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        border: rem(2px) solid CanvasText;
     }
 }

--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -157,7 +157,7 @@ $card-padding-normal: jkl.$spacing-l;
     }
 
     @include jkl.helper-forced-colors-mode {
-        outline: unset;
+        outline: revert;
         border: rem(2px) solid LinkText;
     }
 }

--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -14,7 +14,6 @@ $card-padding-normal: jkl.$spacing-l;
     position: relative;
     overflow: hidden;
     display: block;
-    border: none;
     max-width: 60ch; // TODO: find out if we want this
     background-color: $card-bg-color;
     border-radius: $card-corner-radius;

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -93,6 +93,10 @@ $checkbox-line-height--compact: rem(28px);
 
             & > .jkl-checkbox__check-mark::before {
                 box-shadow: 0 0 0 rem(2px) var(--checkbox-focus-color);
+
+                @include jkl.helper-forced-colors-mode {
+                    border: 4px double CanvasText;
+                }
             }
 
             & > .jkl-checkbox__check-mark {
@@ -122,6 +126,17 @@ $checkbox-line-height--compact: rem(28px);
 
             .jkl-checkbox__check-mark {
                 box-shadow: inset 0 0 0 rem(1px) currentColor, 0 0 0 rem(1px) currentColor;
+
+                @include jkl.helper-forced-colors-mode {
+                    &::before {
+                        border: 2px solid CanvasText;
+                        position: absolute;
+                        top: rem(-1px);
+                        right: rem(-1px);
+                        bottom: rem(-1px);
+                        left: rem(-1px);
+                    }
+                }
             }
         }
 
@@ -196,6 +211,7 @@ $checkbox-line-height--compact: rem(28px);
 
         @include jkl.helper-forced-colors-mode {
             outline: unset;
+            border: 1px solid CanvasText;
         }
     }
 

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -214,7 +214,7 @@ $checkbox-line-height--compact: rem(28px);
         }
 
         @include jkl.helper-forced-colors-mode {
-            outline: unset;
+            outline: revert;
             border: 1px solid ButtonText;
         }
     }

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -197,6 +197,10 @@ $checkbox-line-height--compact: rem(28px);
             opacity: 0;
             @include motion;
             transition-property: opacity, border-color;
+
+            @include jkl.helper-forced-colors-mode {
+                border-color: Highlight;
+            }
         }
 
         // This is the basis of the focus ring

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -193,6 +193,10 @@ $checkbox-line-height--compact: rem(28px);
             bottom: rem(-2px);
             left: rem(-2px);
         }
+
+        @include jkl.helper-forced-colors-mode {
+            outline: unset;
+        }
     }
 
     &--inline {

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -95,7 +95,7 @@ $checkbox-line-height--compact: rem(28px);
                 box-shadow: 0 0 0 rem(2px) var(--checkbox-focus-color);
 
                 @include jkl.helper-forced-colors-mode {
-                    border: 4px double CanvasText;
+                    border: 4px double ButtonText;
                 }
             }
 
@@ -129,7 +129,7 @@ $checkbox-line-height--compact: rem(28px);
 
                 @include jkl.helper-forced-colors-mode {
                     &::before {
-                        border: 2px solid CanvasText;
+                        border: 2px solid ButtonText;
                         position: absolute;
                         top: rem(-1px);
                         right: rem(-1px);
@@ -211,7 +211,7 @@ $checkbox-line-height--compact: rem(28px);
 
         @include jkl.helper-forced-colors-mode {
             outline: unset;
-            border: 1px solid CanvasText;
+            border: 1px solid ButtonText;
         }
     }
 

--- a/packages/core/icons.scss
+++ b/packages/core/icons.scss
@@ -1,3 +1,5 @@
+@use "jkl";
+
 :root {
     --jkl-icon-width: 20px;
 }
@@ -21,4 +23,6 @@
     &--large {
         --jkl-icon-width: 40px;
     }
+
+    @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
 }

--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -38,6 +38,8 @@
         height: $icon-width;
         margin-bottom: -#{jkl.rem(6px)};
         margin-right: -#{$icon-width};
+
+        @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
     }
 
     &--compact {

--- a/packages/core/labels.scss
+++ b/packages/core/labels.scss
@@ -39,7 +39,7 @@
         margin-bottom: -#{jkl.rem(6px)};
         margin-right: -#{$icon-width};
 
-        @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
+        @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
     }
 
     &--compact {

--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -74,7 +74,7 @@ $link-underline-thickness--hover: jkl.rem(2px);
     }
 
     @include jkl.helper-forced-colors-mode {
-        outline: unset;
+        outline: revert;
     }
 }
 

--- a/packages/core/links.scss
+++ b/packages/core/links.scss
@@ -72,6 +72,10 @@ $link-underline-thickness--hover: jkl.rem(2px);
             @include mixins.decorative($content: $north-east-arrow);
         }
     }
+
+    @include jkl.helper-forced-colors-mode {
+        outline: unset;
+    }
 }
 
 .jkl-nav-link {

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -30,7 +30,7 @@
 ///
 /// Brukes til å overstyre stiler for bruk i Forced Colors-modus.
 /// Her vil du typisk legge til fallbacks for manglende box-shadow,
-/// som for eksempel `outline: unset;` og `border: unset;`,
+/// som for eksempel `outline: revert;` og `border: revert;`,
 /// og eventuelle andre problemer som oppstår for brukere av høykontrasttemaer.
 /// Se https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
 /// og https://www.smashingmagazine.com/2022/03/windows-high-contrast-colors-mode-css-custom-properties/
@@ -159,17 +159,17 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
     // Reset alt som er gjort over hvis brukeren har på forced-colors.
     // Da mister vi box-shadow og er avhengig av at borders og outlines synes.
     @include forced-colors-mode {
-        outline: unset;
-        border-style: unset;
-        outline-style: unset;
+        outline: revert;
+        border-style: revert;
+        outline-style: revert;
 
         &:active,
         &:hover,
         &:focus,
         &:link,
         &:visited {
-            outline: unset !important;
-            outline-style: unset;
+            outline: revert !important;
+            outline-style: revert;
         }
 
         /* Remove the inner border and padding in Firefox */
@@ -177,7 +177,7 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
         [type="button"]::-moz-focus-inner,
         [type="reset"]::-moz-focus-inner,
         [type="submit"]::-moz-focus-inner {
-            border-style: unset;
+            border-style: revert;
         }
 
         /* Remove dotted lines around object, especially for firefox */
@@ -186,25 +186,25 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
         a:focus,
         a:link,
         a:visited {
-            outline: unset !important;
-            outline-style: unset;
+            outline: revert !important;
+            outline-style: revert;
         }
 
         button,
         object,
         embed {
-            outline: unset;
+            outline: revert;
         }
 
         /* All Input elements */
         input::-moz-focus-inner {
-            outline: unset;
+            outline: revert;
         }
 
         /* Or more specifically */
         input[type="submit"]::-moz-focus-inner,
         input[type="button"]::-moz-focus-inner {
-            outline: unset;
+            outline: revert;
         }
     }
 }

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -48,21 +48,16 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "ButtonFace", "Can
 /// Hjelper for å sette riktig farge på SVGer i Chrome for brukere med Forced Color-modus.
 /// Se https://melanie-richards.com/blog/currentcolor-svg-hcm/ for detaljer
 ///
-/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $color - Definer hvilken systemfarge som skal brukes. Fargene har en forventet betydning for brukeren. Følg den semantiske betydningen til fargen, ikke velg fargen du selv synes "ser best ut".
-/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $fill [$color - Hvis du trenger ulik fill og stroke. Bruker default $color.
-/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $stroke [$color] - Hvis du trenger ulik fill og stroke. Bruker default $color.
+/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $stroke - Definer hvilken systemfarge som skal brukes til stroke. Fargene har en forventet betydning for brukeren. Følg den semantiske betydningen til fargen, ikke velg fargen du selv synes "ser best ut".
+/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $fill [null] - Som $stroke, bare for fill. Valgfri.
 ///
-@mixin forced-colors-svg-fallback($color, $fill: $color, $stroke: $color) {
-    @if not list.index($_valid-forced-colors-text-values, $color) {
-        @error "#{$color} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
-    }
-
+@mixin forced-colors-svg-fallback($stroke, $fill: null) {
     @if not list.index($_valid-forced-colors-text-values, $stroke) {
-        @error "#{$stroke} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
+        @error "#{$stroke} will not be used for stroke in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
     }
 
-    @if not list.index($_valid-forced-colors-text-values, $fill) {
-        @error "#{$fill} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
+    @if $fill and not list.index($_valid-forced-colors-text-values, $fill) {
+        @error "#{$fill} will not be used for fill in Forced Color mode. Valid options are: null, #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
     }
 
     @media screen and (forced-colors: active) {

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -1,5 +1,6 @@
 @use "sass:string";
 @use "sass:color";
+@use "sass:list";
 @use "../variables/typography";
 
 @mixin light-mode-variables {
@@ -23,6 +24,39 @@
 
     [data-theme="dark"] {
         @content;
+    }
+}
+
+///
+/// Brukes til å overstyre stiler for bruk i Forced Colors-modus.
+/// Her vil du typisk legge til fallbacks for manglende box-shadow,
+/// og eventuelle andre problemer som oppstår for brukere av høykontrasttemaer.
+/// Se https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
+/// og https://www.smashingmagazine.com/2022/03/windows-high-contrast-colors-mode-css-custom-properties/
+///
+/// @content Innholdet plasseres i et media query som matcher hvis høykontrasttema er i bruk
+///
+@mixin forced-colors-mode {
+    @media screen and (forced-colors: active) {
+        @content;
+    }
+}
+
+$_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "GrayText");
+///
+/// Hjelper for å sette riktig farge på SVGer i Chrome for brukere med Forced Color-modus.
+/// Se https://melanie-richards.com/blog/currentcolor-svg-hcm/ for detaljer
+///
+/// @param {"LinkText" | "ButtonText" | "CanvasText" | "GrayText"} $color - Definer hvilken systemfarge som skal brukes. Fargene har en forventet betydning for brukeren. Følg den semantiske betydningen til fargen, ikke velg fargen du selv synes "ser best ut".
+///
+@mixin forced-colors-svg-fallback($color) {
+    @if not list.index($_valid-forced-colors-text-values, $color) {
+        @error "#{$color} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
+    }
+
+    @media screen and (forced-colors: active) {
+        stroke: $color;
+        fill: $color;
     }
 }
 

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -30,6 +30,7 @@
 ///
 /// Brukes til å overstyre stiler for bruk i Forced Colors-modus.
 /// Her vil du typisk legge til fallbacks for manglende box-shadow,
+/// som for eksempel `outline: unset;` og `border: unset;`,
 /// og eventuelle andre problemer som oppstår for brukere av høykontrasttemaer.
 /// Se https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
 /// og https://www.smashingmagazine.com/2022/03/windows-high-contrast-colors-mode-css-custom-properties/

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -158,17 +158,17 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
     // Reset alt som er gjort over hvis brukeren har på forced-colors.
     // Da mister vi box-shadow og er avhengig av at borders og outlines synes.
     @include forced-colors-mode {
-        outline: initial;
-        border-style: initial;
-        outline-style: initial;
+        outline: unset;
+        border-style: unset;
+        outline-style: unset;
 
         &:active,
         &:hover,
         &:focus,
         &:link,
         &:visited {
-            outline: initial !important;
-            outline-style: initial;
+            outline: unset !important;
+            outline-style: unset;
         }
 
         /* Remove the inner border and padding in Firefox */
@@ -176,7 +176,7 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
         [type="button"]::-moz-focus-inner,
         [type="reset"]::-moz-focus-inner,
         [type="submit"]::-moz-focus-inner {
-            border-style: initial;
+            border-style: unset;
         }
 
         /* Remove dotted lines around object, especially for firefox */
@@ -185,25 +185,25 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
         a:focus,
         a:link,
         a:visited {
-            outline: initial !important;
-            outline-style: initial;
+            outline: unset !important;
+            outline-style: unset;
         }
 
         button,
         object,
         embed {
-            outline: initial;
+            outline: unset;
         }
 
         /* All Input elements */
         input::-moz-focus-inner {
-            outline: initial;
+            outline: unset;
         }
 
         /* Or more specifically */
         input[type="submit"]::-moz-focus-inner,
         input[type="button"]::-moz-focus-inner {
-            outline: initial;
+            outline: unset;
         }
     }
 }

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -58,6 +58,12 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
     @media screen and (forced-colors: active) {
         stroke: $color;
         fill: $color;
+
+        & svg,
+        & path {
+            stroke: $color;
+            fill: $color;
+        }
     }
 }
 

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -43,26 +43,36 @@
     }
 }
 
-$_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "GrayText");
+$_valid-forced-colors-text-values: ("LinkText", "ButtonText", "ButtonFace", "CanvasText", "GrayText");
 ///
 /// Hjelper for å sette riktig farge på SVGer i Chrome for brukere med Forced Color-modus.
 /// Se https://melanie-richards.com/blog/currentcolor-svg-hcm/ for detaljer
 ///
-/// @param {"LinkText" | "ButtonText" | "CanvasText" | "GrayText"} $color - Definer hvilken systemfarge som skal brukes. Fargene har en forventet betydning for brukeren. Følg den semantiske betydningen til fargen, ikke velg fargen du selv synes "ser best ut".
+/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $color - Definer hvilken systemfarge som skal brukes. Fargene har en forventet betydning for brukeren. Følg den semantiske betydningen til fargen, ikke velg fargen du selv synes "ser best ut".
+/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $fill [$color - Hvis du trenger ulik fill og stroke. Bruker default $color.
+/// @param {"LinkText" | "ButtonText" | "ButtonFace" | "CanvasText" | "GrayText"} $stroke [$color] - Hvis du trenger ulik fill og stroke. Bruker default $color.
 ///
-@mixin forced-colors-svg-fallback($color) {
+@mixin forced-colors-svg-fallback($color, $fill: $color, $stroke: $color) {
     @if not list.index($_valid-forced-colors-text-values, $color) {
         @error "#{$color} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
     }
 
+    @if not list.index($_valid-forced-colors-text-values, $stroke) {
+        @error "#{$stroke} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
+    }
+
+    @if not list.index($_valid-forced-colors-text-values, $fill) {
+        @error "#{$fill} will not be used in Forced Color mode. Valid options are: #{$_valid-forced-colors-text-values}. Use the correct color for your given context.";
+    }
+
     @media screen and (forced-colors: active) {
-        stroke: $color;
-        fill: $color;
+        stroke: $stroke;
+        fill: $fill;
 
         & svg,
         & path {
-            stroke: $color;
-            fill: $color;
+            stroke: $stroke;
+            fill: $fill;
         }
     }
 }

--- a/packages/core/mixins/_helpers.scss
+++ b/packages/core/mixins/_helpers.scss
@@ -154,6 +154,58 @@ $_valid-forced-colors-text-values: ("LinkText", "ButtonText", "CanvasText", "Gra
     input[type="button"]::-moz-focus-inner {
         outline: 0;
     }
+
+    // Reset alt som er gjort over hvis brukeren har på forced-colors.
+    // Da mister vi box-shadow og er avhengig av at borders og outlines synes.
+    @include forced-colors-mode {
+        outline: initial;
+        border-style: initial;
+        outline-style: initial;
+
+        &:active,
+        &:hover,
+        &:focus,
+        &:link,
+        &:visited {
+            outline: initial !important;
+            outline-style: initial;
+        }
+
+        /* Remove the inner border and padding in Firefox */
+        button::-moz-focus-inner,
+        [type="button"]::-moz-focus-inner,
+        [type="reset"]::-moz-focus-inner,
+        [type="submit"]::-moz-focus-inner {
+            border-style: initial;
+        }
+
+        /* Remove dotted lines around object, especially for firefox */
+        a:hover,
+        a:active,
+        a:focus,
+        a:link,
+        a:visited {
+            outline: initial !important;
+            outline-style: initial;
+        }
+
+        button,
+        object,
+        embed {
+            outline: initial;
+        }
+
+        /* All Input elements */
+        input::-moz-focus-inner {
+            outline: initial;
+        }
+
+        /* Or more specifically */
+        input[type="submit"]::-moz-focus-inner,
+        input[type="button"]::-moz-focus-inner {
+            outline: initial;
+        }
+    }
 }
 
 ///

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -122,6 +122,10 @@ $calendar-width: ($date-width * 7) + ($date-spacing * 6) + ($calendar-padding * 
     &__padding {
         padding: $calendar-padding;
         box-sizing: border-box;
+
+        @include jkl.helper-forced-colors-mode {
+            border: 1px solid CanvasText;
+        }
     }
 
     @include small-device {

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -24,7 +24,7 @@
     }
 
     & .jkl-text-input__action-button {
-        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText, $fill: ButtonFace);
+        @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText, $fill: ButtonFace);
     }
 
     &__calendar-wrapper {

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -23,6 +23,10 @@
         padding-top: rem(10px);
     }
 
+    & .jkl-text-input__action-button {
+        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText, $fill: ButtonFace);
+    }
+
     &__calendar-wrapper {
         position: absolute;
         top: calc(100% + #{rem(14px)});

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -156,7 +156,6 @@ $calendar-width: ($date-width * 7) + ($date-spacing * 6) + ($calendar-padding * 
         align-items: center;
         background-color: transparent;
         color: var(--calendar-text-color);
-        border: none;
         width: rem(32px);
         border-radius: 50%;
         @include jkl.text-style("body/large-screen");
@@ -257,8 +256,6 @@ $calendar-width: ($date-width * 7) + ($date-spacing * 6) + ($calendar-padding * 
     td button {
         @include reset-outline;
         appearance: none;
-        border: 0;
-        outline: none;
         position: relative;
 
         box-sizing: border-box;

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -101,6 +101,17 @@ $focus-ring-width: jkl.rem(2px);
         .jkl-icon--small {
             --jkl-icon-width: #{$arrow-width};
         }
+
+        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        &,
+        &::after {
+            border-top-style: none;
+            border-right-style: none;
+            border-left-style: none;
+        }
     }
 }
 

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -102,7 +102,7 @@ $focus-ring-width: jkl.rem(2px);
             --jkl-icon-width: #{$arrow-width};
         }
 
-        @include jkl.helper-forced-colors-svg-fallback($color: ButtonText);
+        @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
     }
 
     @include jkl.helper-forced-colors-mode {

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -72,6 +72,8 @@ $max-feedback-input-width: 30rem;
     @include motion;
     transition-property: transform, color;
 
+    @include jkl.helper-forced-colors-svg-fallback($color: ButtonFace, $fill: ButtonText);
+
     &::before,
     &::after {
         content: "";

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -72,7 +72,7 @@ $max-feedback-input-width: 30rem;
     @include motion;
     transition-property: transform, color;
 
-    @include jkl.helper-forced-colors-svg-fallback($color: ButtonFace, $fill: ButtonText);
+    @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonFace, $fill: ButtonText);
 
     &::before,
     &::after {

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -20,8 +20,6 @@ $hamburger-line-spacing: rem(-8px);
 
 .jkl-hamburger {
     @include reset-outline;
-    border: none;
-    outline: none;
     cursor: pointer;
     background-color: transparent;
     height: $bounding-touch-size;

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -72,6 +72,10 @@ $hamburger-line-spacing: rem(-8px);
         transition-property: background-color, transform, top, bottom;
 
         @include motion(standard, expressive);
+
+        @include jkl.helper-forced-colors-mode {
+            background-color: ButtonText;
+        }
     }
 
     &:hover {

--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -7,6 +7,8 @@
     cursor: pointer;
     color: inherit;
 
+    @include forced-colors-svg-fallback($color: ButtonText);
+
     &__icon {
         display: inline-block;
         width: rem(20px);

--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -7,7 +7,7 @@
     cursor: pointer;
     color: inherit;
 
-    @include forced-colors-svg-fallback($color: ButtonText);
+    @include forced-colors-svg-fallback($stroke: ButtonText);
 
     &__icon {
         display: inline-block;

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -126,4 +126,24 @@ $list-check-color--inverted: jkl.$color-suksess--darkbg;
             background-image: var(--jkl-list-marker--cross);
         }
     }
+
+    @include jkl.helper-forced-colors-mode {
+        &:not(.jkl-list--ordered) > .jkl-list__item:not(.jkl-list__item--iconed) {
+            list-style: disc solid-diamond(CanvasText);
+        }
+
+        & &:not(.jkl-list--ordered, .jkl-list--iconed) > .jkl-list__item:not(.jkl-list__item--iconed) {
+            list-style: disc outline-diamond(CanvasText);
+        }
+
+        & .jkl-list__item {
+            &--check::before {
+                background-image: check(CanvasText, Canvas);
+            }
+
+            &--cross::before {
+                background-image: cross(CanvasText);
+            }
+        }
+    }
 }

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -49,7 +49,6 @@ $list-check-color--inverted: jkl.$color-suksess--darkbg;
 }
 
 .jkl-list {
-    list-style: disc solid-diamond($list-text-color);
     list-style: disc var(--jkl-list-marker--default);
     padding-left: $list-padding-left;
 
@@ -70,7 +69,6 @@ $list-check-color--inverted: jkl.$color-suksess--darkbg;
     }
 
     & & > .jkl-list__item {
-        list-style: disc outline-diamond($list-text-color);
         list-style: disc var(--jkl-list-marker--secondary);
         margin: 0;
 
@@ -94,12 +92,10 @@ $list-check-color--inverted: jkl.$color-suksess--darkbg;
     }
 
     &__item {
-        color: $list-text-color;
         color: var(--list-text-color);
         padding-left: jkl.rem(4px);
 
         &::marker {
-            color: $list-text-color;
             color: var(--list-text-color);
         }
 
@@ -122,13 +118,11 @@ $list-check-color--inverted: jkl.$color-suksess--darkbg;
 
         &--check::before {
             @include jkl.decorative($content: "\2713");
-            background-image: check($list-check-color, $list-text-color--inverted);
             background-image: var(--jkl-list-marker--check);
         }
 
         &--cross::before {
             @include jkl.decorative($content: "\274C");
-            background-image: cross($list-cross-color);
             background-image: var(--jkl-list-marker--cross);
         }
     }

--- a/packages/loader/loader.scss
+++ b/packages/loader/loader.scss
@@ -40,6 +40,9 @@ $loader-animation-properties: 2500ms linear infinite;
         &--right {
             animation-name: spin-right;
         }
+        @include jkl.helper-forced-colors-mode {
+            background-color: CanvasText;
+        }
     }
 
     &--medium > .jkl-loader__dot {

--- a/packages/logo/logo.scss
+++ b/packages/logo/logo.scss
@@ -15,7 +15,7 @@ $jkl-logo-magic-origin--line: 34.3px; /* Must be the same as the line x1 origin,
     color: var(--logo-color);
 
     // I valget mellom å følge merkevaren og å være lesbar velger vi å være lesbar.
-    @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
+    @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
 
     &__F {
         transform-origin: $jkl-logo-magic-origin--f;
@@ -70,7 +70,7 @@ $jkl-logo-magic-origin--line: 34.3px; /* Must be the same as the line x1 origin,
     color: var(--logo-stamp-color);
 
     // I valget mellom å følge merkevaren og å være lesbar velger vi å være lesbar.
-    @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
+    @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
 
     &--animated {
         .jkl-logo-stamp__text {

--- a/packages/logo/logo.scss
+++ b/packages/logo/logo.scss
@@ -14,6 +14,9 @@ $jkl-logo-magic-origin--line: 34.3px; /* Must be the same as the line x1 origin,
 .jkl-logo {
     color: var(--logo-color);
 
+    // I valget mellom å følge merkevaren og å være lesbar velger vi å være lesbar.
+    @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
+
     &__F {
         transform-origin: $jkl-logo-magic-origin--f;
 
@@ -65,6 +68,9 @@ $jkl-logo-magic-origin--line: 34.3px; /* Must be the same as the line x1 origin,
 
 .jkl-logo-stamp {
     color: var(--logo-stamp-color);
+
+    // I valget mellom å følge merkevaren og å være lesbar velger vi å være lesbar.
+    @include jkl.helper-forced-colors-svg-fallback($color: CanvasText);
 
     &--animated {
         .jkl-logo-stamp__text {

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -161,7 +161,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
     }
 
     @include jkl.helper-forced-colors-mode {
-        border: 4px solid CanvasText;
+        border: 2px solid CanvasText;
 
         &--info {
             border-style: dotted;
@@ -173,6 +173,7 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
 
         &--error {
             border-style: double;
+            border-width: 4px;
         }
     }
 

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -35,6 +35,8 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         position: absolute;
         left: jkl.$spacing-m;
         height: rem(24px);
+
+        @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
     }
 
     &__content {
@@ -72,8 +74,18 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         align-self: flex-start;
         flex-shrink: 0;
 
+        @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
+        @include jkl.helper-forced-colors-mode {
+            background-color: ButtonFace;
+            margin-top: rem(-1px);
+            width: rem(32px);
+            height: rem(32px);
+            padding: rem(4px);
+        }
+
         &:hover {
             color: $dismiss-hover-color;
+            @include jkl.helper-forced-colors-svg-fallback($stroke: ButtonText);
         }
 
         &:focus {
@@ -146,6 +158,22 @@ $bg-color--advarsel: colors.varslingsfarge("advarsel");
         animation: dismiss-animation $dismiss-animation-duration ease-in-out forwards;
         transition: visibility 0ms $dismiss-animation-duration;
         visibility: hidden;
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        border: 4px solid CanvasText;
+
+        &--info {
+            border-style: dotted;
+        }
+
+        &--warning {
+            border-style: dashed;
+        }
+
+        &--error {
+            border-style: double;
+        }
     }
 
     @include small-device {

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -60,6 +60,10 @@ $radio-button-dot-padding--compact: rem(3px);
             + .jkl-radio-button__label > .jkl-radio-button__dot::after {
                 animation: dot-in 150ms ease;
                 background-color: currentColor;
+
+                @include jkl.helper-forced-colors-mode {
+                    background-color: Highlight;
+                }
             }
 
             .jkl-radio-button--error & + .jkl-radio-button__label > .jkl-radio-button__dot::after {
@@ -74,6 +78,10 @@ $radio-button-dot-padding--compact: rem(3px);
 
                 & > .jkl-radio-button__dot::before {
                     box-shadow: 0 0 0 rem(2px) var(--radio-button-focus-color);
+
+                    @include jkl.helper-forced-colors-mode {
+                        border: 4px double ButtonText;
+                    }
                 }
             }
         }
@@ -91,6 +99,17 @@ $radio-button-dot-padding--compact: rem(3px);
 
             & > .jkl-radio-button__dot {
                 box-shadow: inset 0 0 0 rem(1px) currentColor, 0 0 0 rem(1px) currentColor;
+
+                @include jkl.helper-forced-colors-mode {
+                    &::before {
+                        border: 2px solid ButtonText;
+                        position: absolute;
+                        top: rem(-1px);
+                        right: rem(-1px);
+                        bottom: rem(-1px);
+                        left: rem(-1px);
+                    }
+                }
             }
         }
 
@@ -139,6 +158,11 @@ $radio-button-dot-padding--compact: rem(3px);
 
             @include motion;
             transition-property: transform;
+
+            @include jkl.helper-forced-colors-mode {
+                top: rem(3px);
+                left: rem(3px);
+            }
         }
 
         // Focus ring
@@ -152,6 +176,11 @@ $radio-button-dot-padding--compact: rem(3px);
             border-radius: 50%;
 
             box-shadow: 0 0 0 rem(1px) transparent;
+        }
+
+        @include jkl.helper-forced-colors-mode {
+            outline: unset;
+            border: 1px solid ButtonText;
         }
     }
 
@@ -193,6 +222,11 @@ $radio-button-dot-padding--compact: rem(3px);
                 top: $radio-button-dot-padding--compact;
                 height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
                 width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+
+                @include jkl.helper-forced-colors-mode {
+                    top: rem(2.35px);
+                    left: rem(2px);
+                }
             }
         }
     }
@@ -216,6 +250,11 @@ $radio-button-dot-padding--compact: rem(3px);
                 top: $radio-button-dot-padding--compact;
                 height: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
                 width: $radio-button-size--compact - (2 * $radio-button-dot-padding--compact);
+
+                @include jkl.helper-forced-colors-mode {
+                    top: rem(2.35px);
+                    left: rem(2px);
+                }
             }
         }
     }

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -179,7 +179,7 @@ $radio-button-dot-padding--compact: rem(3px);
         }
 
         @include jkl.helper-forced-colors-mode {
-            outline: unset;
+            outline: revert;
             border: 1px solid ButtonText;
         }
     }

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -303,6 +303,35 @@ $select-search-input-selection-color--inverted: color.scale(
             min-height: rem(40px);
         }
     }
+
+    @include jkl.helper-forced-colors-mode {
+        // Vi er en button (hvis ikke native) og får ButtonText, men vi later som vi er en select, og den har CanvasText
+        & .jkl-select__button,
+        & .jkl-select__search-input {
+            color: CanvasText;
+            border: 2px solid ButtonText;
+            background-color: Canvas;
+            outline: revert;
+
+            &:hover {
+                border-color: Highlight;
+            }
+        }
+
+        & .jkl-select__option {
+            color: CanvasText;
+
+            border-top: 1px solid Canvas;
+            border-bottom: 1px solid Canvas;
+
+            &:hover,
+            &:focus {
+                @include no-grow-bold;
+                border-top: 1px solid Highlight;
+                border-bottom: 1px solid Highlight;
+            }
+        }
+    }
 }
 
 .jkl-expand-arrow {
@@ -315,6 +344,8 @@ $select-search-input-selection-color--inverted: color.scale(
 
     @include motion;
     transition-property: transform, color;
+
+    @include jkl.helper-forced-colors-svg-fallback($stroke: CanvasText);
 
     &__up,
     &__down {

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -150,6 +150,11 @@ $focus-ring-width: jkl.rem(2px);
 
         @include jkl.helper-forced-colors-mode {
             outline: revert;
+            color: ButtonText;
+
+            &:hover {
+                background-color: ButtonFace;
+            }
         }
     }
 
@@ -158,6 +163,10 @@ $focus-ring-width: jkl.rem(2px);
 
         &.jkl-table-row--expandable + [aria-hidden="false"] {
             background-color: var(--table-row-highlight-color);
+        }
+
+        @include jkl.helper-forced-colors-mode {
+            background-color: ButtonFace;
         }
     }
 }

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -149,7 +149,7 @@ $focus-ring-width: jkl.rem(2px);
         }
 
         @include jkl.helper-forced-colors-mode {
-            outline: unset;
+            outline: revert;
         }
     }
 

--- a/packages/table/table-row.scss
+++ b/packages/table/table-row.scss
@@ -147,6 +147,10 @@ $focus-ring-width: jkl.rem(2px);
         .jkl-table--collapse-to-list[data-collapse] :not(thead) > &:hover {
             @include responsive-table-row--hover;
         }
+
+        @include jkl.helper-forced-colors-mode {
+            outline: unset;
+        }
     }
 
     &--clicked {

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -57,6 +57,6 @@
     }
 
     @include jkl.helper-forced-colors-mode {
-        border: unset;
+        border: revert;
     }
 }

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -55,4 +55,8 @@
     &[aria-selected="true"] {
         @include no-grow-bold;
     }
+
+    @include jkl.helper-forced-colors-mode {
+        border: unset;
+    }
 }

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -31,6 +31,14 @@
         @include motion("standard", "lazy");
         transition-property: left, width;
         will-change: left, width;
+
+        @include jkl.helper-forced-colors-mode {
+            background-color: Highlight;
+        }
+    }
+
+    @include jkl.helper-forced-colors-mode {
+        border-color: GreyText;
     }
 }
 
@@ -54,9 +62,5 @@
 
     &[aria-selected="true"] {
         @include no-grow-bold;
-    }
-
-    @include jkl.helper-forced-colors-mode {
-        border: revert;
     }
 }

--- a/packages/tag/tag.scss
+++ b/packages/tag/tag.scss
@@ -33,4 +33,26 @@ $tag-background-color--warning: colors.varslingsfarge("advarsel");
     &--success {
         background-color: $tag-background-color--success;
     }
+
+    @include jkl.helper-forced-colors-mode {
+        border: 2px none CanvasText;
+        border-bottom-style: dotted;
+
+        &--info {
+            border-style: dotted;
+        }
+
+        &--warning {
+            border-style: dashed;
+        }
+
+        &--error {
+            border-style: double;
+            border-width: 4px;
+        }
+
+        &--success {
+            border-style: solid;
+        }
+    }
 }

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -202,7 +202,8 @@ $text-input-selection-color--inverted: color.scale(
         }
 
         @include jkl.helper-forced-colors-mode {
-            border: unset;
+            border: revert;
+            backgroun-color: revert;
         }
     }
 

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -210,7 +210,7 @@ $text-input-selection-color--inverted: color.scale(
             background-color: revert;
         }
 
-        @include forced-colors-svg-fallback($color: ButtonText);
+        @include forced-colors-svg-fallback($stroke: ButtonText);
     }
 
     /* Modifications for inline version */

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -57,7 +57,6 @@ $text-input-selection-color--inverted: color.scale(
 }
 
 @mixin shared-input-styles {
-    border: none;
     background: none;
     -webkit-appearance: none;
 
@@ -200,6 +199,10 @@ $text-input-selection-color--inverted: color.scale(
                     box-shadow: inset 0 0 0 rem(2px) var(--text-input-focus-color);
                 }
             }
+        }
+
+        @include jkl.helper-forced-colors-mode {
+            border: unset;
         }
     }
 

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -183,6 +183,10 @@ $text-input-selection-color--inverted: color.scale(
 
         &:hover {
             color: var(--text-input-focus-color);
+
+            @include jkl.helper-forced-colors-mode {
+                border: rem(2px) inset ButtonText;
+            }
         }
 
         &:focus {
@@ -203,8 +207,10 @@ $text-input-selection-color--inverted: color.scale(
 
         @include jkl.helper-forced-colors-mode {
             border: revert;
-            backgroun-color: revert;
+            background-color: revert;
         }
+
+        @include forced-colors-svg-fallback($color: ButtonText);
     }
 
     /* Modifications for inline version */
@@ -299,6 +305,16 @@ $text-input-selection-color--inverted: color.scale(
             }
 
             @include shared-error-styles;
+
+            @include jkl.helper-forced-colors-mode {
+                // Fordi all styling med box-shadow er ut vinduet i forced-colors
+                // så er det igjen textarea som har en border. Da er det _den_
+                // som må ha padding, og her unngår vi å få dobbelt opp.
+                // Det gjør at telleren havner under textarea, men siden vi
+                // heller ikke har noen progress-bar synlig i denne modusen
+                // så er det _godt nok_.
+                padding: 0;
+            }
         }
 
         /*
@@ -327,6 +343,10 @@ $text-input-selection-color--inverted: color.scale(
             transition-property: height;
 
             @include shared-error-styles;
+
+            @include jkl.helper-forced-colors-mode {
+                padding: $text-input-padding;
+            }
         }
 
         .jkl-text-input__input[data-has-content="true"] .jkl-text-area__text-area,

--- a/packages/toggle-switch/toggle-slider.scss
+++ b/packages/toggle-switch/toggle-slider.scss
@@ -130,5 +130,13 @@ $jkl-slider-focus-ring-width: rem(2px);
                 }
             }
         }
+
+        @include jkl.helper-forced-colors-mode {
+            background-color: Canvas;
+
+            & .jkl-toggle-slider__pill {
+                background-color: ButtonFace;
+            }
+        }
     }
 }

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -157,4 +157,40 @@ $disabled-color: jkl.$color-stein;
     html:not([data-mousenavigation]) &:focus > &__slider > &__expanding-pill::after {
         box-shadow: 0 0 0 rem(2px) var(--toggle-focus-outline-color);
     }
+
+    @include jkl.helper-forced-colors-mode {
+        border: none; // Ett av få tilfeller hvor vi faktisk ikke vil ha noen border, selv i denne modusen
+        outline: revert;
+
+        overflow: hidden;
+        border-radius: 99rem;
+
+        & .jkl-toggle-switch__expanding-pill {
+            background-color: Highlight;
+        }
+
+        & .jkl-toggle-switch__slider {
+            &::before {
+                background-color: GrayText;
+            }
+            &::after {
+                background-color: ButtonText;
+            }
+        }
+
+        &:disabled {
+            .jkl-toggle-switch__expanding-pill {
+                background-color: GrayText;
+            }
+
+            .jkl-toggle-switch__slider {
+                &::before {
+                    background-color: GrayText;
+                }
+                &::after {
+                    background-color: ButtonFace;
+                }
+            }
+        }
+    }
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -83,7 +83,7 @@
         "clean:portal": "gatsby clean",
         "build:docs": "gatsby build",
         "build:test": "gatsby build && gatsby serve",
-        "dev": "GATSBY_HOT_LOADER=fast-refresh gatsby develop --host 0.0.0.0",
+        "dev": "gatsby develop --host 0.0.0.0",
         "start": "yarn dev",
         "serve": "gatsby serve"
     },

--- a/portal/src/components/DownloadAsset/DownloadAsset.scss
+++ b/portal/src/components/DownloadAsset/DownloadAsset.scss
@@ -39,6 +39,10 @@
 
         &:focus {
             outline: 0;
+
+            @include jkl.helper-forced-colors-mode {
+                outline: unset;
+            }
         }
     }
 }

--- a/portal/src/components/DownloadAsset/DownloadAsset.scss
+++ b/portal/src/components/DownloadAsset/DownloadAsset.scss
@@ -41,7 +41,7 @@
             outline: 0;
 
             @include jkl.helper-forced-colors-mode {
-                outline: unset;
+                outline: revert;
             }
         }
     }

--- a/portal/src/components/ExampleVideo/ExampleVideo.scss
+++ b/portal/src/components/ExampleVideo/ExampleVideo.scss
@@ -21,6 +21,14 @@
             }
         }
 
+        @include jkl.helper-forced-colors-mode {
+            border: unset;
+
+            &:focus {
+                outline: unset;
+            }
+        }
+
         &--play {
             background: url("./F_Play_Knapp.svg") no-repeat center;
         }

--- a/portal/src/components/ExampleVideo/ExampleVideo.scss
+++ b/portal/src/components/ExampleVideo/ExampleVideo.scss
@@ -22,10 +22,10 @@
         }
 
         @include jkl.helper-forced-colors-mode {
-            border: unset;
+            border: revert;
 
             &:focus {
-                outline: unset;
+                outline: revert;
             }
         }
 

--- a/portal/src/texts/profile/typography.mdx
+++ b/portal/src/texts/profile/typography.mdx
@@ -19,7 +19,9 @@ Vi har vår egen skrifttype: Fremtind Grotesk. Den finnes i snittene Regular, Bo
 hovedsakelig Regular og Bold. Som erstatningsfont bruker vi Calibri Light. Ikke bruk andre skrifttyper når du designer løsninger
 for Fremtind.
 
-[Last ned Fremtind Grotesk ↓](https://github.com/fremtind/jokul/tree/main/packages/webfonts/fonts)
+<a href="https://github.com/fremtind/jokul/tree/main/packages/webfonts/fonts" className="jkl-link jkl-link--external">
+    Last ned Fremtind Grotesk
+</a>
 
 ## Typografisk skala
 


### PR DESCRIPTION
Fixes #2812 

Se issuet for bakgrunn.

Jeg mangler fremdeles gå igjennom:

- Autosuggest
- useBrowserPreferences
- Mangler direkte i portalen
- Utforske muligheten for visuelle regresjonstester i forced-colors-mode, som et tillegg til lyst og mørkt tema
- Oppdatere [Test universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) med noen lærdommer, tips og triks 
- Skrive en bloggpost om hele denne øvelsen

## Hvordan du kan hjelpe

Hvis du har en Windows-maskin tilgjengelig er det en **stor** hjelp om du kan hjelpe med å teste preview branchen. Om du ikke har en Windows-maskin er det også en stor hjelp å gjøre en code review eller regresjonstest av komponentene.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/komigang/mobil) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
