### PR TITLE
fix(formatters-util): bedre typing av options til register with mask

### DIFF
--- a/packages/formatters-util/src/index.ts
+++ b/packages/formatters-util/src/index.ts
@@ -1,7 +1,7 @@
 export type { FormatNumberOptions } from "./util/formatNumber";
 export { formatNumber } from "./util/formatNumber";
 export { parseNumber } from "./util/parseNumber";
-export type { Formatter } from "./util/registerWithMask";
+export type { Formatter, RegisterWithMaskOptions } from "./util/registerWithMask";
 export {
     registerWithMasks,
     registerWithFodselsnummerMask,

--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -22,9 +22,11 @@ const formatters = {
 };
 export type Formatter = keyof typeof formatters;
 
+export type RegisterWithMaskOptions<T> = Omit<RegisterOptions<T>, "setValueAs">;
+
 const registerWithMask =
     (formatter: Formatter) =>
-    <T>(form: UseFormReturn<T>, name: Path<T>, options?: RegisterOptions<T>) => {
+    <T>(form: UseFormReturn<T>, name: Path<T>, options?: RegisterWithMaskOptions<T>) => {
         const setValueAs = (value: string) => value.replace(/\s/g, "");
         const onChange = (event: ChangeEvent<HTMLInputElement>) => {
             options?.onChange?.(event);
@@ -57,15 +59,18 @@ export const registerWithKontonummerMask = registerWithMask("kontonummer");
 export const registerWithTelefonnummerMask = registerWithMask("telefonnummer");
 
 export const registerWithMasks = <T>(form: UseFormReturn<T>) => ({
-    registerWithFodselsnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithFodselsnummerMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
         registerWithMask("fodselsnummer")(form, name, options),
-    registerWithKortnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithKortnummerMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kortnummer")(form, name, options),
-    registerWithKontonummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithKontonummerMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
         registerWithMask("kontonummer")(form, name, options),
-    registerWithTelefonnummerMask: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn =>
+    registerWithTelefonnummerMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
         registerWithMask("telefonnummer")(form, name, options),
-    registerWithNumber: (name: Path<T>, options?: RegisterOptions<T>): UseFormRegisterReturn & { align: "right" } =>
+    registerWithNumber: (
+        name: Path<T>,
+        options?: RegisterWithMaskOptions<T>,
+    ): UseFormRegisterReturn & { align: "right" } =>
         registerWithMask("number")(form, name, options) as unknown as UseFormRegisterReturn & {
             align: "right";
         },


### PR DESCRIPTION
Typingen av options til register-funksjonene fra `registerWithMasks` var litt upresis. Her var `RegisterOptions<T>` fra react-hook-form brukt direkte, men det blir ikke riktig at `setValueAs` er med her. Dersom konsumenten sender med en verdi her, blir den ignorert. Da er det bedre å fjerne den fra typen.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
