### PR TITLE
feat: add defaultTab prop to tabs

### DIFF
--- a/packages/tabs-react/src/Tabs.test.tsx
+++ b/packages/tabs-react/src/Tabs.test.tsx
@@ -4,9 +4,9 @@ import { axe } from "jest-axe";
 import React from "react";
 import { Tabs, Tab, TabList, TabPanel } from ".";
 
-const renderComponent = (onChange?: () => void) =>
+const renderComponent = (onChange?: () => void, defaultTab?: number) =>
     render(
-        <Tabs onChange={onChange}>
+        <Tabs onChange={onChange} defaultTab={defaultTab}>
             <TabList aria-label="testlist">
                 <Tab>Tab 1</Tab>
                 <Tab>Tab 2</Tab>
@@ -47,6 +47,29 @@ describe("Tabs", () => {
         });
 
         expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("shows tab set by defaultTab if defined", async () => {
+        renderComponent(undefined, 2);
+
+        screen.getByText("Tabpanel 3");
+        expect(screen.queryByText("TabPanel 2")).toBeNull();
+        expect(screen.queryByText("TabPanel 1")).toBeNull();
+    });
+
+    it("changes tabs while defaultTab is defined", async () => {
+        const onChange = jest.fn();
+
+        renderComponent(onChange, 2);
+
+        expect(onChange).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await userEvent.click(screen.getByText("Tab 2"));
+        });
+
+        expect(onChange).toHaveBeenCalledWith(1);
+        screen.getByText("Tabpanel 2");
     });
 });
 

--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -7,6 +7,7 @@ import React, { useState, useCallback, useEffect } from "react";
 export interface TabsProps extends WithChildren {
     className?: string;
     onChange?: (tabIndex: number) => void;
+    defaultTab?: number;
 }
 
 /**
@@ -15,8 +16,8 @@ export interface TabsProps extends WithChildren {
  *
  * Docs: https://jokul.fremtind.no/komponenter/tabs
  */
-export const Tabs = ({ onChange, ...props }: TabsProps) => {
-    const [activeIndex, setActiveIndex] = useState(0);
+export const Tabs = ({ onChange, defaultTab, ...props }: TabsProps) => {
+    const [activeIndex, setActiveIndex] = useState(defaultTab ?? 0);
 
     const previousTabIndex = usePreviousValue(activeIndex);
 


### PR DESCRIPTION
Legg til defaultTab som en prop til Tabs. Dette gjør at man kan bestemme hvilke tab som skal være valgt først, ved f.eks. retur fra skjema.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [X] `yarn build` og `yarn ci:test` gir ingen feil
