### PR TITLE
fix: øk specificity for expand-button sin pil

### DIFF
--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -96,13 +96,12 @@
             margin-bottom: 0;
         }
 
-        --jkl-icon-width: var(--jkl-expand-button-arrow-width);
-
-        .jkl-icon--small {
-            --jkl-icon-width: var(--jkl-expand-button-arrow-width);
-        }
-
         @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
+    }
+
+    // Bevisst nøstet for høyere specificity enn core uavhengig av importrekkefølge.
+    .jkl-expand-button__arrow {
+        --jkl-icon-width: var(--jkl-expand-button-arrow-width);
     }
 
     @include jkl.forced-colors-mode {


### PR DESCRIPTION
Unngår at rekkefølgen på import av core kan brekke komponenten visuelt, hvis den kom etter import av expand-button.

Selector går fra `.jkl-expand-button__arrow` til `.jkl-expand-button .jkl-expand-button__arrow`.

ISSUES CLOSED: #3323

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
