### PR TITLE
docs: fiks feil metadata for Lister-seksjonen

### DIFF
--- a/portal/src/components/UU/uu-content/liste.tsx
+++ b/portal/src/components/UU/uu-content/liste.tsx
@@ -4,11 +4,11 @@ import { Anchor, HeadingSmall, InlineCode, Paragraph } from "../../Typography";
 import type { UUContent } from "./uu-content";
 
 const liste: UUContent = {
-    id: "lyd-og-video",
-    title: "Lyd og video",
-    tags: ["media"],
-    wcagRules: ["1.2.1", "1.4.2"],
-    links: [["Vår info om blinkende innhold", "/universell-utforming/guide/#blinkende-innhold"]],
+    id: "lister",
+    title: "Lister",
+    tags: ["liste"],
+    wcagRules: ["2.4.6"],
+    links: [["Jøkuls listekomponenter", "/komponenter/list"]],
     body: () => (
         <>
             <Paragraph>


### PR DESCRIPTION
Førte til at Lyd og bilde-seksjonen ble duplisert (React `key`-trøbbel pga duplikater), og presenterte listeinnhold med feil overskrifter og tags.

Innført i https://github.com/fremtind/jokul/commit/3b5ade89727444ba1ee9ff8e2f6f69e8ffa424fb. 

Fant igjen riktig metadata her: https://github.com/fremtind/jokul/commit/3b5ade89727444ba1ee9ff8e2f6f69e8ffa424fb#diff-28fb5e6a5aee7cd9fba22d3406eeecdb46f2c2a69cc7554ebaa83d4faa6548a2

ISSUES CLOSED: #3316

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
