### PR TITLE
fix: explicitly style colors of option element

### DIFF
--- a/packages/datepicker/_calendar-navigation-dropdown.scss
+++ b/packages/datepicker/_calendar-navigation-dropdown.scss
@@ -28,6 +28,11 @@
         padding: 0;
         padding-inline-end: var(--chevron-size);
 
+        & option {
+            color: var(--jkl-select-text-color);
+            background-color: var(--jkl-select-open-background-color);
+        }
+
         @include jkl.keyboard-navigation {
             &:focus {
                 outline: jkl.rem(2px) solid var(--jkl-calendar-focus-color);


### PR DESCRIPTION
Not alle browsers support this but notably Edge does and coincidentally Edge also does not
properly set colors for darkmode.

ISSUES CLOSED: #3645

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
