### PR TITLE
docs: fiks eksempelet for useMutationObserver

### DIFF
--- a/packages/react-hooks/documentation/MutationObserverExample.tsx
+++ b/packages/react-hooks/documentation/MutationObserverExample.tsx
@@ -1,8 +1,21 @@
 import React, { useState, useRef, FC } from "react";
 import { useMutationObserver } from "../src";
 
-const MutationObserverExample: FC = () => {
+const WillChange: FC = () => {
     const [isOpen, setIsOpen] = useState(false);
+    return (
+        <>
+            <button className="jkl-button jkl-button--secondary jkl-spacing-l--left" onClick={() => setIsOpen(!isOpen)}>
+                Endre status
+            </button>
+            <p className="jkl-spacing-l--top jkl-body">
+                Nåværende status: <strong>{isOpen ? "Åpen" : "Lukket"}</strong>
+            </p>
+        </>
+    );
+};
+
+const MutationObserverExample: FC = () => {
     const [listOfMutations, appendToMutationList] = useState<string[]>([]);
     const mutationTargetRef = useRef(null);
     const listRef = useRef<string[]>();
@@ -16,19 +29,13 @@ const MutationObserverExample: FC = () => {
     };
 
     useMutationObserver(mutationTargetRef, onObservation, { characterData: true, subtree: true });
+
     return (
         <section>
-            <button className="jkl-button jkl-button--secondary jkl-spacing-l--left" onClick={() => setIsOpen(!isOpen)}>
-                Endre status
-            </button>
-            <button className="jkl-button jkl-button--tertiary" onClick={() => appendToMutationList([])}>
-                Nullstill liste
-            </button>
-            <p ref={mutationTargetRef} className="jkl-spacing-l--top jkl-body">
-                Nåværende status: <strong>{isOpen ? "Åpen" : "Lukket"}</strong>
-                <br />
-                Liste over endringer:
-            </p>
+            <div ref={mutationTargetRef}>
+                <WillChange />
+            </div>
+            <p className="jkl-body">Liste over endringer:</p>
             {listOfMutations.length !== 0 && (
                 <ul className="jkl-list jkl-list--unordered jkl-body">
                     {listOfMutations.map((item, idx) => (
@@ -38,6 +45,9 @@ const MutationObserverExample: FC = () => {
                     ))}
                 </ul>
             )}
+            <button className="jkl-button jkl-button--tertiary" onClick={() => appendToMutationList([])}>
+                Nullstill liste
+            </button>
         </section>
     );
 };


### PR DESCRIPTION
Endringen som observeres må skje utenfor komponenten, ellers restartes observeren. Og om vi har tilgang på staten kan vi heller bruke usePreviousValue, eller legge logikken i onClick.

ISSUES CLOSED: #3583

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
