### PR TITLE
fix: wrap kodeeksempel i blokk, og unngå dynamisk import av react i typer

### DIFF
--- a/packages/toggle-switch-react/src/ToggleSwitch.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.tsx
@@ -16,9 +16,11 @@ export type ToggleProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "disable
      * Handler for å håndtere toggling av knappen. Tar inn en boolean som indikerer om knappen er er togglet på
      * eller ikke, samt en MouseEvent eller en PointerEvent avhengig av om togglingen skjedde via klikk eller swipe.
      * @example
+     * ```js
      * function handleChange(event, pressed) {
      *    console.log(`ToggleSwitch er ${pressed ? "på" : "av"}`);
      * }
+     * ```
      */
     onChange?: ToggleChangeHandler<HTMLButtonElement>;
 };

--- a/packages/toggle-switch-react/src/useSwipeGesture.ts
+++ b/packages/toggle-switch-react/src/useSwipeGesture.ts
@@ -1,4 +1,4 @@
-import { type MouseEventHandler, type PointerEventHandler, useCallback, useRef } from "react";
+import { type MouseEventHandler, type PointerEventHandler, type MutableRefObject, useCallback, useRef } from "react";
 import { type ToggleChangeHandler } from "./ToggleSwitch";
 
 type Point = { x: number; y: number };
@@ -19,7 +19,18 @@ type SwipeGestureOptions<T extends HTMLElement> = {
     onPointerCancel?: PointerEventHandler<T>;
 };
 
-export function useSwipeGesture<T extends HTMLElement>(options: SwipeGestureOptions<T>) {
+export function useSwipeGesture<T extends HTMLElement>(
+    options: SwipeGestureOptions<T>,
+): {
+    swipeHandled: MutableRefObject<"on" | "off" | false>;
+    gestureHandlers: {
+        onClick: MouseEventHandler<T>;
+        onPointerDown: PointerEventHandler<T>;
+        onPointerMove: PointerEventHandler<T>;
+        onPointerUp: PointerEventHandler<T>;
+        onPointerCancel: PointerEventHandler<T>;
+    };
+} {
     const swipeHandled = useRef<"on" | "off" | false>(false);
     const gestureStartPosition = useRef<Point>();
 


### PR DESCRIPTION
```diff
- swipeHandled: import("react").MutableRefObject<false | "on" | "off">;
+ swipeHandled: MutableRefObject<"on" | "off" | false>;
// pluss MutableRefObject i importen, da
```

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
