### PR TITLE
chore: unngå dobbelt publisering av portalen

### DIFF
--- a/.github/workflows/release_portal.yml
+++ b/.github/workflows/release_portal.yml
@@ -5,10 +5,12 @@ on:
         branches:
             - main
         paths:
-            - "portal/**"
+            # Bare publiser etter at Lerna har versjonert
+            - "portal/package.json"
 
 jobs:
     portal:
+        if: "contains(github.event.sender.login, 'fremtind-bot')"
         name: Build and deploy portal
         runs-on: ubuntu-latest
         permissions:


### PR DESCRIPTION
Ved endringer i portal-mappa endte vi opp med to back-to-back deploys. En for merge, og en til for versjonering. Lerna og fremtind-bot versjonerer portalen hver gang det er endringer, så sikt inn på det for publiseringen.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
