### PR TITLE
fix: fjern hovereffekt fra siste brødsmule

### DIFF
--- a/packages/breadcrumb/breadcrumb.scss
+++ b/packages/breadcrumb/breadcrumb.scss
@@ -5,6 +5,12 @@
         text-decoration: none;
         background-image: none;
         color: var(--jkl-color);
+
+        &:hover {
+            cursor: default;
+            color: var(--jkl-link-color);
+            background-image: none;
+        }
     }
 
     &__list {


### PR DESCRIPTION
Ikke ønsket visuelt, men beholdes som en lenke for UU.

ISSUES CLOSED: #3128

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
