### PR TITLE
chore: kjør Cypress-tester ved endring i CSS-pakke

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -263,7 +263,7 @@ jobs:
                       done
 
                     if [ "$RUN_ALL_SPECS" = false ] ; then
-                          CHANGED_SPECS=$(printf "%s/**/*.spec.js\n" "${CHANGED_PACKAGES[@]}" | sort | uniq)
+                          CHANGED_SPECS=$(printf "%s-react/**/*.spec.js\n" "${CHANGED_PACKAGES[@]/-react/}" | sort | uniq)
                     fi
                   fi
 


### PR DESCRIPTION
Legger på et -react-suffix på alle mappenavn som mangler det. uniq-filteret sørger for å unngå duplikater.

ISSUES CLOSED: #3493

```sh
CHANGED_PACKAGES=("list" "button" "button-react" "expand-button")
CHANGED_SPECS=$(printf "%s-react/**/*.spec.js\n" "${CHANGED_PACKAGES[@]/-react/}" | sort | uniq)
echo $CHANGED_SPECS

# button-react/**/*.spec.js expand-button-react/**/*.spec.js list-react/**/*.spec.js
```