### PR TITLE
feat: add support for isOpen and onToggle props

### DIFF
--- a/packages/contextual-menu-react/documentation/ContextualMenuExample.tsx
+++ b/packages/contextual-menu-react/documentation/ContextualMenuExample.tsx
@@ -6,8 +6,18 @@ import { ContextualMenu } from "../src/ContextualMenu";
 import { ContextualMenuDivider } from "../src/ContextualMenuDivider";
 import { ContextualMenuItem } from "../src/ContextualMenuItem";
 
-export const contextualMenuExampleKnobs: ExampleKnobsProps = {};
-export const ContextualMenuExample: FC<ExampleComponentProps> = () => {
+export const contextualMenuExampleKnobs: ExampleKnobsProps = {
+    choiceProps: [
+        {
+            name: "isOpen",
+            values: ["true", "false", "tom"],
+            defaultValue: 2,
+        },
+    ],
+};
+export const ContextualMenuExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
+    const isOpen = choiceValues?.["isOpen"] !== "tom" ? choiceValues?.["isOpen"] === "true" : undefined;
+
     return (
         <div
             style={{
@@ -16,6 +26,7 @@ export const ContextualMenuExample: FC<ExampleComponentProps> = () => {
         >
             <ContextualMenu
                 initialPlacement="bottom-start"
+                isOpen={isOpen}
                 triggerElement={
                     <IconButton
                         data-testid="trigger-contextual-menu"

--- a/packages/contextual-menu-react/documentation/ContextualMenuToggleSwitchExample.tsx
+++ b/packages/contextual-menu-react/documentation/ContextualMenuToggleSwitchExample.tsx
@@ -6,9 +6,19 @@ import React, { type FC, useCallback, useState, useRef } from "react";
 import { ExampleComponentProps, ExampleKnobsProps, CodeExample } from "../../../doc-utils";
 import { ContextualMenu, ContextualMenuItemCheckbox } from "../src";
 
-export const contextualMenuToggleSwitchExampleKnobs: ExampleKnobsProps = {};
+export const contextualMenuToggleSwitchExampleKnobs: ExampleKnobsProps = {
+    choiceProps: [
+        {
+            name: "isOpen",
+            values: ["true", "false", "tom"],
+            defaultValue: 2,
+        },
+    ],
+};
 
-export const ContextualMenuToggleSwitchExample: FC<ExampleComponentProps> = () => {
+export const ContextualMenuToggleSwitchExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
+    const isOpen = choiceValues?.["isOpen"] !== "tom" ? choiceValues?.["isOpen"] === "true" : undefined;
+
     const pref = useBrowserPreferences();
     const [colorScheme, setColorScheme] = useState(pref.prefersColorScheme);
 
@@ -48,6 +58,7 @@ export const ContextualMenuToggleSwitchExample: FC<ExampleComponentProps> = () =
         >
             <ContextualMenu
                 initialPlacement="bottom-start"
+                isOpen={isOpen}
                 triggerElement={
                     <IconButton className="jkl-portal-navigation__contextual-menu-trigger" title="Åpne innstillinger">
                         <DotsIcon variant="medium" bold />

--- a/packages/contextual-menu-react/src/ContextualMenu.test.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenu.test.tsx
@@ -50,6 +50,44 @@ describe("ContextualMenu", () => {
         expect(queryByRole("menuitem")).not.toBeInTheDocument();
     });
 
+    test("should render as open if isOpen prop is true", async () => {
+        const { getByRole } = setup(
+            <ContextualMenu
+                initialPlacement="bottom-start"
+                isOpen={true}
+                triggerElement={
+                    <IconButton title="En kontekstuell meny">
+                        <DotsIcon bold />
+                    </IconButton>
+                }
+            >
+                <ContextualMenuItem>Menyvalg</ContextualMenuItem>
+            </ContextualMenu>,
+        );
+
+        expect(getByRole("menuitem", { name: "Menyvalg" })).toBeInTheDocument();
+    });
+
+    test("should not open if isOpen prop is set to false", async () => {
+        const { getByRole, queryByRole, user } = setup(
+            <ContextualMenu
+                initialPlacement="bottom-start"
+                isOpen={false}
+                triggerElement={
+                    <IconButton title="En kontekstuell meny">
+                        <DotsIcon bold />
+                    </IconButton>
+                }
+            >
+                <ContextualMenuItem>Menyvalg</ContextualMenuItem>
+            </ContextualMenu>,
+        );
+
+        await user.click(getByRole("button", { name: "En kontekstuell meny" }));
+
+        expect(queryByRole("menuitem", { name: "Menyvalg" })).not.toBeInTheDocument();
+    });
+
     test("should open menu options when clicking on trigger element", async () => {
         const { getByRole, user } = setup(
             <ContextualMenu
@@ -99,6 +137,32 @@ describe("ContextualMenu", () => {
 
         const ekspandert = await findByRole("menuitem", { name: "Ekspandert" });
         expect(ekspandert).toBeInTheDocument();
+    });
+
+    test("should call onToggle callback when opening and closing", async () => {
+        const onToggle = jest.fn();
+
+        const { getByRole, user } = setup(
+            <ContextualMenu
+                onToggle={onToggle}
+                initialPlacement="bottom-start"
+                triggerElement={
+                    <IconButton title="En kontekstuell meny">
+                        <DotsIcon bold />
+                    </IconButton>
+                }
+            >
+                <ContextualMenuItem>Menyvalg</ContextualMenuItem>
+            </ContextualMenu>,
+        );
+
+        await user.click(getByRole("button", { name: "En kontekstuell meny" }));
+        await user.click(getByRole("button", { name: "En kontekstuell meny" }));
+
+        // Called with false on mount since menu starts out closed
+        expect(onToggle).toHaveBeenNthCalledWith(1, false);
+        expect(onToggle).toHaveBeenNthCalledWith(2, true);
+        expect(onToggle).toHaveBeenNthCalledWith(3, false);
     });
 
     test("should pass jest-axe tests in default state", async () => {

--- a/packages/contextual-menu-react/src/ContextualMenu.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenu.tsx
@@ -24,7 +24,7 @@ import { WithChildren, type DataTestAutoId } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
-import React, { type ButtonHTMLAttributes, forwardRef, type ReactNode, useRef, useState } from "react";
+import React, { type ButtonHTMLAttributes, forwardRef, type ReactNode, useEffect, useRef, useState } from "react";
 import * as ReactIs from "react-is";
 import { useMenuWideEvents } from "./useMenuWideEvents";
 
@@ -51,10 +51,28 @@ export interface ContextualMenuProps
      * `ContextualMenuTriggerButton` fra denne pakken.
      */
     triggerElement: ReactNode;
+    /**
+     * Kan brukes til å styre utenfra om menyen skal være åpen eller ikke.
+     * @default false
+     */
+    isOpen?: boolean;
+    /**
+     * Callback som kalles når menyen åpnes eller lukkes.
+     */
+    onToggle?: (isOpen: boolean) => void;
 }
 
 const ContextualMenuComponent = forwardRef<HTMLButtonElement, ContextualMenuProps>((props, forwardedRef) => {
-    const { children, className, initialPlacement, openOnHover = false, triggerElement, ...triggerProps } = props;
+    const {
+        children,
+        className,
+        initialPlacement,
+        openOnHover = false,
+        triggerElement,
+        isOpen: isOpenOverride,
+        onToggle,
+        ...triggerProps
+    } = props;
 
     const contextualMenuId = useId("jkl-contextual-menu");
 
@@ -65,7 +83,11 @@ const ContextualMenuComponent = forwardRef<HTMLButtonElement, ContextualMenuProp
 
     const listItemsRef = useRef<Array<HTMLButtonElement | null>>([]);
     const [activeIndex, setActiveIndex] = useState<number | null>(null);
-    const { allowHover, isOpen, setIsOpen } = useMenuWideEvents(tree, nodeId, parentId);
+    const { allowHover, isOpen: isOpenDefault, setIsOpen } = useMenuWideEvents(tree, nodeId, parentId);
+
+    const isOpen = isOpenOverride !== undefined ? isOpenOverride : isOpenDefault;
+
+    useEffect(() => onToggle?.(isOpen), [isOpen, onToggle]);
 
     const { x, y, refs, placement, strategy, context } = useFloating({
         nodeId,


### PR DESCRIPTION
Use isOpen if you want full control over when the menu opens or closes 
Use onToggle callback if you want to track the open/closed state of the menu

ISSUES CLOSED: #3626

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
