### PR TITLE
fix: legg til luft over headingen

### DIFF
--- a/packages/table/_table-head.scss
+++ b/packages/table/_table-head.scss
@@ -26,6 +26,10 @@ $_border-size: jkl.rem(-1px);
 
             box-shadow: inset 0 0 0 #000, inset 0 $_border-size 0 var(--jkl-table-row-hover-border-color);
             background-clip: padding-box;
+
+            // legg til litt (nesten-cirka 16px) over headingen
+            vertical-align: bottom;
+            height: 2.3em;
         }
     }
 }


### PR DESCRIPTION
dette gir mer luft mellom heading-raden og nettleseren ved scroll

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [X] `pnpm build` og `pnpm ci:test` gir ingen feil
