### PR TITLE
fix: bruk riktig tekstfarge på benevnelse ved valideringsfeil

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -147,6 +147,10 @@ $_text-input-selection-color--inverted: color.scale(
                 }
             }
         }
+
+        & ~ .jkl-text-input__unit {
+            color: var(--jkl-text-input-error-text-color);
+        }
     }
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #3579

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
