### PR TITLE
La Fremtind-bot oppdatere den samme kommentaren i pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -279,6 +279,7 @@ jobs:
               uses: marocchino/sticky-pull-request-comment@a6749bc8ac4329731f34ce30797c089afdfa9e8c
               with:
                   header: preview
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
                   message: |
                       <span aria-hidden="true">🔄</span> **Gjør klar en forhåndsvisning…**
                       <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}
@@ -324,8 +325,8 @@ jobs:
             - name: Add a comment with a link to the preview
               uses: marocchino/sticky-pull-request-comment@a6749bc8ac4329731f34ce30797c089afdfa9e8c
               with:
-                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
                   header: preview
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
                   message: |
                       <span aria-hidden="true">✅</span> Forhåndsvisning: https://jokul.fremtind.no/${{ env.PREVIEW_PATH }}
                       <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -275,6 +275,14 @@ jobs:
         env:
             PREVIEW_PATH: preview/${{ github.event.pull_request.head.ref }}
         steps:
+            - name: Add a comment with a link to the preview
+              uses: marocchino/sticky-pull-request-comment@a6749bc8ac4329731f34ce30797c089afdfa9e8c
+              with:
+                  header: preview
+                  message: |
+                      <span aria-hidden="true">🔄</span> **Gjør klar en forhåndsvisning…**
+                      <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}
+
             - name: Checkout
               uses: actions/checkout@v3
               with:
@@ -314,6 +322,11 @@ jobs:
                   yarn gh-pages --add --dist portal/public --dest ${{ env.PREVIEW_PATH }} --message "docs: preview #${{ github.event.number }}"
 
             - name: Add a comment with a link to the preview
-              run: gh api --method POST /repos/fremtind/jokul/issues/${{ github.event.number }}/comments -F body='A preview will be available at https://jokul.fremtind.no/${{ env.PREVIEW_PATH }} within a few minutes'
-              env:
-                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
+              uses: marocchino/sticky-pull-request-comment@a6749bc8ac4329731f34ce30797c089afdfa9e8c
+              with:
+                  header: preview
+                  message: |
+                      <span aria-hidden="true">✅</span> Forhåndsvisning: https://jokul.fremtind.no/${{ env.PREVIEW_PATH }}
+                      <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}
+
+                      Forhåndsvisningen blir tilgjengelig innen et par minutter. Den fjernes automatisk når pull requesten lukkes.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -324,6 +324,7 @@ jobs:
             - name: Add a comment with a link to the preview
               uses: marocchino/sticky-pull-request-comment@a6749bc8ac4329731f34ce30797c089afdfa9e8c
               with:
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
                   header: preview
                   message: |
                       <span aria-hidden="true">✅</span> Forhåndsvisning: https://jokul.fremtind.no/${{ env.PREVIEW_PATH }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -271,7 +271,7 @@ jobs:
         permissions:
             actions: write
             contents: write
-            issues: write
+            pull-requests: write
         env:
             PREVIEW_PATH: preview/${{ github.event.pull_request.head.ref }}
         steps:

--- a/portal/src/components/Typography/FormatProvider.tsx
+++ b/portal/src/components/Typography/FormatProvider.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { MDXProvider } from "@mdx-js/react";
-import { Link, WithChildren } from "@fremtind/jkl-core";
+import { WithChildren } from "@fremtind/jkl-core";
 import { DescriptionDetail, DescriptionList, DescriptionTerm } from "@fremtind/jkl-description-list-react";
 import { OrderedList, UnorderedList } from "@fremtind/jkl-list-react";
 import { ComponentExample } from "../../../../doc-utils";
@@ -35,18 +35,10 @@ import {
     CodeBlock,
     Ingress,
     ListItem,
+    Anchor,
+    Blockquote,
 } from "../Typography";
-import { Blockquote } from "./Typography";
 import cn from "classnames";
-
-/** Don't add class jkl-link to <a /> if it's styled as a button */
-const Anchor: FC<{ className?: string }> = (props) => {
-    if (props.className && props.className.includes("jkl-button")) {
-        // eslint-disable-next-line jsx-a11y/anchor-has-content
-        return <a {...props} />;
-    }
-    return <Link {...props} />;
-};
 
 interface WithClassNameProps {
     className?: string;
@@ -70,7 +62,7 @@ const components = {
     ol: withClassName(OrderedList, "jkl-portal-ol"),
     li: ListItem as FC,
     img: PortalImage,
-    a: Anchor as FC,
+    a: Anchor,
     blockquote: Blockquote,
     table: Table,
     thead: TableHead,

--- a/portal/src/components/Typography/Typography.tsx
+++ b/portal/src/components/Typography/Typography.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react";
-import { WithChildren } from "@fremtind/jkl-core";
+import { Link as GatsbyLink } from "gatsby";
+import { Link, WithChildren } from "@fremtind/jkl-core";
 import { ListItem as JklListItem } from "@fremtind/jkl-list-react";
 import { CodeBlock as FTCodeBlock } from "../../../../doc-utils/CodeBlock";
 
@@ -105,3 +106,19 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ children, language, ...res
 export const ListItem: React.FC<WithChildren> = ({ children }) => (
     <JklListItem className="jkl-portal-list-item">{children}</JklListItem>
 );
+
+export const Anchor: React.FC<{ children: React.ReactNode; className?: string; href: string }> = (props) => {
+    /** Don't add class jkl-link to <a /> if it's styled as a button */
+    if (props.className && props.className.includes("jkl-button")) {
+        // eslint-disable-next-line jsx-a11y/anchor-has-content
+        return <a {...props} />;
+    }
+
+    /** Use GatsbyLink for internal links */
+    if (props.href.startsWith("/")) {
+        const { href, ...restProps } = props;
+        return <GatsbyLink to={href} className="jkl-link" {...restProps} />;
+    }
+
+    return <Link {...props} />;
+};

--- a/portal/src/components/Typography/index.ts
+++ b/portal/src/components/Typography/index.ts
@@ -9,5 +9,7 @@ export {
     InlineCode,
     CodeBlock,
     ListItem,
+    Anchor,
+    Blockquote,
 } from "./Typography";
 export { FormatProvider } from "./FormatProvider";


### PR DESCRIPTION
Bruk en godkjent tredjepartsaction for å oppdatere den samme sticky kommentaren ved preview av brancher. Gjør at forhåndsvisningskommentarer ikke ender opp med å spamme ned PRen. Gjør også at man _ikke_ får notification annet enn første gang kommentaren lages.

Tar inn det ene forslaget ditt fra en tidligere PR @piofinn, for å få en endring i portalen å teste med.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
