### PR TITLE
fix: always remove searchvalue onBlur

### DIFF
--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -243,10 +243,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             const nextFocusIsInsideComponent =
                 componentRootElement && componentRootElement.contains(e.relatedTarget as Node);
             if (!nextFocusIsInsideComponent) {
+                if (isSearchable) {
+                    setSearchValue("");
+                }
                 if (onBlur) {
-                    if (isSearchable) {
-                        setSearchValue("");
-                    }
                     onBlur({ type: "blur", target: { name, value: selectedValue || "" } });
                     selectRef.current?.dispatchEvent(new Event("focusout", { bubbles: true }));
                 }


### PR DESCRIPTION
Gjorde en feil ved forrige fiks. Du var nødt til å sende inn en onBlur til komponenten for at den skulle resette søket, men vi vil at den alltid skal resette seg onBlur. 

-   [x] `yarn build` og `yarn ci:test` gir ingen feil
