### PR TITLE
fix: rett opp typedefinisjon for ikoner bygget av factory

### DIFF
--- a/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
@@ -1,8 +1,8 @@
 import cx from "classnames";
-import React, { FC } from "react";
+import React, { type FC } from "react";
 import { ArrowLeftIcon } from "../icons/arrow-left/ArrowLeftIcon";
 import { ArrowRightIcon } from "../icons/arrow-right/ArrowRightIcon";
-import { IconVariant } from "../icons/types";
+import { type IconVariant } from "../icons/types";
 
 export interface ArrowHorizontalAnimatedProps {
     className?: string;

--- a/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
@@ -1,8 +1,8 @@
 import cx from "classnames";
-import React from "react";
+import React, { type FC } from "react";
 import { ArrowDownIcon } from "../icons/arrow-down/ArrowDownIcon";
 import { ArrowUpIcon } from "../icons/arrow-up/ArrowUpIcon";
-import { IconVariant } from "../icons/types";
+import { type IconVariant } from "../icons/types";
 
 export interface ArrowVerticalAnimatedProps {
     className?: string;
@@ -11,13 +11,13 @@ export interface ArrowVerticalAnimatedProps {
     bold?: boolean;
 }
 
-export const ArrowVerticalAnimated = ({
+export const ArrowVerticalAnimated: FC<ArrowVerticalAnimatedProps> = ({
     className,
     pointingDown,
     variant = "inherit",
     bold = false,
     ...rest
-}: ArrowVerticalAnimatedProps) => (
+}) => (
     <div {...rest} className={cx(`jkl-icon jkl-icon--${variant}`, "jkl-animated-vertical-arrows", className)}>
         <div className="jkl-animated-vertical-arrows__slider" data-show={pointingDown ? "down" : "up"}>
             <ArrowDownIcon className="jkl-animated-vertical-arrows__arrow" variant={variant} bold={bold} />

--- a/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
-import React, { FC } from "react";
+import React, { type FC } from "react";
 import { PlusIcon } from "../icons/plus/PlusIcon";
-import { IconVariant } from "../icons/types";
+import { type IconVariant } from "../icons/types";
 
 export interface PlusRemoveAnimatedProps {
     className?: string;

--- a/packages/icons-react/src/icons/arrow-down/ArrowDownIcon.tsx
+++ b/packages/icons-react/src/icons/arrow-down/ArrowDownIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ArrowDownMedium } from "./ArrowDownMedium";
 import { ArrowDownMediumBold } from "./ArrowDownMediumBold";
 import { ArrowDownSmall } from "./ArrowDownSmall";
 import { ArrowDownSmallBold } from "./ArrowDownSmallBold";
 
-export const ArrowDownIcon = makeIconComponent({
+export const ArrowDownIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ArrowDownSmallBold,
         medium: ArrowDownMediumBold,

--- a/packages/icons-react/src/icons/arrow-left/ArrowLeftIcon.tsx
+++ b/packages/icons-react/src/icons/arrow-left/ArrowLeftIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ArrowLeftMedium } from "./ArrowLeftMedium";
 import { ArrowLeftMediumBold } from "./ArrowLeftMediumBold";
 import { ArrowLeftSmall } from "./ArrowLeftSmall";
 import { ArrowLeftSmallBold } from "./ArrowLeftSmallBold";
 
-export const ArrowLeftIcon = makeIconComponent({
+export const ArrowLeftIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ArrowLeftSmallBold,
         medium: ArrowLeftMediumBold,

--- a/packages/icons-react/src/icons/arrow-north-east/ArrowNorthEastIcon.tsx
+++ b/packages/icons-react/src/icons/arrow-north-east/ArrowNorthEastIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ArrowNorthEastMedium } from "./ArrowNorthEastMedium";
 import { ArrowNorthEastMediumBold } from "./ArrowNorthEastMediumBold";
 import { ArrowNorthEastSmall } from "./ArrowNorthEastSmall";
 import { ArrowNorthEastSmallBold } from "./ArrowNorthEastSmallBold";
 
-export const ArrowNorthEastIcon = makeIconComponent({
+export const ArrowNorthEastIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ArrowNorthEastSmallBold,
         medium: ArrowNorthEastMediumBold,

--- a/packages/icons-react/src/icons/arrow-right/ArrowRightIcon.tsx
+++ b/packages/icons-react/src/icons/arrow-right/ArrowRightIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ArrowRightMedium } from "./ArrowRightMedium";
 import { ArrowRightMediumBold } from "./ArrowRightMediumBold";
 import { ArrowRightSmall } from "./ArrowRightSmall";
 import { ArrowRightSmallBold } from "./ArrowRightSmallBold";
 
-export const ArrowRightIcon = makeIconComponent({
+export const ArrowRightIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ArrowRightSmallBold,
         medium: ArrowRightMediumBold,

--- a/packages/icons-react/src/icons/arrow-up/ArrowUpIcon.tsx
+++ b/packages/icons-react/src/icons/arrow-up/ArrowUpIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ArrowUpMedium } from "./ArrowUpMedium";
 import { ArrowUpMediumBold } from "./ArrowUpMediumBold";
 import { ArrowUpSmall } from "./ArrowUpSmall";
 import { ArrowUpSmallBold } from "./ArrowUpSmallBold";
 
-export const ArrowUpIcon = makeIconComponent({
+export const ArrowUpIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ArrowUpSmallBold,
         medium: ArrowUpMediumBold,

--- a/packages/icons-react/src/icons/calendar/CalendarIcon.tsx
+++ b/packages/icons-react/src/icons/calendar/CalendarIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { CalendarMedium } from "./CalendarMedium";
 import { CalendarMediumBold } from "./CalendarMediumBold";
 import { CalendarSmall } from "./CalendarSmall";
 import { CalendarSmallBold } from "./CalendarSmallBold";
 
-export const CalendarIcon = makeIconComponent({
+export const CalendarIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: CalendarSmallBold,
         medium: CalendarMediumBold,

--- a/packages/icons-react/src/icons/check/CheckIcon.tsx
+++ b/packages/icons-react/src/icons/check/CheckIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { CheckMedium } from "./CheckMedium";
 import { CheckMediumBold } from "./CheckMediumBold";
 import { CheckSmall } from "./CheckSmall";
 import { CheckSmallBold } from "./CheckSmallBold";
 
-export const CheckIcon = makeIconComponent({
+export const CheckIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: CheckSmallBold,
         medium: CheckMediumBold,

--- a/packages/icons-react/src/icons/chevron-down/ChevronDownIcon.tsx
+++ b/packages/icons-react/src/icons/chevron-down/ChevronDownIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ChevronDownMedium } from "./ChevronDownMedium";
 import { ChevronDownMediumBold } from "./ChevronDownMediumBold";
 import { ChevronDownSmall } from "./ChevronDownSmall";
 import { ChevronDownSmallBold } from "./ChevronDownSmallBold";
 
-export const ChevronDownIcon = makeIconComponent({
+export const ChevronDownIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ChevronDownSmallBold,
         medium: ChevronDownMediumBold,

--- a/packages/icons-react/src/icons/chevron-left/ChevronLeftIcon.tsx
+++ b/packages/icons-react/src/icons/chevron-left/ChevronLeftIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ChevronLeftMedium } from "./ChevronLeftMedium";
 import { ChevronLeftMediumBold } from "./ChevronLeftMediumBold";
 import { ChevronLeftSmall } from "./ChevronLeftSmall";
 import { ChevronLeftSmallBold } from "./ChevronLeftSmallBold";
 
-export const ChevronLeftIcon = makeIconComponent({
+export const ChevronLeftIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ChevronLeftSmallBold,
         medium: ChevronLeftMediumBold,

--- a/packages/icons-react/src/icons/chevron-right/ChevronRightIcon.tsx
+++ b/packages/icons-react/src/icons/chevron-right/ChevronRightIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ChevronRightMedium } from "./ChevronRightMedium";
 import { ChevronRightMediumBold } from "./ChevronRightMediumBold";
 import { ChevronRightSmall } from "./ChevronRightSmall";
 import { ChevronRightSmallBold } from "./ChevronRightSmallBold";
 
-export const ChevronRightIcon = makeIconComponent({
+export const ChevronRightIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ChevronRightSmallBold,
         medium: ChevronRightMediumBold,

--- a/packages/icons-react/src/icons/chevron-up/ChevronUpIcon.tsx
+++ b/packages/icons-react/src/icons/chevron-up/ChevronUpIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ChevronUpMedium } from "./ChevronUpMedium";
 import { ChevronUpMediumBold } from "./ChevronUpMediumBold";
 import { ChevronUpSmall } from "./ChevronUpSmall";
 import { ChevronUpSmallBold } from "./ChevronUpSmallBold";
 
-export const ChevronUpIcon = makeIconComponent({
+export const ChevronUpIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ChevronUpSmallBold,
         medium: ChevronUpMediumBold,

--- a/packages/icons-react/src/icons/close/CloseIcon.tsx
+++ b/packages/icons-react/src/icons/close/CloseIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { CloseMedium } from "./CloseMedium";
 import { CloseMediumBold } from "./CloseMediumBold";
 import { CloseSmall } from "./CloseSmall";
 import { CloseSmallBold } from "./CloseSmallBold";
 
-export const CloseIcon = makeIconComponent({
+export const CloseIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: CloseSmallBold,
         medium: CloseMediumBold,

--- a/packages/icons-react/src/icons/copy/CopyIcon.tsx
+++ b/packages/icons-react/src/icons/copy/CopyIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { CopyMedium } from "./CopyMedium";
 import { CopyMediumBold } from "./CopyMediumBold";
 import { CopySmall } from "./CopySmall";
 import { CopySmallBold } from "./CopySmallBold";
 
-export const CopyIcon = makeIconComponent({
+export const CopyIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: CopySmallBold,
         medium: CopyMediumBold,

--- a/packages/icons-react/src/icons/dots/DotsIcon.tsx
+++ b/packages/icons-react/src/icons/dots/DotsIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { DotsMedium } from "./DotsMedium";
 import { DotsMediumBold } from "./DotsMediumBold";
 import { DotsSmall } from "./DotsSmall";
 import { DotsSmallBold } from "./DotsSmallBold";
 
-export const DotsIcon = makeIconComponent({
+export const DotsIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: DotsSmallBold,
         medium: DotsMediumBold,

--- a/packages/icons-react/src/icons/error/ErrorIcon.tsx
+++ b/packages/icons-react/src/icons/error/ErrorIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { ErrorMedium } from "./ErrorMedium";
 import { ErrorMediumBold } from "./ErrorMediumBold";
 import { ErrorSmall } from "./ErrorSmall";
 import { ErrorSmallBold } from "./ErrorSmallBold";
 
-export const ErrorIcon = makeIconComponent({
+export const ErrorIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: ErrorSmallBold,
         medium: ErrorMediumBold,

--- a/packages/icons-react/src/icons/hamburger/HamburgerIcon.tsx
+++ b/packages/icons-react/src/icons/hamburger/HamburgerIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { HamburgerMedium } from "./HamburgerMedium";
 import { HamburgerMediumBold } from "./HamburgerMediumBold";
 import { HamburgerSmall } from "./HamburgerSmall";
 import { HamburgerSmallBold } from "./HamburgerSmallBold";
 
-export const HamburgerIcon = makeIconComponent({
+export const HamburgerIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: HamburgerSmallBold,
         medium: HamburgerMediumBold,

--- a/packages/icons-react/src/icons/info/InfoIcon.tsx
+++ b/packages/icons-react/src/icons/info/InfoIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { InfoMedium } from "./InfoMedium";
 import { InfoMediumBold } from "./InfoMediumBold";
 import { InfoSmall } from "./InfoSmall";
 import { InfoSmallBold } from "./InfoSmallBold";
 
-export const InfoIcon = makeIconComponent({
+export const InfoIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: InfoSmallBold,
         medium: InfoMediumBold,

--- a/packages/icons-react/src/icons/plus/PlusIcon.tsx
+++ b/packages/icons-react/src/icons/plus/PlusIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { PlusMedium } from "./PlusMedium";
 import { PlusMediumBold } from "./PlusMediumBold";
 import { PlusSmall } from "./PlusSmall";
 import { PlusSmallBold } from "./PlusSmallBold";
 
-export const PlusIcon = makeIconComponent({
+export const PlusIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: PlusSmallBold,
         medium: PlusMediumBold,

--- a/packages/icons-react/src/icons/question/QuestionIcon.tsx
+++ b/packages/icons-react/src/icons/question/QuestionIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { QuestionMedium } from "./QuestionMedium";
 import { QuestionMediumBold } from "./QuestionMediumBold";
 import { QuestionSmall } from "./QuestionSmall";
 import { QuestionSmallBold } from "./QuestionSmallBold";
 
-export const QuestionIcon = makeIconComponent({
+export const QuestionIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: QuestionSmallBold,
         medium: QuestionMediumBold,

--- a/packages/icons-react/src/icons/search/SearchIcon.tsx
+++ b/packages/icons-react/src/icons/search/SearchIcon.tsx
@@ -1,10 +1,12 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { SearchMedium } from "./SearchMedium";
 import { SearchMediumBold } from "./SearchMediumBold";
 import { SearchSmall } from "./SearchSmall";
 import { SearchSmallBold } from "./SearchSmallBold";
 
-export const SearchIcon = makeIconComponent({
+export const SearchIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: SearchSmallBold,
         medium: SearchMediumBold,

--- a/packages/icons-react/src/icons/success/SuccessIcon.tsx
+++ b/packages/icons-react/src/icons/success/SuccessIcon.tsx
@@ -1,8 +1,10 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { SuccessMedium } from "./SuccessMedium";
 import { SuccessSmall } from "./SuccessSmall";
 
-export const SuccessIcon = makeIconComponent({
+export const SuccessIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: SuccessSmall,
         medium: SuccessMedium,

--- a/packages/icons-react/src/icons/warning/WarningIcon.tsx
+++ b/packages/icons-react/src/icons/warning/WarningIcon.tsx
@@ -1,8 +1,10 @@
+import { type FC } from "react";
 import { makeIconComponent } from "../../IconFactory";
+import { type IconProps } from "../types";
 import { WarningMedium } from "./WarningMedium";
 import { WarningSmall } from "./WarningSmall";
 
-export const WarningIcon = makeIconComponent({
+export const WarningIcon: FC<IconProps> = makeIconComponent({
     bold: {
         small: WarningSmall,
         medium: WarningMedium,


### PR DESCRIPTION
Går fra å generere

```ts
/// <reference types="react" />
export declare const ArrowDownIcon: import("react").FC<import("../types").IconProps>;
```

til å generere

```ts
import { type FC } from "react";
import { type IconProps } from "../types";
export declare const ArrowDownIcon: FC<IconProps>;
```

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
