### PR TITLE
feat: add sticky table header

### DIFF
--- a/doc-utils/ComponentExample.tsx
+++ b/doc-utils/ComponentExample.tsx
@@ -11,6 +11,7 @@ export interface Props {
         choiceProps?: Array<ChoiceProp>;
     };
     codeExample?: CodeExample;
+    style?: React.CSSProperties;
 }
 
 export const ComponentExample: FC<Props> = ({ component, ...rest }) => {

--- a/doc-utils/ExampleBase.tsx
+++ b/doc-utils/ExampleBase.tsx
@@ -19,6 +19,7 @@ export interface Props {
         choiceProps?: Array<ChoiceProp>;
     };
     codeExample?: CodeExample;
+    style?: React.CSSProperties;
 }
 
 function useLocalStorage<T>(key: string, defaultValue: T): [T, (newValue: T) => void] {
@@ -46,7 +47,7 @@ function useLocalStorage<T>(key: string, defaultValue: T): [T, (newValue: T) => 
     return [state, setState];
 }
 
-export const ExampleBase: FC<Props> = ({ component, knobs, title = "Komponent", codeExample, scrollable }) => {
+export const ExampleBase: FC<Props> = ({ component, knobs, title = "Komponent", codeExample, scrollable, style }) => {
     const uid = useId("example");
     const [theme, setTheme] = useLocalStorage<ColorScheme>("jkl-example-theme", "light");
     const [density, setDensity] = useLocalStorage<Density>("jkl-example-density", "comfortable");
@@ -96,6 +97,7 @@ export const ExampleBase: FC<Props> = ({ component, knobs, title = "Komponent", 
                     } ${scrollable ? "jkl-portal-component-example__example-wrapper--scrollable" : ""} ${
                         density === "comfortable" ? "jkl-body" : ""
                     } ${density === "compact" ? "jkl-small" : ""}`.trim()}
+                    style={style}
                 >
                     {example}
                 </div>

--- a/packages/table-react/documentation/Example.tsx
+++ b/packages/table-react/documentation/Example.tsx
@@ -17,6 +17,7 @@ import "../../table/table.scss";
 import "../../button/button.scss";
 import "../../icons/animated-icons.scss";
 import "../../expand-button/expand-button.scss";
+import StickyTableExample, { stickyTableExampleCode } from "./StickyTableExample";
 
 export default function Example() {
     return (
@@ -68,6 +69,13 @@ export default function Example() {
                 component={ExpandableTableExample}
                 knobs={expandableTableExampleKnobs}
                 codeExample={expandableTableExampleCode}
+            />
+            <DevExample
+                style={{ height: "200px" }}
+                scrollable={true}
+                title="Tabell med sticky header"
+                component={StickyTableExample}
+                codeExample={stickyTableExampleCode}
             />
         </>
     );

--- a/packages/table-react/documentation/StickyTableExample.tsx
+++ b/packages/table-react/documentation/StickyTableExample.tsx
@@ -25,7 +25,7 @@ const StickyTableExample: FC<ExampleComponentProps> = ({ boolValues, choiceValue
     const props = type === "Liste" ? { "data-collapse": "true", collapseToList: true } : {};
 
     return (
-        <Table fullWidth {...props} style={{ height: "100px" }}>
+        <Table fullWidth {...props}>
             <TableCaption srOnly>Overskrift for skjermlesere</TableCaption>
             <TableHead srOnly={headless} sticky>
                 <TableRow>
@@ -60,7 +60,7 @@ export default StickyTableExample;
 export const stickyTableExampleCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
 <Table fullWidth collapseToList={${choiceValues?.["Mobilvisning"] === "Liste"}}>
     <TableCaption srOnly>Overskrift for skjermlesere</TableCaption>
-    <TableHead srOnly={${boolValues?.["Skjul overskrift"]}}>
+    <TableHead srOnly={${boolValues?.["Skjul overskrift"]}} sticky>
         <TableRow>
             {columns.map((header, index) => (
                 <TableHeader key={index} density="compact" bold>

--- a/packages/table-react/documentation/StickyTableExample.tsx
+++ b/packages/table-react/documentation/StickyTableExample.tsx
@@ -1,0 +1,88 @@
+import React, { FC } from "react";
+import { ExampleComponentProps } from "../../../doc-utils";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "../src";
+
+const columns = ["Dato", "Saksnummer", "Kundenummer", "Kundenavn", "Milepæl", "Følger saken"];
+
+const rows = [
+    ["24.02.2020", "20-1234567", "010203 99887", "Ola Nordmann", "Opprettet", "Siri Saksbehandler"],
+    ["13.04.2019", "20-8382811", "010203 99887", "Kari Nordkvinne", "Opprettet", "Siri Saksbehandler"],
+    ["31.07.2017", "20-1111", "010203 99887", "Kari Nordkvinne", "Opprettet", "Per Persen"],
+    ["24.02.2020", "20-1234567", "010203 99887", "Ola Nordmann", "Opprettet", "Siri Saksbehandler"],
+    ["13.04.2019", "20-8382811", "010203 99887", "Kari Nordkvinne", "Opprettet", "Siri Saksbehandler"],
+    ["31.07.2017", "20-1111", "010203 99887", "Kari Nordkvinne", "Opprettet", "Per Persen"],
+    ["24.02.2020", "20-1234567", "010203 99887", "Ola Nordmann", "Opprettet", "Siri Saksbehandler"],
+    ["13.04.2019", "20-8382811", "010203 99887", "Kari Nordkvinne", "Opprettet", "Siri Saksbehandler"],
+    ["31.07.2017", "20-1111", "010203 99887", "Kari Nordkvinne", "Opprettet", "Per Persen"],
+    ["24.02.2020", "20-1234567", "010203 99887", "Ola Nordmann", "Opprettet", "Siri Saksbehandler"],
+    ["13.04.2019", "20-8382811", "010203 99887", "Kari Nordkvinne", "Opprettet", "Siri Saksbehandler"],
+    ["31.07.2017", "20-1111", "010203 99887", "Kari Nordkvinne", "Opprettet", "Per Persen"],
+];
+
+const StickyTableExample: FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
+    const headless = boolValues?.["Skjul overskrift"];
+    const type = choiceValues?.["Mobilvisning"];
+    const props = type === "Liste" ? { "data-collapse": "true", collapseToList: true } : {};
+
+    return (
+        <Table fullWidth {...props} style={{ height: "100px" }}>
+            <TableCaption srOnly>Overskrift for skjermlesere</TableCaption>
+            <TableHead srOnly={headless} sticky>
+                <TableRow>
+                    {columns.map((column, index) => (
+                        <TableHeader key={index} density="compact" bold>
+                            {column}
+                        </TableHeader>
+                    ))}
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {rows.map((row, rowIndex) => (
+                    <TableRow key={rowIndex}>
+                        {row.map((cell, cellIndex) => (
+                            <TableCell
+                                key={cellIndex}
+                                data-th={columns[cellIndex]}
+                                align={[1, 2].includes(cellIndex) ? "right" : "left"}
+                            >
+                                {cell}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+export default StickyTableExample;
+
+export const stickyTableExampleCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
+<Table fullWidth collapseToList={${choiceValues?.["Mobilvisning"] === "Liste"}}>
+    <TableCaption srOnly>Overskrift for skjermlesere</TableCaption>
+    <TableHead srOnly={${boolValues?.["Skjul overskrift"]}}>
+        <TableRow>
+            {columns.map((header, index) => (
+                <TableHeader key={index} density="compact" bold>
+                    {header}
+                </TableHeader>
+            ))}
+        </TableRow>
+    </TableHead>
+    <TableBody>
+        {rows.map((row, rowIndex) => (
+            <TableRow key={rowIndex}>
+                {row.map((cell, cellIndex) => (
+                    <TableCell
+                        key={cellIndex}
+                        data-th={columns[cellIndex]}
+                        align={[1, 2].includes(cellIndex) ? "right" : "left"}
+                    >
+                        {cell}
+                    </TableCell>
+                ))}
+            </TableRow>
+        ))}
+    </TableBody>
+</Table>
+`;

--- a/packages/table-react/documentation/Table.mdx
+++ b/packages/table-react/documentation/Table.mdx
@@ -22,6 +22,7 @@ import MobileListTableExample, {
     mobileListTableExampleCode,
     mobileListTableExampleKnobs,
 } from "./MobileListTableExample";
+import StickyTableExample, { stickyTableExampleCode } from "./StickyTableExample";
 
 <Ingress>Vi bruker tabeller for å vise data på en ordnet måte som gjør sammenlikning enkelt.</Ingress>
 
@@ -387,4 +388,16 @@ Hele raden blir automatisk klikkbar, samtidig som man skal sette inn en celle fo
     component={ExpandableTableExample}
     knobs={expandableTableExampleKnobs}
     codeExample={expandableTableExampleCode}
+/>
+
+### Sticky tabell heading
+
+Tabellens header blir festet til toppen av skjermen og flyter over tabellinnholdet om man scroller lenger ned i tabellen enn skjermens høyde. For å sette en egen bakgrunnsfarge kan man overstyre CSS-variabelen `--jkl-table-head-sticky-color`.
+
+<ComponentExample
+    style={{ height: "200px" }}
+    scrollable={true}
+    title="Tabell med sticky header"
+    component={StickyTableExample}
+    codeExample={stickyTableExampleCode}
 />

--- a/packages/table-react/src/TableHead.tsx
+++ b/packages/table-react/src/TableHead.tsx
@@ -4,14 +4,16 @@ import { TableSectionContextProvider } from "./tableSectionContext";
 
 export interface TableHeadProps extends HTMLAttributes<HTMLTableSectionElement> {
     srOnly?: boolean;
+    sticky?: boolean;
 }
 
-const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(({ className, srOnly, ...rest }, ref) => {
+const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(({ className, srOnly, sticky, ...rest }, ref) => {
     return (
         <TableSectionContextProvider state={{ isTableHead: true, isTableBody: false, isTableFooter: false }}>
             <thead
                 className={cx("jkl-table-head", className, {
                     ["jkl-table-head--sr-only"]: srOnly,
+                    ["jkl-table-head--sticky"]: sticky,
                 })}
                 {...rest}
                 ref={ref}

--- a/packages/table/_table-head.scss
+++ b/packages/table/_table-head.scss
@@ -1,7 +1,24 @@
 @use "~@fremtind/jkl-core/jkl";
 
+@include jkl.light-mode-variables {
+    --jkl-table-head-sticky-color: var(--jkl-background-color);
+}
+
+@include jkl.dark-mode-variables {
+    --jkl-table-head-sticky-color: var(--jkl-background-color);
+}
+
 .jkl-table-head {
     &--sr-only {
         @include jkl.screenreader-only;
+    }
+
+    &--sticky {
+        & > .jkl-table-row {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background-color: var(--jkl-table-head-sticky-color);
+        }
     }
 }


### PR DESCRIPTION
reverts 8a555fe to add support for
sticky heading. this is added through an optional prop, and exposing a
css variable to be able to set the background color of the head. this
defaults to the Jøkul background color<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
