### PR TITLE
chore: ikke tving shorthands for grid og flex

### DIFF
--- a/packages/stylelint-config-jkl/rules/declaration.js
+++ b/packages/stylelint-config-jkl/rules/declaration.js
@@ -1,3 +1,4 @@
 module.exports = {
     "declaration-empty-line-before": null,
+    "declaration-block-no-redundant-longhand-properties": [true, { ignoreShorthands: ["/grid/", "/flex/"] }],
 };


### PR DESCRIPTION
Lesbarhet trumfer

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `yarn build` og `yarn ci:test` gir ingen feil
