### PR TITLE
chore: rydd vekk alt unntatt preview-mapper ved deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build:docs": "turbo run build:docs --scope=\"@fremtind/portal\" --include-dependencies --cache-dir=\".turbo\"",
         "commit": "git-cz",
         "predeploy:docs": "yarn run build:docs",
-        "deploy:docs": "gh-pages -f --no-history --add --dist portal/public",
+        "deploy:docs": "gh-pages -f --no-history --remove '[\".\", \"!preview\"]' --dist portal/public",
         "typecheck": "tsc --noEmit",
         "lint": "run-p lint:eslint lint:stylelint",
         "lint:eslint": "eslint '**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
Unngå at sider som ikke lenger er i bruk er tilgjengelige via søkemotorer.

Bruker et globby-pattern for å beholde previews-mappa.

https://github.com/tschaub/gh-pages/blob/ef1c90d2524a51eaa2c9ecc996bb9311b6cd18eb/lib/index.js#L174
https://www.npmjs.com/package/globby

Fixes #3035 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
