### PR TITLE
fix: sørg for at toltip-ikonet ikke strekkes i Safari Mobile

### DIFF
--- a/packages/tooltip/tooltip.scss
+++ b/packages/tooltip/tooltip.scss
@@ -56,9 +56,10 @@ $_focus-ring-width: jkl.rem(2px);
         transition-property: border-color, color;
         height: var(--jkl-tooltip-size);
         width: var(--jkl-tooltip-size);
+        padding: 0;
         background-color: transparent;
         border: $_tooltip-border-width solid var(--jkl-tooltip-button-color);
-        border-radius: 50%;
+        border-radius: 9999px;
         color: var(--jkl-tooltip-button-color);
         cursor: pointer;
         position: relative;
@@ -73,7 +74,7 @@ $_focus-ring-width: jkl.rem(2px);
             right: -($_tooltip-border-width + $_focus-ring-distance);
             bottom: -($_tooltip-border-width + $_focus-ring-distance);
             left: -($_tooltip-border-width + $_focus-ring-distance);
-            border-radius: 50%;
+            border-radius: 9999px;
             box-shadow: 0 0 0 $_focus-ring-width transparent;
         }
 


### PR DESCRIPTION
Fjerner padding på knappen i `Tooltip`, slik at den ikke blir påvirket av nettleser-defaults som gjør den avlang.
Setter også `border-radius` til et høyt tall, slik at vi får en "pille" og ikke en oval _dersom_ knappen blir strukket.

ISSUES CLOSED: #3223

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `yarn build` og `yarn ci:test` gir ingen feil
