### PR TITLE
fix: rett opp i feil bruk av aria-label i Loader

### DIFF
--- a/packages/loader-react/src/Loader.test.tsx
+++ b/packages/loader-react/src/Loader.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
 import React from "react";
 import { Loader } from ".";
 
@@ -21,10 +22,20 @@ describe("Loader", () => {
         expect(screen.getByTestId("jkl-loader")).toHaveClass("testclass");
     });
 
-    it("should apply passed aria-label and title", () => {
+    it("should apply passed title", () => {
         render(<Loader textDescription="Loading" />);
 
-        expect(screen.getByTestId("jkl-loader")).toHaveAttribute("aria-label", "Loading");
+        expect(screen.getByTestId("jkl-loader")).toHaveTextContent("Loading");
         expect(screen.getByTestId("jkl-loader")).toHaveAttribute("title", "Loading");
+    });
+});
+
+describe("a11y", () => {
+    test("should have no axe errors", async () => {
+        const { container } = render(<Loader textDescription="Laster inn" />);
+
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
     });
 });

--- a/packages/loader-react/src/Loader.tsx
+++ b/packages/loader-react/src/Loader.tsx
@@ -42,7 +42,6 @@ export const Loader = ({
     return (
         <span
             aria-busy="true"
-            aria-label={textDescription}
             className={componentClassName}
             data-testautoid={dataTestAutoId}
             data-testid="jkl-loader"
@@ -52,6 +51,7 @@ export const Loader = ({
             <span className="jkl-loader__dot jkl-loader__dot--left" />
             <span className="jkl-loader__dot jkl-loader__dot--middle" />
             <span className="jkl-loader__dot jkl-loader__dot--right" />
+            <span className="jkl-sr-only">{textDescription}</span>
         </span>
     );
 };


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
