### PR TITLE
fix: støtt samme namesyntaks som hook-form

### DIFF
--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -24,7 +24,7 @@ export type Formatter = keyof typeof formatters;
 
 const registerWithMask =
     (formatter: Formatter) =>
-    <T>(form: UseFormReturn<T>, name: keyof T, options?: RegisterOptions<T>) => {
+    <T>(form: UseFormReturn<T>, name: Path<T>, options?: RegisterOptions<T>) => {
         const setValueAs = (value: string) => value.replace(/\s/g, "");
         const onChange = (event: ChangeEvent<HTMLInputElement>) => {
             options?.onChange?.(event);
@@ -35,7 +35,7 @@ const registerWithMask =
                 >,
             );
         };
-        const register = form.register(name as unknown as Path<T>, { ...options, setValueAs, onChange });
+        const register = form.register(name, { ...options, setValueAs, onChange });
         let extra = {};
 
         if (formatter === "number") {
@@ -57,15 +57,15 @@ export const registerWithKontonummerMask = registerWithMask("kontonummer");
 export const registerWithTelefonnummerMask = registerWithMask("telefonnummer");
 
 export const registerWithMasks = <T>(form: UseFormReturn<T>) => ({
-    registerWithFodselsnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithFodselsnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("fodselsnummer")(form, name, options),
-    registerWithKortnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithKortnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kortnummer")(form, name, options),
-    registerWithKontonummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithKontonummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kontonummer")(form, name, options),
-    registerWithTelefonnummerMask: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithTelefonnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
         registerWithMask("telefonnummer")(form, name, options),
-    registerWithNumber: (name: keyof T, options?: RegisterOptions<T>): UseFormRegisterReturn & { align: "right" } =>
+    registerWithNumber: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn & { align: "right" } =>
         registerWithMask("number")(form, name, options) as UseFormRegisterReturn & {
             align: "right";
         },


### PR DESCRIPTION
Støtt pathnotasjon som `foo.bar`

## 🎯 Sjekkliste

-  [x] `yarn build` og `yarn ci:test` gir ingen feil
