### PR TITLE
fix: select hook defaultvalue

### DIFF
--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -47,7 +47,8 @@
         "classnames": "^2.3.2"
     },
     "devDependencies": {
-        "@fremtind/jkl-accordion-react": "^9.0.6"
+        "@fremtind/jkl-accordion-react": "^9.0.6",
+        "react-hook-form": "^7.43.9"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, RenderOptions, waitFor } from "@testing-library
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import { Select } from ".";
 
 function setup(jsx: JSX.Element, renderOptions?: RenderOptions) {
@@ -159,6 +160,33 @@ describe("Select", () => {
         expect(getByTestId("jkl-select__button")).toHaveTextContent("B");
         expect(getByTestId("jkl-native-select")).toHaveValue("B");
         expect(onChange).toHaveBeenCalledTimes(0);
+    });
+
+    it("should show the defaultValue set by react-hook-form (#2924, #3500)", async () => {
+        type FormValues = {
+            stilling: string;
+        };
+
+        function WrappedSelect(props: { defaultValues: FormValues }) {
+            const { register } = useForm<FormValues>({
+                defaultValues: props.defaultValues,
+            });
+            return (
+                <form>
+                    <Select
+                        {...register("stilling", { required: "Du må oppgi eierens stilling" })}
+                        items={["Designer", "Utvikler", "Tester", "Leder", "Annet"]}
+                        label="Stilling"
+                    />
+                </form>
+            );
+        }
+
+        const defaultValue = "Tester";
+        const { getByTestId } = setup(<WrappedSelect defaultValues={{ stilling: defaultValue }} />);
+
+        expect(getByTestId("jkl-native-select")).toHaveValue(defaultValue); // Semantisk valgt
+        expect(getByTestId("jkl-select__button").textContent).toBe(defaultValue); // Visuelt valgt
     });
 
     it("should change the controlled value of the select when clicking on a option", async () => {

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -100,7 +100,7 @@ describe("Select", () => {
         expect(getByTestId("jkl-native-select")).toHaveValue("A");
     });
 
-    it("should not get stuck in a loop if value is not in items", () => {
+    it("should not get stuck in a loop if value is not in items (#3479)", () => {
         const onChange = jest.fn();
         const { getByTestId } = setup(
             <Select label="Items" name="items" items={["A", "B", "C"]} value="D" onChange={onChange} />,

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -165,16 +165,15 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
     const unifiedSelectRef = useCallback(
         (instance: HTMLSelectElement | null) => {
             selectRef.current = instance;
-            if (instance) {
-                setSelectedValue(instance.value);
-            }
-
             if (forwardedSelectRef) {
                 if (typeof forwardedSelectRef === "function") {
                     forwardedSelectRef(instance);
                 } else {
                     forwardedSelectRef.current = instance;
                 }
+            }
+            if (instance) {
+                setSelectedValue(instance.value);
             }
         },
         [selectRef, forwardedSelectRef],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,7 @@ importers:
       '@fremtind/jkl-react-hooks': ^11.1.1
       '@fremtind/jkl-select': ^10.0.3
       classnames: ^2.3.2
+      react-hook-form: ^7.43.9
     dependencies:
       '@fremtind/jkl-core': link:../core
       '@fremtind/jkl-icons-react': link:../icons-react
@@ -834,6 +835,7 @@ importers:
       classnames: 2.3.2
     devDependencies:
       '@fremtind/jkl-accordion-react': link:../accordion-react
+      react-hook-form: 7.43.9
 
   packages/stylelint-config-jkl:
     specifiers:
@@ -18892,6 +18894,13 @@ packages:
     dependencies:
       react: 18.2.0
     dev: false
+
+  /react-hook-form/7.43.9:
+    resolution: {integrity: sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dev: true
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}


### PR DESCRIPTION
Vi sjekket verdien til native-selecten før hook-form rakk å sette defaultValue

ISSUES CLOSED: https://github.com/fremtind/jokul/issues/3500

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
