### PR TITLE
fix: pruk padding i stedet for margin på innholdet i kort

### DIFF
--- a/packages/card-react/src/InfoCard.tsx
+++ b/packages/card-react/src/InfoCard.tsx
@@ -3,7 +3,7 @@ import { Image, ImageProps } from "@fremtind/jkl-image-react";
 import cn from "classnames";
 import React, { FC } from "react";
 import { PaddingOptions, SpacingStep } from "./types";
-import { getSpacingClasses } from "./utils";
+import { getPaddingStyles } from "./utils";
 
 export interface InfoCardProps extends PaddingOptions, WithChildren {
     className?: string;
@@ -19,7 +19,7 @@ export interface InfoCardProps extends PaddingOptions, WithChildren {
 export const InfoCard: FC<InfoCardProps> = ({ title, image, children, density, className, padding = "l", ...rest }) => (
     <div {...rest} className={cn("jkl-info-card", className)} data-density={density}>
         {image && <Image className="jkl-info-card__image" {...image} />}
-        <div className={cn("jkl-info-card__content-wrapper", getSpacingClasses(padding))}>
+        <div className={cn("jkl-info-card__content-wrapper")} style={getPaddingStyles(padding)}>
             {title && <p className="jkl-info-card__title">{title}</p>}
             {children}
         </div>

--- a/packages/card-react/src/NavCard.tsx
+++ b/packages/card-react/src/NavCard.tsx
@@ -4,7 +4,7 @@ import { ErrorTag, InfoTag, SuccessTag, Tag, WarningTag } from "@fremtind/jkl-ta
 import cn from "classnames";
 import React, { ElementType, FC, AnchorHTMLAttributes } from "react";
 import { PaddingOptions } from "./types";
-import { getSpacingClasses } from "./utils";
+import { getPaddingStyles } from "./utils";
 
 export type TagType = "success" | "warning" | "info" | "error";
 
@@ -71,7 +71,7 @@ export const NavCard: FC<NavCardProps> = React.forwardRef<HTMLAnchorElement, Nav
     return (
         <Component ref={ref} className={cn("jkl-nav-card", className)} data-density={density} {...rest}>
             {image && <Image className="jkl-nav-card__image" {...image} />}
-            <div className={cn("jkl-nav-card__content", getSpacingClasses(padding))}>
+            <div className="jkl-nav-card__content" style={getPaddingStyles(padding)}>
                 {tag && <CardTag density={density}>{tag.text}</CardTag>}
                 <div>
                     <p className="jkl-nav-card__link">{title}</p>

--- a/packages/card-react/src/TaskCard.tsx
+++ b/packages/card-react/src/TaskCard.tsx
@@ -2,7 +2,7 @@ import { Density, WithChildren } from "@fremtind/jkl-core";
 import cn from "classnames";
 import React, { FC } from "react";
 import { PaddingOptions } from "./types";
-import { getSpacingClasses } from "./utils";
+import { getPaddingStyles } from "./utils";
 
 export interface TaskCardProps extends PaddingOptions, WithChildren {
     /**
@@ -35,6 +35,8 @@ export const TaskCard: FC<TaskCardProps> = ({
         data-density={density}
         {...rest}
     >
-        <div className={cn("jkl-task-card__content-wrapper", getSpacingClasses(padding))}>{children}</div>
+        <div className="jkl-task-card__content-wrapper" style={getPaddingStyles(padding)}>
+            {children}
+        </div>
     </div>
 );

--- a/packages/card-react/src/types.ts
+++ b/packages/card-react/src/types.ts
@@ -1,32 +1,40 @@
 export const SPACING_STEPS = ["0", "m", "l", "xl", "2xl", "3xl", "4xl"] as const;
 type SpacingSteps = typeof SPACING_STEPS;
-export type BasePadding = SpacingSteps[0 | 1 | 2 | 3];
-export type SpacingStep = SpacingSteps[number];
+export const NEW_SPACING_STEPS = ["0", "16", "24", "40", "64", "104", "168"] as const;
+type NewSpacingSteps = typeof NEW_SPACING_STEPS;
+export type BasePadding = SpacingSteps[0 | 1 | 2 | 3] | NewSpacingSteps[0 | 1 | 2 | 3];
+export type OldSpacingStep = SpacingSteps[number];
+export type NewSpacingStep = NewSpacingSteps[number];
+export type SpacingStep = SpacingSteps[number] | NewSpacingSteps[number];
+
+export function isOldSpacingStep(value: SpacingStep): value is OldSpacingStep {
+    return SPACING_STEPS.includes(value as OldSpacingStep);
+}
 
 export interface PaddingShorthand {
     /**
      * Legger til ekstra rom i toppen av kortet, fra spacing-skalaen til Jøkul.
      * Ikke bruk ekstra topPadding sammen med tag. Verdier lavere enn for venstre og høyre padding
      * blir ignorert.
-     * @default "l" (24px)
+     * @default "24"
      */
     top?: SpacingStep;
     /**
-     * Bruk stegene "m", "l" eller "xl" fra spacing-skalaen til Jøkul.
+     * Bruk stegene fra spacing-skalaen til Jøkul.
      * Hvis left og right har forskjellige verdier brukes den største for begge.
-     * @default "l" (24px)
+     * @default "24"
      */
     right?: BasePadding;
     /**
      * Legger til ekstra rom i bunnen av kortet, fra spacing-skalaen til Jøkul.
      * Verdier lavere enn for venstre og høyre padding blir ignorert.
-     * @default "l" (24px)
+     * @default "24"
      */
     bottom?: SpacingStep;
     /**
-     * Bruk stegene "m", "l" eller "xl" fra spacing-skalaen til Jøkul.
+     * Bruk stegene fra spacing-skalaen til Jøkul.
      * Hvis left og right har forskjellige verdier brukes den største for begge.
-     * @default "l" (24px)
+     * @default "24"
      */
     left?: BasePadding;
 }
@@ -34,7 +42,7 @@ export interface PaddingShorthand {
 export interface PaddingOptions {
     /**
      * Hvor mye rom skal det være rundt innholdet i kortet?
-     * @default "l" (24px)
+     * @default "24"
      */
     padding?: BasePadding | PaddingShorthand;
 }

--- a/packages/card-react/src/utils.ts
+++ b/packages/card-react/src/utils.ts
@@ -1,27 +1,33 @@
-import { SPACING_STEPS } from "./types";
+import { CSSProperties } from "react";
+import { NEW_SPACING_STEPS, SPACING_STEPS, isOldSpacingStep } from "./types";
 import type { BasePadding, PaddingShorthand, SpacingStep } from "./types";
 
-function getSpacingIndex(spacingStep?: SpacingStep, fallback: SpacingStep = "l") {
-    return SPACING_STEPS.indexOf(spacingStep || fallback);
+function getSpacingIndex(spacingStep?: SpacingStep, fallback: SpacingStep = "24"): number {
+    const value = spacingStep || fallback;
+    if (isOldSpacingStep(value)) {
+        return SPACING_STEPS.indexOf(value);
+    } else {
+        return NEW_SPACING_STEPS.indexOf(value);
+    }
 }
 
-export function getSpacingClasses(padding: BasePadding | PaddingShorthand) {
+export function getPaddingStyles(padding: BasePadding | PaddingShorthand): CSSProperties {
     if (typeof padding === "string") {
-        return `jkl-spacing-${padding}--all`;
+        return { padding: `var(--jkl-spacing-${NEW_SPACING_STEPS[getSpacingIndex(padding)]})` };
     }
 
-    // Sett sidepadding til den største av de to innsendte verdiene (eller "l")
+    // Sett sidepadding til den største av de to innsendte verdiene (eller "24")
     const sideSpacingIndex = Math.max(getSpacingIndex(padding.left), getSpacingIndex(padding.right));
-    const sidePadding = SPACING_STEPS[sideSpacingIndex];
+    const sidePadding = NEW_SPACING_STEPS[sideSpacingIndex];
 
     // Sett topp-/bunnpadding til det største av innsendt verdi og sidepadding
-    const topPadding = SPACING_STEPS[Math.max(sideSpacingIndex, getSpacingIndex(padding.top, sidePadding))];
-    const bottomPadding = SPACING_STEPS[Math.max(sideSpacingIndex, getSpacingIndex(padding.bottom, sidePadding))];
+    const topPadding = NEW_SPACING_STEPS[Math.max(sideSpacingIndex, getSpacingIndex(padding.top, sidePadding))];
+    const bottomPadding = NEW_SPACING_STEPS[Math.max(sideSpacingIndex, getSpacingIndex(padding.bottom, sidePadding))];
 
-    return [
-        `jkl-spacing-${topPadding}--top`,
-        `jkl-spacing-${sidePadding}--right`,
-        `jkl-spacing-${bottomPadding}--bottom`,
-        `jkl-spacing-${sidePadding}--left`,
-    ];
+    const top = `var(--jkl-spacing-${topPadding})`;
+    const right = `var(--jkl-spacing-${sidePadding})`;
+    const bottom = `var(--jkl-spacing-${bottomPadding})`;
+    const left = `var(--jkl-spacing-${sidePadding})`;
+
+    return { padding: `${top} ${right} ${bottom} ${left}` };
 }


### PR DESCRIPTION
Bruk padding i stedet for margin på innholdet i kort, for å unngå at marginen kollapser mot annet innhold på siden.

Kortene aksepterer nå også verdier fra den nye spacingskalaen 🎉

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
