### PR TITLE
fix: stopp onBlur i Safari ved klikk i input så kalender

### DIFF
--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -266,6 +266,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>((props, 
             })}
             {...rest}
             ref={datepickerRef}
+            tabIndex={-1} // Må være her for Safari onBlur quirk! https://bugs.webkit.org/show_bug.cgi?id=22261
         >
             <Label standAlone {...labelProps} forceCompact={forceCompact} htmlFor={inputId}>
                 {label}

--- a/packages/datepicker-react/src/internal/Calendar.tsx
+++ b/packages/datepicker-react/src/internal/Calendar.tsx
@@ -291,6 +291,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
                             label={yearLabel}
                             type="number"
                             className="jkl-calendar__year-selector"
+                            inputClassName="jkl-calendar__year-selector-input"
                             width="5rem"
                             variant="small"
                             onChange={handleYearChange}
@@ -299,6 +300,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
                         />
                         <NativeSelect
                             className="jkl-calendar__month-selector"
+                            selectClassName="jkl-calendar__year-selector-select"
                             label={monthLabel}
                             items={months.map((name: string, i: number) => ({
                                 value: String(i),

--- a/packages/datepicker-react/src/internal/Calendar.tsx
+++ b/packages/datepicker-react/src/internal/Calendar.tsx
@@ -300,7 +300,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
                         />
                         <NativeSelect
                             className="jkl-calendar__month-selector"
-                            selectClassName="jkl-calendar__year-selector-select"
+                            selectClassName="jkl-calendar__month-selector-select"
                             label={monthLabel}
                             items={months.map((name: string, i: number) => ({
                                 value: String(i),

--- a/packages/datepicker-react/src/utils.ts
+++ b/packages/datepicker-react/src/utils.ts
@@ -60,6 +60,8 @@ export function isBlurTargetOutside(e: React.FocusEvent<HTMLButtonElement | HTML
         "jkl-datepicker__action-button",
         "jkl-calendar__date",
         "jkl-datepicker__input",
+        "jkl-calendar__year-selector-input",
+        "jkl-calendar__month-selector-select",
     ];
 
     for (const knownTarget of knownBlurTargetsInsideDatepicker) {

--- a/packages/datepicker-react/src/utils.ts
+++ b/packages/datepicker-react/src/utils.ts
@@ -56,6 +56,7 @@ export function isBlurTargetOutside(e: React.FocusEvent<HTMLButtonElement | HTML
     }
 
     const knownBlurTargetsInsideDatepicker = [
+        "jkl-datepicker",
         "jkl-datepicker__action-button",
         "jkl-calendar__date",
         "jkl-datepicker__input",

--- a/packages/datepicker-react/src/utils.ts
+++ b/packages/datepicker-react/src/utils.ts
@@ -60,6 +60,7 @@ export function isBlurTargetOutside(e: React.FocusEvent<HTMLButtonElement | HTML
         "jkl-datepicker__action-button",
         "jkl-calendar__date",
         "jkl-datepicker__input",
+        "jkl-calendar__month-button",
         "jkl-calendar__year-selector-input",
         "jkl-calendar__month-selector-select",
     ];

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -11,6 +11,7 @@ export interface NativeSelectProps {
     labelProps?: Omit<LabelProps, "children" | "forceCompact" | "standAlone">;
     items: Array<string | ValuePair>;
     className?: string;
+    selectClassName?: string;
     inline?: boolean;
     helpLabel?: string;
     errorLabel?: string;
@@ -47,6 +48,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
             value,
             forceCompact,
             width,
+            selectClassName,
             ...rest
         },
         ref,
@@ -69,7 +71,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
                     <select
                         ref={ref}
                         id={uid}
-                        className="jkl-select__button"
+                        className={cn("jkl-select__button", selectClassName)}
                         defaultValue={value ? undefined : ""}
                         value={value}
                         {...rest}

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -22,6 +22,7 @@ export interface Props extends BaseProps {
     forceCompact?: boolean;
     inline?: boolean;
     action?: Action;
+    inputClassName?: string;
 }
 
 export const TextInput = forwardRef<HTMLInputElement, Props>(
@@ -38,6 +39,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
             forceCompact,
             action,
             "data-testautoid": testAutoId,
+            inputClassName,
             ...inputProps
         },
         ref,
@@ -74,6 +76,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
                         describedBy={describedBy}
                         invalid={!!errorLabel}
                         data-testautoid={testAutoId}
+                        className={inputClassName}
                         {...inputProps}
                     />
                     {action && (


### PR DESCRIPTION
Vi baserer oss på å sjekke event.relatedTarget for å se om vi skal
trigge onBlur. Den er null dersom elementet som klikkes på ikke er
fokuserbart.

https://stackoverflow.com/a/42764495

Kalenderknapper er fokuserbare, men av _grunner_ så velger Safari
på macOS å ikke flytte fokus til knappen. Det slutter i stedet å
eksistere fokus. Argumentet har vært at det er sånn native-plattformen
fungerer, så f**k websiden din 🤷

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus

Det Safari derimot vil gjøre er å sende _parent_ som relatedTarget
dersom den har en tabindex, selv hvis den er -1. Ikke spør meg hvorfor.

https://codepen.io/andy-blum/pen/PoEzOwB

Vi setter tabIndex til -1 på rotnivå i datepicker så vi alltid har
en relatedTarget i Safari når det trykkes på knapper, uansett om
det er toggle for å åpne/lukke, klikk på en dato, eller klikk på
knapper for å navigere mellom måneder.<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
