### PR TITLE
feat(core): dynamisk spacing etter skjermstørrelse

### DIFF
--- a/packages/core/documentation/Spacing/Spacing.tsx
+++ b/packages/core/documentation/Spacing/Spacing.tsx
@@ -6,22 +6,11 @@ function stringLiteralArray<T extends string>(a: T[]) {
     return a;
 }
 
-const spacings = stringLiteralArray([
-    "spacing-3xs",
-    "spacing-2xs",
-    "spacing-xs",
-    "spacing-s",
-    "spacing-m",
-    "spacing-l",
-    "spacing-xl",
-    "spacing-2xl",
-    "spacing-3xl",
-    "spacing-4xl",
-]);
+const spacings = stringLiteralArray(["2", "4", "8", "12", "16", "24", "32", "40", "64", "104", "168"]);
 
-type spacingClass = typeof spacings[number];
+type Spacing = typeof spacings[number];
 
-const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
+const SpacingTableRow: React.FC<{ spacing: Spacing }> = ({ spacing }) => {
     const getComputedProperty = (node: HTMLElement | null, cssProperty: string) => {
         return (node && window?.getComputedStyle(node)?.getPropertyValue(cssProperty)) || "N/A";
     };
@@ -41,7 +30,7 @@ const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
     return (
         <tr className="jkl-portal-spacing-example-table__row">
             <td data-header="Spacing:" className="jkl-portal-spacing-example-table__data">
-                <div className={`jkl-${spacing}--top`} style={{ display: "none" }} ref={ref} />
+                <div className={`jkl-spacing-${spacing}--top`} style={{ display: "none" }} ref={ref} />
                 <div
                     aria-label={`${spacing},  ${pxValue}`}
                     style={{
@@ -52,26 +41,28 @@ const SpacingTableRow: React.FC<{ spacing: spacingClass }> = ({ spacing }) => {
                 />
             </td>
             <td data-header="Variabel:" className="jkl-portal-spacing-example-table__data">
-                <code className="jkl-portal-inline-code">${spacing}</code>
-            </td>
-            <td data-header="Rem:" className="jkl-portal-spacing-example-table__data">
-                <code className="jkl-portal-inline-code">{remValue}rem</code>
+                <code className="jkl-portal-inline-code">jkl.${`spacing-${spacing}`}</code>
+                <br />
+                <code className="jkl-portal-inline-code">{`var(--jkl-spacing-${spacing})`}</code>
             </td>
             <td data-header="Pixelverdi:" className="jkl-portal-spacing-example-table__data">
                 <code className="jkl-portal-inline-code">{pxValue}</code>
+            </td>
+            <td data-header="Rem:" className="jkl-portal-spacing-example-table__data">
+                <code className="jkl-portal-inline-code">{remValue}rem</code>
             </td>
         </tr>
     );
 };
 
-const SpacingTable: React.FC<{ values: spacingClass[] }> = ({ values }) => (
+const SpacingTable: React.FC<{ values: Spacing[] }> = ({ values }) => (
     <table className="jkl-portal-spacing-example-table">
         <thead>
             <tr>
                 <th className="jkl-portal-spacing-example-table__header">Spacing</th>
                 <th className="jkl-portal-spacing-example-table__header">Variabel</th>
+                <th className="jkl-portal-spacing-example-table__header">Piksler</th>
                 <th className="jkl-portal-spacing-example-table__header">Rem</th>
-                <th className="jkl-portal-spacing-example-table__header">Pixler</th>
             </tr>
         </thead>
         <tbody>

--- a/packages/core/documentation/spacing.mdx
+++ b/packages/core/documentation/spacing.mdx
@@ -7,33 +7,96 @@ group: util
 
 import { SpacingScaleTable } from "./Spacing/Spacing";
 
-<Ingress>Vi tilbyr Sass-variabler og utility-klasser for verdiene i spacing-skalaene til Jøkul.</Ingress>
+<Ingress>
+    Vi tilbyr CSS- og Sass-variabler, en Sass-mixin, og nytteklasser for verdiene i spacing-skalaene til Jøkul. Disse
+    støtter også dynamisk spacing.
+</Ingress>
 
 ## Bruk
 
-I Jøkul har vi en spacing-skala som er basert på t-skjorte størrelser. Du kan bruke skalaene ved hjelp av SASS-variabler som du kan sette inn i ditt eget stilark, eller bruke hjelpeklassene direkte på elementer i koden.
+I Jøkul har vi en spacing-skala som er basert på pikselstørrelser. Du kan bruke skalaene ved hjelp av CSS- eller Sass-variabler som du kan sette inn i ditt eget stilark, bruke en Sass-mixin, eller bruke nytteklassene direkte på elementer i koden.
 
-Variablene kan importeres fra `~@fremtind/jkl-core/jkl`. Husk å bruke riktig importsyntaks for byggverktøyet ditt når du importerer. De kan da brukes slik:
+### Variabler
+
+Sass-variablene kan importeres fra `~@fremtind/jkl-core/jkl`. Husk å bruke riktig importsyntaks for byggverktøyet ditt når du importerer. De kan da brukes slik:
 
 ```scss
 @use "~@fremtind/jkl-core/jkl";
 
 .jkl-your-component {
-    padding-left: jkl.$spacing-s;
+    padding-left: jkl.$spacing-12;
 }
 ```
 
-Utility-klassene setter en verdi fra spacingskalaene som margin på elementet som har klassen. Det finnes varianter for å sette margin på `top`, `right`, `bottom` og `left`, samt for `all`e sider. Klassene kan brukes slik:
+CSS-variablene kan brukes direkte uten noen import, så lenge core-stilene fra Jøkul er i bruk i løsningen din.
+
+```css
+.jkl-your-component {
+    margin-top: var(--jkl-spacing-32);
+}
+```
+
+### Nytteklasser
+
+Nytteklassene setter en verdi fra spacingskalaene som margin på elementet som har klassen. Det finnes varianter for å sette margin på `top`, `right`, `bottom` og `left`, samt for `all`e sider. Klassene kan brukes slik:
 
 ```html
-<div class="jkl-spacing-xl--all">
-    <span class="jkl-spacing-s--right">Hallo</span>
+<div class="jkl-spacing-40--all">
+    <span class="jkl-spacing-12--right">Hallo</span>
     verden
 </div>
 ```
 
-<div class="jkl-spacing-xl--top" />
+### Sass-mixin
 
-### Skala
+Sass-mixinen `jkl.spacing()` fungerer på samme måte som nytteklassene, ved at den setter marginer på elementet som har klassen den brukes i. Du kan sette samme margin på alle sider, eller spesifisere en av sidene `top`, `right`, `bottom` eller `left`:
+
+```scss
+@use "~@fremtind/jkl-core/jkl";
+
+.jkl-your-component {
+    @include jkl.spacing("12"); // tilsvarer margin: jkl.$spacing-12;
+}
+
+.jkl-your-component {
+    @include jkl.spacing("40", "top"); // tilsvarer margin-top: jkl.$spacing-40;
+}
+```
+
+## Dynamisk spacing
+
+Både CSS-variablene, Sass-mixinen og nytteklassene støtter at spacingen endrer seg etter skjermstørrelse. Det finnes variabler for de mest brukte kombinasjonene, og med mixinen kan du definere kombinasjoner fritt.
+
+Der det veksles mellom to størrelser skjer byttet ved overgangen fra liten til mellomstor skjerm, og der det er tre verdier skjer byttene ved henholdsvis liten/mellomstor- og mellomstor/stor-overgangene.
+
+```scss
+@use "~@fremtind/jkl-core/jkl";
+
+// 16px på små skjermer og 24px på medium skjermer og oppover:
+.jkl-your-component {
+    @include jkl.spacing("16/24");
+}
+
+// 16px på små og mellomstore skjermer og 24px på store skjermer og oppover:
+.jkl-your-component {
+    padding: var(--jkl-spacing-16-16-24);
+}
+
+// 16px på små, 24px på mellomstore, og 32px på store skjermer og oppover:
+.jkl-your-component {
+    @include jkl.spacing("16/24/32", "left");
+}
+```
+
+```html
+<!-- 32px på små, 40px på mellomstore, og 64px på store skjermer og oppover -->
+<div class="jkl-spacing-32-40-64--top">
+    <span class="jkl-spacing-12">Hallo verden</span>
+</div>
+```
+
+<div class="jkl-spacing-40--top" />
+
+## Skala
 
 <SpacingScaleTable />

--- a/packages/core/jkl/_index.scss
+++ b/packages/core/jkl/_index.scss
@@ -9,7 +9,7 @@
 @forward "screenreader";
 @forward "screens";
 @forward "shadows";
-@forward "spacing" hide $spacing, $spacing-steps, $positions;
+@forward "spacing" hide $spacing, $combinations, $positions;
 @forward "theme";
 @forward "typography" hide $text-styles;
 @forward "underline";

--- a/packages/core/jkl/_index.scss
+++ b/packages/core/jkl/_index.scss
@@ -9,7 +9,7 @@
 @forward "screenreader";
 @forward "screens";
 @forward "shadows";
-@forward "spacing" hide $spacing, $positions;
+@forward "spacing" hide $spacing, $spacing-steps, $positions;
 @forward "theme";
 @forward "typography" hide $text-styles;
 @forward "underline";

--- a/packages/core/jkl/_index.scss
+++ b/packages/core/jkl/_index.scss
@@ -9,7 +9,7 @@
 @forward "screenreader";
 @forward "screens";
 @forward "shadows";
-@forward "spacing" hide $spacing;
+@forward "spacing" hide $spacing, $positions;
 @forward "theme";
 @forward "typography" hide $text-styles;
 @forward "underline";

--- a/packages/core/jkl/_spacing.scss
+++ b/packages/core/jkl/_spacing.scss
@@ -1,3 +1,8 @@
+@use "sass:string";
+@use "sass:map";
+@use "sass:list";
+@use "screens";
+
 /// Tilsvarer 2px
 /// @type Number
 $spacing-3xs: 0.125rem;
@@ -41,14 +46,78 @@ $spacing-4xl: 10.5rem;
 /// Lar deg gjøre oppslag på navnet uten `spacing`-prefix for å få ut rem-verdien
 /// @type Map
 $spacing-new: (
-    "3xs": $spacing-3xs,
-    "2xs": $spacing-2xs,
-    "xs": $spacing-xs,
-    "s": $spacing-s,
-    "m": $spacing-m,
-    "l": $spacing-l,
-    "xl": $spacing-xl,
-    "2xl": $spacing-2xl,
-    "3xl": $spacing-3xl,
-    "4xl": $spacing-4xl,
+    "3xs": (
+        "small-screen": $spacing-3xs,
+        "large-screen": $spacing-3xs,
+    ),
+    "2xs": (
+        "small-screen": $spacing-2xs,
+        "large-screen": $spacing-2xs,
+    ),
+    "xs": (
+        "small-screen": $spacing-xs,
+        "large-screen": $spacing-xs,
+    ),
+    "s": (
+        "small-screen": $spacing-s,
+        "large-screen": $spacing-s,
+    ),
+    "m": (
+        "small-screen": $spacing-m,
+        "large-screen": $spacing-m,
+    ),
+    "l": (
+        "small-screen": $spacing-m,
+        "large-screen": $spacing-l,
+    ),
+    "xl": (
+        "small-screen": $spacing-l,
+        "large-screen": $spacing-xl,
+    ),
+    "2xl": (
+        "small-screen": $spacing-xl,
+        "large-screen": $spacing-2xl,
+    ),
+    "3xl": (
+        "small-screen": $spacing-2xl,
+        "large-screen": $spacing-3xl,
+    ),
+    "4xl": (
+        "small-screen": $spacing-3xl,
+        "large-screen": $spacing-4xl,
+    ),
 );
+
+$positions: (top, bottom, left, right);
+
+@mixin spacing($spacing-name) {
+    // Separate spacing/position into spacing and position variables:
+    $start-index: string.index($spacing-name, "/") or 0;
+    $end-index: string.index($spacing-name, "/") or 9999999;
+    $spacing: string.slice($spacing-name, 0, $start-index - 1);
+    $position: string.slice($spacing-name, $end-index + 1);
+
+    @if map.has-key($spacing-new, $spacing) {
+        $variants: map.get($spacing-new, $spacing);
+
+        @if string.length($position) == 0 {
+            margin: map.get($variants, "small-screen");
+
+            @include screens.from-medium-device {
+                margin: map.get($variants, "large-screen");
+            }
+        } @else {
+            @if list.index($positions, $position) {
+                margin-#{$position}: map.get($variants, "small-screen");
+
+                @include screens.from-medium-device {
+                    margin-#{$position}: map.get($variants, "large-screen");
+                }
+            } @else {
+                @error "The spacing #{$spacing} has no position called #{$position}. Try one of these: #{$positions}";
+            }
+        }
+    } @else {
+        @error "No spacing with the name #{$spacing} was found. Try one of these: #{map.keys($spacing-new)}";
+    }
+}

--- a/packages/core/jkl/_spacing.scss
+++ b/packages/core/jkl/_spacing.scss
@@ -6,31 +6,49 @@
 /// Tilsvarer 2px
 /// @type Number
 $spacing-2: 0.125rem;
+/// Tilsvarer 2px
+/// @deprecated Bruk heller $spacing-2
+/// @type Number
 $spacing-3xs: $spacing-2;
 
 /// Tilsvarer 4px
 /// @type Number
 $spacing-4: 0.25rem;
+/// Tilsvarer 4px
+/// @deprecated Bruk heller $spacing-4
+/// @type Number
 $spacing-2xs: $spacing-4;
 
 /// Tilsvarer 8px
 /// @type Number
 $spacing-8: 0.5rem;
+/// Tilsvarer 8px
+/// @deprecated Bruk heller $spacing-8
+/// @type Number
 $spacing-xs: $spacing-8;
 
 /// Tilsvarer 12px
 /// @type Number
 $spacing-12: 0.75rem;
+/// Tilsvarer 12px
+/// @deprecated Bruk heller $spacing-12
+/// @type Number
 $spacing-s: $spacing-12;
 
 /// Tilsvarer 16px
 /// @type Number
 $spacing-16: 1rem;
+/// Tilsvarer 16px
+/// @deprecated Bruk heller $spacing-16
+/// @type Number
 $spacing-m: $spacing-16;
 
 /// Tilsvarer 24px
 /// @type Number
 $spacing-24: 1.5rem;
+/// Tilsvarer 24px
+/// @deprecated Bruk heller $spacing-24
+/// @type Number
 $spacing-l: $spacing-24;
 
 /// Tilsvarer 32px
@@ -40,21 +58,33 @@ $spacing-32: 2rem;
 /// Tilsvarer 40px
 /// @type Number
 $spacing-40: 2.5rem;
+/// Tilsvarer 40px
+/// @deprecated Bruk heller $spacing-40
+/// @type Number
 $spacing-xl: $spacing-40;
 
 /// Tilsvarer 64px
 /// @type Number
 $spacing-64: 4rem;
+/// Tilsvarer 64px
+/// @deprecated Bruk heller $spacing-64
+/// @type Number
 $spacing-2xl: $spacing-64;
 
 /// Tilsvarer 104px
 /// @type Number
 $spacing-104: 6.5rem;
+/// Tilsvarer 104px
+/// @deprecated Bruk heller $spacing-104
+/// @type Number
 $spacing-3xl: $spacing-104;
 
 /// Tilsvarer 168px
 /// @type Number
 $spacing-168: 10.5rem;
+/// Tilsvarer 168px
+/// @deprecated Bruk heller $spacing-168
+/// @type Number
 $spacing-4xl: $spacing-168;
 
 /// Lar deg gjøre oppslag på navnet uten `spacing`-prefix for å få ut rem-verdien
@@ -93,7 +123,7 @@ $spacing-pairs: (("16", "24"), ("24", "40"), ("32", "40"), ("40", "64"), ("64", 
 $positions: (top, bottom, left, right);
 
 /// Gir deg marginer basert på stegene i spacing-skalaen.
-/// @param $steps Enten navnet på ett steg i skalaen, eller navnet på tosteg i skalaen adskilt av "/".
+/// @param {"2/4" | "2/8" | "2/12" | "2/16" | "2/24" | "2/32" | "2/40" | "2/64" | "2/104" | "2/168" | "4/8" | "4/14" | "4/16" | "4/44" | "4/34" | "4/40" | "4/64" | "4/104" | "4/168" | "8/12" | "8/16" | "8/84" | "8/38" | "8/40" | "8/64" | "8/104" | "8/168" | "12/16" | "12/124" | "12/32" | "12/40" | "12/64" | "12/104" | "12/168" | "16/24" | "16/32" | "16/40" | "16/64" | "16/104" | "16/168" | "24/32" | "24/40" | "24/64" | "24/104" | "24/168" | "32/40" | "32/64" | "32/104" | "32/168" | "40/64" | "40/104" | "40/168" | "64/104" | "64/168" | "104/168"} $steps Enten navnet på ett steg i skalaen, eller navnet på tosteg i skalaen adskilt av "/".
 /// Dersom du oppgir to steg brukes det første på små skjermer og det andre på store.
 /// @param {"top" | "right" | "bottom" | "left"} $position Lar deg spesifisere margin for kun én av sidene
 /// @example
@@ -117,7 +147,7 @@ $positions: (top, bottom, left, right);
     }
 
     // Return only one value if step-2 is missing or both steps are the same
-    @if (string.length($step-2) == 0) or ($step-1 == $step-2) {
+    @if string.length($step-2) == 0 or $step-1 == $step-2 {
         @if map.has-key($spacing, $step-1) {
             margin#{$position}: map.get($spacing, $step-1);
         } @else {

--- a/packages/core/jkl/_spacing.scss
+++ b/packages/core/jkl/_spacing.scss
@@ -5,119 +5,132 @@
 
 /// Tilsvarer 2px
 /// @type Number
-$spacing-3xs: 0.125rem;
+$spacing-2: 0.125rem;
+$spacing-3xs: $spacing-2;
 
 /// Tilsvarer 4px
 /// @type Number
-$spacing-2xs: 0.25rem;
+$spacing-4: 0.25rem;
+$spacing-2xs: $spacing-4;
 
 /// Tilsvarer 8px
 /// @type Number
-$spacing-xs: 0.5rem;
+$spacing-8: 0.5rem;
+$spacing-xs: $spacing-8;
 
 /// Tilsvarer 12px
 /// @type Number
-$spacing-s: 0.75rem;
+$spacing-12: 0.75rem;
+$spacing-s: $spacing-12;
 
 /// Tilsvarer 16px
 /// @type Number
-$spacing-m: 1rem;
+$spacing-16: 1rem;
+$spacing-m: $spacing-16;
 
 /// Tilsvarer 24px
 /// @type Number
-$spacing-l: 1.5rem;
+$spacing-24: 1.5rem;
+$spacing-l: $spacing-24;
+
+/// Tilsvarer 32px
+/// @type Number
+$spacing-32: 2rem;
 
 /// Tilsvarer 40px
 /// @type Number
-$spacing-xl: 2.5rem;
+$spacing-40: 2.5rem;
+$spacing-xl: $spacing-40;
 
 /// Tilsvarer 64px
 /// @type Number
-$spacing-2xl: 4rem;
+$spacing-64: 4rem;
+$spacing-2xl: $spacing-64;
 
 /// Tilsvarer 104px
 /// @type Number
-$spacing-3xl: 6.5rem;
+$spacing-104: 6.5rem;
+$spacing-3xl: $spacing-104;
 
 /// Tilsvarer 168px
 /// @type Number
-$spacing-4xl: 10.5rem;
+$spacing-168: 10.5rem;
+$spacing-4xl: $spacing-168;
 
 /// Lar deg gjøre oppslag på navnet uten `spacing`-prefix for å få ut rem-verdien
 /// @type Map
-$spacing-new: (
-    "3xs": (
-        "small-screen": $spacing-3xs,
-        "large-screen": $spacing-3xs,
-    ),
-    "2xs": (
-        "small-screen": $spacing-2xs,
-        "large-screen": $spacing-2xs,
-    ),
-    "xs": (
-        "small-screen": $spacing-xs,
-        "large-screen": $spacing-xs,
-    ),
-    "s": (
-        "small-screen": $spacing-s,
-        "large-screen": $spacing-s,
-    ),
-    "m": (
-        "small-screen": $spacing-m,
-        "large-screen": $spacing-m,
-    ),
-    "l": (
-        "small-screen": $spacing-m,
-        "large-screen": $spacing-l,
-    ),
-    "xl": (
-        "small-screen": $spacing-l,
-        "large-screen": $spacing-xl,
-    ),
-    "2xl": (
-        "small-screen": $spacing-xl,
-        "large-screen": $spacing-2xl,
-    ),
-    "3xl": (
-        "small-screen": $spacing-2xl,
-        "large-screen": $spacing-3xl,
-    ),
-    "4xl": (
-        "small-screen": $spacing-3xl,
-        "large-screen": $spacing-4xl,
-    ),
+$spacing: (
+    "2": $spacing-2,
+    "4": $spacing-4,
+    "8": $spacing-8,
+    "12": $spacing-12,
+    "16": $spacing-16,
+    "24": $spacing-24,
+    "32": $spacing-32,
+    "40": $spacing-40,
+    "64": $spacing-64,
+    "104": $spacing-104,
+    "168": $spacing-168,
+    // Gamle t-skjortestørrelser for kompatibilitet
+    "3xs": $spacing-3xs,
+    "2xs": $spacing-2xs,
+    "xs": $spacing-xs,
+    "s": $spacing-s,
+    "m": $spacing-m,
+    "l": $spacing-l,
+    "xl": $spacing-xl,
+    "2xl": $spacing-2xl,
+    "3xl": $spacing-3xl,
+    "4xl": $spacing-4xl,
 );
 
+/// Her defineres par av spacinger for dynamiske spacing-klasser, som f.eks. .jkl-spacing-16-24
+/// @type Map
+$spacing-pairs: (("16", "24"), ("24", "40"), ("32", "40"), ("40", "64"), ("64", "104"), ("104", "168"));
+
+/// Posisjoner som kan benyttes for spacing
+/// @type Map
 $positions: (top, bottom, left, right);
 
-@mixin spacing($spacing-name) {
-    // Separate spacing/position into spacing and position variables:
-    $start-index: string.index($spacing-name, "/") or 0;
-    $end-index: string.index($spacing-name, "/") or 9999999;
-    $spacing: string.slice($spacing-name, 0, $start-index - 1);
-    $position: string.slice($spacing-name, $end-index + 1);
+/// Gir deg marginer basert på stegene i spacing-skalaen.
+/// @param $steps Enten navnet på ett steg i skalaen, eller navnet på tosteg i skalaen adskilt av "/".
+/// Dersom du oppgir to steg brukes det første på små skjermer og det andre på store.
+/// @param {"top" | "right" | "bottom" | "left"} $position Lar deg spesifisere margin for kun én av sidene
+/// @example
+/// .class {
+///     @include jkl.spacing("40/64");
+/// }
+/// @example
+/// .class {
+///     @include jkl.spacing("16", "bottom");
+/// }
+@mixin spacing($steps, $position: null) {
+    // Separate "step-1/step-2" into separate variables:
+    $start-index: string.index($steps, "/") or 0;
+    $end-index: string.index($steps, "/") or 9999999;
+    $step-1: string.slice($steps, 0, $start-index - 1);
+    $step-2: string.slice($steps, $end-index + 1);
 
-    @if map.has-key($spacing-new, $spacing) {
-        $variants: map.get($spacing-new, $spacing);
+    @if $position and list.index($positions, $position) {
+        // Rephrase e.g. "bottom" to "-bottom" for easier interpolation
+        $position: "-#{$position}";
+    }
 
-        @if string.length($position) == 0 {
-            margin: map.get($variants, "small-screen");
-
-            @include screens.from-medium-device {
-                margin: map.get($variants, "large-screen");
-            }
+    // Return only one value if step-2 is missing or both steps are the same
+    @if (string.length($step-2) == 0) or ($step-1 == $step-2) {
+        @if map.has-key($spacing, $step-1) {
+            margin#{$position}: map.get($spacing, $step-1);
         } @else {
-            @if list.index($positions, $position) {
-                margin-#{$position}: map.get($variants, "small-screen");
-
-                @include screens.from-medium-device {
-                    margin-#{$position}: map.get($variants, "large-screen");
-                }
-            } @else {
-                @error "The spacing #{$spacing} has no position called #{$position}. Try one of these: #{$positions}";
-            }
+            @error "Could not find the spacing step \"#{$step-1}\" in our spacing scale";
         }
     } @else {
-        @error "No spacing with the name #{$spacing} was found. Try one of these: #{map.keys($spacing-new)}";
+        @if map.has-key($spacing, $step-1) and map.has-key($spacing, $step-2) {
+            margin#{$position}: map.get($spacing, $step-1);
+            @include screens.from-medium-device {
+                margin#{$position}: map.get($spacing, $step-2);
+            }
+        } @else {
+            @error "Either \"#{$step-1}\" or \"#{$step-2}\" does not exist in our spacing scale";
+        }
     }
 }

--- a/packages/core/jkl/_spacing.scss
+++ b/packages/core/jkl/_spacing.scss
@@ -114,53 +114,130 @@ $spacing: (
     "4xl": $spacing-4xl,
 );
 
-/// Her defineres par av spacinger for dynamiske spacing-klasser, som f.eks. .jkl-spacing-16-24
+/// Her defineres kombinasjoner av spacinger til bruk i nytteklasser for spacing.
+/// Nytteklasser for alle enkeltspacinger, samt kombinasjoner, i denne listen
+/// blir automatisk generert i core.css, med versjoner for alle posisjoner (top, right, etc.).
 /// @type Map
-$spacing-pairs: (("16", "24"), ("24", "40"), ("32", "40"), ("40", "64"), ("64", "104"), ("104", "168"));
+$combinations: (
+    "2",
+    "4",
+    "8",
+    "12",
+    "16",
+    "24",
+    "32",
+    "40",
+    "64",
+    "104",
+    "168",
+    "16" "24",
+    "24" "40",
+    "24" "32",
+    "32" "40",
+    "40" "64",
+    "64" "104",
+    "104" "168",
+    "16" "16" "24",
+    "16" "24" "32",
+    "16" "24" "40",
+    "24" "24" "32",
+    "24" "24" "40",
+    "24" "32" "40",
+    "32" "32" "40",
+    "32" "40" "64",
+    "40" "40" "64",
+    "40" "64" "104",
+    "64" "64" "104",
+    "64" "104" "168",
+    "104" "104" "168"
+);
 
 /// Posisjoner som kan benyttes for spacing
 /// @type Map
 $positions: (top, bottom, left, right);
 
+/// Deler opp en streng i substrenger, gitt et tegn du vil bruke som avdeler.
+/// @param { string } $string En streng du vil dele opp
+/// @param { string } $delimiter [null] En string du vil bruke som avdeler, f.eks. komma
+/// @return { list } Returnerer en liste med substrenger
+/// @example
+/// splitString("24/40", "/"); // "24", "40"
+@function _split-string($string, $delimiter: null) {
+    // Returner en liste med uendret streng hvis ingen separator er satt, eller strengen er tom
+    @if not $delimiter or string.length($string) == 0 {
+        @return ($string);
+    }
+
+    // Finn index til separatoren
+    $delimiter-index: string.index($string, $delimiter);
+
+    // Returner en liste med uendret streng hvis ikke separatoren finnes i strengen
+    @if not $delimiter-index {
+        @return ($string);
+    }
+
+    $first-value: string.slice($string, 0, $delimiter-index - 1);
+    // Finn eventuelt flere substrenger ved å kjøre funksjonen rekursivt
+    $other-values: _split-string(string.slice($string, $delimiter-index + 1), $delimiter);
+
+    // Returner en kommaseparert liste over substrengene
+    @return list.join($first-value, $other-values, "comma");
+}
+
+/// Setter marginer ut fra et steg i spacing-skalaen
+/// @param {"2" | "4" | "8" | "12" | "16" | "24" | "32" | "40" | "64" | "104" | "168"} $spacing-step Et steg i spacingskalaen
+/// @param {"top" | "right" | "bottom" | "left"} $position En posisjon du vil sette spacingen i
+/// @output margin-<posisjon>: <verdi i spacing-skalaen>;
+@mixin _single-spacing($spacing-step, $position) {
+    @if $position and list.index($positions, $position) {
+        // Legg til bindestrek foran posisjonen for enklere interpolering
+        $position: "-#{$position}";
+    }
+
+    @if map.has-key($spacing, $spacing-step) {
+        margin#{$position}: map.get($spacing, $spacing-step);
+    } @else {
+        @error "Fant ikke \"#{$spacing-step}\" i våre spacing-verdier";
+    }
+}
+
 /// Gir deg marginer basert på stegene i spacing-skalaen.
-/// @param {"2/4" | "2/8" | "2/12" | "2/16" | "2/24" | "2/32" | "2/40" | "2/64" | "2/104" | "2/168" | "4/8" | "4/14" | "4/16" | "4/44" | "4/34" | "4/40" | "4/64" | "4/104" | "4/168" | "8/12" | "8/16" | "8/84" | "8/38" | "8/40" | "8/64" | "8/104" | "8/168" | "12/16" | "12/124" | "12/32" | "12/40" | "12/64" | "12/104" | "12/168" | "16/24" | "16/32" | "16/40" | "16/64" | "16/104" | "16/168" | "24/32" | "24/40" | "24/64" | "24/104" | "24/168" | "32/40" | "32/64" | "32/104" | "32/168" | "40/64" | "40/104" | "40/168" | "64/104" | "64/168" | "104/168"} $steps Enten navnet på ett steg i skalaen, eller navnet på tosteg i skalaen adskilt av "/".
-/// Dersom du oppgir to steg brukes det første på små skjermer og det andre på store.
+/// @param $steps Navnet på ett, to eller tre steg i spacing-skalaen, adskilt av "/".
+/// Stegene trer i kraft fra henholdsvis små, mellomstore og store skjermstørrelser i den rekkefølgen du angir dem.
 /// @param {"top" | "right" | "bottom" | "left"} $position Lar deg spesifisere margin for kun én av sidene
 /// @example
 /// .class {
+///     // Gir spacing-40 på små skjermer, og spacing-64 fra mellomstore skjermer
 ///     @include jkl.spacing("40/64");
+/// }
+/// @example
+/// .class {
+///     // Gir spacing-40 på små skjermer, spacing-64 på mellomstore skjermer, og spacing-104 fra store skjermer
+///     @include jkl.spacing("40/64/104");
 /// }
 /// @example
 /// .class {
 ///     @include jkl.spacing("16", "bottom");
 /// }
 @mixin spacing($steps, $position: null) {
-    // Separate "step-1/step-2" into separate variables:
-    $start-index: string.index($steps, "/") or 0;
-    $end-index: string.index($steps, "/") or 9999999;
-    $step-1: string.slice($steps, 0, $start-index - 1);
-    $step-2: string.slice($steps, $end-index + 1);
+    $steps: _split-string($steps, "/");
 
-    @if $position and list.index($positions, $position) {
-        // Rephrase e.g. "bottom" to "-bottom" for easier interpolation
-        $position: "-#{$position}";
+    @if list.length($steps) > 3 {
+        @error "Du kan ikke oppgi fler enn tre spacing-steg";
+    } @else if list.length($steps) < 1 {
+        @error "Du må oppgi minst ett spacing-steg";
     }
 
-    // Return only one value if step-2 is missing or both steps are the same
-    @if string.length($step-2) == 0 or $step-1 == $step-2 {
-        @if map.has-key($spacing, $step-1) {
-            margin#{$position}: map.get($spacing, $step-1);
-        } @else {
-            @error "Could not find the spacing step \"#{$step-1}\" in our spacing scale";
+    @include _single-spacing(list.nth($steps, 1), $position);
+
+    @if list.length($steps) > 1 {
+        @include screens.from-medium-device {
+            @include _single-spacing(list.nth($steps, 2), $position);
         }
-    } @else {
-        @if map.has-key($spacing, $step-1) and map.has-key($spacing, $step-2) {
-            margin#{$position}: map.get($spacing, $step-1);
-            @include screens.from-medium-device {
-                margin#{$position}: map.get($spacing, $step-2);
-            }
-        } @else {
-            @error "Either \"#{$step-1}\" or \"#{$step-2}\" does not exist in our spacing scale";
+    }
+    @if list.length($steps) > 2 {
+        @include screens.from-large-device {
+            @include _single-spacing(list.nth($steps, 3), $position);
         }
     }
 }

--- a/packages/core/styles/_spacing.scss
+++ b/packages/core/styles/_spacing.scss
@@ -4,9 +4,9 @@
 @use "../jkl/spacing";
 @use "../jkl/screens";
 
-@function get-class-name($spacingCombination) {
+@function get-class-name($spacing-combination) {
     $class-name: "jkl-spacing";
-    @each $spacing in $spacingCombination {
+    @each $spacing in $spacing-combination {
         $class-name: "#{$class-name}-#{$spacing}";
     }
     @return $class-name;
@@ -14,36 +14,36 @@
 
 // Sett CSS-variabler for alle spacing-kombinasjoner
 :root {
-    @each $spacingCombination in spacing.$combinations {
-        $_step: list.nth($spacingCombination, 1);
+    @each $spacing-combination in spacing.$combinations {
+        $_step: list.nth($spacing-combination, 1);
 
-        --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
+        --#{get-class-name($spacing-combination)}: #{map.get(spacing.$spacing, $_step)};
     }
 
     @include screens.from-medium-device {
-        @each $spacingCombination in spacing.$combinations {
-            @if list.length($spacingCombination) > 1 {
-                $_step: list.nth($spacingCombination, 2);
+        @each $spacing-combination in spacing.$combinations {
+            @if list.length($spacing-combination) > 1 {
+                $_step: list.nth($spacing-combination, 2);
 
-                --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
+                --#{get-class-name($spacing-combination)}: #{map.get(spacing.$spacing, $_step)};
             }
         }
     }
 
     @include screens.from-large-device {
-        @each $spacingCombination in spacing.$combinations {
-            @if list.length($spacingCombination) > 2 {
-                $_step: list.nth($spacingCombination, 3);
+        @each $spacing-combination in spacing.$combinations {
+            @if list.length($spacing-combination) > 2 {
+                $_step: list.nth($spacing-combination, 3);
 
-                --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
+                --#{get-class-name($spacing-combination)}: #{map.get(spacing.$spacing, $_step)};
             }
         }
     }
 }
 
 // Lag nytteklasser for alle spacing-kombinasjoner og -posisjoner
-@each $spacingCombination in spacing.$combinations {
-    $_class-name: get-class-name($spacingCombination);
+@each $spacing-combination in spacing.$combinations {
+    $_class-name: get-class-name($spacing-combination);
     .#{$_class-name} {
         &--all {
             margin: var(--#{$_class-name});

--- a/packages/core/styles/_spacing.scss
+++ b/packages/core/styles/_spacing.scss
@@ -1,44 +1,73 @@
+@use "sass:list";
 @use "sass:map";
+@use "sass:string";
 @use "../jkl/spacing";
 @use "../jkl/screens";
 
-@each $name, $spacing in spacing.$spacing {
-    .jkl-spacing-#{$name} {
-        &--all {
-            margin: $spacing;
-        }
+@function get-class-name($spacingCombination) {
+    $class-name: "jkl-spacing";
+    @each $spacing in $spacingCombination {
+        $class-name: "#{$class-name}-#{$spacing}";
+    }
+    @return $class-name;
+}
 
-        @each $position in spacing.$positions {
-            &--#{$position} {
-                margin-#{$position}: $spacing;
+// Sett CSS-variabler for alle spacing-kombinasjoner
+:root {
+    @each $spacingCombination in spacing.$combinations {
+        $_step: list.nth($spacingCombination, 1);
+
+        --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
+    }
+
+    @include screens.from-medium-device {
+        @each $spacingCombination in spacing.$combinations {
+            @if list.length($spacingCombination) > 1 {
+                $_step: list.nth($spacingCombination, 2);
+
+                --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
+            }
+        }
+    }
+
+    @include screens.from-large-device {
+        @each $spacingCombination in spacing.$combinations {
+            @if list.length($spacingCombination) > 2 {
+                $_step: list.nth($spacingCombination, 3);
+
+                --#{get-class-name($spacingCombination)}: #{map.get(spacing.$spacing, $_step)};
             }
         }
     }
 }
 
-@each $from, $to in spacing.$spacing-pairs {
-    .jkl-spacing-#{$from}-#{$to} {
+// Lag nytteklasser for alle spacing-kombinasjoner og -posisjoner
+@each $spacingCombination in spacing.$combinations {
+    $_class-name: get-class-name($spacingCombination);
+    .#{$_class-name} {
         &--all {
-            margin: map.get(spacing.$spacing, $from);
+            margin: var(--#{$_class-name});
         }
 
         @each $position in spacing.$positions {
             &--#{$position} {
-                margin-#{$position}: map.get(spacing.$spacing, $from);
+                margin-#{$position}: var(--#{$_class-name});
             }
         }
     }
 }
-@include screens.from-medium-device {
-    @each $from, $to in spacing.$spacing-pairs {
-        .jkl-spacing-#{$from}-#{$to} {
+
+// Lag nytteklasser for de gamle spacingene for å sikre bakoverkompatibilitet
+@each $spacing, $value in spacing.$spacing {
+    @if not list.index(spacing.$combinations, $spacing) {
+        .jkl-spacing-#{$spacing} {
             &--all {
-                margin: map.get(spacing.$spacing, $to);
+                margin: $value;
             }
 
             @each $position in spacing.$positions {
                 &--#{$position} {
-                    margin-#{$position}: map.get(spacing.$spacing, $to);
+                    margin-#{$position}: $value;
                 }
             }
         }

--- a/packages/core/styles/_spacing.scss
+++ b/packages/core/styles/_spacing.scss
@@ -1,15 +1,45 @@
+@use "sass:map";
 @use "../jkl/spacing";
-
-$_positions: (top, bottom, left, right);
+@use "../jkl/screens";
 
 @each $name, $spacing in spacing.$spacing-new {
+    $small-spacing: map.get($spacing, "small-screen");
+    $large-spacing: map.get($spacing, "large-screen");
+
     .jkl-spacing-#{$name} {
         &--all {
-            margin: $spacing;
+            margin: $small-spacing;
         }
-        @each $position in $_positions {
+
+        @each $position in spacing.$positions {
             &--#{$position} {
-                margin-#{$position}: $spacing;
+                margin-#{$position}: $small-spacing;
+            }
+        }
+    }
+
+    @include screens.from-medium-device {
+        .jkl-spacing-#{$name} {
+            &--all {
+                margin: $large-spacing;
+            }
+
+            @each $position in spacing.$positions {
+                &--#{$position} {
+                    margin-#{$position}: $large-spacing;
+                }
+            }
+        }
+    }
+
+    .jkl-static-spacing-#{$name} {
+        &--all {
+            margin: $large-spacing;
+        }
+
+        @each $position in spacing.$positions {
+            &--#{$position} {
+                margin-#{$position}: $large-spacing;
             }
         }
     }

--- a/packages/core/styles/_spacing.scss
+++ b/packages/core/styles/_spacing.scss
@@ -2,44 +2,44 @@
 @use "../jkl/spacing";
 @use "../jkl/screens";
 
-@each $name, $spacing in spacing.$spacing-new {
-    $small-spacing: map.get($spacing, "small-screen");
-    $large-spacing: map.get($spacing, "large-screen");
-
+@each $name, $spacing in spacing.$spacing {
     .jkl-spacing-#{$name} {
         &--all {
-            margin: $small-spacing;
+            margin: $spacing;
         }
 
         @each $position in spacing.$positions {
             &--#{$position} {
-                margin-#{$position}: $small-spacing;
+                margin-#{$position}: $spacing;
             }
         }
     }
+}
 
-    @include screens.from-medium-device {
-        .jkl-spacing-#{$name} {
+@each $from, $to in spacing.$spacing-pairs {
+    .jkl-spacing-#{$from}-#{$to} {
+        &--all {
+            margin: $from;
+        }
+
+        @each $position in spacing.$positions {
+            &--#{$position} {
+                margin-#{$position}: $from;
+            }
+        }
+    }
+}
+@include screens.from-medium-device {
+    @each $from, $to in spacing.$spacing-pairs {
+        .jkl-spacing-#{$from}-#{$to} {
             &--all {
-                margin: $large-spacing;
+                margin: $to;
             }
 
             @each $position in spacing.$positions {
                 &--#{$position} {
-                    margin-#{$position}: $large-spacing;
+                    margin-#{$position}: $to;
                 }
-            }
-        }
-    }
-
-    .jkl-static-spacing-#{$name} {
-        &--all {
-            margin: $large-spacing;
-        }
-
-        @each $position in spacing.$positions {
-            &--#{$position} {
-                margin-#{$position}: $large-spacing;
             }
         }
     }

--- a/packages/core/styles/_spacing.scss
+++ b/packages/core/styles/_spacing.scss
@@ -19,12 +19,12 @@
 @each $from, $to in spacing.$spacing-pairs {
     .jkl-spacing-#{$from}-#{$to} {
         &--all {
-            margin: $from;
+            margin: map.get(spacing.$spacing, $from);
         }
 
         @each $position in spacing.$positions {
             &--#{$position} {
-                margin-#{$position}: $from;
+                margin-#{$position}: map.get(spacing.$spacing, $from);
             }
         }
     }
@@ -33,12 +33,12 @@
     @each $from, $to in spacing.$spacing-pairs {
         .jkl-spacing-#{$from}-#{$to} {
             &--all {
-                margin: $to;
+                margin: map.get(spacing.$spacing, $to);
             }
 
             @each $position in spacing.$positions {
                 &--#{$position} {
-                    margin-#{$position}: $to;
+                    margin-#{$position}: map.get(spacing.$spacing, $to);
                 }
             }
         }

--- a/portal/src/components/APIDocumentation/APIDocumentation.tsx
+++ b/portal/src/components/APIDocumentation/APIDocumentation.tsx
@@ -62,12 +62,12 @@ interface APIDocumentationProps {
 
 export const APIDocumentation: FC<APIDocumentationProps> = ({ types }) => {
     return (
-        <section className="jkl-spacing-3xl--bottom jkl-portal-paragraph">
-            <h2 className="jkl-heading-1 jkl-spacing-3xl--top">React API</h2>
-            <p className="jkl-body jkl-spacing-m--top">
+        <section className="jkl-spacing-104--bottom jkl-portal-paragraph">
+            <h2 className="jkl-heading-1 jkl-spacing-104--top">React API</h2>
+            <p className="jkl-body jkl-spacing-16--top">
                 Her finner du en oversikt over props på komponentene i pakken.
             </p>
-            <Accordion className="jkl-spacing-xl--top jkl-portal-api-docs">
+            <Accordion className="jkl-spacing-40--top jkl-portal-api-docs">
                 {Object.entries(types).map(([displayName, propTypes]) => {
                     const ownProps = propTypes.props ? Object.values(propTypes.props).filter(isOwnProp) : [];
                     const externalProps = propTypes.props ? Object.values(propTypes.props).filter(isExternalProp) : [];

--- a/portal/src/components/Documentation/Icons/index.tsx
+++ b/portal/src/components/Documentation/Icons/index.tsx
@@ -86,7 +86,7 @@ const icons = [
 export const PortalIconExample: FC = () => {
     return (
         <>
-            <table className={`jkl-icon-table jkl-spacing-xl--top`}>
+            <table className={`jkl-icon-table jkl-spacing-40--top`}>
                 <TableHeader />
                 <tbody>
                     {icons.map((ico) => (

--- a/portal/src/components/Documentation/Picture/HeroImage.tsx
+++ b/portal/src/components/Documentation/Picture/HeroImage.tsx
@@ -22,9 +22,9 @@ const HeroImage: React.FC<Props> = ({ title, children }) => {
                     }
                     className="jkl-portal-hero__card"
                 >
-                    <h1 className="jkl-title jkl-spacing-xl--bottom">{title}</h1>
+                    <h1 className="jkl-title jkl-spacing-40--bottom">{title}</h1>
                     <p className="jkl-body">{children}</p>
-                    <div className="jkl-portal-hero__card__arrow jkl-title-small jkl-spacing-l--top">↓</div>
+                    <div className="jkl-portal-hero__card__arrow jkl-title-small jkl-spacing-24--top">↓</div>
                 </button>
             </div>
         </div>

--- a/portal/src/components/Experimental/Experimental.tsx
+++ b/portal/src/components/Experimental/Experimental.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export const Experimental: React.FC<WithChildren> = ({ children }) => {
     return (
         <WarningMessageBox
-            className="jkl-portal-paragraph jkl-spacing-xl--top jkl-spacing-xl--bottom"
+            className="jkl-portal-paragraph jkl-spacing-40--top jkl-spacing-40--bottom"
             title="Eksperimentell komponent"
             role="none presentation"
         >

--- a/portal/src/components/TypograhyTable/TypographyTable.tsx
+++ b/portal/src/components/TypograhyTable/TypographyTable.tsx
@@ -39,9 +39,9 @@ const VariantTable: FC<{ variant: "desktop" | "mobile" }> = ({ variant }) => (
 export const TypographyTable: FC = () => {
     const [skala, setSkala] = useState("Desktop");
     return (
-        <div className="jkl-portal-content jkl-spacing-xl--bottom">
+        <div className="jkl-portal-content jkl-spacing-40--bottom">
             <ToggleSlider
-                className="jkl-spacing-xl--bottom"
+                className="jkl-spacing-40--bottom"
                 defaultValue={skala}
                 labels={["Desktop", "Mobile"]}
                 onToggle={setSkala}

--- a/portal/src/components/form-components/FormComponentsExample.tsx
+++ b/portal/src/components/form-components/FormComponentsExample.tsx
@@ -38,11 +38,11 @@ export const FormComponentsExample: FC<ExampleComponentProps> = ({ boolValues })
     console.table(formData);
 
     return (
-        <form className="jkl-spacing-xl--left" onSubmit={handleSubmit((valid) => console.table(valid))}>
-            <p className="jkl-heading-4 jkl-spacing-m--bottom">Hvem er eier av forsikringen?</p>
+        <form className="jkl-spacing-40--left" onSubmit={handleSubmit((valid) => console.table(valid))}>
+            <p className="jkl-heading-4 jkl-spacing-16--bottom">Hvem er eier av forsikringen?</p>
             {radioButtonGroup && (
                 <RadioButtonGroup
-                    className="jkl-spacing-l--bottom"
+                    className="jkl-spacing-24--bottom"
                     labelProps={{ variant: "small" }}
                     legend="Kjønn"
                     errorLabel={formState.errors.kjonn?.message}
@@ -69,13 +69,13 @@ export const FormComponentsExample: FC<ExampleComponentProps> = ({ boolValues })
                                 message: "Fødselsnummeret må bestå av 11 siffer",
                             },
                         })}
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         label="Fødselsnummer"
                         errorLabel={formState.errors.fodselsnummer?.message}
                     />
                     <TextInput
                         {...register("navn", { required: "Du må fylle ut eierens for- og etternavn" })}
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         label="For- og etternavn"
                         errorLabel={formState.errors.navn?.message}
                     />
@@ -83,7 +83,7 @@ export const FormComponentsExample: FC<ExampleComponentProps> = ({ boolValues })
             )}
             {datePickers && (
                 <DatePicker
-                    className="jkl-spacing-l--bottom"
+                    className="jkl-spacing-24--bottom"
                     disableAfterDate={formatInput(new Date())}
                     errorLabel={formState.errors.fodselsdato?.message}
                     label="Fødselsdato"
@@ -102,7 +102,7 @@ export const FormComponentsExample: FC<ExampleComponentProps> = ({ boolValues })
             {select && (
                 <Select
                     {...register("stilling", { required: "Du må oppgi eierens stilling" })}
-                    className="jkl-spacing-xl--bottom"
+                    className="jkl-spacing-40--bottom"
                     errorLabel={formState.errors.stilling?.message}
                     items={["Designer", "Utvikler", "Tester", "Leder", "Annet"]}
                     label="Stilling"

--- a/portal/src/components/form-field-anatomy/FormFieldAnatomy.tsx
+++ b/portal/src/components/form-field-anatomy/FormFieldAnatomy.tsx
@@ -6,11 +6,11 @@ import "./form-field-anatomy.scss";
 
 export const FormFieldAnatomy: FC = () => {
     return (
-        <div className="jkl-spacing-2xl--bottom">
+        <div className="jkl-spacing-64--bottom">
             <section className="jkl-portal-component-example">
                 <div className="jkl-portal-component-example__example-wrapper">
                     <form
-                        className="jkl-portal-form-field-anatomy jkl-spacing-xl--left"
+                        className="jkl-portal-form-field-anatomy jkl-spacing-40--left"
                         onSubmit={(e) => e.preventDefault()}
                     >
                         <span
@@ -19,7 +19,7 @@ export const FormFieldAnatomy: FC = () => {
                         >
                             <span className="jkl-portal-form-field-anatomy__indicator-number">1</span>
                         </span>
-                        <p className="jkl-heading-4 jkl-spacing-m--bottom">Forsikringseier</p>
+                        <p className="jkl-heading-4 jkl-spacing-16--bottom">Forsikringseier</p>
                         <span
                             className="jkl-portal-form-field-anatomy__indicator jkl-portal-form-field-anatomy__indicator--label"
                             aria-hidden="true"
@@ -39,7 +39,7 @@ export const FormFieldAnatomy: FC = () => {
                             <span className="jkl-portal-form-field-anatomy__indicator-number">4</span>
                         </span>
                         <TextInput
-                            className="jkl-spacing-l--bottom"
+                            className="jkl-spacing-24--bottom"
                             name="fodselsnummer"
                             label="Fødselsnummer"
                             defaultValue="Input"

--- a/portal/src/layout/header/BlogPageHeader.tsx
+++ b/portal/src/layout/header/BlogPageHeader.tsx
@@ -8,7 +8,7 @@ export const BlogPageHeader: FC<Frontmatter> = ({ title, author, publishDate }) 
     return (
         <>
             <h1 className="jkl-title">{title}</h1>
-            <div className="jkl-spacing-l--top jkl-spacing-l--bottom">
+            <div className="jkl-spacing-24--top jkl-spacing-24--bottom">
                 <p data-testid="blog-author">{author}</p>
                 {publishDate && <p data-testid="blog-publishDate">{publishDate}</p>}
             </div>

--- a/portal/src/layout/portal-footer/PortalFooter.tsx
+++ b/portal/src/layout/portal-footer/PortalFooter.tsx
@@ -47,7 +47,7 @@ export const PortalFooter: React.FC<PortalFooterProps> = ({ className }) => {
                             title: "Takk! Jøkul blir enda bedre med dine tilbakemeldinger.",
                             children: (
                                 <>
-                                    <p className="jkl-spacing-s--bottom">
+                                    <p className="jkl-spacing-12--bottom">
                                         Spill gjerne inn på GitHub, eller delta på forum (hver tirsdag{" "}
                                         <time dateTime="14:00">kl. 14</time>)!
                                     </p>

--- a/portal/src/pages/404.tsx
+++ b/portal/src/pages/404.tsx
@@ -5,7 +5,7 @@ import { MainContent } from "../layout/MainContent";
 
 const NotFoundPage: FC = () => (
     <MainContent>
-        <h1 className="jkl-title jkl-spacing-2xl--bottom jkl-spacing-2xl--top">Oj sann, der fikk du en blank side!</h1>
+        <h1 className="jkl-title jkl-spacing-64--bottom jkl-spacing-64--top">Oj sann, der fikk du en blank side!</h1>
         <p className="jkl-portal-paragraph">
             Det beklager vi. Du kan prøve å:
             <ul>

--- a/portal/src/pages/blog.tsx
+++ b/portal/src/pages/blog.tsx
@@ -12,9 +12,9 @@ const IndexPage: FC<PageProps<PageData>> = ({ data }) => {
 
     return (
         <MainContent>
-            <h1 className="jkl-title jkl-spacing-2xl--bottom">Blogg</h1>
+            <h1 className="jkl-title jkl-spacing-64--bottom">Blogg</h1>
             <p className="jkl-portal-paragraph">Velkommen til Jøkul — design­systemet til Fremtind.</p>
-            <h2 className="jkl-heading-1 jkl-spacing-xl--top jkl-spacing-l--bottom">Alt fra bloggen</h2>
+            <h2 className="jkl-heading-1 jkl-spacing-40--top jkl-spacing-24--bottom">Alt fra bloggen</h2>
             <ul className="jkl-portal-blog__post-list">
                 {posts.map((post) => {
                     const title = post.frontmatter.title || post.fields.path;

--- a/portal/src/pages/demoer/feilmelding-500-med-melding.tsx
+++ b/portal/src/pages/demoer/feilmelding-500-med-melding.tsx
@@ -5,7 +5,7 @@ import { MainContent } from "../../layout/MainContent";
 
 const NotFoundPageWithMessage: FC = () => (
     <MainContent>
-        <h1 className="jkl-title jkl-spacing-2xl--bottom jkl-spacing-2xl--top">
+        <h1 className="jkl-title jkl-spacing-64--bottom jkl-spacing-64--top">
             Huff da, nå har det skjedd en feil hos oss!
         </h1>
         <div className="jkl-portal-paragraph">

--- a/portal/src/pages/demoer/feilmelding-500.tsx
+++ b/portal/src/pages/demoer/feilmelding-500.tsx
@@ -4,7 +4,7 @@ import { MainContent } from "../../layout/MainContent";
 
 const NotFoundPage: FC = () => (
     <MainContent>
-        <h1 className="jkl-title jkl-spacing-2xl--bottom jkl-spacing-2xl--top">
+        <h1 className="jkl-title jkl-spacing-64--bottom jkl-spacing-64--top">
             Huff da, nå har det skjedd en feil hos oss!
         </h1>
         <p className="jkl-portal-paragraph">Vi setter i gang med å fikse feilen. Imens kan du prøve å:</p>

--- a/portal/src/pages/demoer/skjemavalidering.tsx
+++ b/portal/src/pages/demoer/skjemavalidering.tsx
@@ -61,9 +61,9 @@ const Skjemavalideringseksempel: FC = () => {
     const onSubmit = (valid: FormValues) => console.table(valid);
 
     return (
-        <MainContent className="jkl-spacing-xl--bottom">
-            <div className=" jkl-spacing-2xl--bottom">
-                <h1 className="jkl-title jkl-spacing-xl--bottom">Skjema&shy;validerings&shy;eksempel</h1>
+        <MainContent className="jkl-spacing-40--bottom">
+            <div className=" jkl-spacing-64--bottom">
+                <h1 className="jkl-title jkl-spacing-40--bottom">Skjema&shy;validerings&shy;eksempel</h1>
             </div>
             <div>
                 <ToggleSlider hideLegend defaultValue={value} labels={["Vanlig", "Kompakt"]} onToggle={setValue}>
@@ -83,7 +83,7 @@ const Skjemavalideringseksempel: FC = () => {
                         isSubmitted={isSubmitted}
                         isValid={isValid}
                     />
-                    <p className="jkl-heading-4 jkl-spacing-m--bottom">Hvem er eier av forsikringen?</p>
+                    <p className="jkl-heading-4 jkl-spacing-16--bottom">Hvem er eier av forsikringen?</p>
                     <TextInput
                         {...register("fodselsnummer", {
                             required: "Du må fylle ut eierens fødselsnummer",
@@ -92,7 +92,7 @@ const Skjemavalideringseksempel: FC = () => {
                                 message: "Fødselsnummeret må bestå av 11 siffer",
                             },
                         })}
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         label="Fødselsnummer"
                         errorLabel={formState.errors.fodselsnummer?.message}
                     />
@@ -100,7 +100,7 @@ const Skjemavalideringseksempel: FC = () => {
                         {...register("fornavn", {
                             required: "Du må fylle ut eierens fornavn",
                         })}
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         autoComplete="given-name"
                         label="Fornavn"
                         errorLabel={formState.errors.fornavn?.message}
@@ -109,13 +109,13 @@ const Skjemavalideringseksempel: FC = () => {
                         {...register("etternavn", {
                             required: "Du må fylle ut eierens etternavn",
                         })}
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         autoComplete="family-name"
                         label="Etternavn"
                         errorLabel={formState.errors.etternavn?.message}
                     />
                     <DatePicker
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         disableAfterDate={formatInput(new Date())}
                         errorLabel={formState.errors.fodselsdato?.message}
                         label="Fødselsdato"
@@ -132,14 +132,14 @@ const Skjemavalideringseksempel: FC = () => {
                     />
                     <Select
                         {...register("stilling", { required: "Du må oppgi eierens stilling" })}
-                        className="jkl-spacing-xl--bottom"
+                        className="jkl-spacing-40--bottom"
                         errorLabel={formState.errors.stilling?.message}
                         items={["Designer", "Utvikler", "Tester", "Leder", "Annet"]}
                         label="Stilling"
                         width="14rem"
                     />
                     <RadioButtonGroup
-                        className="jkl-spacing-l--bottom"
+                        className="jkl-spacing-24--bottom"
                         labelProps={{ variant: "small" }}
                         legend="Under 23"
                         errorLabel={formState.errors.u23?.message}
@@ -161,7 +161,7 @@ const Skjemavalideringseksempel: FC = () => {
                     </RadioButtonGroup>
                     <FieldGroup
                         legend="Er klient"
-                        className="jkl-spacing-xl--bottom"
+                        className="jkl-spacing-40--bottom"
                         labelProps={{ variant: "small" }}
                         errorLabel={formState.errors.klient?.message}
                     >

--- a/portal/src/pages/kom-i-gang/hjelp.tsx
+++ b/portal/src/pages/kom-i-gang/hjelp.tsx
@@ -135,7 +135,7 @@ const DegOgJokul: FC = () => (
         </p>
 
         <NavCard
-            className="jkl-spacing-xl--top"
+            className="jkl-spacing-40--top"
             style={{ maxWidth: "35rem" }}
             to="/kom-i-gang/jobb-med-teamet"
             component={GatsbyLink}

--- a/portal/src/pages/kom-i-gang/jobb-med-teamet.tsx
+++ b/portal/src/pages/kom-i-gang/jobb-med-teamet.tsx
@@ -45,7 +45,7 @@ const JobbMedTeamet: FC = () => (
         </UnorderedList>
         <NavCard
             href="mailto:fremtind.designsystem@fremtind.no?subject=Hjelp%20oss%20med%3A"
-            className="jkl-spacing-xl--top"
+            className="jkl-spacing-40--top"
             style={{ maxWidth: "25rem" }}
             title="Fasilitering med Jøkul-teamet"
             description="Få skreddersydd designsystem-analyse, coaching og rådgivning fra Jøkul-teamet."
@@ -89,7 +89,7 @@ const JobbMedTeamet: FC = () => (
             kontakt!
         </Paragraph>
         <NavCard
-            className="jkl-spacing-xl--top"
+            className="jkl-spacing-40--top"
             style={{ maxWidth: "25rem" }}
             to="/kom-i-gang/slik-er-jokul-satt-sammen"
             component={GatsbyLink}

--- a/portal/src/pages/kom-i-gang/lekegrind.tsx
+++ b/portal/src/pages/kom-i-gang/lekegrind.tsx
@@ -10,7 +10,7 @@ import { MainContent } from "../../layout/MainContent";
 const pageTitle = "Lekegrind";
 
 const defaultCode = `
-<h2 className="jkl-heading-2 jkl-spacing-s--bottom">Velkommen hit</h2>
+<h2 className="jkl-heading-2 jkl-spacing-12--bottom">Velkommen hit</h2>
 <p className="jkl-portal-paragraph">Her kan du teste Jøkuls komponenter direkte i nettleseren.</p>
 <p className="jkl-portal-paragraph">Bare finn komponenten du vil teste blant Jøkuls komponenter, og lim inn koden i tekstfeltet.</p>
 <NavCard href="/komponenter/card" padding="l" target="_blank" title="Jøkul-komponenter" style={{maxWidth:"360px"}} />
@@ -30,11 +30,11 @@ const Lekegrind: FC = () => {
             <PageTitle>{pageTitle}</PageTitle>
 
             <LiveProvider code={code?.trim()}>
-                <div className="jkl-spacing-l--bottom">
+                <div className="jkl-spacing-24--bottom">
                     <LiveEditor onChange={handleChange} />
                 </div>
                 <LiveError />
-                <div className="jkl-spacing-2xl--bottom">
+                <div className="jkl-spacing-64--bottom">
                     <LivePreview />
                 </div>
             </LiveProvider>

--- a/portal/src/texts/blog/dynamisk-spacing/ConversionTable.tsx
+++ b/portal/src/texts/blog/dynamisk-spacing/ConversionTable.tsx
@@ -1,0 +1,18 @@
+import { DataTable } from "@fremtind/jkl-table-react";
+import React from "react";
+
+const CONVERSIONS = [
+    ["spacing-3xs", "spacing-2"],
+    ["spacing-2xs", "spacing-4"],
+    ["spacing-xs", "spacing-8"],
+    ["spacing-s", "spacing-12"],
+    ["spacing-m", "spacing-16"],
+    ["spacing-l", "spacing-24"],
+    ["(fantes ikke)", "spacing-32"],
+    ["spacing-xl", "spacing-40"],
+    ["spacing-2xl", "spacing-64"],
+    ["spacing-3xl", "spacing-104"],
+    ["spacing-4xl", "spacing-168"],
+];
+
+export const ConversionTable = () => <DataTable columns={["Gammelt steg", "Nytt steg"]} rows={CONVERSIONS} />;

--- a/portal/src/texts/blog/dynamisk-spacing/dynamisk-spacing.mdx
+++ b/portal/src/texts/blog/dynamisk-spacing/dynamisk-spacing.mdx
@@ -1,0 +1,119 @@
+---
+title: Kom i gang med ny spacing-skala og dynamisk spacing
+author: Jøkul-teamet v/Pio Rasch-Halvorsen
+publishDate: "2022.12.06"
+---
+
+import { ConversionTable } from "./ConversionTable";
+
+<Ingress>
+    Med siste versjon av `jkl-core` har vi gått over til en ny spacing-skala basert på pikselverdier, og det er lagt
+    bedre til rette for spacing som endrer seg etter skjermstørrelse. Her er noen tips til hvordan du kommer i gang med
+    de nye funksjonene.
+</Ingress>
+
+<picture className="jkl-portal-image">
+    <img
+        className="jkl-portal-image__img jkl-spacing-40--bottom"
+        alt=""
+        loading="lazy"
+        decoding="async"
+        src="/assets/blog/updates/november-2022/nov-dynamisk-spacing.png"
+    />
+</picture>
+
+Aller først: **Endringene er ikke breaking**. Det vil si at du fortsatt kan bruke spacing-verdiene og -klassene du allerede har i koden din. De gamle verdiene vil imidlertid kunne bli avviklet helt på et senere tidspunkt, så vi anbefaler uansett at du bytter ut gamle verdier når du kommer over dem i koden din.
+
+## Gamle og nye verdier
+
+Alle stegene i spacing-skalaen har nå navn etter pikselverdien de representerer. Det har også kommet inn et nytt steg i skalaen, `spacing-32`. Bruk tabellen under for å oversette fra de gamle til de nye stegene.
+
+<ConversionTable />
+
+## Nye Sass- og CSS-variabler
+
+Alle de nye spacingstegene er tilgjengelige som variabler i Sass når du har tatt i bruk `@fremtind/jkl-core/jkl`, og som CSS-variabler dersom core-stilarket er lastet inn på siden. Hvis du tidligere har brukt Sass-variablene kan du enkelt gjøre en search and replace fra tabellen over for å oppgradere til de nye verdiene.
+
+```scss
+// For å bruke Sass-variablene må du ta inn jkl-biblioteket
+@use "~@fremtind/jkl-core/jkl";
+
+.min-komponent {
+    padding-top: jkl.$spacing-16;
+}
+
+// CSS-variablene kan brukes direkte
+.min-andre-komponent {
+    margin-block: var(--jkl-spacing-64);
+}
+```
+
+## Nye nytteklasser og ny Sass-mixin
+
+Nytteklassene for spacing setter en spacing-verdi som margin på en eller flere sider av et element, og kan brukes direkte i HTML- eller JSX-koden din. Den nye Sass-mixinen fungerer på samme måte, og kan inkluderes i klassene du skriver for komponentene dine.
+
+### Nytteklasser
+
+Disse fungerer som før, ved at de setter en verdi fra spacingskalaene som margin på elementet som har klassen. Det finnes varianter for å sette margin på `top`, `right`, `bottom` og `left`, samt for `all`e sider. Klassene kan brukes slik:
+
+```html
+<div class="jkl-spacing-64--top jkl-spacing-64--bottom">
+    <span class="jkl-spacing-16--all">Hei, verden!</span>
+</div>
+```
+
+Du kan enkelt konvertere fra de gamle til de nye nytteklassene ved å gjøre en search and replace fra tabellen over.
+
+### Sass-mixin
+
+Dette er en helt ny mixin som kommer med `jkl`-biblioteket. Akkurat som nytteklassene setter den marginer i klassen de er en del av. Du bruker mixinen slik:
+
+```scss
+@use "~@fremtind/jkl-core/jkl";
+
+.min-komponent {
+    @include jkl-spacing("64"); // Setter spacingen på alle sider, lik margin: jkl.$spacing-64;
+}
+
+.min-andre-komponent {
+    @include jkl-spacing("64", "left"); // Setter spacing kun på venstre side
+}
+```
+
+## Dynamisk spacing
+
+Den største nyheten med de nye spacing-verdiene er at vi også legger bedre til rette for spacinger som endrer seg ut fra skjermstørrelse. Dette er ganske vanlig på for eksempel layout-komponenter, og vi har derfor laget CSS-variabler og nytteklasser for de vanligste kombinasjonene. Trenger du andre kombinasjoner av verdier kan du bruke Sass-mixinen.
+
+Det finnes variabler og nytteklasser med både to og tre steg: Det første steget brukes fra små skjermer, det andre steget brukes fra mellomstore skjermer, og det tredje steget (hvis det finnes) brukes fra store skjermer. Utiver at de har flere steg i seg brukes variablene og nytteklassene på samme måte som sine statiske varianter:
+
+```html
+<div class="jkl-spacing-64-104--top">
+    <span class="jkl-spacing-16-24-32--all">Hei, verden!</span>
+</div>
+```
+
+```css
+.min-komponent {
+    margin-block: var(--jkl-spacing-40-64);
+}
+```
+
+```scss
+@use "~@fremtind/jkl-core/jkl";
+
+.min-komponent {
+    @include jkl-spacing("64/104");
+}
+
+.min-andre-komponent {
+    @include jkl-spacing("16/24/32", "bottom");
+}
+```
+
+Hvis du vil ha samme spacing på små og mellomstore skjermer bruker du varianten med tre steg, og skriver samme verdi for de to første stegene: `var(--jkl-spacing-16-16-24)`, `jkl.spacing("64/64/104")` eller `class="jkl-spacing-24-24-40"`
+
+## Jøkul-teamet hjelper deg gjerne!
+
+Vi har forsøkt å gjøre det så enkelt som mulig å ta i bruk den nye spacing-skalaen, men hvis noe er uklart eller du står fast på noen måte er det bare å ta kontakt med oss i Jøkul-teamet! Vi hjelper deg gjerne med å komme i gang eller å finne ut av feil.
+
+God spacing!

--- a/portal/src/texts/blog/iePlussJokulErlikSant/iePlussJokulErlikSant.mdx
+++ b/portal/src/texts/blog/iePlussJokulErlikSant/iePlussJokulErlikSant.mdx
@@ -7,7 +7,7 @@ publishDate: "2020.08.05"
 
 import { WarningMessageBox } from "@fremtind/jkl-message-box-react";
 
-<WarningMessageBox title="Du ser på en gammel bloggpost" className="jkl-spacing-2xl--bottom">
+<WarningMessageBox title="Du ser på en gammel bloggpost" className="jkl-spacing-64--bottom">
     Støtten for Internet Explorer har blitt droppet i Jøkul etter at denne bloggposten ble skrevet.
 </WarningMessageBox>
 

--- a/portal/src/texts/blog/updates/mars-2022.mdx
+++ b/portal/src/texts/blog/updates/mars-2022.mdx
@@ -38,7 +38,7 @@ Ellers skjer det mye jobbing i Jøkul-teamet med forbedringer "under panseret" b
 Et vanlig mønster er å bruke [knapper](/komponenter/buttons) med piler til navigasjon i skjemaflyter med flere steg. De ulike Buttons har fått nye varianter med pil på høyre og venstre side. Om du for eksempel har knapper med teksene _Forrige_ og _Neste_ kan du vurdere å legge på disse pilene. Stakseth og kennidenni ordnet denne varianten i Figma og i kode.
 
 <div>
-    <SecondaryButton arrow="left" className="jkl-spacing-s--right">
+    <SecondaryButton arrow="left" className="jkl-spacing-12--right">
         Forrige
     </SecondaryButton>
     <PrimaryButton arrow="right">Neste</PrimaryButton>

--- a/portal/src/texts/guider/hvordanEndreJokul.mdx
+++ b/portal/src/texts/guider/hvordanEndreJokul.mdx
@@ -8,14 +8,17 @@ order: 1
 
 Det er mange som bruker designsystemet vårt. Noen er godt kjent med det, andre har vært litt innom det, mens noen ikke kjenner til det i det hele tatt. For å tilrettelegge for godt samarbeid, foregår all utvikling knyttet til Jøkul på GitHub. Hvis ikke du er kjent med GitHub fra før av, anbefaler vi at du [tar kurset vårt](https://www.figma.com/proto/HOmcpKHfjHnS9f8397hfxU/Github-for-Designere?page-id=0%3A1&node-id=1%3A2&viewport=260%2C48%2C0.1&scaling=scale-down-width&starting-point-node-id=1%3A2).
 
-<p className="jkl-small jkl-spacing-s--bottom">Vet du allerede hvor du skal? Her er snarveiene.</p>
+<p className="jkl-small jkl-spacing-12--bottom">Vet du allerede hvor du skal? Her er snarveiene.</p>
 
-<a className="jkl-button jkl-button--primary jkl-spacing-m--right" href="https://github.com/fremtind/jokul/discussions">
+<a
+    className="jkl-button jkl-button--primary jkl-spacing-16--right"
+    href="https://github.com/fremtind/jokul/discussions"
+>
     Åpne en diskusjon
 </a>
 
 <a
-    className="jkl-button jkl-button--secondary jkl-spacing-m--right"
+    className="jkl-button jkl-button--secondary jkl-spacing-16--right"
     href="https://github.com/fremtind/jokul/issues/new/choose"
 >
     Start et issue
@@ -61,7 +64,7 @@ Nesten alt kan bli dobbelt så bra, bare du deler det med et par andre. Det mest
 -   En god tommelfingerregel for når et bidrag burde starte som en [diskusjon](https://github.com/fremtind/jokul/discussions) kan være at du ønsker flere innspill fra andre, eller at du har et spørsmål eller en utfordring du rett og slett bare trenger å lufte bredt.
 -   Du vet som regel at bidraget ditt er godt nok detaljert til å bli et [issue](https://github.com/fremtind/jokul/issues/new/choose) når det er lett å estimere hvor lang tid det tar å lansere bidraget, og det kan knyttes til et behov i et aktivt prosjekt ute hos leveranseteamene.
 
-<p className="jkl-small jkl-spacing-s--bottom">
+<p className="jkl-small jkl-spacing-12--bottom">
     PS: Hvis du tør å delegere ansvaret for oppgaven til deg selv, så er den som regel godt nok beskrevet ;)
 </p>
 

--- a/portal/src/texts/profile/farger.mdx
+++ b/portal/src/texts/profile/farger.mdx
@@ -76,7 +76,7 @@ Vi bruker de samme fargene for mørk modus og lys modus.
     Denne gulfargen er til advarsler.
 </PrimaryColor>
 
-<PrimaryColor title="Feilfarge" colorVariable="feil" className="jkl-spacing-2xl--bottom">
+<PrimaryColor title="Feilfarge" colorVariable="feil" className="jkl-spacing-64--bottom">
     En rødfarge som vi bruker til feeilmeldinger eller andre viktige varsler.
 </PrimaryColor>
 
@@ -102,7 +102,7 @@ Tekstfargene våre er snøhvit eller granitt. Se fargebeskrivelsene for å finne
 
 For å skape en varm og hyggelig brukeropplevelse jobber vi med lyse bakgrunnsfarger.
 
-<Grid className="jkl-spacing-xl--bottom">
+<Grid className="jkl-spacing-40--bottom">
     <PortalImage
         alt="Skjermbilde av en detaljside for en bilforsikring"
         src="/assets/documentation/farger/bilforsikring_detaljside.png"
@@ -112,7 +112,7 @@ For å skape en varm og hyggelig brukeropplevelse jobber vi med lyse bakgrunnsfa
         src="/assets/documentation/farger/betaling_faktura.png"
     />
 </Grid>
-<Grid className="jkl-spacing-xl--bottom">
+<Grid className="jkl-spacing-40--bottom">
     <PortalImage
         alt="Skjermbilde av en detaljside for en livsforsikring"
         src="/assets/documentation/farger/liv_detaljside.png"
@@ -126,7 +126,7 @@ For å skape en varm og hyggelig brukeropplevelse jobber vi med lyse bakgrunnsfa
 
 Vi bruker fire meldingsfarger pluss to ekstra farger i hjelpetekster.
 
-<Grid className="jkl-spacing-xl--bottom">
+<Grid className="jkl-spacing-40--bottom">
     <PortalImage
         alt="Skjermbilde av et skjema for kjøp av hundeforsikring med en valideringsfeil"
         src="/assets/documentation/farger/hund_feilmelding.png"

--- a/portal/src/texts/profile/skjemadesign.mdx
+++ b/portal/src/texts/profile/skjemadesign.mdx
@@ -28,7 +28,7 @@ Hver skjemakomponent har en ledetekst. Det kan være en overskrift med et spørs
 Vi avgrenser seksjoner tydelig fra hverandre. Hvis seksjonene ligger på en felles bakgrunn, bruker vi luft til å vise dette skillet. Ellers kan vi ramme dem inn i egne kort. Hvis det er nødvendig, kan vi ha en overskrift på hver seksjon.
 
 <PortalImage
-    className="jkl-spacing-xl--bottom"
+    className="jkl-spacing-40--bottom"
     src="/assets/documentation/skjemadesign/skjemadesign_hund.png"
     alt="Skjermbilde av et skjemadesign fra kjøpsflyten for hundeforsikring"
 />
@@ -63,7 +63,7 @@ Vi viser ingen valideringsfeil før brukeren har prøvd å trykke seg videre i s
 Et unntak gjøres dersom et valg gjort i skjemaet gjør at vi vet at brukeren ikke får lov til å gå videre i flyten. I disse tilfellene viser vi en [InfoMessageBox](/komponenter/messagebox) under skjemafeltet som forklarer hvorfor brukeren ikke trenger fortsette med utfyllingen av skjemaet, og hva neste steg er for dem. Beskjeden dukker opp med en gang valget er gjort så brukeren slipper fylle ut unødvendig informasjon.
 
 <PortalImage
-    className="jkl-spacing-xl--bottom"
+    className="jkl-spacing-40--bottom"
     src="/assets/documentation/skjemadesign/skjemavalidering_blocker.png"
     alt="Skjermbilde av et skjema hvor vi informerer brukeren om riktig vei videre i en InfoMessageBox"
 />
@@ -77,7 +77,7 @@ Innholdet i denne meldingsboksen skal være _selve feilmeldingene_. Det holder i
 Vi scroller automatisk opp så toppen av meldingsboksen er synlig for brukeren. Første inputfelt under oppsummeringen får tastaturfokus, sånn at tastaturbrukere enklere kan komme i gang med rettingen av feil.
 
 <PortalImage
-    className="jkl-spacing-xl--bottom"
+    className="jkl-spacing-40--bottom"
     src="/assets/documentation/skjemadesign/skjemavalidering_error_summary.png"
     alt="Skjermbilde av en oppsummering av fire valideringsfeil vist i en ErrorMessageBox"
 />
@@ -124,8 +124,8 @@ Det vil uansett kunne bli noe vertikal bevegelse når vi fjerner feilmeldingene 
 Det er mange detaljer her, og mye å sette seg inn i. Et bilde sier mer enn tusen ord, og et interaktivt eksempel sier enda mer enn det!
 
 <a
-    href="/demoer/skjemavalidering"
-    className="jkl-spacing-l--top jkl-spacing-2xl--bottom jkl-button jkl-button--primary"
+    href="/eksempler/skjemavalidering"
+    className="jkl-spacing-24--top jkl-spacing-64--bottom jkl-button jkl-button--primary"
 >
     Gå til eksempelet
 </a>

--- a/portal/src/texts/profile/spacing.mdx
+++ b/portal/src/texts/profile/spacing.mdx
@@ -16,6 +16,10 @@ import { SpacingScaleTable } from "../../../../packages/core/documentation/Spaci
 
 <SpacingScaleTable />
 
+### Dynamisk spacing
+
+På mindre skjermer ønsker man ofte mindre marginer og avstander enn på store skjermer. Vi tilbyr derfor egne variabler og hjelpeklasser for utviklere med vanlige kombinasjoner av spacinger som endrer seg ut fra skjermstørrelse. Du kan lese mer om disse i [Komponenter-seksjonen](/komponenter/spacing) av siden.
+
 ### Praktisk
 
 For å gjøre det lettere å jobbe med skalaen i Figma kan du sette verdien av "big nudge" til 8px. Dette gjør du under Hamburgermeny (øverst til venstre) &rarr; Preferences &rarr; Nudge Amount.

--- a/portal/src/texts/universell-utforming/ResponsivtDesign.mdx
+++ b/portal/src/texts/universell-utforming/ResponsivtDesign.mdx
@@ -34,7 +34,7 @@ Se etter layoutproblemer. Om du finner noen, snakk med designer, og kom gjerne m
     </InfoMessageBox>
 </div>
 
-<div className="jkl-portal-paragraph jkl-spacing-xl--top">
+<div className="jkl-portal-paragraph jkl-spacing-40--top">
     <dl>
         <dt>Medium</dt>
         <dd>


### PR DESCRIPTION
Som tatt opp på forum denne uka kan det være aktuelt med dynamisk spacing for de store spacingene.
Dette for å gjøre spacing mer i tråd med øvrige komponenter og tekst som blir mindre på liten skjermstørrelse.
Målet med at kun store spacing-størrelser endrer seg er at det kun er avstand mellom element-grupper som skal reduseres, ikke mellom enkeltelementer som f.eks. label og input.

Dette løsningsforslaget legger opp til at klassene våre som default er dynamiske, men at vi også tilbyr en klasse for statisk spacing. (Eventuelt kan dette snus på, at vi tilbyr en ny dynamisk spacing-klasse for å unngå breaking change.)
Ettersom spacing-variabler bare er verdier som benyttes build time, kan ikke de gjøres dynamiske. Som alternativ til variabler i konsumenters SCSS-filer har jeg laget en mixin som tar spacing med alternativ /position.

Det mangler dokumentasjon av mixin i SCSS-fila, og kanskje også dokumentasjon andre steder, men jeg vil i første omgang lufte løsningsforslaget.

### Eksempler på bruk
#### ...som gir dynamisk spacing
```jsx
<div className="jkl-spacing-2xl--bottom">
```
```scss
.my-class {
  @include spacing("2xl/bottom");
}
```
#### ...som gir statisk spacing (slik det var før)
```jsx
<div className="jkl-static-spacing-2xl--bottom">
```
```scss
.my-class {
  margin-bottom: jkl.$spacing-2xl;
}
```

#### commit message
Spacing-klasser er default dynamiske.
La til klasse .jkl-static-spacing(--position) for å kunne låse seg til statisk spacing.
Spacing-variabler i SCSS er bare verdier, så disse kan ikke gjøres dynamiske.
La til spacing-mixin som erstatning for variabler i SCSS.

BREAKING CHANGE: spacing-klasser gir dynamisk spacing som default

## 🎯 Sjekkliste

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
