### PR TITLE
Rendre TooltipContent og ContextualMenu i portaler

### DIFF
--- a/packages/contextual-menu-react/src/ContextualMenu.test.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenu.test.tsx
@@ -208,7 +208,12 @@ describe("ContextualMenu", () => {
         await user.click(getByRole("button", { name: "En kontekstuell meny" }));
         expect(getByRole("menuitem", { name: "Ekspanderende" })).toBeInTheDocument();
 
-        const results = await axe(container);
+        const results = await axe(container, {
+            rules: {
+                // Denne klager over focus guards fra FloatingUI, som ikke skal leses opp
+                "aria-command-name": { enabled: false },
+            },
+        });
 
         expect(results).toHaveNoViolations();
     });
@@ -242,7 +247,12 @@ describe("ContextualMenu", () => {
 
         await act(async () => {}); // La @floating-ui posisjonere undermenyen ferdig (https://floating-ui.com/docs/react#testing)
 
-        const results = await axe(container);
+        const results = await axe(container, {
+            rules: {
+                // Denne klager over focus guards fra FloatingUI, som ikke skal leses opp
+                "aria-command-name": { enabled: false },
+            },
+        });
 
         expect(results).toHaveNoViolations();
     });

--- a/packages/contextual-menu-react/src/ContextualMenu.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenu.tsx
@@ -173,7 +173,7 @@ const ContextualMenuComponent = forwardRef<HTMLButtonElement, ContextualMenuProp
                             returnFocus={!isNested}
                         >
                             <motion.div
-                                className={cn("jkl-contextual-menu", className)}
+                                className={cn("jkl jkl-contextual-menu", className)}
                                 data-theme={theme}
                                 role="menu"
                                 initial={{ opacity: 0 }}

--- a/packages/tooltip-react/src/TooltipContent.tsx
+++ b/packages/tooltip-react/src/TooltipContent.tsx
@@ -1,4 +1,4 @@
-import { type Placement, useMergeRefs } from "@floating-ui/react";
+import { type Placement, useMergeRefs, FloatingPortal } from "@floating-ui/react";
 import { useId } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
@@ -51,45 +51,60 @@ export const TooltipContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElemen
     const ref = useMergeRefs([forwardedRef, refs.setFloating]);
     const contentId = useId("jkl-tooltip-content");
 
+    // Siden tooltipet rendres på rot må vi hente lokal dark/light-verdi fra triggeren
+    // Vi må gjøre dette for å ta hensyn til at tema kan styres lokalt for deler av UIet
+    let theme: string | undefined;
+    if (refs.reference.current) {
+        const backgroundColor = getComputedStyle(refs.reference.current as HTMLElement).getPropertyValue(
+            "--jkl-background-color",
+        );
+        // Sett theme til dark hvis bakgrunnsfargen er mørkere enn 50% av hvit
+        // dette gir oss slingringsmonn i tilfelle verdien av Jøkuls bakgrunnsfarge endres
+        theme = parseInt(backgroundColor.replace("#", ""), 16) < 0xffffff / 2 ? "dark" : "light";
+    }
+
     return (
-        <AnimatePresence>
-            {/* For å kunne bruke tekstinnholdet i tooltip som beskrivende tekst, selv når ikke
+        <FloatingPortal>
+            <AnimatePresence>
+                {/* For å kunne bruke tekstinnholdet i tooltip som beskrivende tekst, selv når ikke
             tooltip er synlig, må vi rendre et skjult element å referere til for å hente innholdet. */}
-            {triggerOn === "hover" && (
-                <span ref={refs.setDescription} hidden>
-                    {children}
-                </span>
-            )}
-            {isOpen && (
-                <motion.span
-                    key={contentId}
-                    ref={ref}
-                    initial={{ opacity: 0, ...getPositionAnimation(placement, 5) }}
-                    animate={{ opacity: 1, ...getPositionAnimation(placement, 0) }}
-                    exit={{
-                        opacity: 0,
-                        ...getPositionAnimation(placement, -5),
-                        transition: { ease: "easeIn", duration: 0.15 },
-                    }}
-                    transition={{ ease: "easeOut", duration: 0.25 }}
-                    data-placement={placement}
-                    aria-live={triggerOn === "click" ? "assertive" : undefined}
-                    className={cn("jkl jkl-tooltip-content", className)}
-                    {...getFloatingProps({ ...props, id: contentId })}
-                    style={{ ...floatingStyles }}
-                >
-                    {children}
-                    <span
-                        aria-hidden
-                        className="jkl-tooltip-content__arrow"
-                        ref={arrowElement}
-                        style={{
-                            left: isPositioned ? `${arrow?.x}px` : "",
-                            top: isPositioned ? `${arrow?.y}px` : "",
+                {triggerOn === "hover" && (
+                    <span ref={refs.setDescription} hidden>
+                        {children}
+                    </span>
+                )}
+                {isOpen && (
+                    <motion.span
+                        key={contentId}
+                        ref={ref}
+                        initial={{ opacity: 0, ...getPositionAnimation(placement, 5) }}
+                        animate={{ opacity: 1, ...getPositionAnimation(placement, 0) }}
+                        exit={{
+                            opacity: 0,
+                            ...getPositionAnimation(placement, -5),
+                            transition: { ease: "easeIn", duration: 0.15 },
                         }}
-                    />
-                </motion.span>
-            )}
-        </AnimatePresence>
+                        transition={{ ease: "easeOut", duration: 0.25 }}
+                        data-placement={placement}
+                        aria-live={triggerOn === "click" ? "assertive" : undefined}
+                        className={cn("jkl jkl-tooltip-content", className)}
+                        {...getFloatingProps({ ...props, id: contentId })}
+                        style={{ ...floatingStyles }}
+                        data-theme={theme}
+                    >
+                        {children}
+                        <span
+                            aria-hidden
+                            className="jkl-tooltip-content__arrow"
+                            ref={arrowElement}
+                            style={{
+                                left: isPositioned ? `${arrow?.x}px` : "",
+                                top: isPositioned ? `${arrow?.y}px` : "",
+                            }}
+                        />
+                    </motion.span>
+                )}
+            </AnimatePresence>
+        </FloatingPortal>
     );
 });


### PR DESCRIPTION
I dag rendres popupene fra Tooltip og ContextualMenu ved siden av triggeren i DOMet. Det kan føre til uventet oppførsel hvis triggeren ligger inne i et element som har scroll eller som har `overflow` satt til en verdi i CSS. Under er et par eksempler fra den nye Jøkul-portalen der meny og tooltip dyttes til venstre fordi sidemenyen kan ha scroll.

<img width="481" alt="Skjermbilde 2023-08-23 kl  12 20 05" src="https://github.com/fremtind/jokul/assets/25739615/da8850a2-62ba-4a3e-b0ac-196197e66a5d">
<img width="227" alt="Skjermbilde 2023-08-23 kl  12 20 22" src="https://github.com/fremtind/jokul/assets/25739615/506c9007-08cc-4ec9-9fc4-212a2bb95924">

Ved å rendre i en portal på "rot" (inne i `body`-elementet) vil popupene heller ta høyde for nettleservinduet når det skal beregne plassering, noe som vil gi forventet oppførsel i tilfellene over.

Måtte legge inn en liten workaround for å ta hensyn til lokal dark/light mode satt med `data-theme`, men det ser ut til å fungere fint.

## 🎯 Sjekkliste
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
