### PR TITLE
feat: support fallback items on non-matching search

### DIFF
--- a/packages/text-input-react/documentation/AutosuggestExample.tsx
+++ b/packages/text-input-react/documentation/AutosuggestExample.tsx
@@ -11,6 +11,7 @@ export const autosuggestExampleKnobs: ExampleKnobsProps = {
         "Max antall treff",
         "Placeholder",
         "Vis ikoner",
+        "Ingen treff med valg",
     ],
     choiceProps: [
         {
@@ -54,8 +55,16 @@ export const AutosuggestExample: React.FC<ExampleComponentProps> = ({ boolValues
                 placeholder={boolValues?.Placeholder ? "Velg et land" : undefined}
                 showDropdownControllerButton={boolValues?.["Vis ikoner"]}
                 noHitsMessage={boolValues?.["Ingen treff"] ? "Fant ingen land, men du kan skrive ferdig" : undefined}
-                maxNumberOfHits={boolValues?.["Mis maks 3 treff"] ? 3 : undefined}
+                maxNumberOfHits={boolValues?.["Max antall treff"] ? 3 : undefined}
                 variant={(choiceValues?.Variant as "small" | "medium" | "large") || "medium"}
+                noHits={
+                    boolValues?.["Ingen treff med valg"]
+                        ? {
+                              text: <p className="jkl-body">Fant ingen land. Vil du velge et av disse:</p>,
+                              items: ["Norge", "Sverige", "Danmark"],
+                          }
+                        : undefined
+                }
             />
             <p className="jkl-body jkl-spacing-m--top">Du har valgt: {value}</p>
         </div>
@@ -97,9 +106,17 @@ return (
             noHitsMessage="Fant ingen land, men du kan skrive ferdig"`
         : ""
 }${
-    boolValues?.["Mis maks 3 treff"]
+    boolValues?.["Max antall treff"]
         ? `
             maxNumberOfHits={3}`
+        : ""
+}${
+    boolValues?.["Ingen treff med valg"]
+        ? `
+            noHits={{
+                text: <p className="jkl-body">Fant ingen land. Vil du velge et av disse:</p>,
+                items: ["Norge", "Sverige", "Danmark"],
+            }}`
         : ""
 }
             variant="${choiceValues?.Variant}"

--- a/packages/text-input-react/src/autosuggest/Autosuggest.test.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.test.tsx
@@ -78,4 +78,39 @@ describe("Autosuggest", () => {
         const label = getByText("Velg land");
         expect(label).toHaveClass("jkl-label--sr-only");
     });
+
+    it("shows no hits message and fallback options", () => {
+        const { getByTestId, queryAllByTestId, getByText } = renderMount({
+            noHits: {
+                text: <p className="jkl-body">No countries found, do you want one of these</p>,
+                items: ["Norway", "Sweden", "Denmark"],
+            },
+        });
+
+        const input = getByTestId("autosuggest__input");
+        fireEvent.change(input, { target: { value: "gibberish" } });
+
+        expect(getByText("No countries found, do you want one of these")).toBeInTheDocument();
+
+        const items = queryAllByTestId("autosuggest__item");
+        expect(queryAllByTestId("autosuggest__item")).toHaveLength(3);
+        expect(items[0]).toHaveTextContent("Norway");
+        expect(items[1]).toHaveTextContent("Sweden");
+        expect(items[2]).toHaveTextContent("Denmark");
+    });
+
+    it("shows no hits message without fallback options", () => {
+        const { getByTestId, queryAllByTestId, getByText } = renderMount({
+            noHits: {
+                text: <p className="jkl-body">No countries found</p>,
+                items: [],
+            },
+        });
+
+        const input = getByTestId("autosuggest__input");
+        fireEvent.change(input, { target: { value: "gibberish" } });
+
+        expect(getByText("No countries found")).toBeInTheDocument();
+        expect(queryAllByTestId("autosuggest__item")).toHaveLength(0);
+    });
 });

--- a/packages/text-input-react/src/autosuggest/Autosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/Autosuggest.tsx
@@ -27,10 +27,12 @@ export type CommonProps = (
     variant?: "large" | "medium" | "small";
     density?: Density;
     placeholder?: string;
+    /** @deprecated Bruk noHits med text og evt. defaultverdier for items */
     noHitsMessage?: ReactNode;
     maxNumberOfHits?: number;
     showDropdownControllerButton?: boolean;
     onInputValueChange?: (inputValue: string) => void;
+    noHits?: { items: string[]; text: ReactNode };
 };
 
 export interface AutosuggestStringItemProps {

--- a/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
@@ -2,7 +2,7 @@ import { Label, SupportLabel } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
 import Downshift, { DownshiftProps } from "downshift";
-import React from "react";
+import React, { ReactNode } from "react";
 import { CommonProps } from "./Autosuggest";
 import ControllerButton from "./ControllerButton";
 import Menu from "./Menu";
@@ -15,6 +15,7 @@ type BaseAutosuggestProps<T> = CommonProps & {
     downshiftProps: DownshiftProps<T>;
     showDropdownControllerButton?: boolean;
     onConfirm?: () => void;
+    noHits?: { text: ReactNode; items: T[] };
 };
 
 function BaseAutosuggest<T>({
@@ -38,6 +39,7 @@ function BaseAutosuggest<T>({
     onConfirm = () => {
         /* noop */
     },
+    noHits,
 }: BaseAutosuggestProps<T>): JSX.Element {
     const uid = useId(inputId || "jkl-text-input", { generateSuffix: !inputId });
     const lid = useId(labelId || "jkl-label", { generateSuffix: !labelId });
@@ -128,6 +130,7 @@ function BaseAutosuggest<T>({
                                 itemToString={itemToString}
                                 noHitsMessage={noHitsMessage}
                                 maxNumberOfHits={maxNumberOfHits}
+                                noHits={noHits}
                             />
                         )}
                         <SupportLabel id={supportId} errorLabel={errorLabel} helpLabel={helpLabel} density={density} />

--- a/packages/text-input-react/src/autosuggest/Menu.tsx
+++ b/packages/text-input-react/src/autosuggest/Menu.tsx
@@ -33,9 +33,9 @@ function Menu<T>({
         <div data-testid="autosuggest__menu" style={{ position: "relative" }}>
             <div className="jkl-autosuggest__menu">
                 {(noHitsMessage || noHits) && visibleItems.length === 0 && (
-                <div className="jkl-autosuggest__no-hits-message" aria-live="polite">
-                    {noHitsMessage || noHits?.text}
-                </div>
+                    <div className="jkl-autosuggest__no-hits-message" aria-live="polite">
+                        {noHitsMessage || noHits?.text}
+                    </div>
                 )}
 
                 {itemList.length > 0 && (

--- a/packages/text-input-react/src/autosuggest/Menu.tsx
+++ b/packages/text-input-react/src/autosuggest/Menu.tsx
@@ -9,6 +9,7 @@ interface MenuProps<T> {
     itemToString: (item: T | null) => string;
     noHitsMessage?: ReactNode;
     maxNumberOfHits?: number;
+    noHits?: { items: T[]; text: ReactNode };
 }
 
 function Menu<T>({
@@ -18,36 +19,44 @@ function Menu<T>({
     itemToString,
     noHitsMessage,
     maxNumberOfHits = Infinity,
+    noHits,
 }: MenuProps<T>): JSX.Element | null {
     const visibleItems = items.length > maxNumberOfHits ? items.slice(0, maxNumberOfHits) : items;
 
-    if (visibleItems.length === 0 && !noHitsMessage) {
+    if (visibleItems.length === 0 && !noHitsMessage && !noHits) {
         return null;
     }
 
+    const itemList = visibleItems.length === 0 && noHits ? noHits.items : visibleItems;
+
     return (
-        <div data-testid="autosuggest__menu" style={{ position: "relative" }}>
-            <ul
-                {...getMenuProps({
-                    className: "jkl-autosuggest__menu",
-                })}
-            >
-                {visibleItems.length === 0 && <div className="jkl-autosuggest__no-hits-message">{noHitsMessage}</div>}
-                {visibleItems.map((item, index) => (
-                    <li
-                        {...getItemProps({
-                            item,
-                            className: cn("jkl-autosuggest__item", {
-                                "jkl-autosuggest__item--active": index === highlightedIndex,
-                            }),
-                        })}
-                        data-testid="autosuggest__item"
-                        key={itemToString(item)}
-                    >
-                        {itemToString(item)}
-                    </li>
-                ))}
-            </ul>
+        <div data-testid="autosuggest__menu" className="jkl-autosuggest__menu" style={{ position: "relative" }}>
+            {(noHitsMessage || noHits) && visibleItems.length === 0 && (
+                <div className="jkl-autosuggest__no-hits-message">{noHitsMessage || noHits?.text}</div>
+            )}
+
+            {itemList.length > 0 && (
+                <ul
+                    {...getMenuProps({
+                        className: "jkl-autosuggest__item-list",
+                    })}
+                >
+                    {itemList.map((item, index) => (
+                        <li
+                            {...getItemProps({
+                                item,
+                                className: cn("jkl-autosuggest__item", {
+                                    "jkl-autosuggest__item--active": index === highlightedIndex,
+                                }),
+                            })}
+                            data-testid="autosuggest__item"
+                            key={itemToString(item)}
+                        >
+                            {itemToString(item)}
+                        </li>
+                    ))}
+                </ul>
+            )}
         </div>
     );
 }

--- a/packages/text-input-react/src/autosuggest/Menu.tsx
+++ b/packages/text-input-react/src/autosuggest/Menu.tsx
@@ -30,33 +30,35 @@ function Menu<T>({
     const itemList = visibleItems.length === 0 && noHits ? noHits.items : visibleItems;
 
     return (
-        <div data-testid="autosuggest__menu" className="jkl-autosuggest__menu" style={{ position: "relative" }}>
-            {(noHitsMessage || noHits) && visibleItems.length === 0 && (
-                <div className="jkl-autosuggest__no-hits-message">{noHitsMessage || noHits?.text}</div>
-            )}
+        <div data-testid="autosuggest__menu" style={{ position: "relative" }}>
+            <div className="jkl-autosuggest__menu">
+                {(noHitsMessage || noHits) && visibleItems.length === 0 && (
+                    <div className="jkl-autosuggest__no-hits-message">{noHitsMessage || noHits?.text}</div>
+                )}
 
-            {itemList.length > 0 && (
-                <ul
-                    {...getMenuProps({
-                        className: "jkl-autosuggest__item-list",
-                    })}
-                >
-                    {itemList.map((item, index) => (
-                        <li
-                            {...getItemProps({
-                                item,
-                                className: cn("jkl-autosuggest__item", {
-                                    "jkl-autosuggest__item--active": index === highlightedIndex,
-                                }),
-                            })}
-                            data-testid="autosuggest__item"
-                            key={itemToString(item)}
-                        >
-                            {itemToString(item)}
-                        </li>
-                    ))}
-                </ul>
-            )}
+                {itemList.length > 0 && (
+                    <ul
+                        {...getMenuProps({
+                            className: "jkl-autosuggest__item-list",
+                        })}
+                    >
+                        {itemList.map((item, index) => (
+                            <li
+                                {...getItemProps({
+                                    item,
+                                    className: cn("jkl-autosuggest__item", {
+                                        "jkl-autosuggest__item--active": index === highlightedIndex,
+                                    }),
+                                })}
+                                data-testid="autosuggest__item"
+                                key={itemToString(item)}
+                            >
+                                {itemToString(item)}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
         </div>
     );
 }

--- a/packages/text-input-react/src/autosuggest/Menu.tsx
+++ b/packages/text-input-react/src/autosuggest/Menu.tsx
@@ -33,7 +33,9 @@ function Menu<T>({
         <div data-testid="autosuggest__menu" style={{ position: "relative" }}>
             <div className="jkl-autosuggest__menu">
                 {(noHitsMessage || noHits) && visibleItems.length === 0 && (
-                    <div className="jkl-autosuggest__no-hits-message">{noHitsMessage || noHits?.text}</div>
+                <div className="jkl-autosuggest__no-hits-message" aria-live="polite">
+                    {noHitsMessage || noHits?.text}
+                </div>
                 )}
 
                 {itemList.length > 0 && (

--- a/packages/text-input/_autosuggest.scss
+++ b/packages/text-input/_autosuggest.scss
@@ -128,7 +128,6 @@
         border-radius: 0 0 jkl.rem(3px) jkl.rem(3px);
         box-sizing: border-box;
         color: var(--jkl-autosuggest-text-color);
-        list-style-type: none;
         position: absolute;
         top: 0;
         left: -#{jkl.rem(1px)};
@@ -137,8 +136,15 @@
         max-height: 60vh;
         overflow-y: auto;
         padding: var(--jkl-autosuggest-menu-padding);
+        width: calc(100% + jkl.rem(2px));
         z-index: jkl.$z-index--dropdown;
         -webkit-overflow-scrolling: touch;
+    }
+
+    &__item-list {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
     }
 
     &__item {


### PR DESCRIPTION
ISSUES CLOSED: #3062

Lagt til noHits props som tar i mot et objekt som kan ta i mot text som en ReactNode, og også en fallback items liste som kan vises ved ingen treff.

## 🎯 Sjekkliste

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
