### PR TITLE
refactor: fjern framer-motion fra FormErrorMessageBox

### DIFF
--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@fremtind/jkl-alert-message": "^6.0.0",
-        "@fremtind/jkl-icon-button-react": "^0.8.27",
+        "@fremtind/jkl-icon-button-react": "^1.0.0",
         "classnames": "^2.2.6"
     },
     "devDependencies": {

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -37,7 +37,7 @@
         "@babel/runtime": "^7.17.8",
         "@fremtind/jkl-core": "^10.0.0",
         "@fremtind/jkl-datepicker": "^8.0.0",
-        "@fremtind/jkl-icon-button-react": "^0.8.27",
+        "@fremtind/jkl-icon-button-react": "^1.0.0",
         "@fremtind/jkl-react-hooks": "^9.0.0",
         "@fremtind/jkl-select-react": "^10.0.0",
         "@fremtind/jkl-text-input-react": "^10.0.0",

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.17.8",
-        "@fremtind/jkl-icon-button": "^0.5.25"
+        "@fremtind/jkl-icon-button": "^1.0.0"
     },
     "devDependencies": {
         "@fremtind/browserslist-config-jkl": "^0.6.1",

--- a/packages/message-box-react/documentation/Example.tsx
+++ b/packages/message-box-react/documentation/Example.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { DevExample } from "../../../doc-utils";
 import { MessageBoxExample, messageBoxExampleKnobs } from "./MessageBoxExample";
 import "../../message-box/message-box.scss";
+import { FormErrorMessageBoxExample, formErrorMessageBoxKnobs } from "./FormErrorMessageBoxExample";
 
 export default function Example() {
-    return <DevExample component={MessageBoxExample} knobs={messageBoxExampleKnobs} />;
+    return (
+        <>
+            <DevExample component={MessageBoxExample} knobs={messageBoxExampleKnobs} />
+            <DevExample component={FormErrorMessageBoxExample} knobs={formErrorMessageBoxKnobs} />
+        </>
+    );
 }

--- a/packages/message-box-react/documentation/Example.tsx
+++ b/packages/message-box-react/documentation/Example.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { DevExample } from "../../../doc-utils";
+import { FormErrorMessageBoxExample, formErrorMessageBoxKnobs } from "./FormErrorMessageBoxExample";
 import { MessageBoxExample, messageBoxExampleKnobs } from "./MessageBoxExample";
 import "../../message-box/message-box.scss";
-import { FormErrorMessageBoxExample, formErrorMessageBoxKnobs } from "./FormErrorMessageBoxExample";
 
 export default function Example() {
     return (

--- a/packages/message-box-react/documentation/FormErrorMessageBoxExample.tsx
+++ b/packages/message-box-react/documentation/FormErrorMessageBoxExample.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { ExampleComponentProps } from "../../../doc-utils";
+import { ExampleComponentProps, ExampleKnobsProps } from "../../../doc-utils";
 import { FormErrorMessageBox } from "../src";
+
+export const formErrorMessageBoxKnobs: ExampleKnobsProps = {
+    boolProps: ["Full width", "Compact", "Submitted", "Gyldig fornavn", "Gyldig etternavn"],
+};
 
 export const FormErrorMessageBoxExample: React.FC<ExampleComponentProps> = ({ boolValues }) => {
     return (
-        <>
+        <div>
             <FormErrorMessageBox
                 errors={[
                     !boolValues?.["Gyldig fornavn"] ? "Du må oppgi fornavn" : undefined,
@@ -20,7 +24,7 @@ export const FormErrorMessageBoxExample: React.FC<ExampleComponentProps> = ({ bo
             <p className="jkl-small">
                 Velg <i>Submitted</i> for å animere inn komponenten
             </p>
-        </>
+        </div>
     );
 };
 

--- a/packages/message-box-react/documentation/MessageBox.mdx
+++ b/packages/message-box-react/documentation/MessageBox.mdx
@@ -6,7 +6,11 @@ group: meldinger
 ---
 
 import { MessageBoxExample, messageBoxExampleKnobs, messageBoxExampleCode } from "./MessageBoxExample";
-import { FormErrorMessageBoxExample, formErrorMessageBoxExampleCode } from "./FormErrorMessageBoxExample";
+import {
+    FormErrorMessageBoxExample,
+    formErrorMessageBoxKnobs,
+    formErrorMessageBoxExampleCode,
+} from "./FormErrorMessageBoxExample";
 
 <Ingress>
     En melding er en beskjed til brukeren som vises i tilknytning til innhold på siden. Det kan være et varsel om at noe
@@ -39,9 +43,7 @@ Som beskrevet i [Skjemavalidering](/profil/skjemadesign#skjemavalidering) bruker
 <ComponentExample
     title="FormErrorMessageBox"
     component={FormErrorMessageBoxExample}
-    knobs={{
-        boolProps: ["Full width", "Compact", "Submitted", "Gyldig fornavn", "Gyldig etternavn"],
-    }}
+    knobs={formErrorMessageBoxKnobs}
     codeExample={formErrorMessageBoxExampleCode}
 />
 

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -39,6 +39,7 @@
         "@fremtind/jkl-core": "^10.0.0",
         "@fremtind/jkl-icon-button-react": "^1.0.0",
         "@fremtind/jkl-message-box": "^6.0.0",
+        "@fremtind/jkl-react-hooks": "9.0.0",
         "classnames": "^2.2.6"
     },
     "peerDependencies": {

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -36,13 +36,10 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.17.8",
-        "@fremtind/jkl-icon-button-react": "^0.8.27",
+        "@fremtind/jkl-core": "^10.0.0",
+        "@fremtind/jkl-icon-button-react": "^1.0.0",
         "@fremtind/jkl-message-box": "^6.0.0",
-        "classnames": "^2.2.6",
-        "framer-motion": "^6.2.8"
-    },
-    "devDependencies": {
-        "@fremtind/jkl-core": "^10.0.0"
+        "classnames": "^2.2.6"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/message-box-react/src/FormErrorMessageBox.tsx
+++ b/packages/message-box-react/src/FormErrorMessageBox.tsx
@@ -1,6 +1,5 @@
-import cx from "classnames";
-import { motion, AnimatePresence } from "framer-motion";
 import React, { forwardRef, useEffect, useRef } from "react";
+import cn from "classnames";
 import { MessageBoxProps, ErrorMessageBox } from "./MessageBox";
 
 export interface FormErrorMessageBoxProps {
@@ -20,52 +19,43 @@ const defaultMessageBoxProps = {
 };
 
 export const FormErrorMessageBox = forwardRef<HTMLDivElement, FormErrorMessageBoxProps>(
-    (props, ref): JSX.Element | null => {
+    (props, forwardedRef): JSX.Element | null => {
         const { className, errors, isSubmitted, isValid, messageBoxProps, ...rest } = props;
-        const previousErrors = useRef<Array<string | undefined>>(errors);
 
+        const showSummary = isSubmitted && !isValid;
+
+        const previousErrors = useRef<Array<string | undefined>>(errors);
         useEffect(() => {
             previousErrors.current = errors;
         }, [errors]);
-
         const hasNewErrors = errors.length > previousErrors.current.length;
 
         return (
-            <AnimatePresence>
-                {isSubmitted && !isValid && (
-                    <motion.div
-                        ref={ref}
-                        className={cx("jkl-form-error-message-box", className)}
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        {...rest}
-                    >
-                        <ErrorMessageBox
-                            {...defaultMessageBoxProps}
-                            {...messageBoxProps}
-                            role={hasNewErrors ? "alert" : "presentation"} // Unngå å repetere hele oppsummeringen etter hvert som feilene rettes
-                        >
-                            <ul className="jkl-list">
-                                {errors
-                                    .filter((error) => typeof error !== "undefined")
-                                    .map((error) => (
-                                        <motion.li
-                                            className="jkl-list__item"
-                                            key={error}
-                                            layout
-                                            animate={{ opacity: 1 }}
-                                            exit={{ opacity: 0 }}
-                                        >
-                                            {error}
-                                        </motion.li>
-                                    ))}
-                            </ul>
-                        </ErrorMessageBox>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+            <div
+                ref={forwardedRef}
+                className={cn("jkl-form-error-message-box", className, {
+                    "jkl-form-error-message-box--hidden": !showSummary,
+                })}
+                {...rest}
+            >
+                <ErrorMessageBox
+                    {...defaultMessageBoxProps}
+                    {...messageBoxProps}
+                    role={hasNewErrors ? "alert" : "presentation"} // Unngå å repetere hele oppsummeringen etter hvert som feilene rettes
+                >
+                    <ul className="jkl-list">
+                        {errors
+                            .filter((error) => typeof error !== "undefined")
+                            .map((error) => (
+                                <li className="jkl-list__item" key={error}>
+                                    {error}
+                                </li>
+                            ))}
+                    </ul>
+                </ErrorMessageBox>
+            </div>
         );
     },
 );
+
 FormErrorMessageBox.displayName = "FormErrorMessageBox";

--- a/packages/message-box-react/src/FormErrorMessageBox.tsx
+++ b/packages/message-box-react/src/FormErrorMessageBox.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef, useEffect, useRef } from "react";
+import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
+import React, { forwardRef, useEffect, useRef } from "react";
 import { MessageBoxProps, ErrorMessageBox } from "./MessageBox";
 
 export interface FormErrorMessageBoxProps {
@@ -24,6 +25,8 @@ export const FormErrorMessageBox = forwardRef<HTMLDivElement, FormErrorMessageBo
 
         const showSummary = isSubmitted && !isValid;
 
+        const [messageBoxRef] = useAnimatedHeight<HTMLDivElement>(showSummary);
+
         const previousErrors = useRef<Array<string | undefined>>(errors);
         useEffect(() => {
             previousErrors.current = errors;
@@ -31,16 +34,11 @@ export const FormErrorMessageBox = forwardRef<HTMLDivElement, FormErrorMessageBo
         const hasNewErrors = errors.length > previousErrors.current.length;
 
         return (
-            <div
-                ref={forwardedRef}
-                className={cn("jkl-form-error-message-box", className, {
-                    "jkl-form-error-message-box--hidden": !showSummary,
-                })}
-                {...rest}
-            >
+            <div ref={forwardedRef} className={cn("jkl-form-error-message-box", className)} {...rest}>
                 <ErrorMessageBox
                     {...defaultMessageBoxProps}
                     {...messageBoxProps}
+                    ref={messageBoxRef}
                     role={hasNewErrors ? "alert" : "presentation"} // Unngå å repetere hele oppsummeringen etter hvert som feilene rettes
                 >
                     <ul className="jkl-list">

--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -1,7 +1,7 @@
 import { WithChildren } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
-import classNames from "classnames";
-import React, { AriaRole } from "react";
+import cn from "classnames";
+import React, { AriaRole, forwardRef } from "react";
 
 export interface MessageBoxProps extends WithChildren {
     title?: string;
@@ -108,44 +108,39 @@ const getRole = (messageType: messageTypes) => {
 };
 
 function messageFactory(messageType: messageTypes) {
-    const MessageBox: React.FC<MessageBoxProps> = ({
-        title,
-        fullWidth,
-        forceCompact,
-        className = "",
-        dismissed,
-        dismissAction,
-        children,
-        role,
-    }) => {
-        const componentClassName = classNames("jkl-message-box", "jkl-message-box--" + messageType, className, {
-            "jkl-message-box--full": fullWidth,
-            "jkl-message-box--compact": forceCompact,
-            "jkl-message-box--dismissed": dismissed,
-        });
+    const MessageBox = forwardRef<HTMLDivElement, MessageBoxProps>(
+        ({ title, fullWidth, forceCompact, className = "", dismissed, dismissAction, children, role }, ref) => {
+            const componentClassName = cn("jkl-message-box", "jkl-message-box--" + messageType, className, {
+                "jkl-message-box--full": fullWidth,
+                "jkl-message-box--compact": forceCompact,
+                "jkl-message-box--dismissed": dismissed,
+            });
 
-        const hasStringChild = React.Children.map(children, (child) => typeof child === "string");
+            const hasStringChild = React.Children.map(children, (child) => typeof child === "string");
 
-        const newChildren = hasStringChild?.[0] ? <p className="jkl-body">{children}</p> : children;
+            const newChildren = hasStringChild?.[0] ? <p className="jkl-body">{children}</p> : children;
 
-        return (
-            <div className={componentClassName} role={role || getRole(messageType)} data-theme="light">
-                {getIcon(messageType)}
-                <div className="jkl-message-box__content">
-                    {title !== undefined && <p className="jkl-message-box__title">{title}</p>}
-                    {newChildren}
+            return (
+                <div ref={ref} className={componentClassName} role={role || getRole(messageType)} data-theme="light">
+                    {getIcon(messageType)}
+                    <div className="jkl-message-box__content">
+                        {title !== undefined && <p className="jkl-message-box__title">{title}</p>}
+                        {newChildren}
+                    </div>
+                    {dismissAction?.handleDismiss && (
+                        <IconButton
+                            className="jkl-message-box__dismiss-button"
+                            iconType="clear"
+                            buttonTitle={dismissAction.buttonTitle || "Lukk"}
+                            onClick={dismissAction.handleDismiss}
+                        />
+                    )}
                 </div>
-                {dismissAction?.handleDismiss && (
-                    <IconButton
-                        className="jkl-message-box__dismiss-button"
-                        iconType="clear"
-                        buttonTitle={dismissAction.buttonTitle || "Lukk"}
-                        onClick={dismissAction.handleDismiss}
-                    />
-                )}
-            </div>
-        );
-    };
+            );
+        },
+    );
+
+    MessageBox.displayName = "MessageBox";
 
     return MessageBox;
 }

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -197,8 +197,4 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
     @include jkl.text-style("body");
 
     padding-bottom: jkl.$spacing-xl;
-
-    &--hidden {
-        display: none;
-    }
 }

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -197,4 +197,8 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
     @include jkl.text-style("body");
 
     padding-bottom: jkl.$spacing-xl;
+
+    &--hidden {
+        display: none;
+    }
 }

--- a/packages/react-hooks/src/useAnimatedHeight.tsx
+++ b/packages/react-hooks/src/useAnimatedHeight.tsx
@@ -75,15 +75,15 @@ export function useAnimatedHeight<T extends HTMLElement>(
                 // Første render eller rerender med isOpen false
                 return;
             }
+        } else if (isOpen && wasOpen) {
+            // Re-render etter å ha vært lukket, men forblitt åpen.
+            return;
         }
 
         options?.onTransitionStart?.(isOpen);
 
         if (prefersReducedMotion) {
-            const element = getElement(elementRef);
-            if (element) {
-                element.removeAttribute("style");
-            }
+            element.removeAttribute("style");
             if (isOpen) {
                 options?.onFirstVisible?.();
             }

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.17.8",
-        "@fremtind/jkl-icon-button-react": "^0.8.27",
+        "@fremtind/jkl-icon-button-react": "^1.0.0",
         "@fremtind/jkl-icons-react": "^5.0.0",
         "@fremtind/jkl-react-hooks": "^9.0.0",
         "@fremtind/jkl-text-input": "^8.0.0",

--- a/portal/package.json
+++ b/portal/package.json
@@ -27,7 +27,7 @@
         "@fremtind/jkl-footer-react": "^2.0.0",
         "@fremtind/jkl-formatters-util": "^2.3.1",
         "@fremtind/jkl-hamburger-react": "^9.0.0",
-        "@fremtind/jkl-icon-button-react": "^0.8.27",
+        "@fremtind/jkl-icon-button-react": "^1.0.0",
         "@fremtind/jkl-icons-react": "^5.0.0",
         "@fremtind/jkl-image-react": "^3.0.0",
         "@fremtind/jkl-list-react": "^7.0.0",

--- a/scripts/scaffold/templates/component-react/package.json
+++ b/scripts/scaffold/templates/component-react/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.17.8",
-        "@fremtind/jkl-core": "^9.0.0",
+        "@fremtind/jkl-core": "^10.0.0",
         "@fremtind/jkl-scaffold": "^1.0.0-alpha.0"
     },
     "peerDependencies": {

--- a/scripts/scaffold/templates/component/package.json
+++ b/scripts/scaffold/templates/component/package.json
@@ -23,7 +23,7 @@
         "dev": "echo \"Error: run dev from scaffold-react\" && exit 1"
     },
     "dependencies": {
-        "@fremtind/jkl-core": "^9.0.0"
+        "@fremtind/jkl-core": "^10.0.0"
     },
     "repository": {
         "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,21 +1426,6 @@
   dependencies:
     "@babel/runtime" "^7.17.8"
 
-"@fremtind/jkl-icon-button-react@^0.8.27":
-  version "0.8.27"
-  resolved "https://registry.yarnpkg.com/@fremtind/jkl-icon-button-react/-/jkl-icon-button-react-0.8.27.tgz#0c44c2c8054782c94fc312a2851e6852347ead1d"
-  integrity sha512-NGt2gT0GG/kVAAK+TEfyeiDuAmwD6To8ieeh9PioAFGDNTisLUWxL1DrJKLOZfm1HrL6QIG1P9b38yLxSWjfvA==
-  dependencies:
-    "@babel/runtime" "^7.17.8"
-    "@fremtind/jkl-icon-button" "^0.5.25"
-
-"@fremtind/jkl-icon-button@^0.5.25":
-  version "0.5.25"
-  resolved "https://registry.yarnpkg.com/@fremtind/jkl-icon-button/-/jkl-icon-button-0.5.25.tgz#f2685e689e8cc598d6cdd00f72255ddd974c0aa3"
-  integrity sha512-VWwVkN81pbmJJaq6T8sxl+VP+ccmNPirNyiGZXmNAdgIBhTzcPNsZVckRIA6ntPziIL9MwVADmjmcTwLjnfF+A==
-  dependencies:
-    "@fremtind/jkl-core" "^9.7.0"
-
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10416,19 +10416,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^6.2.8:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.3.3.tgz#58978fe6955d13000351ea4c134c9bc052638967"
-  integrity sha512-wo0dCnoq5vn4L8YVOPO9W54dliH78vDaX0Lj+bSPUys6Nt5QaehrS3uaYa0q5eVeikUgtTjz070UhQ94thI5Sw==
-  dependencies:
-    framesync "6.0.1"
-    hey-listen "^1.0.8"
-    popmotion "11.0.3"
-    style-value-types "5.0.0"
-    tslib "^2.1.0"
-  optionalDependencies:
-    "@emotion/is-prop-valid" "^0.8.2"
-
 framer-motion@^6.3.6:
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.3.6.tgz#9ca52544a7d0c74668f880eb2cab4a5de6dc71a0"


### PR DESCRIPTION
Bundlestørrelsen ble altfor stor i forhold til hva vi fikk igjen.

ISSUES CLOSED: #2895

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
