### PR TITLE
fix: bruk bakgrunnsfargen fra temaet på åpen native select

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -78,6 +78,7 @@ $_select-search-input-selection-color--inverted: color.scale(
             font-weight: normal;
             font-family: sans-serif;
             color: var(--jkl-select-text-color);
+            background-color: var(--jkl-select-open-background-color);
 
             &:disabled {
                 color: var(--jkl-select-text-disabled-color);


### PR DESCRIPTION
Fikser en feil der bakgrunnsfargen ble satt til rød feilfarge om feltet hadde valideringsfeil.

ISSUES CLOSED: #2807

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
