### PR TITLE
chore: increase threshold for visual diff regression tests

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -126,6 +126,7 @@ Cypress.Commands.add("takeSnapshots", (options = {}) => {
 
         const snapshotConfig = {
             title: forcedColorsActive ? `${Cypress.currentTest.titlePath.join(" ")} in high contrast` : undefined,
+            maxDiffThreshold: 0.042,
         };
 
         cy.get("#screenshot-mode-toggle").trigger("click", { force: true });


### PR DESCRIPTION
What exactly this number should be will probably be a matter of trial and error but it's becoming clear that with the current workflow setup it can't be the default of 0.01

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
