### PR TITLE
Update Combobox.tsx

### DIFF
--- a/packages/combobox-react/src/Combobox.tsx
+++ b/packages/combobox-react/src/Combobox.tsx
@@ -254,7 +254,7 @@ export const Combobox: FC<ComboboxProps> = ({
                         type: "blur",
                         target: {
                             name,
-                            value: selectedValue?.[0].value || "",
+                            value: selectedValue?.[0]?.value || "",
                             selectedOptions: selectedValue,
                         },
                     });


### PR DESCRIPTION
react-dom.development.js:4312 Uncaught TypeError: Cannot read properties of undefined (reading 'value')
    at Combobox.tsx:257:55
    at HTMLUnknownElement.callCallback2 (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:4291:25)
    at executeDispatch (react-dom.development.js:9041:3)
    at processDispatchQueueItemsInOrder (react-dom.development.js:9073:7)
    at processDispatchQueue (react-dom.development.js:9086:5)
    at dispatchEventsForPlugins (react-dom.development.js:9097:3)
    at react-dom.development.js:9288:12

Trigges av onBlur på tomt felt

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
