### PR TITLE
fix: sett charset i CSS-filene som genereres

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/alert-message/alert-message.scss
+++ b/packages/alert-message/alert-message.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";

--- a/packages/breadcrumb/breadcrumb.scss
+++ b/packages/breadcrumb/breadcrumb.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 .jkl-breadcrumb {

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 

--- a/packages/card/card.scss
+++ b/packages/card/card.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 @use "deprecated-card";
 @use "info-card";

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";

--- a/packages/contact-information/contact-information.scss
+++ b/packages/contact-information/contact-information.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/content-toggle/content-toggle.scss
+++ b/packages/content-toggle/content-toggle.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 

--- a/packages/contextual-menu/contextual-menu.scss
+++ b/packages/contextual-menu/contextual-menu.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 @use "contextual-menu-item";
 @use "contextual-menu-divider";

--- a/packages/cookie-consent/cookie-consent.scss
+++ b/packages/cookie-consent/cookie-consent.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 $_card-corner-radius: jkl.rem(2px);

--- a/packages/core/core.scss
+++ b/packages/core/core.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:map";
 @use "jkl";
 @use "jkl/typography";

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/description-list/description-list.scss
+++ b/packages/description-list/description-list.scss
@@ -1,4 +1,4 @@
-/* autoprefixer grid: autoplace */
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @mixin _horizontal-list {

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 

--- a/packages/footer/footer.scss
+++ b/packages/footer/footer.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 $_hamburger-line-height: jkl.rem(2px);

--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/icons/icons.scss
+++ b/packages/icons/icons.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 .jkl-icon {

--- a/packages/image/image.scss
+++ b/packages/image/image.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 .jkl-image {

--- a/packages/input-group/input-group.scss
+++ b/packages/input-group/input-group.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 @use "field-group";
 @use "labels";

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @function _solid-diamond($color) {

--- a/packages/loader/loader.scss
+++ b/packages/loader/loader.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 

--- a/packages/loader/skeleton-loader.scss
+++ b/packages/loader/skeleton-loader.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 

--- a/packages/logo/logo.scss
+++ b/packages/logo/logo.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:string";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:color";
 @use "sass:math";
 @use "~@fremtind/jkl-core/jkl";

--- a/packages/summary-table/summary-table.scss
+++ b/packages/summary-table/summary-table.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/table/table.scss
+++ b/packages/table/table.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @use "table-caption";

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @include jkl.light-mode-variables {

--- a/packages/tag/tag.scss
+++ b/packages/tag/tag.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";
 

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:color";
 @use "~@fremtind/jkl-core/jkl";
 @use "~@fremtind/jkl-core/jkl/colors";

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 @use "./toggle-slider";

--- a/packages/tooltip/tooltip.scss
+++ b/packages/tooltip/tooltip.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";
 
 $_tooltip-border-width: jkl.rem(1px);

--- a/packages/webfonts/webfonts.scss
+++ b/packages/webfonts/webfonts.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 $webfonts-dir: "/fonts" !default;
 
 @font-face {

--- a/scripts/scaffold/templates/component/scaffold.scss
+++ b/scripts/scaffold/templates/component/scaffold.scss
@@ -1,1 +1,2 @@
+@charset "UTF-8";
 @use "~@fremtind/jkl-core/jkl";


### PR DESCRIPTION
Ha en ekstra sikkerhet der hvor browser/server-kommunikasjonen ikke setter encodingen.

ISSUES CLOSED: #3467

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
