### PR TITLE
fix: rett opp et synkroniseringsproblem

### DIFF
--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -183,16 +183,24 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             const nextValue = item.value;
             setSearchValue("");
             setSelectedValue(nextValue);
-            if (onChange) {
-                onChange({ type: "change", target: { name, value: nextValue } });
-            }
-            if (selectRef.current) {
-                selectRef.current.dispatchEvent(new Event("change", { bubbles: true }));
-            }
             toggleListVisibility();
         },
-        [onChange, setSearchValue, setSelectedValue, toggleListVisibility, name],
+        [setSearchValue, setSelectedValue, toggleListVisibility],
     );
+
+    // La komponenten rendre <select> med den valgte verdien før onChange trigges, slik at
+    // react-hook-form@>7.41.1 behandler feltet som at det har en verdi.
+    useEffect(() => {
+        if (value === selectedValue) {
+            return;
+        }
+        if (onChange) {
+            onChange({ type: "change", target: { name, value: selectedValue } });
+        }
+        if (selectRef.current) {
+            selectRef.current.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+    }, [onChange, name, value, selectedValue]);
 
     /// Fokushåndtering
 


### PR DESCRIPTION
ref sin value (`<select>`) og eventet sin value var ulik, noe som forvirret react-hook-form sin validering av required

ISSUES CLOSED: #3373

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
