### PR TITLE
Nye hooks for å animere mellom to høyder, eller basert på innhold

### DIFF
--- a/packages/react-hooks/documentation/AnimationBetweenExample.tsx
+++ b/packages/react-hooks/documentation/AnimationBetweenExample.tsx
@@ -1,0 +1,64 @@
+import type { CodeExample } from "doc-utils";
+import React, { type FC, useState } from "react";
+import { useAnimatedHeightBetween } from "../src";
+import "./animation-example.scss";
+
+const AnimationBetweenExample: FC = () => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [animationRef] = useAnimatedHeightBetween(isExpanded, { timing: "expressive" });
+
+    return (
+        <section ref={animationRef} className="animation-between-example">
+            <p className="jkl-heading-2">Lorem Ipsum</p>
+            <p className="jkl-body">
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+                industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+                scrambled it to make a type specimen book.
+            </p>
+            <p className="jkl-body">
+                It has survived not only five centuries, but also the leap into electronic typesetting, remaining
+                essentially unchanged.
+            </p>
+            <p className="jkl-body">
+                It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and
+                more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+            </p>
+            <button
+                className="jkl-button jkl-button--secondary"
+                data-density="compact"
+                onClick={() => setIsExpanded((prev) => !prev)}
+            >{`Vis ${isExpanded ? "mindre" : "mer"}`}</button>
+        </section>
+    );
+};
+
+export default AnimationBetweenExample;
+
+export const animationBetweenExampleCode: CodeExample = `
+const [isExpanded, setIsExpanded] = useState(false);
+const [animationRef] = useAnimatedHeightBetween(isExpanded, { timing: "expressive" });
+
+return (
+    <section ref={animationRef} className="animation-between-example">
+        <p className="jkl-heading-2">Lorem Ipsum</p>
+        <p className="jkl-body">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+        </p>
+        <p className="jkl-body">
+            It has survived not only five centuries, but also the leap into electronic typesetting, remaining
+            essentially unchanged.
+        </p>
+        <p className="jkl-body">
+            It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and
+            more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        </p>
+        <button
+            className="jkl-button jkl-button--secondary"
+            data-density="compact"
+            onClick={() => setIsExpanded((prev) => !prev)}
+        >{\`Vis \${isExpanded ? "mindre" : "mer"}\`}</button>
+    </section>
+);
+`;

--- a/packages/react-hooks/documentation/AnimationExample.tsx
+++ b/packages/react-hooks/documentation/AnimationExample.tsx
@@ -17,7 +17,7 @@ const AnimationExample: FC = () => {
     return (
         <section>
             <button className="jkl-button jkl-button--secondary" onClick={() => setIsOpen((isOpen) => !isOpen)}>
-                Animate {isOpen ? "Out" : "In"}
+                Animer {isOpen ? "ut" : "inn"}
             </button>
             <div ref={animationRef}>
                 <div className="lorem-text">

--- a/packages/react-hooks/documentation/AutoAnimationExample.tsx
+++ b/packages/react-hooks/documentation/AutoAnimationExample.tsx
@@ -1,0 +1,116 @@
+import type { CodeExample } from "doc-utils";
+import React, { type FC, useState } from "react";
+import { useAutoAnimatedHeight } from "../src";
+import "./animation-example.scss";
+
+const content1 = (
+    <>
+        <p className="jkl-body">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+        </p>
+    </>
+);
+const content2 = (
+    <>
+        <p className="jkl-body">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+        </p>
+        <p className="jkl-body">
+            It has survived not only five centuries, but also the leap into electronic typesetting, remaining
+            essentially unchanged.
+        </p>
+    </>
+);
+const content3 = (
+    <>
+        <p className="jkl-body">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+        </p>
+        <p className="jkl-body">
+            It has survived not only five centuries, but also the leap into electronic typesetting, remaining
+            essentially unchanged.
+        </p>
+        <p className="jkl-body">
+            It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and
+            more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        </p>
+    </>
+);
+
+const content4 = (
+    <>
+        <p className="jkl-body">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+        </p>
+        <p className="jkl-body">
+            It has survived not only five centuries, but also the leap into electronic typesetting, remaining
+            essentially unchanged.
+        </p>
+        <p className="jkl-body">
+            It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and
+            more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        </p>
+        <p className="jkl-body">
+            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
+            Latin literature from 45 BC, making it over 2000 years old.
+        </p>
+    </>
+);
+
+const contentBlocks = [content1, content2, content3, content4];
+
+function randomContentBlock(except?: JSX.Element): JSX.Element {
+    let content = contentBlocks[Math.floor(Math.random() * contentBlocks.length)];
+    if (content === except) {
+        content = randomContentBlock(except);
+    }
+    return content;
+}
+
+const AutoAnimationExample: FC = () => {
+    const [content, setContent] = useState(randomContentBlock());
+    const animationRef = useAutoAnimatedHeight(content);
+
+    const changeContent = () => {
+        setContent(randomContentBlock(content));
+    };
+
+    return (
+        <section ref={animationRef} className="auto-animation-example">
+            <p className="jkl-heading-2">Lorem Ipsum</p>
+            {content}
+            <button className="jkl-button jkl-button--secondary" data-density="compact" onClick={changeContent}>
+                Endre innhold
+            </button>
+        </section>
+    );
+};
+
+export default AutoAnimationExample;
+
+export const autoAnimationExampleCode: CodeExample = `
+const [content, setContent] = useState(randomContentBlock());
+const animationRef = useAutoAnimatedHeight(content);
+
+const changeContent = () => {
+    setContent(randomContentBlock(content));
+};
+
+return (
+    <section ref={animationRef} className="auto-animation-example">
+        <p className="jkl-heading-2">Lorem Ipsum</p>
+        {content}
+        <button className="jkl-button jkl-button--secondary" data-density="compact" onClick={changeContent}>
+            Endre innhold
+        </button>
+    </section>
+);
+`;

--- a/packages/react-hooks/documentation/Example.tsx
+++ b/packages/react-hooks/documentation/Example.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DevExample } from "../../../doc-utils";
+import AnimationBetweenExample from "./AnimationBetweenExample";
 import AnimationExample from "./AnimationExample";
 import BrowserPreferencesExample from "./BrowserPreferencesExample";
 import ClickOutsideExample from "./ClickOutsideExample";
@@ -17,6 +18,7 @@ export default function Example() {
     return (
         <>
             <DevExample component={AnimationExample} />
+            <DevExample component={AnimationBetweenExample} />
             <DevExample component={ClickOutsideExample} />
             <DevExample component={FocusOutsideExample} />
             <DevExample component={KeyListenerExample} />

--- a/packages/react-hooks/documentation/Example.tsx
+++ b/packages/react-hooks/documentation/Example.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DevExample } from "../../../doc-utils";
 import AnimationBetweenExample from "./AnimationBetweenExample";
 import AnimationExample from "./AnimationExample";
+import AutoAnimationExample from "./AutoAnimationExample";
 import BrowserPreferencesExample from "./BrowserPreferencesExample";
 import ClickOutsideExample from "./ClickOutsideExample";
 import FocusOutsideExample from "./FocusOutsideExample";
@@ -19,6 +20,7 @@ export default function Example() {
         <>
             <DevExample component={AnimationExample} />
             <DevExample component={AnimationBetweenExample} />
+            <DevExample component={AutoAnimationExample} />
             <DevExample component={ClickOutsideExample} />
             <DevExample component={FocusOutsideExample} />
             <DevExample component={KeyListenerExample} />

--- a/packages/react-hooks/documentation/animation-example.scss
+++ b/packages/react-hooks/documentation/animation-example.scss
@@ -1,0 +1,51 @@
+@use "~@fremtind/jkl-core/jkl";
+
+.animation-between-example {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--jkl-spacing-16);
+    border: jkl.rem(1px) solid var(--jkl-color);
+    border-radius: jkl.rem(4px);
+    box-sizing: border-box;
+    padding: var(--jkl-spacing-24);
+    padding-bottom: var(--jkl-spacing-64);
+    width: 45ch;
+    max-width: 80%;
+
+    &[data-expanded="false"] {
+        height: 300px;
+        overflow-y: hidden;
+
+        &::after {
+            content: "";
+            position: absolute;
+            inset: 50% 0 0;
+            background: linear-gradient(
+                0deg,
+                var(--jkl-background-color) 0%,
+                var(--jkl-background-color) 30%,
+                transparent 100%
+            );
+
+            @include jkl.motion("standard", "expressive");
+            transition-property: opacity;
+            opacity: 1;
+        }
+    }
+
+    &[data-expanded="true"] {
+        height: auto;
+
+        &::after {
+            opacity: 0;
+        }
+    }
+
+    & > button {
+        position: absolute;
+        bottom: var(--jkl-spacing-16);
+        align-self: center;
+        z-index: jkl.$z-index--overlay;
+    }
+}

--- a/packages/react-hooks/documentation/animation-example.scss
+++ b/packages/react-hooks/documentation/animation-example.scss
@@ -1,5 +1,24 @@
 @use "~@fremtind/jkl-core/jkl";
 
+.auto-animation-example {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--jkl-spacing-16);
+    border: jkl.rem(1px) solid var(--jkl-color);
+    border-radius: jkl.rem(4px);
+    box-sizing: border-box;
+    padding: var(--jkl-spacing-24);
+    width: 45ch;
+    max-width: 80%;
+
+    & > button {
+        position: absolute;
+        top: calc(var(--jkl-spacing-24) + var(--jkl-spacing-4));
+        right: var(--jkl-spacing-24);
+    }
+}
+
 .animation-between-example {
     position: relative;
     display: flex;

--- a/packages/react-hooks/documentation/animation.mdx
+++ b/packages/react-hooks/documentation/animation.mdx
@@ -6,6 +6,7 @@ group: hooks
 
 import AnimationExample, { animationExampleCode } from "./AnimationExample";
 import AnimationBetweenExample, { animationBetweenExampleCode } from "./AnimationBetweenExample";
+import AutoAnimationExample, { autoAnimationExampleCode } from "./AutoAnimationExample";
 
 <Ingress>
     Animering av ting inn og ut av DOMet i React er ikke lett, men med useAnimatedHeight blir jobben en god del lettere.
@@ -15,6 +16,8 @@ import AnimationBetweenExample, { animationBetweenExampleCode } from "./Animatio
 
 Hooken tar seg av all CSS for animasjonen selv. Du kan overstyre animasjonen om du trenger en annen timing eller easing-funksjon.
 
+## Animering mellom to høyder
+
 Dersom du ikke vil skjule elementet helt, men heller animere mellom to høyder, kan du bruke `useAnimatedHeightBetween`. Her styrer du selv
 høyden på elementet, og hooken tar seg av animasjonen. Hooken setter `data-expanded` til `true` når elementet er åpent, og `false` når det er lukket,
 og animerer høyden på elementet mellom de to tilstandene.
@@ -23,4 +26,15 @@ og animerer høyden på elementet mellom de to tilstandene.
     title="useAnimatedHeightBetween"
     component={AnimationBetweenExample}
     codeExample={animationBetweenExampleCode}
+/>
+
+## Animering basert på innhold
+
+Hvis du vil at elementet skal animeres når det får endret innhold kan du bruke `useAutoAnimatedHeight`. Her kan du sende inn innholdet, eller
+en annen verdi, som hooken lytter på endring i. Ved endring animeres elementet til sin nye høyde dersom den er endret.
+
+<ComponentExample
+    title="useAutoAnimatedHeight"
+    component={AutoAnimationExample}
+    codeExample={autoAnimationExampleCode}
 />

--- a/packages/react-hooks/documentation/animation.mdx
+++ b/packages/react-hooks/documentation/animation.mdx
@@ -5,6 +5,7 @@ group: hooks
 ---
 
 import AnimationExample, { animationExampleCode } from "./AnimationExample";
+import AnimationBetweenExample, { animationBetweenExampleCode } from "./AnimationBetweenExample";
 
 <Ingress>
     Animering av ting inn og ut av DOMet i React er ikke lett, men med useAnimatedHeight blir jobben en god del lettere.
@@ -13,3 +14,13 @@ import AnimationExample, { animationExampleCode } from "./AnimationExample";
 <ComponentExample title="useAnimatedHeight" component={AnimationExample} codeExample={animationExampleCode} />
 
 Hooken tar seg av all CSS for animasjonen selv. Du kan overstyre animasjonen om du trenger en annen timing eller easing-funksjon.
+
+Dersom du ikke vil skjule elementet helt, men heller animere mellom to høyder, kan du bruke `useAnimatedHeightBetween`. Her styrer du selv
+høyden på elementet, og hooken tar seg av animasjonen. Hooken setter `data-expanded` til `true` når elementet er åpent, og `false` når det er lukket,
+og animerer høyden på elementet mellom de to tilstandene.
+
+<ComponentExample
+    title="useAnimatedHeightBetween"
+    component={AnimationBetweenExample}
+    codeExample={animationBetweenExampleCode}
+/>

--- a/packages/react-hooks/documentation/animation.mdx
+++ b/packages/react-hooks/documentation/animation.mdx
@@ -20,7 +20,7 @@ Hooken tar seg av all CSS for animasjonen selv. Du kan overstyre animasjonen om 
 
 Dersom du ikke vil skjule elementet helt, men heller animere mellom to høyder, kan du bruke `useAnimatedHeightBetween`. Her styrer du selv
 høyden på elementet, og hooken tar seg av animasjonen. Hooken setter `data-expanded` til `true` når elementet er åpent, og `false` når det er lukket,
-og animerer høyden på elementet mellom de to tilstandene.
+og animerer høyden på elementet mellom de to tilstandene. Se et [eksempel på stilark](https://github.com/fremtind/jokul/blob/main/packages/react-hooks/documentation/animation-example.scss) på GitHub-repoet vårt.
 
 <ComponentExample
     title="useAnimatedHeightBetween"

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -1,5 +1,4 @@
-export type { UseAnimatedHeightOptions } from "./useAnimatedHeight";
-export { useAnimatedHeight } from "./useAnimatedHeight";
+export { useAnimatedHeight, useAnimatedHeightBetween, type UseAnimatedHeightOptions } from "./useAnimatedHeight";
 export type { UseAriaLiveRegionOptions } from "./useAriaLiveRegion";
 export { useAriaLiveRegion } from "./useAriaLiveRegion";
 export { useClickOutside } from "./useClickOutside";

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -1,4 +1,10 @@
-export { useAnimatedHeight, useAnimatedHeightBetween, type UseAnimatedHeightOptions } from "./useAnimatedHeight";
+export {
+    useAnimatedHeight,
+    useAnimatedHeightBetween,
+    useAutoAnimatedHeight,
+    type UseAutoAnimatedHeightOptions,
+    type UseAnimatedHeightOptions,
+} from "./useAnimatedHeight";
 export type { UseAriaLiveRegionOptions } from "./useAriaLiveRegion";
 export { useAriaLiveRegion } from "./useAriaLiveRegion";
 export { useClickOutside } from "./useClickOutside";

--- a/packages/react-hooks/src/useAnimatedHeight/index.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/index.ts
@@ -1,3 +1,4 @@
 export type { UseAnimatedHeightOptions } from "./types";
 export { useAnimatedHeight } from "./useAnimatedHeight";
 export { useAnimatedHeightBetween } from "./useAnimatedHeightBetween";
+export { useAutoAnimatedHeight, type UseAutoAnimatedHeightOptions } from "./useAutoAnimateHeight";

--- a/packages/react-hooks/src/useAnimatedHeight/index.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/index.ts
@@ -1,0 +1,3 @@
+export type { UseAnimatedHeightOptions } from "./types";
+export { useAnimatedHeight } from "./useAnimatedHeight";
+export { useAnimatedHeightBetween } from "./useAnimatedHeightBetween";

--- a/packages/react-hooks/src/useAnimatedHeight/types.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/types.ts
@@ -1,0 +1,27 @@
+import type { Easing, Timing } from "@fremtind/jkl-core";
+import type { RefObject } from "react";
+
+export interface UseAnimatedHeightOptions<T extends HTMLElement = HTMLElement> {
+    display?: "block" | "grid" | "flex";
+    /**
+     * Overstyr standard easingfunksjon
+     * @default "standard"
+     */
+    easing?: Easing;
+    /**
+     * Overstyr standard timing
+     * @default "productive"
+     */
+    timing?: Timing;
+    onTransitionStart?: (isOpening: boolean, ref: RefObject<T>) => void;
+    /**
+     * Kalles rett etter at elementet har fått display: block; i stedet for hidden;
+     * Nyttig om du må flytte fokus inn i elementet og ikke vil vente til animasjonen er ferdig.
+     * Her er ikke innholdet _visuelt_ synlig ennå, men det er "synlig" for DOM i den
+     * forstand at det _ikke_ er display: hidden;
+     *
+     * `isOpen` er alltid `true`. Det sendes som første parameter for å ha lik funksjonssignatur som `onTransitionEnd`.
+     */
+    onFirstVisible?: (isOpen: boolean, ref: RefObject<T>) => void;
+    onTransitionEnd?: (isOpen: boolean, ref: RefObject<T>) => void;
+}

--- a/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
@@ -73,6 +73,13 @@ function expandElement<T extends HTMLElement>(
     });
 }
 
+/**
+ * Lar deg enklere animere mellom to tilstander, gitt ved å sette `data-expanded` på et element til `true` eller `false`.
+ * Du bestemmer selv hvilke stiler elementet skal ha i de to tilstandene (vha CSS/Sass), og høyden animeres dersom den endrer seg.
+ * @param isExpanded indikerer om elementet skal være utvidet eller ikke
+ * @param options konfigurasjon for animasjonen, og lyttere for når animasjonen starter og slutter
+ * @returns En tuple med referanse til elementet og en funksjon som kan trigge animasjonen
+ */
 export function useAnimatedHeightBetween<T extends HTMLElement>(
     isExpanded: boolean,
     options?: Omit<UseAnimatedHeightOptions<T>, "display" | "onFirstVisible">,

--- a/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
@@ -1,0 +1,163 @@
+import { timings, easings } from "@fremtind/jkl-core";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
+import { useBrowserPreferences } from "../useBrowserPreferences/useBrowserPreferences";
+import { usePreviousValue } from "../usePreviousValue/usePreviousValue";
+import { UseAnimatedHeightOptions } from "./types";
+
+const defaultEasing = "standard";
+const defaultTiming = "productive";
+
+function collapseElement<T extends HTMLElement>(
+    elementRef: RefObject<T>,
+    transition: string,
+    raf1: React.MutableRefObject<number | undefined>,
+    raf2: React.MutableRefObject<number | undefined>,
+) {
+    const element = elementRef.current;
+
+    if (!element) return;
+
+    element.removeAttribute("style");
+    const expandedHeight = element.scrollHeight;
+
+    raf1.current = requestAnimationFrame(() => {
+        // Hent kollapset høyde
+        element.style.removeProperty("transition");
+        element.dataset["expanded"] = "false";
+        const collapsedHeight = element.getBoundingClientRect().height;
+        element.dataset["expanded"] = "true";
+
+        // Sett høyde tilbake til utvidet høyde
+        element.style.setProperty("height", `${expandedHeight}px`);
+        element.style.setProperty("overflow-y", "hidden");
+
+        raf2.current = requestAnimationFrame(() => {
+            // Sett høyde til kollapset høyde og start transition
+            element.style.setProperty("transition", transition);
+            element.style.setProperty("height", `${collapsedHeight}px`);
+            element.dataset["expanded"] = "false";
+        });
+    });
+}
+
+function expandElement<T extends HTMLElement>(
+    elementRef: RefObject<T>,
+    transition: string,
+    raf1: React.MutableRefObject<number | undefined>,
+    raf2: React.MutableRefObject<number | undefined>,
+) {
+    const element = elementRef.current;
+
+    if (!element) return;
+
+    element.removeAttribute("style");
+    const expandedHeight = element.scrollHeight;
+    console.log(`Expanding to ${expandedHeight}px`);
+
+    raf1.current = requestAnimationFrame(() => {
+        // Hent utvidet høyde
+        element.style.removeProperty("transition");
+        element.dataset["expanded"] = "false";
+        const collapsedHeight = element.getBoundingClientRect().height;
+
+        // Sett høyde tilbake til kollapset høyde
+        element.style.setProperty("height", `${collapsedHeight}px`);
+        element.style.setProperty("overflow-y", "hidden");
+
+        raf2.current = requestAnimationFrame(() => {
+            // Sett høyde til utvidet høyde  og start transition
+            element.style.setProperty("transition", transition);
+            element.style.setProperty("height", `${expandedHeight}px`);
+            element.dataset["expanded"] = "true";
+        });
+    });
+}
+
+export function useAnimatedHeightBetween<T extends HTMLElement>(
+    isExpanded: boolean,
+    options?: Omit<UseAnimatedHeightOptions<T>, "display" | "onFirstVisible">,
+): [RefObject<T>, () => void] {
+    const wasExpanded = usePreviousValue(isExpanded);
+    const easing = options?.easing || defaultEasing;
+    const timing = options?.timing || defaultTiming;
+    const transition = `${timings[timing]} height ${easings[easing]}`;
+
+    const { prefersReducedMotion } = useBrowserPreferences();
+
+    const raf1 = useRef<number>();
+    const raf2 = useRef<number>();
+    const elementRef = useRef<T>(null);
+
+    const handleTransitionEnd = useCallback(
+        (event: TransitionEvent) => {
+            const element = elementRef.current;
+
+            // Ignore bubbling transitions from within container
+            if (element && event.target === element) {
+                element.removeAttribute("style");
+                options?.onTransitionEnd?.(isExpanded, elementRef);
+            }
+        },
+        [options, isExpanded],
+    );
+
+    const runAnimation = useCallback(() => {
+        const element = elementRef.current;
+
+        if (!element) return;
+
+        if (wasExpanded === undefined) {
+            // Første render
+            element.dataset["expanded"] = isExpanded ? "true" : "false";
+        }
+
+        if ((!isExpanded && !wasExpanded) || (isExpanded && wasExpanded)) {
+            // Ingen endring
+            return;
+        }
+
+        options?.onTransitionStart?.(isExpanded, elementRef);
+
+        if (prefersReducedMotion) {
+            element.removeAttribute("style");
+            element.dataset["expanded"] = isExpanded ? "true" : "false";
+            options?.onTransitionEnd?.(isExpanded, elementRef); // make sure to call callback when animation is off
+            return;
+        }
+
+        if (isExpanded) {
+            expandElement(elementRef, transition, raf1, raf2);
+        } else {
+            collapseElement(elementRef, transition, raf1, raf2);
+        }
+    }, [wasExpanded, isExpanded, options, prefersReducedMotion, transition]);
+
+    useEffect(() => {
+        runAnimation();
+    }, [isExpanded, runAnimation]);
+
+    useEffect(() => {
+        const element = elementRef.current;
+        if (element) {
+            element.addEventListener("transitionend", handleTransitionEnd);
+        }
+
+        return () => {
+            if (element) {
+                element.removeEventListener("transitionend", handleTransitionEnd);
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isExpanded]);
+
+    useEffect(() => {
+        const r1 = raf1.current;
+        const r2 = raf2.current;
+        return () => {
+            r1 && cancelAnimationFrame(r1);
+            r2 && cancelAnimationFrame(r2);
+        };
+    }, [raf1, raf2]);
+
+    return [elementRef, runAnimation];
+}

--- a/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/useAnimatedHeightBetween.ts
@@ -52,7 +52,6 @@ function expandElement<T extends HTMLElement>(
 
     element.removeAttribute("style");
     const expandedHeight = element.scrollHeight;
-    console.log(`Expanding to ${expandedHeight}px`);
 
     raf1.current = requestAnimationFrame(() => {
         // Hent utvidet høyde

--- a/packages/react-hooks/src/useAnimatedHeight/useAutoAnimateHeight.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/useAutoAnimateHeight.ts
@@ -1,0 +1,127 @@
+import { easings, timings, type Easing, type Timing } from "@fremtind/jkl-core";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { useBrowserPreferences } from "../useBrowserPreferences/useBrowserPreferences";
+import { usePreviousValue } from "../usePreviousValue/usePreviousValue";
+
+const defaultEasing = "standard";
+const defaultTiming = "expressive";
+
+export type UseAutoAnimatedHeightOptions<T extends HTMLElement> = {
+    easing?: Easing;
+    /**
+     * Overstyr standard timing
+     * @default "productive"
+     */
+    timing?: Timing;
+    onTransitionStart?: (ref: RefObject<T>) => void;
+    onTransitionEnd?: (ref: RefObject<T>) => void;
+};
+
+export function useAutoAnimatedHeight<T extends HTMLElement = HTMLElement>(
+    trigger: any,
+    options?: UseAutoAnimatedHeightOptions<T>,
+) {
+    const previousTriggerValue = usePreviousValue(trigger);
+    const [previousHeight, setPreviousHeight] = useState(0);
+
+    const easing = options?.easing || defaultEasing;
+    const timing = options?.timing || defaultTiming;
+    const transition = `${timings[timing]} height ${easings[easing]}`;
+
+    const { prefersReducedMotion } = useBrowserPreferences();
+
+    const raf1 = useRef<number>();
+    const raf2 = useRef<number>();
+    const elementRef = useRef<T>(null);
+
+    const handleTransitionEnd = useCallback(
+        (event: TransitionEvent) => {
+            const element = elementRef.current;
+
+            // Ignore bubbling transitions from within container
+            if (element && event.target === element) {
+                element.removeAttribute("style");
+                options?.onTransitionEnd?.(elementRef);
+            }
+        },
+        [options],
+    );
+
+    const animateElement = useCallback(() => {
+        const element = elementRef.current;
+
+        if (!element) return;
+
+        element.removeAttribute("style");
+        const newHeight = element.scrollHeight;
+
+        raf1.current = requestAnimationFrame(() => {
+            // Sett høyde tilbake til forrige høyde
+            element.style.removeProperty("transition");
+            element.style.setProperty("height", `${previousHeight}px`);
+            element.style.setProperty("overflow-y", "hidden");
+
+            raf2.current = requestAnimationFrame(() => {
+                // Sett høyde til kollapset høyde og start transition
+                element.style.setProperty("transition", transition);
+                element.style.setProperty("height", `${newHeight}px`);
+            });
+        });
+
+        setPreviousHeight(newHeight);
+    }, [transition, previousHeight]);
+
+    const runAnimation = useCallback(() => {
+        const element = elementRef.current;
+
+        if (!element) return;
+
+        if (previousTriggerValue === undefined) {
+            // Første render
+            setPreviousHeight(element.scrollHeight);
+            return;
+        }
+
+        if (trigger === previousTriggerValue) {
+            // Ingen endring
+            return;
+        }
+
+        options?.onTransitionStart?.(elementRef);
+
+        if (prefersReducedMotion) {
+            options?.onTransitionEnd?.(elementRef); // make sure to call callback when animation is off
+            return;
+        }
+
+        animateElement();
+    }, [animateElement, trigger, previousTriggerValue, options, prefersReducedMotion]);
+
+    useEffect(() => {
+        runAnimation();
+    }, [trigger, runAnimation]);
+
+    useEffect(() => {
+        const element = elementRef.current;
+        if (element) {
+            element.addEventListener("transitionend", handleTransitionEnd);
+        }
+
+        return () => {
+            if (element) {
+                element.removeEventListener("transitionend", handleTransitionEnd);
+            }
+        };
+    }, [handleTransitionEnd]);
+
+    useEffect(() => {
+        const r1 = raf1.current;
+        const r2 = raf2.current;
+        return () => {
+            r1 && cancelAnimationFrame(r1);
+            r2 && cancelAnimationFrame(r2);
+        };
+    }, [raf1, raf2]);
+
+    return elementRef;
+}

--- a/packages/react-hooks/src/useAnimatedHeight/useAutoAnimateHeight.ts
+++ b/packages/react-hooks/src/useAnimatedHeight/useAutoAnimateHeight.ts
@@ -10,13 +10,20 @@ export type UseAutoAnimatedHeightOptions<T extends HTMLElement> = {
     easing?: Easing;
     /**
      * Overstyr standard timing
-     * @default "productive"
+     * @default "expressive"
      */
     timing?: Timing;
     onTransitionStart?: (ref: RefObject<T>) => void;
     onTransitionEnd?: (ref: RefObject<T>) => void;
 };
 
+/**
+ * Gjør det enklere å animere høyden på et element når innholdet endrer seg, men kan brukes på mer generelt grunnlag.
+ * Hooken tar inn en triggerverdi, og når denne endrer seg animeres høyden på elementet dersom den har endret seg.
+ * @param trigger verdien som brukes til å trigge animasjonen. Dersom denne endrer seg animeres høyden på elementet.
+ * @param options konfigurasjon for animasjonen, og lyttere for når animasjonen starter og slutter
+ * @returns en referanse til elementet som skal animeres
+ */
 export function useAutoAnimatedHeight<T extends HTMLElement = HTMLElement>(
     trigger: any,
     options?: UseAutoAnimatedHeightOptions<T>,


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

Legger til to nye hooks i `jkl-react-hooks`:

- `useAnimatedHeightBetween` lar deg enklere animere mellom to tilstander, gitt ved å sette `data-expanded` på elementet til `true` eller `false`. Du bestemmer selv hvilke stiler elementet skal ha i de to tilstandene, og høyden animeres dersom den endrer seg.
- `useAutoAnimatedHeight` gjør det enklere å animere høyden på et element når innholdet endrer seg, men kan brukes på mer generelt grunnlag. Hooken tar inn en triggerverdi, og når denne endrer seg animeres høyden på elementet dersom den har endret seg.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
