### PR TITLE
chore: rekonfigurer cache keys for å unngå uendelig vekst

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,9 +88,9 @@ jobs:
               id: nx-cache
               with:
                   path: .nx
-                  key: nx-${{ github.ref_name }}-${{ github.sha }}
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
                   restore-keys: |
-                      nx-${{ github.ref_name }}-
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
 
             - name: Install dependencies and build packages
               if: steps.changes.outputs.has_matches == 'true' && !contains(github.event.sender.login, 'fremtind-bot')
@@ -170,9 +170,9 @@ jobs:
               id: nx-cache
               with:
                   path: .nx
-                  key: nx-${{ github.ref_name }}-${{ github.sha }}
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
                   restore-keys: |
-                      nx-${{ github.ref_name }}-
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
 
             - name: Install dependencies
               run: pnpm ci:install
@@ -219,9 +219,9 @@ jobs:
               id: nx-cache
               with:
                   path: .nx
-                  key: nx-${{ github.ref_name }}-${{ github.sha }}
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
                   restore-keys: |
-                      nx-${{ github.ref_name }}-
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
 
             - name: Build packages
               run: pnpm ci:install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ jobs:
               id: nx-cache
               with:
                   path: .nx
-                  key: nx-${{ github.ref_name }}-${{ github.sha }}
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
                   restore-keys: |
-                      nx-${{ github.ref_name }}-
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
 
             - name: Try logout
               continue-on-error: true

--- a/.github/workflows/release_portal.yml
+++ b/.github/workflows/release_portal.yml
@@ -44,9 +44,9 @@ jobs:
               id: nx-cache
               with:
                   path: .nx
-                  key: nx-${{ github.ref_name }}-${{ github.sha }}
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
                   restore-keys: |
-                      nx-${{ github.ref_name }}-
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
 
             - name: Caching Gatsby
               id: gatsby-cache-build


### PR DESCRIPTION
Via https://medium.com/emoteev-blog/10x-faster-ci-with-nx-and-github-actions-9a51fc4e82a6

Ser cachen vår har gradvist vokst til å bli problematisk. Ser ut som vi tar vare på mer enn vi bør.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
