### PR TITLE
fix: navcards on frontpage now shows correct color on text

### DIFF
--- a/portal/src/pages/index.scss
+++ b/portal/src/pages/index.scss
@@ -38,11 +38,6 @@
 
                 .jkl-portal__card-list {
                     margin-left: jkl.$spacing-3xl;
-
-                    a {
-                        text-decoration: none;
-                        color: jkl.$color-granitt;
-                    }
                 }
             }
 

--- a/portal/src/pages/index.tsx
+++ b/portal/src/pages/index.tsx
@@ -78,16 +78,25 @@ const IndexPage: React.FC = () => {
                             />
                         </div>
                         <CardList vertical>
-                            <NavCard title="Introduksjon" to="/kom-i-gang/introduksjon" component={Link}>
-                                Start her om Jøkul er nytt for deg.
-                            </NavCard>
-                            <NavCard title="For designere" to="/kom-i-gang/design" component={Link}>
-                                Branching, Variants, Auto-Layout, breakpoints, praktiske plugins, “uskrevne regler” og
-                                mer.
-                            </NavCard>
-                            <NavCard title="For utviklere" to="/kom-i-gang/utvikling" component={Link}>
-                                Om pakker, steder å finne kodeeksempler og dokumentasjon, nyttige verktøy og mer.
-                            </NavCard>
+                            <NavCard
+                                title="Introduksjon"
+                                to="/kom-i-gang/introduksjon"
+                                component={Link}
+                                description="Start her om Jøkul er nytt for deg."
+                            />
+                            <NavCard
+                                title="For designere"
+                                to="/kom-i-gang/design"
+                                component={Link}
+                                description="Branching, Variants, Auto-Layout, breakpoints, praktiske plugins, “uskrevne regler” og
+                                mer."
+                            />
+                            <NavCard
+                                title="For utviklere"
+                                to="/kom-i-gang/utvikling"
+                                component={Link}
+                                description="Om pakker, steder å finne kodeeksempler og dokumentasjon, nyttige verktøy og mer."
+                            />
                         </CardList>
                     </div>
                 </section>


### PR DESCRIPTION
Se prod på hjemmesiden. Tekstfargen er feil i navcard

## 🎯 Sjekkliste

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
