### PR TITLE
fix: gjør at ikonet får riktig størrelse hvis man globalt setter box-sizing:border-box

### DIFF
--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -51,7 +51,7 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
     &__icon {
         align-self: flex-start;
         height: var(--jkl-alert-message-icon-height);
-        padding: var(--jkl-alert-message-icon-padding);
+        margin: var(--jkl-alert-message-icon-padding);
         flex-shrink: 0;
 
         @include jkl.forced-colors-svg-fallback($stroke: CanvasText);


### PR DESCRIPTION
Viss man setter box-sizing: border-box på alle elementer globalt(som me gjør i SeOpp) blir ikonet på AlertMessage veldig lite på grunn av padding som blei lagt i ein nylig commit. Har endra paddingen til margin så den ikkje skal bli kalkulert med i størrelsen.
