### PR TITLE
Fiks feil der Select går i loop hvis innsendt verdi (value) ikke finnes i items

### DIFF
--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -100,6 +100,17 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue("A");
     });
 
+    it("should not get stuck in a loop if value is not in items", () => {
+        const onChange = jest.fn();
+        const { getByTestId } = setup(
+            <Select label="Items" name="items" items={["A", "B", "C"]} value="D" onChange={onChange} />,
+        );
+
+        expect(getByTestId("jkl-select__button")).toHaveTextContent("Velg");
+        expect(getByTestId("jkl-native-select")).toHaveValue("");
+        expect(onChange).toHaveBeenCalledTimes(0);
+    });
+
     it("should not call onChange if value is undefined (#3421)", () => {
         const onChange = jest.fn();
         const { getByTestId } = setup(

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -144,10 +144,16 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             }),
         [items, isSearchable, searchValue, searchFn],
     );
+    const valueIsInItems: boolean = useMemo(() => {
+        if (typeof value === "undefined") {
+            return false;
+        }
+        return items.some((item) => (typeof item === "string" ? item === value : item.value === value));
+    }, [value, items]);
 
     /// Valg av <option>
 
-    const [selectedValue, setSelectedValue] = useState<string>(value || "");
+    const [selectedValue, setSelectedValue] = useState<string>(valueIsInItems && value !== undefined ? value : "");
     const hasSelectedValue = selectedValue !== "";
     const selectedValueLabel = useMemo(
         () => visibleItems.find((item) => item.value === selectedValue)?.label || defaultPrompt,
@@ -179,12 +185,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
         if (value === previousValue) {
             return;
         }
-        if (typeof value === "undefined") {
+        if (typeof value === "undefined" || !valueIsInItems) {
             setSelectedValue("");
         } else {
             setSelectedValue(value);
         }
-    }, [setSelectedValue, value, previousValue]);
+    }, [setSelectedValue, value, previousValue, valueIsInItems]);
 
     const selectOption = useCallback(
         (item: Option) => {


### PR DESCRIPTION
Sjekk at `value` faktisk finnes i `items` før vi forsøker å sette det som `selectedValue`. Slik unngår vi en uendelig loop der vi forsøker å endre verdien mellom innsendt `value` og tom streng.

closes #3479 

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
