### PR TITLE
fix: rett feil i selector for handlingsknapp i input

### DIFF
--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -132,7 +132,7 @@ $_text-input-selection-color--inverted: color.scale(
             background-color: var(--jkl-text-input-error-selection-color-color);
         }
 
-        & ~ .jkl-text-input__action-button {
+        & ~ .jkl-text-input-action-button {
             color: var(--jkl-text-input-error-placeholder-color);
 
             &:hover {


### PR DESCRIPTION
Hang igjen etter hopp fra 9.x til 10.x i text-input

ISSUES CLOSED: #3595 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
