### PR TITLE
chore: bytt om på hvordan pakken publiseres for å unngå rename-mishaps

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,9 @@
+.turbo
+documentation
+integration
+src
+CHANGELOG.md
+esbuild.*
+gulpfile.js
+MIGRATION.md
+tsconfig*

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,15 +26,6 @@
     "directories": {
         "lib": "build"
     },
-    "files": [
-        "build",
-        "functions",
-        "mixins",
-        "styles",
-        "variables",
-        "*.css",
-        "*.scss"
-    ],
     "scripts": {
         "clean": "rimraf .turbo/ build/ node_modules/ **/*.css",
         "build": "run-s build:*",


### PR DESCRIPTION
Dette er vel andre gangen jeg innfører denne feilen. Gå fra en include til en exclude. Ta med alt som ikke er config, tester, TypeScript-kilder og dokumentasjon.

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
