### PR TITLE
fix: using React default export to avoid warnings when using react below v18

### DIFF
--- a/packages/react-hooks/src/useId.ts
+++ b/packages/react-hooks/src/useId.ts
@@ -1,5 +1,4 @@
-// @ts-ignore: wait for types to land in main
-import { useState, useId as useReactId } from "react";
+import React from "react";
 import { nanoid } from "nanoid";
 
 export interface UseIdOptions {
@@ -7,20 +6,23 @@ export interface UseIdOptions {
     generateSuffix?: boolean;
 }
 
+// @ts-ignore: wait for types to land in main
+const useReactId = React.useId;
+
 const defaultOptions: UseIdOptions = {
     generateSuffix: true,
 };
 
 const useLegacyId = (id: string, options = defaultOptions): string => {
     const elementId = options.generateSuffix ? `${id}-${nanoid(8)}` : id;
-    const [elId] = useState(elementId);
+    const [elId] = React.useState(elementId);
     return elId;
 };
 
 const useModernId = (id: string, options = defaultOptions): string => {
     const reactId = useReactId();
     const elementId = options.generateSuffix ? `${id}-${reactId}` : id;
-    const [elId] = useState(elementId);
+    const [elId] = React.useState(elementId);
     return elId;
 };
 


### PR DESCRIPTION
Fikk litt warnings ved kompiliering ved bruk av useId dersom man hadde react versjon lavere enn 18.

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
