### PR TITLE
chore: legg til nodemon for autorestart av devserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "lerna": "^5.1.8",
         "lerna-clean-changelogs-cli": "^2.0.17",
         "lint-staged": "^13.0.3",
+        "nodemon": "^2.0.19",
         "npm-run-all": "^4.1.5",
         "patch-package": "^6.4.7",
         "postcss": "^8.4.14",

--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/breadcrumb-react/package.json
+++ b/packages/breadcrumb-react/package.json
@@ -32,8 +32,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -36,8 +36,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -31,8 +31,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/constants-util/package.json
+++ b/packages/constants-util/package.json
@@ -28,8 +28,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "repository": {

--- a/packages/content-toggle-react/package.json
+++ b/packages/content-toggle-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/cookie-consent-react/package.json
+++ b/packages/cookie-consent-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,8 +43,7 @@
         "build:scripts": "node ./esbuild.prod.mjs",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "repository": {

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/description-list-react/package.json
+++ b/packages/description-list-react/package.json
@@ -40,8 +40,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "bugs": {

--- a/packages/expand-button-react/package.json
+++ b/packages/expand-button-react/package.json
@@ -32,8 +32,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/field-group-react/package.json
+++ b/packages/field-group-react/package.json
@@ -31,8 +31,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "repository": {

--- a/packages/footer-react/package.json
+++ b/packages/footer-react/package.json
@@ -32,8 +32,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/formatters-util/package.json
+++ b/packages/formatters-util/package.json
@@ -32,8 +32,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/hamburger-react/package.json
+++ b/packages/hamburger-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -36,8 +36,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -40,8 +40,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -36,8 +36,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -35,8 +35,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -35,8 +35,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -33,8 +33,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/tabs-react/package.json
+++ b/packages/tabs-react/package.json
@@ -32,8 +32,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/tag-react/package.json
+++ b/packages/tag-react/package.json
@@ -34,8 +34,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -38,8 +38,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -35,8 +35,7 @@
         "build": "run-s build:*",
         "test": "echo \"Error: run tests from root\" && exit 1",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
-        "dev:server": "node ./dist/server.js",
-        "predev": "node ./esbuild.dev.mjs",
+        "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8004,7 +8004,7 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.2, chokidar@^3.5.3:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.2, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -13335,6 +13335,11 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
 ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
@@ -16578,7 +16583,23 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
-nopt@1.0.10:
+nodemon@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.19.tgz#cac175f74b9cb8b57e770d47841995eebe4488bd"
+  integrity sha512-4pv1f2bMDj0Eeg/MhGqxrtveeQ5/G/UVe9iO6uTZzjnRluSA4PVWf8CW99LUPwGB3eNIA7zUFoP77YuI7hOc0A==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^3.2.7"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.8"
+    semver "^5.7.1"
+    simple-update-notifier "^1.0.7"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
+nopt@1.0.10, nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
   integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
@@ -18328,6 +18349,11 @@ psl@^1.1.28, psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
+
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
@@ -19561,7 +19587,7 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.0.0:
+semver@7.0.0, semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
@@ -19775,6 +19801,13 @@ simple-swizzle@^0.2.2:
   integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
   dependencies:
     is-arrayish "^0.3.1"
+
+simple-update-notifier@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz#7edf75c5bdd04f88828d632f762b2bc32996a9cc"
+  integrity sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==
+  dependencies:
+    semver "~7.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -20704,7 +20737,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -21121,6 +21154,13 @@ token-types@^4.1.1:
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
+
 tough-cookie@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
@@ -21514,6 +21554,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 underscore.string@^3.3.5:
   version "3.3.6"


### PR DESCRIPTION
Sørger for at endringer i klient-bundle reflekteres i SSR, unngå hydreringsfeil.

Ulempe: hvis man har to devservere oppe hvor den ene får random portnummer blir det randomisert på nytt hver endring. OK tradeoff?