### PR TITLE
fix: reset statisk høyde ved bruk av data-compactlayout

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -404,6 +404,7 @@ $_text-input-selection-color--inverted: color.scale(
         &.jkl-text-input--compact,
         &.jkl-text-input--inline {
             .jkl-text-input__input {
+                height: revert;
                 max-height: $_text-input-height--compact;
 
                 &[data-has-content="true"] {


### PR DESCRIPTION
Unngå at telleren kolliderer med teksten og sørg for at textarea ekspanderer.

ISSUES CLOSED: #2931

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
