### PR TITLE
fix: hindre automatisk scrolling når modal åpnes

### DIFF
--- a/packages/cookie-consent/cookie-consent.scss
+++ b/packages/cookie-consent/cookie-consent.scss
@@ -5,6 +5,9 @@ $_container-width: jkl.rem(660px);
 $_container-width--compact: jkl.rem(320px);
 
 .jkl-cookie-consent-modal {
+    position: fixed;
+    z-index: jkl.$z-index--modal !important;
+
     &[aria-hidden="true"] {
         display: none;
     }
@@ -17,7 +20,6 @@ $_container-width--compact: jkl.rem(320px);
         right: 0;
         bottom: 0;
         transition: 0.2s;
-        z-index: jkl.$z-index--modal !important;
     }
 
     &__content {


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
Når CookieConsentModal åpnast blir sida automatisk scrolla til botnen. Dette kan gjenskapast på komponentsida i portalen(https://jokul.fremtind.no/komponenter/cookieconsent). Grunnen til dette er at rot-elementet i modalen ikkje bruker position fixed. Posisjonen til elementet blir derfor der det er plassert i DOMen, som er nederst. Når modalen blir åpna blir den foksuert og nettlesaren scroller automatisk ned til det fokuserte elementet.

For å fikse dette la eg til position: fixed på rot-elementet på modalen.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
