### PR TITLE
fix: ikke kjør animasjon ved første render i useAnimatedHeight

### DIFF
--- a/packages/react-hooks/src/useAnimatedHeight.tsx
+++ b/packages/react-hooks/src/useAnimatedHeight.tsx
@@ -70,7 +70,10 @@ export function useAnimatedHeight<T extends HTMLElement>(
 
     const runAnimation = useCallback(() => {
         const element = getElement(elementRef);
-        if (!element) {
+
+        // Ikke kjør animasjonen hvis elementet ikke er rendret,
+        // eller hvis det er første render.
+        if (!element || wasOpen === undefined) {
             return;
         }
 


### PR DESCRIPTION
Sørg for at vi ikke animerer elementer med useAnimatedHeight som skal starte åpne på første render

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
