### PR TITLE
fix: IconButton - fikset bug der jøkul sitt className var forsvunnet

### DIFF
--- a/packages/icon-button-react/src/IconButton.tsx
+++ b/packages/icon-button-react/src/IconButton.tsx
@@ -33,7 +33,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props,
             ref={ref}
             type="button"
             title={buttonTitle}
-            className={(cn("jkl-icon-button"), className)}
+            className={cn("jkl-icon-button", className)}
             data-testid="jkl-icon-button"
             data-density={density}
             {...rest}


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
I forrige release avicon-button-react nettopp en bug der classNamet jkl-icon-button var forsvunnet. Wups! Fikset det her. 
