### PR TITLE
feat: add masked input for numbers

### DIFF
--- a/packages/formatters-util/documentation/Example.tsx
+++ b/packages/formatters-util/documentation/Example.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { DevExample } from "../../../doc-utils";
 import FormattersExample from "./FormattersExample";
+import InputMaskExample from "./InputMaskExample";
 
 export default function Example() {
-    return <DevExample component={FormattersExample} />;
+    return (
+        <>
+            <DevExample component={FormattersExample} />
+            <DevExample component={InputMaskExample} />
+        </>
+    );
 }

--- a/packages/formatters-util/documentation/InputMaskExample.tsx
+++ b/packages/formatters-util/documentation/InputMaskExample.tsx
@@ -13,6 +13,7 @@ interface Skjema {
     fodselsnummer: string;
     kortnummer: string;
     kontonummer: string;
+    tall: number;
 }
 
 export const InputMaskExample: VFC<ExampleComponentProps> = () => {
@@ -24,6 +25,7 @@ export const InputMaskExample: VFC<ExampleComponentProps> = () => {
         registerWithKontonummerMask,
         registerWithKortnummerMask,
         registerWithTelefonnummerMask,
+        registerWithNumber,
     } = registerWithMasks(form);
 
     return (
@@ -41,6 +43,7 @@ export const InputMaskExample: VFC<ExampleComponentProps> = () => {
                 <TextInput label="Fødselsnummer" maxLength={12} {...registerWithFodselsnummerMask("fodselsnummer")} />
                 <TextInput label="Kortnummer" maxLength={19} {...registerWithKortnummerMask("kortnummer")} />
                 <TextInput label="Kontonummer" maxLength={13} {...registerWithKontonummerMask("kontonummer")} />
+                <TextInput label="Tall" {...registerWithNumber("tall")} />
                 <PrimaryButton type="submit">Send inn</PrimaryButton>
                 {formData && (
                     <>

--- a/packages/formatters-util/documentation/input-mask-example.scss
+++ b/packages/formatters-util/documentation/input-mask-example.scss
@@ -1,4 +1,6 @@
 @use "~@fremtind/jkl-core/jkl";
+@use "~@fremtind/jkl-text-input/text-input";
+@use "~@fremtind/jkl-button/button";
 
 .input-mask-example-form {
     width: 100%;

--- a/packages/formatters-util/src/util/parseNumber.ts
+++ b/packages/formatters-util/src/util/parseNumber.ts
@@ -22,7 +22,8 @@ export function parseNumber(input: string | number) {
     }
 
     // remove all spaces from number
-    const arrNumber = input.replaceAll(" ", "").split("");
+    const spaceRegex = /\s/g;
+    const arrNumber = input.replaceAll(spaceRegex, "").split("");
 
     // find what separator is used for decimal notation
     const decimalNotator = arrNumber.reduce<"." | "," | null>((notator, currentItem) => {

--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -1,5 +1,12 @@
 import type { ChangeEvent } from "react";
-import type { Path, PathValue, RegisterOptions, UnpackNestedValue, UseFormReturn } from "react-hook-form";
+import type {
+    Path,
+    PathValue,
+    RegisterOptions,
+    UnpackNestedValue,
+    UseFormRegisterReturn,
+    UseFormReturn,
+} from "react-hook-form";
 import { formatFodselsnummer } from "../fodselsnummer/formatFodselsnummer";
 import { formatKortnummer } from "../kortnummer/formatKortnummer";
 import { formatKontonummer } from "../kontonummer/formatKontonummer";
@@ -28,7 +35,16 @@ const registerWithMask =
                 >,
             );
         };
-        return form.register(name as unknown as Path<T>, { ...options, setValueAs, onChange });
+        const register = form.register(name as unknown as Path<T>, { ...options, setValueAs, onChange });
+        let extra = {};
+
+        if (formatter === "number") {
+            extra = {
+                align: "right", // Se https://github.com/fremtind/jokul/pull/2898
+            };
+        }
+
+        return Object.assign(register, extra);
     };
 
 /** @deprecated Bruk `registerWithMasks` i stedet */
@@ -41,14 +57,16 @@ export const registerWithKontonummerMask = registerWithMask("kontonummer");
 export const registerWithTelefonnummerMask = registerWithMask("telefonnummer");
 
 export const registerWithMasks = <T>(form: UseFormReturn<T>) => ({
-    registerWithFodselsnummerMask: (name: keyof T, options?: RegisterOptions<T>) =>
+    registerWithFodselsnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("fodselsnummer")(form, name, options),
-    registerWithKortnummerMask: (name: keyof T, options?: RegisterOptions<T>) =>
+    registerWithKortnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kortnummer")(form, name, options),
-    registerWithKontonummerMask: (name: keyof T, options?: RegisterOptions<T>) =>
+    registerWithKontonummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kontonummer")(form, name, options),
-    registerWithTelefonnummerMask: (name: keyof T, options?: RegisterOptions<T>) =>
+    registerWithTelefonnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("telefonnummer")(form, name, options),
-    registerWithNumber: (name: keyof T, options?: RegisterOptions<T>) =>
-        registerWithMask("number")(form, name, options),
+    registerWithNumber: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn & { align: "right" } =>
+        registerWithMask("number")(form, name, options) as UseFormRegisterReturn & {
+            align: "right";
+        },
 });

--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -4,12 +4,14 @@ import { formatFodselsnummer } from "../fodselsnummer/formatFodselsnummer";
 import { formatKortnummer } from "../kortnummer/formatKortnummer";
 import { formatKontonummer } from "../kontonummer/formatKontonummer";
 import { formatTelefonnummer } from "../telefonnummer/formatTelefonnummer";
+import { formatNumber } from "./formatNumber";
 
 const formatters = {
     fodselsnummer: formatFodselsnummer,
     kortnummer: formatKortnummer,
     kontonummer: formatKontonummer,
     telefonnummer: formatTelefonnummer,
+    number: formatNumber,
 };
 export type Formatter = keyof typeof formatters;
 
@@ -47,4 +49,6 @@ export const registerWithMasks = <T>(form: UseFormReturn<T>) => ({
         registerWithMask("kontonummer")(form, name, options),
     registerWithTelefonnummerMask: (name: keyof T, options?: RegisterOptions<T>) =>
         registerWithMask("telefonnummer")(form, name, options),
+    registerWithNumber: (name: keyof T, options?: RegisterOptions<T>) =>
+        registerWithMask("number")(form, name, options),
 });

--- a/packages/text-input-react/documentation/TextInput.mdx
+++ b/packages/text-input-react/documentation/TextInput.mdx
@@ -12,6 +12,7 @@ displayTypes: |
 import { TextInput, TextArea } from "../src";
 import { TextInputExample, textInputExampleCode } from "./TextInputExample";
 import { TextAreaExample, textAreaExampleCode } from "./TextAreaExample";
+import { InputMaskExample, inputMaskExampleCode } from "../../formatters-util/documentation/InputMaskExample";
 
 <Ingress>
     Vi bruker tekstfelt og tekstområder når vi vil at brukerne skal legge inn informasjon som tekst eller tall hvor vi
@@ -72,6 +73,14 @@ Vanligvis starter tekstområdet minimert og likner et vanlig tekstfelt. Når det
 Du kan velge om feltet alltid skal ekspanderes til å vise alt innhold. Eventuell scrolling flyttes da til siden. Innhold under skjemafeltet vil dyttes nedover.
 
 Dersom du har begrensninger på antall tegn kan du velge å vise en teller. Telleren vil ha en standard hjelpetekst om feltet går over grensen. Teksten kan overstyres. Det er ingen blokkering som hindrer brukeren å gå over grensen. Brukeren skal få fullføre tankerekken sin før hen redigerer teksten til å være innenfor grensen. Dersom feltet har en teller vises som standard en _progress bar_ som krymper etter hvert som teksten blir lenger. Denne kan du velge å skru av og bare vise telleren.
+
+**Maskert input:** Brukes til å håndtere lange tall som kan være vanskelige å lese.
+
+Eksempler på tilfeller hvor en maskert input kan være nyttig er når brukeren skal skrive inn fødselsnummer, kortnummer, kontonummer eller andre lange tall. Dette gjør at tallene blir enklere å lese, og gjør det lettere for brukeren å være sikre på at de har skrevet inn riktig informasjon.
+
+<ComponentExample title="Bruk med formaterer" component={InputMaskExample} codeExample={inputMaskExampleCode} />
+
+[Les mer om formattering og maskering av input](/komponenter/formatters#maskering-av-skjemafelter)
 
 ## Bruk
 

--- a/packages/text-input-react/src/BaseInputField.tsx
+++ b/packages/text-input-react/src/BaseInputField.tsx
@@ -6,6 +6,7 @@ import React, {
     KeyboardEventHandler,
     MouseEventHandler,
 } from "react";
+import cn from "classnames";
 
 export interface BaseProps {
     id?: string;
@@ -27,6 +28,10 @@ export interface BaseProps {
     type?: "text" | "number" | "tel" | "password" | "email" | "year";
     name?: string;
     defaultValue?: string;
+    /**
+     * @default "left"
+     */
+    align?: "left" | "right";
 }
 
 export interface Props extends BaseProps {
@@ -51,11 +56,13 @@ function getWidthAsStyle(width?: string, maxLength?: number): CSSProperties | un
 }
 
 export const BaseInputField = forwardRef<HTMLInputElement, Props>(
-    ({ id, describedBy, invalid, maxLength, width, type = "text", className = "", ...rest }, ref) => (
+    ({ id, describedBy, invalid, maxLength, width, type = "text", align = "left", className = "", ...rest }, ref) => (
         <input
             ref={ref}
             id={id}
-            className={`jkl-text-input__input ${className}`}
+            className={cn("jkl-text-input__input", className, {
+                "jkl-text-input__input--align-right": align === "right",
+            })}
             style={getWidthAsStyle(width, maxLength)}
             aria-describedby={describedBy}
             aria-invalid={invalid}

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -164,6 +164,10 @@ $text-input-selection-color--inverted: color.scale(
         }
 
         @include shared-error-styles;
+
+        &--align-right {
+            text-align: right;
+        }
     }
 
     &__action-button {


### PR DESCRIPTION
Legg til maskert input for felter som bare trenger tusenskilletegn.

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
