### PR TITLE
fix: bruk riktig padding på compact Select med søk

### DIFF
--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -72,7 +72,7 @@ $_select-search-input-selection-color--inverted: color.scale(
     --jkl-select-arrow-width: #{jkl.rem(10px)};
     --jkl-select-arrow-right: #{jkl.rem(11px)};
     --jkl-select-button-padding: #{jkl.$spacing-2xs} #{jkl.$spacing-l} #{jkl.$spacing-2xs} #{jkl.$spacing-xs};
-    --jkl-select-search-input-padding: #{jkl.$spacing-xs} #{jkl.$spacing-3xs};
+    --jkl-select-search-input-padding: #{jkl.$spacing-2xs} #{jkl.$spacing-xs};
     --jkl-select-native-padding: #{jkl.$spacing-2xs} #{jkl.$spacing-l} #{jkl.$spacing-2xs} #{jkl.$spacing-2xs};
     --jkl-select-option-padding: #{jkl.$spacing-xs};
 }


### PR DESCRIPTION
Oppdaterer padding til riktige verdier
## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
