### PR TITLE
docs: fix typo

### DIFF
--- a/packages/field-group-react/README.md
+++ b/packages/field-group-react/README.md
@@ -1,4 +1,4 @@
-# [`@fremtind/field-group-react`](https://jokul.fremtind.no/komponenter/fieldgroup)
+# [`@fremtind/jkl-field-group-react`](https://jokul.fremtind.no/komponenter/fieldgroup)
 
 ## Beskrivelse
 


### PR DESCRIPTION
Fikset skrivefeil i pakkenavn fra `@fremtind/field-group-react` til `@fremtind/jkl-field-group-react`. Feil navn resulterte i at pakken ikke ble funnet ved installering med `yarn`.
