### PR TITLE
fix: send det som blir verdien etter endring i onChange

### DIFF
--- a/packages/combobox-react/package.json
+++ b/packages/combobox-react/package.json
@@ -30,7 +30,7 @@
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",
-        "test": "echo \"Error: run tests from root\" && exit 1",
+        "test": "jest --testMatch '**/combobox-react/**/*.test.+(ts|tsx|js)' --config=../../jest.config.js",
         "dev:js": "ESBUILD_WATCH=true node ./esbuild.dev.mjs",
         "dev:server": "nodemon ./dist/server.js",
         "dev": "run-p dev:*"

--- a/packages/combobox-react/src/Combobox.test.tsx
+++ b/packages/combobox-react/src/Combobox.test.tsx
@@ -90,6 +90,7 @@ describe("Combobox", () => {
     });
 
     it("should change the value of the combobox when selecting two options", async () => {
+        const onChangeSpy = jest.fn();
         function WrappedCombobox() {
             const [selectedValues, setSelectedValues] = useState<Array<ComboboxValuePair>>([]);
 
@@ -107,6 +108,7 @@ describe("Combobox", () => {
                     items={items}
                     value={selectedValues}
                     onChange={(event) => {
+                        onChangeSpy(event);
                         setSelectedValues(event.target.selectedOptions);
                     }}
                 />
@@ -135,9 +137,22 @@ describe("Combobox", () => {
         expect(selectedTags).toHaveLength(2);
         expect(selectedTags[0]).toHaveTextContent("Item 1");
         expect(selectedTags[1]).toHaveTextContent("Item 2");
+
+        expect(onChangeSpy).toHaveBeenCalledTimes(2);
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                target: expect.objectContaining({
+                    selectedOptions: [
+                        expect.objectContaining({ label: "Item 1", value: "1" }),
+                        expect.objectContaining({ label: "Item 2", value: "2" }),
+                    ],
+                }),
+            }),
+        );
     });
 
     it("should clear all values when clicking remove all button", async () => {
+        const onChangeSpy = jest.fn();
         function WrappedCombobox() {
             const [selectedValues, setSelectedValues] = useState<Array<ComboboxValuePair>>([]);
 
@@ -155,6 +170,7 @@ describe("Combobox", () => {
                     items={items}
                     value={selectedValues}
                     onChange={(event) => {
+                        onChangeSpy(event);
                         setSelectedValues(event.target.selectedOptions);
                     }}
                 />
@@ -188,6 +204,16 @@ describe("Combobox", () => {
         });
 
         expect(getByTestId("jkl-combobox__tags")).not.toContain(<Tag />);
+
+        expect(onChangeSpy).toHaveBeenCalledTimes(3);
+        expect(onChangeSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                target: expect.objectContaining({
+                    value: "",
+                    selectedOptions: [],
+                }),
+            }),
+        );
     });
 });
 

--- a/packages/combobox-react/src/Combobox.tsx
+++ b/packages/combobox-react/src/Combobox.tsx
@@ -120,13 +120,17 @@ export const Combobox: FC<ComboboxProps> = ({
         setSelectedValue(newValue);
         onChange({
             type: "change",
-            target: { name, value: option, selectedOptions: selectedValue },
+            target: { name, value: option, selectedOptions: newValue },
         });
         e.stopPropagation();
     };
 
     const onTagRemoveAll = () => {
         setSelectedValue([]);
+        onChange({
+            type: "change",
+            target: { name, value: "", selectedOptions: [] },
+        });
     };
 
     // Håndtere valgt verdi i listen
@@ -144,7 +148,7 @@ export const Combobox: FC<ComboboxProps> = ({
             setSelectedValue(newValue);
             onChange({
                 type: "change",
-                target: { name, value: option, selectedOptions: selectedValue },
+                target: { name, value: option, selectedOptions: newValue },
             });
         },
         [selectedValue, setSelectedValue, onChange, name, removeOption, items],


### PR DESCRIPTION
Fikser et problem der selectedOptions sendte forrige verdi, og ikke ble sendt ved fjerning av alle verdier.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
