### PR TITLE
fix: la brukeren scrolle i TextArea som starter åpent

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -323,8 +323,7 @@ $_text-input-selection-color--inverted: color.scale(
     height: auto;
     width: 100%;
 
-    &--auto-expand,
-    &--start-open {
+    &--auto-expand {
         .jkl-text-input__input,
         .jkl-text-area__text-area {
             overflow: hidden; // Skjul scrollbar når høyden autojusteres


### PR DESCRIPTION
ISSUES CLOSED: #3140

## 🎯 Sjekkliste

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
