### PR TITLE
feat: la useIntersectionObserver ta inn flere elementer

### DIFF
--- a/packages/react-hooks/documentation/IntersectionObserverExample.tsx
+++ b/packages/react-hooks/documentation/IntersectionObserverExample.tsx
@@ -15,11 +15,7 @@ const IntersectionObserverExample: FC = () => {
     useIntersectionObserver(targetRef, onIntersect, fallback, options);
 
     return (
-        <div
-            className={`jkl-intersection-example ${
-                isInViewport ? "jkl-intersection-example--visible" : "jkl-intersection-example--not-visible"
-            }`}
-        >
+        <div className="jkl jkl-intersection-example" data-theme={isInViewport ? "dark" : "light"}>
             <p className="jkl-body jkl-spacing-xl--all" style={{ height: "100vh" }}>
                 Scroll for å endre farge
             </p>

--- a/packages/react-hooks/documentation/index.scss
+++ b/packages/react-hooks/documentation/index.scss
@@ -10,20 +10,11 @@
 }
 
 .jkl-intersection-example {
-    transition: jkl.timing("expressive") background-color ease-in-out;
+    @include jkl.motion("standard", "expressive");
+    transition-property: background-color, border-color;
     border-radius: jkl.rem(4px);
-}
-
-.jkl-intersection-example--visible {
-    background-color: jkl.$color-stein;
-
-    @include jkl.forced-colors-mode {
-        background-color: Highlight;
-    }
-}
-
-.jlk-intersection-example--not-visible {
-    background-color: Canvas;
+    border: jkl.rem(1px) solid;
+    border-color: currentColor;
 }
 
 .focus-outside-example {

--- a/packages/react-hooks/documentation/intersectionObserver.mdx
+++ b/packages/react-hooks/documentation/intersectionObserver.mdx
@@ -7,9 +7,10 @@ group: hooks
 import IntersectionObserverExample from "./IntersectionObserverExample";
 
 <Ingress>
-    useIntersectionObserver lar deg lytte på om et element er synlig eller ikke. Det gjør det mulig å animere innhold
-    inn, eller prelaste innhold som er rett uten for viewporten. I eksemplet brukes det til å bytte bakgrunnsfarge når
-    andre paragrafen kommer helt inn i visning.
+    useIntersectionObserver lar deg observere et eller flere elementer, og kalle en funksjon hver gang et av dem beveger
+    seg inn eller ut av et område av skjermen.
 </Ingress>
+
+Bruk useInteractionObserver når du vil utsette lasting av innhold til det nærmer seg den synlige delen av skjermen, eller bruk den til å utløse endringer på siden ut fra hvilket innhold som er synlig. I eksemplet under skifter boksen farge ettersom det nederste avsnittet beveger seg inn og ut av det synlige området.
 
 <ComponentExample title="useIntersectionObserver" component={IntersectionObserverExample} />

--- a/packages/react-hooks/src/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/react-hooks/src/useIntersectionObserver/useIntersectionObserver.ts
@@ -1,12 +1,39 @@
 import { useEffect, useRef, RefObject } from "react";
 
+type ValidElement = HTMLElement | SVGElement;
+type Target = RefObject<ValidElement> | RefObject<NodeListOf<ValidElement>> | NodeListOf<ValidElement>;
+
+function isNodeList(target: Target | ValidElement): target is NodeListOf<ValidElement> {
+    return (target as NodeListOf<ValidElement>).forEach !== undefined;
+}
+
 const hasWindowWithIntersectionObserver = () =>
     typeof window !== "undefined" && typeof IntersectionObserver !== "undefined";
 
 export const useIntersectionObserver = (
-    targetRef: RefObject<HTMLElement | SVGElement>,
+    /**
+     * Elementet eller elementene som skal observeres. Du kan sende in en React ref
+     * til et HTMLElement eller SVG Element, eller en NodeList av samme type elementer
+     * (returneres f.eks. av document.querySelectorAll), eller en React ref med en
+     * NodeList av samme type elementer.
+     */
+    target: Target,
+    /**
+     * Callback-funksjon som utføres når et av elementene
+     * som observeres overlapper angitt mål. Se
+     * https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#parameters
+     * for mer info.
+     */
     onIntersect: IntersectionObserverCallback,
+    /**
+     * Funksjon som kalles dersom nettleseren ikke støtter IntersectionOpserver-APIet.
+     */
     fallback: VoidFunction,
+    /**
+     * Objekt med innstillinger for oberveren. Se
+     * https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#parameters
+     * for mer info.
+     */
     options?: Partial<IntersectionObserverInit>,
 ): void => {
     const observerRef = useRef<IntersectionObserver>(null);
@@ -14,16 +41,18 @@ export const useIntersectionObserver = (
     useEffect(() => {
         let observer = observerRef.current;
         if (hasWindowWithIntersectionObserver()) {
-            const target = targetRef.current;
-
             if (observer) {
                 observer.disconnect();
             }
 
             observer = new IntersectionObserver(onIntersect, options);
 
-            if (target) {
-                observer.observe(target);
+            if (isNodeList(target)) {
+                target.forEach((element) => observer?.observe(element));
+            } else if (target.current && isNodeList(target.current)) {
+                target.current.forEach((element) => observer?.observe(element));
+            } else if (target.current) {
+                observer.observe(target.current);
             }
         } else {
             fallback();
@@ -33,5 +62,5 @@ export const useIntersectionObserver = (
                 observer.disconnect();
             }
         };
-    }, [targetRef, onIntersect, fallback, options]);
+    }, [target, onIntersect, fallback, options]);
 };


### PR DESCRIPTION
La `useIntersectionObserver` ta inn flere elementer som en NodeList, slik at man enklere kan observere flere elementer samtidig.

ISSUES CLOSED: #3182

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
