### PR TITLE
fix: ikke vis feilbakgrunn på åpen select

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -308,7 +308,8 @@ $_select-search-input-selection-color--inverted: color.scale(
         }
     }
 
-    &--invalid {
+    /* stylelint-disable-next-line selector-not-notation -- dette er faktisk en simple :not-selector */
+    &--invalid:not(&--open) {
         .jkl-select__search-input,
         .jkl-select__button {
             background-color: var(--jkl-select-error-background-color);


### PR DESCRIPTION
ISSUES CLOSED: #3101

Fjern bakgrunn med feilfarge for åpen Select.

## 🎯 Sjekkliste

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
