### PR TITLE
fix: fiks en bug hvor verdi 0 fikk formatValuta til å feile

### DIFF
--- a/packages/formatters-util/src/valuta/formatValuta.test.ts
+++ b/packages/formatters-util/src/valuta/formatValuta.test.ts
@@ -31,4 +31,8 @@ describe("formatValuta", () => {
     it("passes through strings that cannot be parsed as numbers", () => {
         expect(formatValuta("hundreogtjuetre")).toEqual(`hundreogtjuetre`);
     });
+
+    it("handles a sum of 0", () => {
+        expect(formatValuta("0")).toEqual(`0${nbsp}kr`);
+    });
 });

--- a/packages/formatters-util/src/valuta/formatValuta.ts
+++ b/packages/formatters-util/src/valuta/formatValuta.ts
@@ -28,7 +28,7 @@ const defaultOptions: FormatValutaOptions = {
  */
 export function formatValuta(input: string | number, options?: FormatValutaOptions) {
     const number = parseNumber(input);
-    if (!number) {
+    if (isNaN(number)) {
         return input.toString();
     }
 


### PR DESCRIPTION
Fiks at en sum av 0 ikke blir tolket som false.

## 🎯 Sjekkliste

-   [X] `yarn build` og `yarn ci:test` gir ingen feil
