### PR TITLE
feat: uniformt API for å skjule labels visuelt, RadioButton tar children

### DIFF
--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -61,6 +61,8 @@ Avhengig av situasjonen kan det hende en knapp teknisk sett er et `<a />`-elemen
 
 ## Eksempler på bruk
 
+Du finner et [eksempel på en primærknapp brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 <PortalImage
     src="/assets/documentation/button/button-primary-loading.gif"
     caption="En primærknapp som har startet en handling og nå er i lastemodus."

--- a/packages/checkbox-react/documentation/Checkbox.mdx
+++ b/packages/checkbox-react/documentation/Checkbox.mdx
@@ -29,6 +29,8 @@ En gruppe avmerkingsbokser må ha en god overskrift, og ledeteksten til hver avm
 
 En avmerkingsboks som står alene trenger ikke noen overskrift, så lenge ledeteksten er god og beskrivende. Når en avmerkingsboks står alene, er det gjerne for å bekrefte noe, for eksempel: "Jeg bekrefter at opplysningene jeg har gitt er riktige".
 
+Du finner et [eksempel på en sjekkboks brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 <Grid>
     <DoDontExample
         type="do"

--- a/packages/core/src/components/Label.spec.tsx
+++ b/packages/core/src/components/Label.spec.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Label } from "./Label";
+import { LabelVariant } from "../types";
+
+describe("Label", () => {
+    const variants: LabelVariant[] = ["small", "medium", "large"];
+    variants.forEach((variant) => {
+        it(`renders the expected class for variant ${variant}`, () => {
+            render(<Label variant={variant}>Hello</Label>);
+            expect(screen.getByText("Hello")).toHaveClass(`jkl-label--${variant}`);
+        });
+    });
+
+    it("renders the expected class for forceCompact", () => {
+        render(<Label forceCompact>Hello</Label>);
+        expect(screen.getByText("Hello")).toHaveClass("jkl-label--compact");
+    });
+
+    it("renders the expected class for srOnly", () => {
+        render(<Label srOnly>Hello</Label>);
+        expect(screen.getByText("Hello")).toHaveClass("jkl-label--sr-only");
+    });
+});

--- a/packages/datepicker-react/documentation/Datepicker.mdx
+++ b/packages/datepicker-react/documentation/Datepicker.mdx
@@ -20,6 +20,8 @@ import { DatepickerExample, datepickerExampleKnobs, datepickerExampleCode } from
     codeExample={datepickerExampleCode}
 />
 
+Du finner et [eksempel på datovelger brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 ## Typer og bruk
 
 -   Enkel datovelger, til når brukeren skal velge en dato som er nær dagens dato

--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -509,6 +509,14 @@ describe("Datepicker", () => {
         const testAutoId = input.getAttribute("data-testautoid");
         expect(testAutoId).toEqual("jkl-datepicker__testautoid");
     });
+
+    it("supports label only for screen readers", () => {
+        const thePast = new Date(2019, 11, 24);
+        render(<DatePicker initialDate={thePast} label="Hello" labelProps={{ srOnly: true }} />);
+
+        const label = screen.getByText("Hello");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
 });
 
 describe("after user types string", () => {

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { DataTestAutoId, Label, LabelVariant, SupportLabel } from "@fremtind/jkl-core";
+import { DataTestAutoId, Label, LabelProps, LabelVariant, SupportLabel } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
 import {
     useAnimatedHeight,
@@ -35,6 +35,7 @@ type onKeyDownEventHandler = (date?: Date, e?: React.KeyboardEvent<HTMLInputElem
 interface Props extends DataTestAutoId {
     name?: string;
     label?: string;
+    labelProps?: Omit<LabelProps, "children" | "forceCompact">;
     monthLabel?: string;
     yearLabel?: string;
     placeholder?: string;
@@ -50,6 +51,7 @@ interface Props extends DataTestAutoId {
     className?: string;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     forceCompact?: boolean;
     disableBeforeDate?: Date;
@@ -66,6 +68,7 @@ export const DatePicker = forwardRef<HTMLElement, Props>(
         {
             name,
             label = "Velg dato",
+            labelProps,
             placeholder = "dd.mm.åååå",
             calendarButtonTitle,
             showCalendarLabel = calendarButtonTitle || "Åpne kalender",
@@ -198,7 +201,7 @@ export const DatePicker = forwardRef<HTMLElement, Props>(
 
         return (
             <div className={componentClassName}>
-                <Label standAlone htmlFor={inputId} variant={variant} forceCompact={forceCompact}>
+                <Label standAlone variant={variant} {...labelProps} forceCompact={forceCompact} htmlFor={inputId}>
                     {label}
                 </Label>
                 <div className={inputWrapperClassName} ref={wrapperRef} data-testid="jkl-datepicker__input-wrapper">

--- a/packages/field-group-react/documentation/FieldGroup.mdx
+++ b/packages/field-group-react/documentation/FieldGroup.mdx
@@ -28,6 +28,8 @@ import { FieldGroupExample, fieldGroupExampleCode } from "./FieldGroupExample";
     codeExample={fieldGroupExampleCode}
 />
 
+Du finner et [eksempel på et feltsett brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 ## Tekst og validering
 
 Velg størrelse på overskriften til et feltsett etter [prinsippene for skjemadesign](/profil/skjemadesign). Ha en kort og tydelig overskrift, som beskriver hva brukeren skal velge. Hvis du trenger å gi mer forklaring, kan du sette en hjelpetekst under feltsettet.

--- a/packages/field-group-react/src/FieldGroup.test.tsx
+++ b/packages/field-group-react/src/FieldGroup.test.tsx
@@ -9,6 +9,12 @@ describe("FieldGroup", () => {
 
         expect(screen.getByText("Hello")).toBeInTheDocument;
     });
+    it("supports legend only for screen readers", () => {
+        render(<FieldGroup legend="Hello" labelProps={{ srOnly: true }}></FieldGroup>);
+
+        const label = screen.getByText("Hello");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
     it("should render the correct help text", () => {
         render(<FieldGroup legend="Hello" helpLabel="Helpful text"></FieldGroup>);
 

--- a/packages/field-group-react/src/FieldGroup.tsx
+++ b/packages/field-group-react/src/FieldGroup.tsx
@@ -9,6 +9,7 @@ export interface FieldGroupProps extends DataTestAutoId, FieldsetHTMLAttributes<
     className?: string;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     forceCompact?: boolean;
 }
@@ -29,7 +30,7 @@ export const FieldGroup: FC<FieldGroupProps> = ({
     return (
         <fieldset className={componentClassName} data-testautoid={testAutoId} {...rest}>
             <legend className="jkl-field-group__legend">
-                <Label variant={variant} forceCompact={forceCompact} {...labelProps}>
+                <Label variant={variant} {...labelProps} forceCompact={forceCompact}>
                     {legend}
                 </Label>
             </legend>

--- a/packages/radio-button-react/documentation/RadioButton.mdx
+++ b/packages/radio-button-react/documentation/RadioButton.mdx
@@ -26,6 +26,8 @@ import { RadioButtonPreselectedExample, radioButtonPreselectedExampleCode } from
 
 Over radioknappene setter vi normalt inn en tydelig overskrift, som forteller hva det er brukeren skal velge mellom. Radioknappene skal alltid beskrives med en slik overskrift, men den kan i noen tilfeller skjules visuelt. I tillegg skal hver radioknapp alltid ha en kort og tydelig ledetekst til høyre for knappen, som beskriver alternativet.
 
+Du finner et [eksempel på radioknapper brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 ## Bruk
 
 En gruppe radioknapper kan enten settes opp under eller ved siden av hverandre. Det er mest brukervennlig å sette dem opp vertikalt.

--- a/packages/radio-button-react/documentation/RadioButtonExample.tsx
+++ b/packages/radio-button-react/documentation/RadioButtonExample.tsx
@@ -35,7 +35,9 @@ export const RadioButtonExample: VFC<ExampleComponentProps> = ({ boolValues, cho
             onChange={(e) => setSelectedValue(e.target.value)}
         >
             {choices.map((value) => (
-                <RadioButton key={value} label={value} value={value} />
+                <RadioButton key={value} value={value}>
+                    {value}
+                </RadioButton>
             ))}
         </RadioButtonGroup>
     );
@@ -57,7 +59,9 @@ export const radioButtonExampleCode = ({ boolValues, choiceValues }: ExampleComp
     onChange={(e) => setSelectedValue(e.target.value)}
 >
     {choices.map((value) => (
-        <RadioButton key={value} label={value} value={value} />
+        <RadioButton key={value} value={value}>
+            {value}
+        </RadioButton>
     ))}
 </RadioButtonGroup>
 `;

--- a/packages/radio-button-react/documentation/RadioButtonInputRequiredExample.tsx
+++ b/packages/radio-button-react/documentation/RadioButtonInputRequiredExample.tsx
@@ -1,9 +1,9 @@
-import React, { VFC } from "react";
+import React, { FC } from "react";
 import { LabelVariant } from "@fremtind/jkl-core";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { RadioButtonGroup, RadioButton } from "../src";
 
-export const RadioButtonInputRequiredExample: VFC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
+export const RadioButtonInputRequiredExample: FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [selectedValue, setSelectedValue] = React.useState("");
     const variant = choiceValues && choiceValues["Variant"] ? (choiceValues["Variant"] as LabelVariant) : "medium";
 
@@ -17,8 +17,8 @@ export const RadioButtonInputRequiredExample: VFC<ExampleComponentProps> = ({ bo
             value={selectedValue}
             onChange={(e) => setSelectedValue(e.target.value)}
         >
-            <RadioButton label="Ja" value="y" />
-            <RadioButton label="Nei" value="n" />
+            <RadioButton value="y">Ja</RadioButton>
+            <RadioButton value="n">Nei</RadioButton>
         </RadioButtonGroup>
     );
 };
@@ -33,7 +33,7 @@ export const radioButtonInputRequiredExampleCode = ({ boolValues, choiceValues }
     value={selectedValue}
     onChange={(e) => setSelectedValue(e.target.value)}
 >
-    <RadioButton label="Ja" value="y" />
-    <RadioButton label="Nei" value="n" />
+    <RadioButton value="y">Ja</RadioButton>
+    <RadioButton value="n">Nei</RadioButton>
 </RadioButtonGroup>
 `;

--- a/packages/radio-button-react/documentation/RadioButtonPreselectedExample.tsx
+++ b/packages/radio-button-react/documentation/RadioButtonPreselectedExample.tsx
@@ -17,7 +17,9 @@ export const RadioButtonPreselectedExample: VFC<ExampleComponentProps> = ({ bool
             onChange={(e) => setSelectedValue(e.target.value)}
         >
             {choices.map((value) => (
-                <RadioButton key={value} label={value} value={value} />
+                <RadioButton key={value} value={value}>
+                    {value}
+                </RadioButton>
             ))}
         </RadioButtonGroup>
     );
@@ -34,7 +36,7 @@ export const radioButtonPreselectedExampleCode = ({ boolValues }: ExampleCompone
     onChange={(e) => setSelectedValue(e.target.value)}
 >
     {choices.map((value) => (
-        <RadioButton key={value} label={value} value={value} />
+        <RadioButton key={value} value={value}>{value}</RadioButton>
     ))}
 </RadioButtonGroup>
 `;

--- a/packages/radio-button-react/src/RadioButton.tsx
+++ b/packages/radio-button-react/src/RadioButton.tsx
@@ -4,16 +4,18 @@ import { useId } from "@fremtind/jkl-react-hooks";
 import { useRadioGroupContext } from "./radioGroupContext";
 
 export interface RadioButtonProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "children"> {
-    label: ReactNode;
+    children?: ReactNode;
     value: string;
     /** Kan også settes på RadioButtonGroup, men settes på RadioButton f. eks. av react-hook-form */
     name?: string;
     /** Kan også settes på RadioButtonGroup, men settes på RadioButton f. eks. av react-hook-form */
     onChange?: ChangeEventHandler<HTMLInputElement>;
+    /** @deprecated Bruk children */
+    label?: ReactNode;
 }
 
 export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>((props, ref) => {
-    const { className, checked, label, value, ...rest } = props;
+    const { className, checked, children, label, value, ...rest } = props;
     const inputId = useId("jkl-radio-button");
 
     const { name, inline, invalid, forceCompact, value: selectedValue, onChange } = useRadioGroupContext();
@@ -45,7 +47,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>((props
             />
             <label data-testid="jkl-radio-button__label-tag" htmlFor={inputId} className="jkl-radio-button__label">
                 <span aria-hidden className="jkl-radio-button__dot" />
-                <span className="jkl-radio-button__text">{label}</span>
+                <span className="jkl-radio-button__text">{label || children}</span>
             </label>
         </div>
     );

--- a/packages/radio-button-react/src/RadioButtonGroup.test.tsx
+++ b/packages/radio-button-react/src/RadioButtonGroup.test.tsx
@@ -9,8 +9,8 @@ describe("RadioButtons", () => {
     it("renders a legend with the correct value", () => {
         render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy">
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         expect(screen.getByText("Er du fornøyd?")).toBeInTheDocument();
@@ -19,8 +19,8 @@ describe("RadioButtons", () => {
     it("renders radio buttons for each choice", () => {
         render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy">
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         expect(screen.getByLabelText("Ja")).toBeInTheDocument();
@@ -31,8 +31,8 @@ describe("RadioButtons", () => {
         const onChange = jest.fn();
         render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy" value="n" onChange={onChange}>
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         expect(screen.getByLabelText("Nei")).toHaveAttribute("checked");
@@ -41,8 +41,8 @@ describe("RadioButtons", () => {
     it("does not preselect a value if empty", () => {
         render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy">
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         expect(screen.getByLabelText("Ja")).not.toHaveAttribute("checked");
@@ -56,8 +56,8 @@ describe("RadioButtons", () => {
         }) as ChangeEventHandler<HTMLInputElement>);
         render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy" value={value} onChange={onChange}>
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         await act(async () => {
@@ -75,8 +75,8 @@ describe("RadioButtons", () => {
                 data-testid="jkl-radio-button-group"
                 data-testautoid="jkl-radio-button-group__testautoid"
             >
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         const component = await screen.findByTestId("jkl-radio-button-group");
@@ -88,8 +88,8 @@ describe("a11y", () => {
     test("radio buttons should be a11y compliant", async () => {
         const { container } = render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy">
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         const results = await axe(container);
@@ -99,8 +99,8 @@ describe("a11y", () => {
     test("inline radio buttons should be a11y compliant", async () => {
         const { container } = render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy" inline>
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         const results = await axe(container);
@@ -111,8 +111,8 @@ describe("a11y", () => {
     test("compact radio buttons should be a11y compliant", async () => {
         const { container } = render(
             <RadioButtonGroup legend="Er du fornøyd?" name="happy" forceCompact>
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         const results = await axe(container);
@@ -130,8 +130,8 @@ describe("a11y", () => {
                 value="n"
                 onChange={onChange}
             >
-                <RadioButton label="Ja" value="y" />
-                <RadioButton label="Nei" value="n" />
+                <RadioButton value="y">Ja</RadioButton>
+                <RadioButton value="n">Nei</RadioButton>
             </RadioButtonGroup>,
         );
         const results = await axe(container);

--- a/packages/select-react/documentation/Select.mdx
+++ b/packages/select-react/documentation/Select.mdx
@@ -19,6 +19,8 @@ Om du har fem eller færre valg kan det være bedre å bruke [Radio buttons](/ko
 
 Hvis du trenger en nedtrekksliste med mange valg, kan du også legge inn en søke- eller filtreringsfunksjon. Dersom brukeren alltid må scrolle i listen over valg er det kanskje på tide å la de søke.
 
+Du finner et [eksempel på en nedtrekksliste brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 ## Tekst og validering
 
 Bruk [prinsippene for skjemadesign](/profil/skjemadesign) til å velge størrelse på overskriften til listen. Lag en kort og tydelig tekst, som forteller hva det er brukeren skal gjøre i nedtrekkslisten. Hvis det trengs, kan du legge en hjelpetekst under listen for å forklare mer.

--- a/packages/select-react/src/NativeSelect.test.tsx
+++ b/packages/select-react/src/NativeSelect.test.tsx
@@ -47,6 +47,13 @@ describe("NativeSelect", () => {
 
         expect(screen.getByTestId("jkl-select")).toHaveClass("jkl-select--compact");
     });
+
+    it("supports labels only for screen readers", () => {
+        render(<NativeSelect name="count" items={["1", "2"]} label="test" labelProps={{ srOnly: true }} />);
+
+        const label = screen.getByText("test");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
 });
 
 describe("a11y", () => {

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { FocusEventHandler, ChangeEventHandler, forwardRef } from "react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair } from "@fremtind/jkl-core";
+import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair, LabelProps } from "@fremtind/jkl-core";
 import cn from "classnames";
 import { ExpandArrow } from "./ExpandArrow";
 
@@ -8,11 +8,13 @@ export interface NativeSelectProps {
     id?: string;
     name?: string;
     label: string;
+    labelProps?: Omit<LabelProps, "children" | "forceCompact" | "standAlone">;
     items: Array<string | ValuePair>;
     className?: string;
     inline?: boolean;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     placeholder?: string;
     value?: string;
@@ -28,6 +30,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         {
             id,
             label,
+            labelProps,
             items,
             className = "",
             inline = false,
@@ -53,7 +56,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
                     "jkl-select--invalid": !!errorLabel,
                 })}
             >
-                <Label standAlone htmlFor={uid} variant={variant} forceCompact={forceCompact}>
+                <Label variant={variant} {...labelProps} standAlone htmlFor={uid} forceCompact={forceCompact}>
                     {label}
                 </Label>
                 <div className="jkl-select__outer-wrapper" style={{ width }}>

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -243,6 +243,13 @@ describe("Select", () => {
 
         expect(screen.getByTestId("jkl-select__button")).toHaveTextContent("Item 2");
     });
+
+    it("supports labels only for screen readers", () => {
+        render(<Select name="count" items={["1", "2"]} label="test" labelProps={{ srOnly: true }} />);
+
+        const label = screen.getByText("test");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
 });
 
 describe("Searchable select", () => {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -9,7 +9,15 @@ import React, {
     useCallback,
     useMemo,
 } from "react";
-import { Label, LabelVariant, SupportLabel, ValuePair, getValuePair, DataTestAutoId } from "@fremtind/jkl-core";
+import {
+    Label,
+    LabelVariant,
+    SupportLabel,
+    ValuePair,
+    getValuePair,
+    DataTestAutoId,
+    LabelProps,
+} from "@fremtind/jkl-core";
 import { useId, useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import { useListNavigation } from "./useListNavigation";
 import cn from "classnames";
@@ -38,6 +46,7 @@ export interface SelectProps extends DataTestAutoId {
     id?: string;
     name: string;
     label: string;
+    labelProps?: Omit<LabelProps, "children" | "forceCompact" | "standAlone">;
     items: Array<string | ValuePair>;
     /**
      * @default false
@@ -51,6 +60,7 @@ export interface SelectProps extends DataTestAutoId {
     value?: string;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     /**
      * @default false
@@ -71,6 +81,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             items,
             value,
             label,
+            labelProps,
             onChange,
             onBlur,
             onFocus,
@@ -274,11 +285,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                 {...rest}
             >
                 <Label
-                    standAlone={isSearchable} // Use <label> as the element when isSearchable=true for accessibility
-                    htmlFor={isSearchable ? searchInputId : undefined}
                     variant={variant}
+                    {...labelProps}
+                    standAlone={isSearchable} // Use <label> as the element when isSearchable=true for accessibility
+                    htmlFor={isSearchable ? searchInputId : labelProps?.htmlFor}
+                    srOnly={inline || labelProps?.srOnly}
                     forceCompact={forceCompact}
-                    srOnly={inline}
                 >
                     {label}
                 </Label>

--- a/packages/text-input-react/documentation/TextInput.mdx
+++ b/packages/text-input-react/documentation/TextInput.mdx
@@ -39,6 +39,8 @@ import { TextAreaExample, textAreaExampleCode } from "./TextAreaExample";
 Innholdet i tekstfelt kan være fritekst eller begrenses til et fast format, for eksempel fire siffer for postnummer eller at en e-postadresse må ha en alfakrøll og et toppdomene.
 Vi har en variant av tekstfelt kalt <i>inline</i>. Denne er til spesialtilfeller, hvis vi for eksempel trenger å plassere et tekstfelt i en setning.
 
+Du finner et [eksempel på tekstfelt brukt i skjemakontekst](/eksempler/skjemavalidering/) under Profil og Skjemadesign. [Koden til eksempelet](https://github.com/fremtind/jokul/blob/main/portal/src/pages/eksempler/skjemavalidering.tsx) finner du på GitHub.
+
 **Tekstområder:** brukes til fritekstfelter hvor det forventes å kunne komme mer enn én setning.
 
 <ComponentExample

--- a/packages/text-input-react/src/TextArea.test.tsx
+++ b/packages/text-input-react/src/TextArea.test.tsx
@@ -16,6 +16,13 @@ describe("TextArea", () => {
         const component = screen.getByTestId("jkl-text-area");
         expect(component).toHaveClass("test-class");
     });
+
+    it("supports labels only for screen readers", () => {
+        render(<TextArea label="testing" labelProps={{ srOnly: true }} />);
+
+        const label = screen.getByText("testing");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
 });
 
 describe("a11y", () => {

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, FocusEvent, useRef, useState, useEffect, RefObject } from "react";
 import cn from "classnames";
 import { useId } from "@fremtind/jkl-react-hooks";
-import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
+import { Label, SupportLabel, LabelVariant, LabelProps } from "@fremtind/jkl-core";
 import { BaseProps } from "./BaseInputField";
 
 type Counter = {
@@ -28,8 +28,10 @@ export interface Props extends BaseProps {
     /** @deprecated Foretrekk counter-propen sin maxLength for å la brukerne fullføre en tankerekke før de redigerer seg innenfor maksgrensen */
     maxLength?: number;
     label: string;
+    labelProps?: Omit<LabelProps, "children" | "forceCompact" | "standAlone">;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     forceCompact?: boolean;
     /** Sett antall rader skjemafeltet ekspanderes til ved focus. Innholdet scroller om feltet fylles med mer innhold enn det er plass til. */
@@ -46,6 +48,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
         id,
         variant,
         label,
+        labelProps,
         className,
         helpLabel,
         errorLabel,
@@ -126,7 +129,14 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
 
     return (
         <div data-testid="jkl-text-area" className={componentClassName}>
-            <Label standAlone htmlFor={uid} srOnly={inline} variant={variant} forceCompact={forceCompact}>
+            <Label
+                variant={variant}
+                {...labelProps}
+                standAlone
+                srOnly={inline || labelProps?.srOnly}
+                forceCompact={forceCompact}
+                htmlFor={uid}
+            >
                 {label}
             </Label>
             {!counter && (

--- a/packages/text-input-react/src/TextInput.test.tsx
+++ b/packages/text-input-react/src/TextInput.test.tsx
@@ -112,6 +112,13 @@ describe("TextInput", () => {
             expect(component).toHaveClass("jkl-text-input--inline");
         });
     });
+
+    it("supports labels only for screen readers", () => {
+        render(<TextInput label="testing" labelProps={{ srOnly: true }} />);
+
+        const label = screen.getByText("testing");
+        expect(label).toHaveClass("jkl-label--sr-only");
+    });
 });
 
 describe("a11y", () => {

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, ButtonHTMLAttributes, MouseEventHandler } from "react";
 import classNames from "classnames";
 import { useId } from "@fremtind/jkl-react-hooks";
-import { Label, SupportLabel, LabelVariant } from "@fremtind/jkl-core";
+import { Label, SupportLabel, LabelVariant, LabelProps } from "@fremtind/jkl-core";
 import { IconButton, IconVariant } from "@fremtind/jkl-icon-button-react";
 import { BaseInputField, BaseProps } from "./BaseInputField";
 
@@ -13,8 +13,10 @@ export interface Action extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>,
 
 export interface Props extends BaseProps {
     label: string;
+    labelProps?: Omit<LabelProps, "children" | "forceCompact" | "standAlone">;
     helpLabel?: string;
     errorLabel?: string;
+    /** @deprecated Bruk `labelProps.variant`  */
     variant?: LabelVariant;
     "data-testautoid"?: string;
     forceCompact?: boolean;
@@ -28,6 +30,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
             id,
             className,
             label,
+            labelProps,
             helpLabel,
             errorLabel,
             variant,
@@ -54,7 +57,14 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
         );
         return (
             <div data-testid="jkl-text-input" className={componentClassName}>
-                <Label forceCompact={forceCompact} standAlone srOnly={inline} htmlFor={uid} variant={variant}>
+                <Label
+                    variant={variant}
+                    {...labelProps}
+                    srOnly={inline || labelProps?.srOnly}
+                    standAlone
+                    forceCompact={forceCompact}
+                    htmlFor={uid}
+                >
                     {label}
                 </Label>
                 <div className="jkl-text-input__input-wrapper">

--- a/packages/text-input-react/src/autosuggest/Autosuggest.test.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.test.tsx
@@ -1,33 +1,29 @@
 import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 
-import { Autosuggest } from "./Autosuggest";
+import { Autosuggest, AutosuggestProps } from "./Autosuggest";
 
-interface Props {
-    onChange?: (item: string) => void;
-    allItems?: string[];
-    maxNumberOfHits?: number;
-}
-
-const defaultProps = {
-    label: "Velg land",
-    onChange: () => null,
-    allItems: [
-        "Afghanistan",
-        "Aland Islands",
-        "Algeria",
-        "Australia",
-        "Austria",
-        "Bahrain",
-        "Bangladesh",
-        "Benin",
-        "Bermuda",
-        "Bhutan",
-    ],
-    value: "",
-};
-
-const renderMount = (props?: Props) => render(<Autosuggest {...defaultProps} {...props} />);
+const renderMount = (props?: Partial<AutosuggestProps>) =>
+    render(
+        <Autosuggest
+            label="Velg land"
+            onChange={() => null}
+            allItems={[
+                "Afghanistan",
+                "Aland Islands",
+                "Algeria",
+                "Australia",
+                "Austria",
+                "Bahrain",
+                "Bangladesh",
+                "Benin",
+                "Bermuda",
+                "Bhutan",
+            ]}
+            value=""
+            {...(props as unknown)}
+        />,
+    );
 
 describe("Autosuggest", () => {
     it("renders with menu closed by default", () => {
@@ -74,5 +70,12 @@ describe("Autosuggest", () => {
         expect(items[1]).toHaveTextContent("argentina");
         // 3. Starts with
         expect(items[2]).toHaveTextContent("Argentina the country");
+    });
+
+    it("supports labels only for screen readers", () => {
+        const { getByText } = renderMount({ labelProps: { srOnly: true } });
+
+        const label = getByText("Velg land");
+        expect(label).toHaveClass("jkl-label--sr-only");
     });
 });

--- a/packages/text-input-react/src/autosuggest/Autosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.tsx
@@ -1,3 +1,4 @@
+import { LabelProps } from "@fremtind/jkl-core";
 import { StateChangeOptions } from "downshift";
 import React, { ReactNode, useEffect, useState } from "react";
 import BaseAutosuggest from "./BaseAutosuggest";
@@ -6,11 +7,13 @@ import { filter } from "./utils";
 export type CommonProps = (
     | {
           label: string;
+          labelProps?: Omit<LabelProps, "children" | "standAlone">;
           inputId?: null;
           labelId?: null;
       }
     | {
           label?: null;
+          labelProps?: null;
           inputId: string;
           labelId: string;
       }

--- a/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Downshift, { DownshiftProps } from "downshift";
 import cn from "classnames";
-import { SupportLabel } from "@fremtind/jkl-core";
+import { Label, SupportLabel } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
 import { CommonProps } from "./Autosuggest";
 import ControllerButton from "./ControllerButton";
@@ -20,6 +20,7 @@ type BaseAutosuggestProps<T> = CommonProps & {
 function BaseAutosuggest<T>({
     className = "",
     label,
+    labelProps,
     inputId,
     labelId,
     leadText,
@@ -65,14 +66,16 @@ function BaseAutosuggest<T>({
                 return (
                     <div className={`jkl-autosuggest ${className}`}>
                         {label && (
-                            <label
+                            <Label
+                                variant={variant}
+                                {...labelProps}
                                 {...getLabelProps({
                                     id: lid,
-                                    className: `jkl-label jkl-label--${variant}`,
                                 })}
+                                standAlone
                             >
                                 {label}
-                            </label>
+                            </Label>
                         )}
                         {leadText && <p className="jkl-body jkl-spacing-l--bottom">{leadText}</p>}
                         <div

--- a/portal/src/texts/blog/updates/april-2022.mdx
+++ b/portal/src/texts/blog/updates/april-2022.mdx
@@ -15,6 +15,7 @@ import { Link } from "gatsby";
     -   TextInput og TextArea er responsive igjen
     -   Ditto navigasjonskort
 -   Støtte for React 18 og server-side rendering
+-   Mulig å skjule _labels_ for alle skjemafelter visuelt
 
 Ellers pågår det en viktig diskusjon om [compact og mobil i Figma-skisser](https://github.com/fremtind/jokul/discussions/2843). Om du har vært frustrert med tingenes tilstand er **nå** tiden for å si ifra.
 
@@ -87,6 +88,14 @@ Sitter du inne med noen _hvordan kan jeg_-spørsmål som kunne trengt en guide? 
 React 18 ble [lansert 29. mars](https://reactjs.org/blog/2022/03/29/react-v18.html), og Jøkul ble ferdig migrert 8. april. I forbindelse med oppgraderingen, nå som Reacts egen `useId` er tilgjengelig i versjon 18, har Jøkul fått støtte for _server-side rendering_ og hydrering i klienten. Om du for eksempel vil bruke Jøkul i Remix skal det være mulig.
 
 Jøkul støtter fortsatt React 17. Om du skulle støte på noen problemer med å bruke Jøkul på versjon 17 så si ifra!
+
+## Skjule labels visuelt
+
+Nå er det mulig å gjøre så labels på skjemafelter bare dukker opp for skjermlesere. Alle skjemafelter har fått propen `labelProps`, som du kan bruke til å sette `labelProps.srOnly`.
+
+```tsx
+<TextInput label="Godt navn" labelProps={{ srOnly: true }} />
+```
 
 ## Diverse bugfikser
 


### PR DESCRIPTION
- Gjør `labelProps` tilgjengelig i skjemakomponenter der det manglet (for `labelProps.srOnly` i hovedsak, men med fleksibilitet)
- Gjør så `RadioButton` tar `children` på samme måte som `Checkbox`
- Lenk til eksempel på skjema og skjemakode fra komponentdocs så det er mulig å oppdage

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
