### PR TITLE
fix: gjør typen for event handlere gjenbrukbar

### DIFF
--- a/packages/datepicker-react/src/types.ts
+++ b/packages/datepicker-react/src/types.ts
@@ -3,22 +3,25 @@ import { ChangeEvent, KeyboardEvent, FocusEvent, ButtonHTMLAttributes } from "re
 
 export type DateValidationError = "WRONG_FORMAT" | "OUTSIDE_LOWER_BOUND" | "OUTSIDE_UPPER_BOUND";
 
-export type DatePickerChangeEventHandler =
-    | ((e: ChangeEvent<HTMLInputElement>) => void)
-    | ((e: ChangeEvent<HTMLInputElement>, date: Date | null) => void)
-    | ((e: ChangeEvent<HTMLInputElement>, date: Date | null, meta: DatePickerMetadata) => void);
+export type DatePickerChangeEventHandler = (
+    e: ChangeEvent<HTMLInputElement>,
+    date: Date | null,
+    meta: DatePickerMetadata,
+) => void;
 
-export type DatePickerBlurEventHandler =
-    | ((e: FocusEvent<HTMLInputElement>) => void)
-    | ((e: FocusEvent<HTMLInputElement>, date: Date | null) => void)
-    | ((e: FocusEvent<HTMLInputElement>, date: Date | null, meta: DatePickerMetadata) => void);
+export type DatePickerBlurEventHandler = (
+    e: FocusEvent<HTMLInputElement>,
+    date: Date | null,
+    meta: DatePickerMetadata,
+) => void;
 
 export type DatePickerFocusEventHandler = DatePickerBlurEventHandler;
 
-export type DatePickerKeyDownEventHandler =
-    | ((e: KeyboardEvent<HTMLInputElement>) => void)
-    | ((e: KeyboardEvent<HTMLInputElement>, date: Date | null) => void)
-    | ((e: KeyboardEvent<HTMLInputElement>, date: Date | null, meta: DatePickerMetadata) => void);
+export type DatePickerKeyDownEventHandler = (
+    e: KeyboardEvent<HTMLInputElement>,
+    date: Date | null,
+    meta: DatePickerMetadata,
+) => void;
 
 export type DatePickerMetadata = {
     error: DateValidationError | null;


### PR DESCRIPTION
union types kan ikke brukes til å definere funksjoner, så med definisjonen under vil a og b bli implisitt `any` i stedet for typene definert av DatePickerChangeEventHandler.

`const handleChange: DatePickerChangeEventHandler => (a, b) => {}`

Denne PRen fikser dette, så man kan gjenbruke eventhandler definisjonene fra DatePicker.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
