### PR TITLE
feat: pek /beta på prodmiljøet av ny portal

### DIFF
--- a/portal/src/pages/beta.tsx
+++ b/portal/src/pages/beta.tsx
@@ -4,7 +4,7 @@ import { MainContent } from "../layout/MainContent";
 
 export const Head: React.FC = () => <Seo title="Beta av den nye Jøkul-portalen" />;
 
-const betaLink = "https://portalen.distlosn-ds-jkl-preprod.aws.fremtind.no";
+const betaLink = "https://jkl-portal.aws.fremtind.no";
 
 const BetaPage: React.FC = () => {
     if (window.location) {


### PR DESCRIPTION
Endre redirect fra `jokul.fremtind.no/beta` slik at den peker på prodmiljøet av den nye portalen

