### PR TITLE
feat: IconButton - gjør at custom className ikke overrider default className

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
+registry=https://registry.npmjs.org/
+
 ### PNPM-innstillinger: https://pnpm.io/npmrc
 # Lerna kjører ikke pnpm publish/pack, så workspace: kan ikke brukes
 save-workspace-protocol=false
 # Med save-workspace-protocol skrudd av vil vi sørge for å bruke workspace selv om nyere er på registry
 prefer-workspace-packages=true
-

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -41,7 +41,8 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^11.2.1",
-        "@fremtind/jkl-icon-button": "^2.0.8"
+        "@fremtind/jkl-icon-button": "^2.0.8",
+        "classnames": "^2.3.2"
     },
     "devDependencies": {
         "@fremtind/jkl-toggle-switch-react": "^10.0.12"

--- a/packages/icon-button-react/src/IconButton.tsx
+++ b/packages/icon-button-react/src/IconButton.tsx
@@ -1,4 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
+import cn from "classnames";
 import React, { ButtonHTMLAttributes, forwardRef } from "react";
 import { IconCalendar } from "./Icons/IconCalendar";
 import { IconClear } from "./Icons/IconClear";
@@ -26,13 +27,13 @@ function getIcon(iconType: IconVariant) {
 }
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
-    const { iconType = "clear", buttonTitle, density, ...rest } = props;
+    const { iconType = "clear", buttonTitle, density, className, ...rest } = props;
     return (
         <button
             ref={ref}
             type="button"
             title={buttonTitle}
-            className="jkl-icon-button"
+            className={(cn("jkl-icon-button"), className)}
             data-testid="jkl-icon-button"
             data-density={density}
             {...rest}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,9 +556,11 @@ importers:
       '@fremtind/jkl-core': ^11.2.1
       '@fremtind/jkl-icon-button': ^2.0.8
       '@fremtind/jkl-toggle-switch-react': ^10.0.12
+      classnames: ^2.3.2
     dependencies:
       '@fremtind/jkl-core': link:../core
       '@fremtind/jkl-icon-button': link:../icon-button
+      classnames: 2.3.2
     devDependencies:
       '@fremtind/jkl-toggle-switch-react': link:../toggle-switch-react
 


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
Prøver å style en IconButton, men viss eg legger på className blir default className overridet. Burde eg merke denne som en breaking change? Viss nokon legger på className på ein IconButton kan endringen min få uønska virkningar.
