### PR TITLE
feat: legg til hook for navigering til tabs via URL

### DIFF
--- a/packages/tabs-react/documentation/TabNavigationExample.tsx
+++ b/packages/tabs-react/documentation/TabNavigationExample.tsx
@@ -1,0 +1,82 @@
+import React, { FC } from "react";
+import { CodeExample, ExampleComponentProps, ExampleKnobsProps } from "../../../doc-utils";
+import { TabList, Tab, Tabs, TabPanel, useTabNavigation } from "../src";
+
+export const tabNavigationExampleKnobs: ExampleKnobsProps = {};
+
+export const TabNavigationExample: FC<ExampleComponentProps> = () => {
+    const TAB_TITLES = ["Bedrifter", "Bedriftsansvarlige", "Rådgivere"];
+
+    const { handleTabChange, navigatedTab } = useTabNavigation(TAB_TITLES, {
+        urlParameter: "tab",
+        navigateFunction: console.log,
+    });
+
+    return (
+        <Tabs key={navigatedTab} defaultTab={navigatedTab} onChange={handleTabChange}>
+            <TabList aria-label="tabs">
+                {TAB_TITLES.map((tabTitle) => (
+                    <Tab key={tabTitle}>{tabTitle}</Tab>
+                ))}
+            </TabList>
+            <TabPanel>
+                <div className="jkl-spacing-m--all">Innhold for Bedrifter</div>
+            </TabPanel>
+            <TabPanel>
+                <div className="jkl-spacing-m--all">Innhold for Bedriftansvarlige</div>
+            </TabPanel>
+            <TabPanel>
+                <div className="jkl-spacing-m--all">
+                    Innhold for Rådgivere
+                    <Tabs>
+                        <TabList aria-label="subtabs">
+                            <Tab>Bedrift AS</Tab>
+                            <Tab>Alternativ AS</Tab>
+                        </TabList>
+                        <TabPanel className="jkl-spacing-m--all">Innhold for Bedrift AS</TabPanel>
+                        <TabPanel className="jkl-spacing-m--all">Innhold for Alternativ AS</TabPanel>
+                    </Tabs>
+                </div>
+            </TabPanel>
+        </Tabs>
+    );
+};
+
+export const tabNavigationExampleCode: CodeExample = () => `
+const TAB_TITLES = ["Bedrifter", "Bedriftsansvarlige", "Rådgivere"];
+
+const { chosenTab, handleTabChange, navigatedTab } = useTabNavigation(TAB_TITLES, {
+    urlParameter: "tab",
+    navigateFunction: console.log,
+});
+
+return (
+    <Tabs key={navigatedTab} defaultTab={chosenTab} onChange={handleTabChange}>
+        <TabList aria-label="tabs">
+            {TAB_TITLES.map((tabTitle) => (
+                <Tab key={tabTitle}>{tabTitle}</Tab>
+            ))}
+        </TabList>
+        <TabPanel>
+            <div className="jkl-spacing-m--all">Innhold for Bedrifter</div>
+        </TabPanel>
+        <TabPanel>
+            <div className="jkl-spacing-m--all">Innhold for Bedriftansvarlige</div>
+        </TabPanel>
+        <TabPanel>
+            <div className="jkl-spacing-m--all">
+                Innhold for Rådgivere
+                <Tabs>
+                    <TabList aria-label="subtabs">
+                        <Tab>Bedrift AS</Tab>
+                        <Tab>Alternativ AS</Tab>
+                    </TabList>
+                    <TabPanel className="jkl-spacing-m--all">Innhold for Bedrift AS</TabPanel>
+                    <TabPanel className="jkl-spacing-m--all">Innhold for Alternativ AS</TabPanel>
+                </Tabs>
+            </div>
+        </TabPanel>
+    </Tabs>
+)`;
+
+export default TabNavigationExample;

--- a/packages/tabs-react/documentation/Tabs.mdx
+++ b/packages/tabs-react/documentation/Tabs.mdx
@@ -6,6 +6,7 @@ group: knapper
 ---
 
 import TabsExample, { tabsExampleCode, tabsExampleKnobs } from "./TabsExample";
+import TabNavigationExample, { tabNavigationExampleCode, tabNavigationExampleKnobs } from "./TabNavigationExample";
 import "@fremtind/jkl-tabs/tabs.css";
 
 <Ingress>
@@ -28,6 +29,19 @@ import "@fremtind/jkl-tabs/tabs.css";
 -   Bør ikke brukes når det er nødvendig å sammenligne eller se innholdet i de ulike fanene samtidig. Hvis dette er et behov, er det bedre å bruke accordion.
 -   Bør ikke brukes hvis man trenger å lese gjennom alt innholdet for å forstå en stegvis prosess.
 -   Skal ikke brukes for å sende brukeren til en ny side.
+
+## Bruk av tabs som sidenavigasjon
+
+Noen ganger vil det være naturlig å bruke tabs som undernavigasjon på en side, og i slike tilfeller vil det være ønskelig å kunne lenke til en spesifikk tab på siden. Vi tilbyr en hook, `useTabNavigation` som hjelper til med implementasjonen av dette. Den oppdaterer URLen når brukeren velger en tab, og bytter automatisk til eventuell tab som er angitt i URLen som lastes inn.
+
+<ComponentExample
+    title="TabNavigation"
+    component={TabNavigationExample}
+    knobs={tabNavigationExampleKnobs}
+    codeExample={tabNavigationExampleCode}
+/>
+
+Som standard bruker funksjonen standard Web API for å endre adressen når du klikker på en tab, men du kan også sende inn en egen funksjon for å navigere dersom du bruker rammeverk som Gatsby, Next.js eller Remix. I eksemplet over logger vi bare adressen til konsollen.
 
 ## Eksempler på bruk
 

--- a/packages/tabs-react/src/TabList.tsx
+++ b/packages/tabs-react/src/TabList.tsx
@@ -65,6 +65,17 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
         }
     }, []);
 
+    const indicatorStyle =
+        // Unngå at indikatoren starter helt til venstre og animeres bort
+        // til valgt tab ved rerender
+        activeRect && tabsRect
+            ? {
+                  left: activeRect.left - tabsRect.left,
+                  bottom: -1,
+                  width: activeRect.width,
+              }
+            : undefined;
+
     return (
         <div role="tablist" ref={tabsRef} {...rest} className={cn("jkl-tablist", className)}>
             {React.Children.map(children, (tab, tabIndex) => {
@@ -83,14 +94,7 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
                     : null;
             })}
 
-            <span
-                className="jkl-tablist__indicator"
-                style={{
-                    left: (activeRect?.left || 0) - (tabsRect?.left || 0),
-                    bottom: -1,
-                    width: (activeRect?.width || 0) - (density === "compact" ? 32 : 38),
-                }}
-            />
+            <span className="jkl-tablist__indicator" style={indicatorStyle} />
         </div>
     );
 };

--- a/packages/tabs-react/src/index.ts
+++ b/packages/tabs-react/src/index.ts
@@ -2,3 +2,4 @@ export * from "./Tabs";
 export * from "./TabList";
 export * from "./Tab";
 export * from "./TabPanel";
+export * from "./useTabNavigation";

--- a/packages/tabs-react/src/index.ts
+++ b/packages/tabs-react/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./Tabs";
-export * from "./TabList";
-export * from "./Tab";
-export * from "./TabPanel";
-export * from "./useTabNavigation";
+export { Tabs, type TabsProps } from "./Tabs";
+export { TabList, type TabListProps } from "./TabList";
+export { Tab, type TabProps } from "./Tab";
+export { TabPanel, type TabPanelProps } from "./TabPanel";
+export { type TabNavigationOptions, useTabNavigation } from "./useTabNavigation";

--- a/packages/tabs-react/src/useTabNavigation.ts
+++ b/packages/tabs-react/src/useTabNavigation.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from "react";
+
+const slugify = (input: string) =>
+    input.toLocaleLowerCase().replace(/æ/g, "ae").replace(/ø/, "oe").replace(/å/, "aa").replace(/(\W)/g, "-");
+
+const getSearchParameter = (parameter: string) => {
+    if (typeof window !== "undefined") {
+        const pageParams = new URLSearchParams(window.location.search);
+        return pageParams.get(parameter);
+    }
+    return null;
+};
+
+export type TabNavigationOptions = {
+    /**
+     * En tekststreng du vil bruke som URL-parameter for valgt tab
+     * Vil gi utslag i lenker på formen `dinløsning.com/dinside?[urlParameter]=din-tab`
+     * @default "seksjon"
+     */
+    urlParameter?: string;
+    /**
+     * Navigasjonsfunksjon fra eventuell Router du bruker i applikasjonen din,
+     * for å få URL-endringen inn i nettleserhistorien på riktig måte.
+     * Hvis denne ikke defineres legges endringen inn i `window.history`.
+     */
+    navigateFunction?: (sectionPath: string) => void;
+    /**
+     * Eventuell funksjonalitet du vil ha utført ved onChange fra Tabs-komponenten
+     */
+    onChange?: (tabIndex: number) => void;
+};
+
+/**
+ * useTabNavigation lar deg behandle navigering i tabs som navigasjon på en side, ved å legge til et søkeattributt i sidens
+ * URL med henvisning til gjeldende tab. Dermed kan du også lenke til en spesifikk tab ved å bruke samme syntaks i lenkene dine.
+ *
+ * @param tabTitles Overskriftene på tabene du vil bruke (tips: bruk dette arrayet til å rendre Tabs i komponenten også)
+ * @param options Valgfritt objekt med valg for håndtering av navigasjonen
+ * @returns Et objekt med indeksen for valgt tab og en funksjon for håndtering av onChange i Tabs-komponenten
+ */
+export const useTabNavigation = (tabTitles: string[], options?: Partial<TabNavigationOptions>) => {
+    const { urlParameter, navigateFunction, onChange } = { urlParameter: "seksjon", ...options };
+
+    const getTabFromURL = useCallback(() => {
+        const paramSection = tabTitles.findIndex((section) => slugify(section) === getSearchParameter(urlParameter));
+        return paramSection < 0 ? 0 : paramSection;
+    }, [tabTitles, urlParameter]);
+
+    const [navigatedTab, setNavigatedTab] = useState(getTabFromURL());
+
+    const navigate = useCallback(
+        /**
+         * Oppdater URL med sti til valgt tab, eller naviger med angitt funksjon
+         * @param sectionID Indeks til tab som navigeres til
+         */
+        (sectionID: number) => {
+            const tabString = slugify(tabTitles[sectionID]);
+            if (navigateFunction) {
+                navigateFunction(`?${urlParameter}=${tabString}`);
+            } else if (typeof window !== "undefined") {
+                // Legger til en URL i historien til nettleseren uten å laste siden på nytt
+                // https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
+                window.history.pushState(null, tabTitles[sectionID], `?${urlParameter}=${tabString}`);
+            }
+        },
+        [tabTitles, navigateFunction, urlParameter],
+    );
+
+    useEffect(() => {
+        const updateCurrentTab = () => {
+            setNavigatedTab(getTabFromURL());
+        };
+
+        if (typeof window !== "undefined") {
+            // Oppdater valgt tab dersom man går frem eller tilbake i historien i nettleservinduet
+            window.addEventListener("popstate", updateCurrentTab);
+        }
+
+        return () => {
+            if (typeof window !== "undefined") {
+                window.removeEventListener("popstate", updateCurrentTab);
+            }
+        };
+    }, [getTabFromURL]);
+
+    useEffect(() => {
+        if (typeof window !== "undefined" && typeof document !== "undefined") {
+            // Scroll til eventuell hash-lenke (dokumentet kan ikke gjøre dette automatisk,
+            // siden innholdet ikke nødvendigvis er lastet før vi oppdaterer havigatedTab)
+            if (window.location.hash !== "") {
+                const hash = decodeURI(window.location.hash);
+                document.querySelector(hash)?.scrollTo();
+            }
+        }
+    }, []);
+
+    const handleTabChange = (tabIndex: number) => {
+        onChange?.(tabIndex);
+        navigate(tabIndex);
+    };
+
+    return {
+        handleTabChange,
+        navigatedTab,
+    };
+};

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -17,27 +17,30 @@
 @include jkl.comfortable-density-variables {
     @include jkl.declare-font-variables("jkl-tab", "body");
 
-    --jkl-tab-padding: #{jkl.$spacing-xs} #{jkl.$spacing-xl} #{jkl.$spacing-s} #{jkl.$spacing-3xs};
+    --jkl-tab-padding: #{jkl.$spacing-xs} 0 #{jkl.$spacing-s};
+    --jkl-tab-gap: #{jkl.$spacing-xl};
 }
 
 @include jkl.compact-density-variables {
     @include jkl.declare-font-variables("jkl-tab", "small");
 
-    --jkl-tab-padding: #{jkl.$spacing-3xs} #{jkl.rem(32px)} #{jkl.$spacing-2xs} 0;
+    --jkl-tab-padding: #{jkl.$spacing-3xs} 0 #{jkl.$spacing-2xs};
+    --jkl-tab-gap: #{jkl.rem(32px)};
 }
 
 .jkl-tablist {
     position: relative;
     display: flex;
     flex-direction: row;
+    gap: var(--jkl-tab-gap);
     padding: 0;
     margin: 0;
-    border-bottom: 1px jkl.$color-svaberg solid;
+    border-bottom: jkl.rem(1px) jkl.$color-svaberg solid;
     width: 100%;
 
     &__indicator {
         position: absolute;
-        height: 2px;
+        height: jkl.rem(2px);
         background-color: var(--jkl-tab-indicator-color);
         @include jkl.motion("standard", "lazy");
         transition-property: left, width;
@@ -72,10 +75,7 @@
         &::after {
             content: "";
             position: absolute;
-            top: jkl.rem(2px);
-            right: jkl.rem(6px); // Hold avstand til neste fane
-            bottom: jkl.rem(1px);
-            left: jkl.rem(-2px);
+            inset: jkl.rem(0) jkl.rem(-2px) jkl.rem(1px);
             box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-tab-focus-border-color);
         }
     }


### PR DESCRIPTION
Legg til en hook `useTabNavigation` som lar deg bytte til en tab gjennom et URL-parameter, og oppdaterer URLen med riktig parameter når brukeren bytter tab selv.

Det er noen ting som _ikke_ løses med denne implementasjonen. F.eks. er tab-ene fortsatt buttons, så man kan ikke åpne i ny fane. Hvis vi vil ha med den funksjonaliteten får vi enten en større omskriving av komponenten, eller en ny variant som brukes til navigasjon. Jeg hadde lyst til å holde ting litt modulært, og synes ikke det er vanlige tabs sin oppgave å vite noe om statusen til siden de er på, så da ble det denne løsningen 😅 Jeg har derfor heller _ikke_ merket at denne løser #3143, i hvert fall enn så lenge.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
