### PR TITLE
fjern 'jøkul' fra "Ny oppgave" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ny-oppgave.md
+++ b/.github/ISSUE_TEMPLATE/ny-oppgave.md
@@ -1,6 +1,6 @@
 ---
-name: Ny Jøkul-oppgave
-about: Du har funnet noe som kan endres på eller legges til i designsystemet
+name: Ny oppgave
+about: Du har en idé til noe som kan endres på eller legges til i designsystemet
 title: ''
 labels: "✨ enhancement"
 assignees: ''


### PR DESCRIPTION
Alt i repoet handler om Jøkul, vi trenger kanskje ikke repetere navnet vårt overalt?