### PR TITLE
fix: children is no longer optional

### DIFF
--- a/packages/button-react/src/types.ts
+++ b/packages/button-react/src/types.ts
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, ReactNode } from "react";
 
 export interface Props extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
     forceCompact?: boolean;
@@ -8,6 +8,7 @@ export interface Props extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, 
         textDescription: string;
     };
     arrow?: "left" | "right";
+    children: ReactNode;
 }
 
 export type ValidButtons = "primary" | "secondary" | "tertiary";


### PR DESCRIPTION
Vi har hatt nettopp en feil der en knapp stod og lastet selv om `showLoader: false`. Dette var fordi vi hadde fjernet teksten på knappen ved et uhell under en refaktorering, og brukte nettopp litt til på å finne feilen fordi vi ikke fikk noe feilmelding fordi children er optional. Kan ikke se noen grunn for at den skal være optional. 

Vurderte også å se litt på logikken for at den loader selv om loading er false, men tenker at det ikke vil være noe problem nå som children ikke er optional lenger. 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
