### PR TITLE
fix: use box shadow as border so it stays with the sticky content

### DIFF
--- a/packages/table/_table-head.scss
+++ b/packages/table/_table-head.scss
@@ -8,6 +8,8 @@
     --jkl-table-head-sticky-color: var(--jkl-background-color);
 }
 
+$_border-size: jkl.rem(-1px);
+
 .jkl-table-head {
     &--sr-only {
         @include jkl.screenreader-only;
@@ -19,6 +21,11 @@
             top: 0;
             z-index: 1;
             background-color: var(--jkl-table-head-sticky-color);
+
+            border-bottom: none;
+
+            box-shadow: inset 0 0 0 #000, inset 0 $_border-size 0 var(--jkl-table-row-border-color);
+            background-clip: padding-box;
         }
     }
 }

--- a/packages/table/_table-head.scss
+++ b/packages/table/_table-head.scss
@@ -24,7 +24,7 @@ $_border-size: jkl.rem(-1px);
 
             border-bottom: none;
 
-            box-shadow: inset 0 0 0 #000, inset 0 $_border-size 0 var(--jkl-table-row-border-color);
+            box-shadow: inset 0 0 0 #000, inset 0 $_border-size 0 var(--jkl-table-row-hover-border-color);
             background-clip: padding-box;
         }
     }


### PR DESCRIPTION
Det ble bedre, men langt i fra fullkomment... Jeg klarte ikke å få borders til å feste seg, selv om det visst nok skal gå an å gjøre triks med `border-collapse`. Om noen vil prøve seg, er det bare å gjøre et forsøk.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [X] `pnpm build` og `pnpm ci:test` gir ingen feil
