### PR TITLE
fix: onChange hvis value er undefined, og render loop ved endring av value utenfra

### DIFF
--- a/packages/footer-react/src/Footer.test.tsx
+++ b/packages/footer-react/src/Footer.test.tsx
@@ -12,13 +12,11 @@ describe("Footer", () => {
                     {
                         title: "Personvern og vilkår",
                         href: "https://www.fremtind.no/personvern/",
-                        external: false,
                     },
                     {
                         title: "Bruk av informasjonskapsler",
                         component: "button",
                         onClick: () => alert("Åpne cookieConsent"),
-                        external: false,
                     },
                 ]}
             />,
@@ -44,13 +42,11 @@ describe("Footer", () => {
                     {
                         title: "Personvern og vilkår",
                         href: "https://www.fremtind.no/personvern/",
-                        external: false,
                     },
                     {
                         title: "Bruk av informasjonskapsler",
                         component: "button",
                         onClick: () => alert("Åpne cookieConsent"),
-                        external: false,
                     },
                 ]}
             />,

--- a/packages/select-react/documentation/SelectExample.tsx
+++ b/packages/select-react/documentation/SelectExample.tsx
@@ -49,7 +49,7 @@ export const SelectExample: FC<ExampleComponentProps> = ({ boolValues, choiceVal
         { value: "9", label: "Sony" },
         { value: "10", label: "Doro" },
     ];
-    const [value, setValue] = useState<string>();
+    const [value, setValue] = useState<string>("");
 
     const errorLabel =
         boolValues && boolValues["Med feil"] ? "Du må velge merket til telefonen, for eksempel Apple." : undefined;

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -46,8 +46,6 @@ describe("Select", () => {
     });
 
     it("should open when arrow down is pressed", async () => {
-        // Testen produserer en tom DOMException. Undersøkelser i jsdom ga ikke noe hint om årsak.
-
         const screen = setup(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
@@ -76,9 +74,30 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue(value);
     });
 
+    it("should not call onChange if value is undefined (#3421)", () => {
+        const onChange = jest.fn();
+        const { getByTestId } = setup(
+            <Select
+                label="Items"
+                name="items"
+                items={[
+                    { label: "Item 1", value: "1" },
+                    { label: "Item 2", value: "2" },
+                    { label: "Item 3", value: "3" },
+                ]}
+                value={undefined}
+                onChange={onChange}
+            />,
+        );
+
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("Velg");
+        expect(getByTestId("jkl-native-select")).toHaveValue("");
+        expect(onChange).toHaveBeenCalledTimes(0);
+    });
+
     it("should change the controlled value of the select when clicking on a option", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -156,20 +175,22 @@ describe("Select", () => {
     });
 
     it("displays the ValuePair label of selected item on first render", () => {
+        const onChange = jest.fn();
         const valuePairs = [{ value: "datagreier", label: "Fin lesbar tekst" }];
 
         const { getByTestId } = setup(
-            <Select name="datagreier" label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />,
+            <Select name="datagreier" label="test" items={valuePairs} value="datagreier" onChange={onChange} />,
         );
 
         expect(getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
         expect(getByTestId("jkl-native-select")).toHaveValue("datagreier");
+        expect(onChange).not.toHaveBeenCalled();
     });
 
     it("should call onFocus when clicking on select dropdown", async () => {
         const onFocus = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -201,7 +222,7 @@ describe("Select", () => {
     it("should call onBlur when clicking on something outside Select", async () => {
         const onBlur = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -241,7 +262,7 @@ describe("Select", () => {
     it("should not call onBlur when clicking on a dropdown item", async () => {
         const onBlur = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -366,7 +387,7 @@ describe("Select", () => {
 describe("Searchable select", () => {
     it("should keep search input hidden by default", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -391,7 +412,7 @@ describe("Searchable select", () => {
 
     it("should change the value of the select when clicking on a option", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -427,7 +448,7 @@ describe("Searchable select", () => {
 
     it("should change visibility of search input when opening select dropdown", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -461,7 +482,7 @@ describe("Searchable select", () => {
 
     it("should keep all items visible when nothing has been typed into search input", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -502,7 +523,7 @@ describe("Searchable select", () => {
 
     it("should change visibility of options who's label does not match the input search value", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 11", value: "A" },
@@ -554,7 +575,7 @@ describe("Searchable select", () => {
 
     it("should clear search input after selecting an item and opening select options again", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 11", value: "A" },
@@ -607,7 +628,7 @@ describe("Searchable select", () => {
 
     it("should have a case insensitive search", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "ITEM 1", value: "1" },
@@ -664,7 +685,7 @@ describe("Searchable select", () => {
 
     it("should focus search input field when clicking dropdown button", async () => {
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -696,7 +717,7 @@ describe("Searchable select", () => {
     it("should call onFocus when select button is clicked in searchable Select", async () => {
         const onFocus = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -729,7 +750,7 @@ describe("Searchable select", () => {
     it("should not call onBlur when clicking on a searchable Select", async () => {
         const onBlur = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -762,7 +783,7 @@ describe("Searchable select", () => {
     it("should call onBlur when clicking on something outside searchable Select", async () => {
         const onBlur = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -805,7 +826,7 @@ describe("Searchable select", () => {
     it("should call onFocus only once when performing multiple actions and focus shifts inside the searchable Select", async () => {
         const onBlur = jest.fn();
         function WrappedSelect() {
-            const [state, setState] = useState<string>();
+            const [state, setState] = useState<string>("");
 
             const items = [
                 { label: "Item 1", value: "1" },
@@ -976,7 +997,7 @@ describe("a11y", () => {
     test("aria-label should update correctly on change", async () => {
         const onChange = jest.fn();
         function WrappedSelect() {
-            const [value, setValue] = useState<string>();
+            const [value, setValue] = useState<string>("");
 
             const items = [
                 { value: "apple", label: "Apple" },

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1,13 +1,23 @@
 import { Accordion, AccordionItem } from "@fremtind/jkl-accordion-react";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, RenderOptions, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import React, { useEffect, useState } from "react";
 import { Select } from ".";
 
+function setup(jsx: JSX.Element, renderOptions?: RenderOptions) {
+    return {
+        user: userEvent.setup({
+            delay: 5,
+            advanceTimers: jest.advanceTimersByTime,
+            skipHover: true,
+        }),
+        ...render(jsx, renderOptions),
+    };
+}
 describe("Select", () => {
     it("should render correct amount of options", () => {
-        const { getAllByTestId } = render(
+        const { getAllByTestId } = setup(
             <Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />,
         );
 
@@ -17,14 +27,14 @@ describe("Select", () => {
     });
 
     it("should be inline when specified", () => {
-        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const screen = setup(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const dropdown = screen.getByTestId("jkl-select");
         expect(dropdown).toHaveClass("jkl-select--inline");
     });
 
     it("should open when clicked", async () => {
-        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const screen = setup(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -37,7 +47,7 @@ describe("Select", () => {
     it("should open when arrow down is pressed", async () => {
         // Testen produserer en tom DOMException. Undersøkelser i jsdom ga ikke noe hint om årsak.
 
-        render(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const screen = setup(<Select name="snoop" inline items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -50,7 +60,7 @@ describe("Select", () => {
     it("should use the specified value", () => {
         const onChange = jest.fn();
         const value = "drop";
-        render(
+        const screen = setup(
             <Select
                 name="snoop"
                 onChange={onChange}
@@ -67,7 +77,7 @@ describe("Select", () => {
     });
 
     it("should have default text value in button when no option selected", () => {
-        render(<Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const screen = setup(<Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
 
         const button = screen.getByTestId("jkl-select__button");
 
@@ -75,7 +85,7 @@ describe("Select", () => {
     });
 
     it("can be forced into compact mode", () => {
-        render(<Select name="count" items={["1", "2"]} label="test" density="compact" />);
+        const screen = setup(<Select name="count" items={["1", "2"]} label="test" density="compact" />);
 
         expect(screen.getByTestId("jkl-select")).toHaveAttribute("data-density", "compact");
     });
@@ -83,7 +93,9 @@ describe("Select", () => {
     it("displays the ValuePair label of selected item on first render", () => {
         const valuePairs = [{ value: "datagreier", label: "Fin lesbar tekst" }];
 
-        render(<Select name="datagreier" label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />);
+        const screen = setup(
+            <Select name="datagreier" label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />,
+        );
 
         expect(screen.getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
     });
@@ -109,7 +121,7 @@ describe("Select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
 
@@ -144,7 +156,7 @@ describe("Select", () => {
                 </>
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
         const outsideSelectButtonElement = screen.getByText("OUTSIDE BUTTON");
@@ -184,7 +196,7 @@ describe("Select", () => {
                 </>
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
 
@@ -202,7 +214,7 @@ describe("Select", () => {
     });
 
     it("should support toggling a Select inside an AccordionItem without getting stuck in a render-loop (#1466)", async () => {
-        render(
+        const screen = setup(
             <Accordion>
                 <AccordionItem title="Velg tingen" startExpanded>
                     <Select name="items" items={[{ label: "Item 3", value: "3" }]} label="Ting" />
@@ -236,7 +248,7 @@ describe("Select", () => {
             );
         };
 
-        render(<TestControlledSelect />);
+        const screen = setup(<TestControlledSelect />);
 
         await act(async () => {
             await userEvent.click(screen.getByText("Click"));
@@ -246,7 +258,7 @@ describe("Select", () => {
     });
 
     it("supports labels only for screen readers", () => {
-        render(<Select name="count" items={["1", "2"]} label="test" labelProps={{ srOnly: true }} />);
+        const screen = setup(<Select name="count" items={["1", "2"]} label="test" labelProps={{ srOnly: true }} />);
 
         const label = screen.getByText("test");
         expect(label).toHaveClass("jkl-label--sr-only");
@@ -273,7 +285,7 @@ describe("Select", () => {
             );
         };
 
-        render(<DoThing />);
+        const screen = setup(<DoThing />);
         expect(screen.getByTestId("jkl-select__button")).toHaveTextContent("A");
 
         await waitFor(() => {
@@ -303,7 +315,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         expect(screen.getByLabelText("List of items", { selector: "input" })).not.toBeVisible();
     });
@@ -328,7 +340,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
         const openDropdownButtonElement = screen.getByText("Velg");
 
         await act(async () => {
@@ -363,7 +375,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const openDropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -400,7 +412,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const openDropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -441,7 +453,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const openDropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -493,7 +505,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const openDropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -546,7 +558,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const openDropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -600,7 +612,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
         const searchInputElement = screen.getByLabelText("List of items", { selector: "input" });
@@ -633,7 +645,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
 
@@ -666,7 +678,7 @@ describe("Searchable select", () => {
                 />
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
 
@@ -702,7 +714,7 @@ describe("Searchable select", () => {
                 </>
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
         const outsideSelectButtonElement = screen.getByText("OUTSIDE BUTTON");
@@ -745,7 +757,7 @@ describe("Searchable select", () => {
                 </>
             );
         }
-        render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
         const outsideSelectButtonElement = screen.getByText("OUTSIDE BUTTON");
@@ -778,7 +790,7 @@ describe("Searchable select", () => {
     });
 
     it("should support toggling a Select inside an AccordionItem without getting stuck in a render-loop (#1466)", async () => {
-        render(
+        const screen = setup(
             <Accordion>
                 <AccordionItem title="Velg tingen" startExpanded>
                     <Select name="items" searchable items={[{ label: "Item 3", value: "3" }]} label="Ting" />
@@ -801,7 +813,7 @@ describe("Searchable select", () => {
             { label: "Item 3", value: "3" },
         ];
 
-        render(<Select name="items" items={items} label="Ting" searchable />);
+        const screen = setup(<Select name="items" items={items} label="Ting" searchable />);
 
         const openDropdownButtonElement = screen.getByTestId("jkl-select__button");
         await act(async () => {
@@ -825,7 +837,7 @@ describe("Searchable select", () => {
             { label: "baz", value: "3" },
         ];
 
-        render(
+        const screen = setup(
             <Select
                 name="items"
                 items={items}
@@ -858,7 +870,7 @@ describe("Searchable select", () => {
 
 describe("a11y", () => {
     test("searchable select should be a11y compliant", async () => {
-        const { container } = render(
+        const { container } = setup(
             <Select name="items" searchable label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
         );
         const results = await axe(container);
@@ -866,7 +878,7 @@ describe("a11y", () => {
         expect(results).toHaveNoViolations();
     });
     test("select should be a11y compliant", async () => {
-        const { container } = render(
+        const { container } = setup(
             <Select name="items" label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,
         );
         const results = await axe(container);
@@ -875,7 +887,7 @@ describe("a11y", () => {
     });
 
     test("compact select should be a11y compliant", async () => {
-        const { container } = render(
+        const { container } = setup(
             <Select
                 name="items"
                 density="compact"
@@ -916,7 +928,7 @@ describe("a11y", () => {
             );
         }
 
-        const screen = render(<WrappedSelect />);
+        const screen = setup(<WrappedSelect />);
 
         const dropdownButtonElement = screen.getByText("Velg");
         await act(async () => {

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -15,6 +15,7 @@ function setup(jsx: JSX.Element, renderOptions?: RenderOptions) {
         ...render(jsx, renderOptions),
     };
 }
+
 describe("Select", () => {
     it("should render correct amount of options", () => {
         const { getAllByTestId } = setup(
@@ -60,7 +61,7 @@ describe("Select", () => {
     it("should use the specified value", () => {
         const onChange = jest.fn();
         const value = "drop";
-        const screen = setup(
+        const { getByTestId } = setup(
             <Select
                 name="snoop"
                 onChange={onChange}
@@ -70,18 +71,18 @@ describe("Select", () => {
             />,
         );
 
-        const button = screen.getByTestId("jkl-select__button");
-
         expect(onChange).toHaveBeenCalledTimes(0);
-        expect(button).toHaveTextContent(value);
+        expect(getByTestId("jkl-select__button")).toHaveTextContent(value);
+        expect(getByTestId("jkl-native-select")).toHaveValue(value);
     });
 
     it("should have default text value in button when no option selected", () => {
-        const screen = setup(<Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />);
+        const { getByTestId } = setup(
+            <Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />,
+        );
 
-        const button = screen.getByTestId("jkl-select__button");
-
-        expect(button).toHaveTextContent("Velg");
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("Velg");
+        expect(getByTestId("jkl-native-select")).toHaveValue("");
     });
 
     it("can be forced into compact mode", () => {
@@ -93,11 +94,12 @@ describe("Select", () => {
     it("displays the ValuePair label of selected item on first render", () => {
         const valuePairs = [{ value: "datagreier", label: "Fin lesbar tekst" }];
 
-        const screen = setup(
+        const { getByTestId } = setup(
             <Select name="datagreier" label="test" items={valuePairs} value={"datagreier"} onChange={() => {}} />,
         );
 
-        expect(screen.getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
+        expect(getByTestId("jkl-select__button").innerHTML).toBe("Fin lesbar tekst");
+        expect(getByTestId("jkl-native-select")).toHaveValue("datagreier");
     });
 
     it("should call onFocus when clicking on select dropdown", async () => {
@@ -248,13 +250,14 @@ describe("Select", () => {
             );
         };
 
-        const screen = setup(<TestControlledSelect />);
+        const { getByText, getByTestId } = setup(<TestControlledSelect />);
 
         await act(async () => {
-            await userEvent.click(screen.getByText("Click"));
+            await userEvent.click(getByText("Click"));
         });
 
-        expect(screen.getByTestId("jkl-select__button")).toHaveTextContent("Item 2");
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("Item 2");
+        expect(getByTestId("jkl-native-select")).toHaveValue("2");
     });
 
     it("supports labels only for screen readers", () => {
@@ -285,11 +288,13 @@ describe("Select", () => {
             );
         };
 
-        const screen = setup(<DoThing />);
-        expect(screen.getByTestId("jkl-select__button")).toHaveTextContent("A");
+        const { getByTestId } = setup(<DoThing />);
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("A");
+        expect(getByTestId("jkl-native-select")).toHaveValue("A");
 
         await waitFor(() => {
-            expect(screen.getByTestId("jkl-select__button")).toHaveTextContent("B");
+            expect(getByTestId("jkl-select__button")).toHaveTextContent("B");
+            expect(getByTestId("jkl-native-select")).toHaveValue("B");
         });
     });
 });
@@ -340,19 +345,20 @@ describe("Searchable select", () => {
                 />
             );
         }
-        const screen = setup(<WrappedSelect />);
-        const openDropdownButtonElement = screen.getByText("Velg");
+        const { getByRole, getByText, getByTestId } = setup(<WrappedSelect />);
+        const openDropdownButtonElement = getByText("Velg");
 
         await act(async () => {
             await userEvent.click(openDropdownButtonElement);
         });
 
-        const selectOption1Element = screen.getByRole("option", { name: "Item 1" });
+        const selectOption1Element = getByRole("option", { name: "Item 1" });
 
         await act(async () => {
             await userEvent.click(selectOption1Element);
         });
         expect(openDropdownButtonElement.textContent).toBe("Item 1");
+        expect(getByTestId("jkl-native-select")).toHaveValue("1");
     });
 
     it("should change visibility of search input when opening select dropdown", async () => {
@@ -877,6 +883,7 @@ describe("a11y", () => {
 
         expect(results).toHaveNoViolations();
     });
+
     test("select should be a11y compliant", async () => {
         const { container } = setup(
             <Select name="items" label="Select" items={["1", "2"]} value="1" helpLabel="Velg en av to" />,

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -113,6 +113,33 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue("1");
     });
 
+    it("should change the uncontrolled value of the select when clicking on a option", async () => {
+        function WrappedSelect() {
+            const items = [
+                { label: "Item 1", value: "1" },
+                { label: "Item 2", value: "2" },
+                { label: "Item 3", value: "3" },
+            ];
+            return <Select name="items" label="List of items" items={items} />;
+        }
+
+        const { getByRole, getByText, getByTestId } = setup(<WrappedSelect />);
+        const openDropdownButtonElement = getByText("Velg");
+
+        await act(async () => {
+            await userEvent.click(openDropdownButtonElement);
+        });
+
+        const selectOption1Element = getByRole("option", { name: "Item 1" });
+
+        await act(async () => {
+            await userEvent.click(selectOption1Element);
+        });
+
+        expect(openDropdownButtonElement.textContent).toBe("Item 1");
+        expect(getByTestId("jkl-native-select")).toHaveValue("1");
+    });
+
     it("should have default text value in button when no option selected", () => {
         const { getByTestId } = setup(
             <Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />,

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -74,6 +74,35 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue(value);
     });
 
+    it("should not get stuck in a loop when changing the value from outside (https://github.com/fremtind/jokul/issues/3421#issuecomment-1440155891)", () => {
+        const onChange = jest.fn();
+        const DoThing = () => {
+            const [value, setValue] = useState<string>("");
+            useEffect(() => {
+                setValue("A");
+            }, []);
+            return (
+                <div className="build-info-page">
+                    <Select
+                        name={"Hello"}
+                        label={"Utbetalingsmottaker"}
+                        items={["A", "B", "C"]}
+                        value={value}
+                        onChange={(e) => {
+                            setValue(e.target.value);
+                            onChange();
+                        }}
+                    />
+                </div>
+            );
+        };
+
+        const { getByTestId } = setup(<DoThing />);
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("A");
+        expect(getByTestId("jkl-native-select")).toHaveValue("A");
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
     it("should not call onChange if value is undefined (#3421)", () => {
         const onChange = jest.fn();
         const { getByTestId } = setup(

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -76,6 +76,43 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue(value);
     });
 
+    it("should change the controlled value of the select when clicking on a option", async () => {
+        function WrappedSelect() {
+            const [state, setState] = useState<string>();
+
+            const items = [
+                { label: "Item 1", value: "1" },
+                { label: "Item 2", value: "2" },
+                { label: "Item 3", value: "3" },
+            ];
+            return (
+                <Select
+                    name="items"
+                    label="List of items"
+                    items={items}
+                    value={state}
+                    onChange={(e) => setState(e.target.value)}
+                />
+            );
+        }
+
+        const { getByRole, getByText, getByTestId } = setup(<WrappedSelect />);
+        const openDropdownButtonElement = getByText("Velg");
+
+        await act(async () => {
+            await userEvent.click(openDropdownButtonElement);
+        });
+
+        const selectOption1Element = getByRole("option", { name: "Item 1" });
+
+        await act(async () => {
+            await userEvent.click(selectOption1Element);
+        });
+
+        expect(openDropdownButtonElement.textContent).toBe("Item 1");
+        expect(getByTestId("jkl-native-select")).toHaveValue("1");
+    });
+
     it("should have default text value in button when no option selected", () => {
         const { getByTestId } = setup(
             <Select name="snoop" items={["drop", "it", "like", "its", "hot"]} label="Snoop" />,

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -401,6 +401,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             <select
                 name={name}
                 tabIndex={-1}
+                data-testid="jkl-native-select"
                 className="jkl-sr-only"
                 aria-hidden
                 ref={unifiedSelectRef}


### PR DESCRIPTION
Driv litt TDD for å forhåpentligvis unngå regresjoner som dette. Fikser de to feilene nevnt i #3421

- Ikke fyr av `onChange` ved første render hvis `value` er `undefined`.
- Unngå å havne i en loop om man endrer `value` utenfra, og har en `onChange` som setter `value` basert på `e.target.value` (som man jo gjerne har).

## 🎯 Sjekkliste

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
