### PR TITLE
fix: spesifiser type for eksportert hook som typescript ikke inferrer

### DIFF
--- a/packages/contextual-menu-react/src/useMenuWideEvents.ts
+++ b/packages/contextual-menu-react/src/useMenuWideEvents.ts
@@ -1,7 +1,15 @@
 import { FloatingTreeType } from "@floating-ui/react";
 import { useEffect, useState } from "react";
 
-export const useMenuWideEvents = (tree: FloatingTreeType | null, nodeId: string, parentId: string | null) => {
+export const useMenuWideEvents = (
+    tree: FloatingTreeType | null,
+    nodeId: string,
+    parentId: string | null,
+): {
+    allowHover: boolean;
+    isOpen: boolean;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+} => {
     const [allowHover, setAllowHover] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
 


### PR DESCRIPTION
Ved fersk boot av Jøkul kræsjer Tyepscript når den forsøker å inferre returtypen av `useMenuWideEvents`-hooken i `ContextualMenu`. Vi legger til spesifikke typer for å ungå dette.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
