### PR TITLE
fix: fix a bug where delete and backspace would reset caret position

### DIFF
--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -70,8 +70,8 @@ const registerWithMask =
 
         // save the caret position before the change occured
         const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
-            if (event.target.selectionStart !== null) {
-                onKeyDownCaretPosition = event.target.selectionStart;
+            if ((event.target as HTMLInputElement).selectionStart !== null) {
+                onKeyDownCaretPosition = (event.target as HTMLInputElement).selectionStart as number;
             }
             onKeyDownKeyPressed = event.key;
         };


### PR DESCRIPTION
Fikser en bug hvor delete og backspace inne i teksten fikk markøren til å flytte seg til enden.