### PR TITLE
3751 expandable non js

### DIFF
--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -6,6 +6,7 @@ import React from "react";
 export type ExpandDirection = "up" | "down";
 
 export interface ExpandButtonProps extends WithChildren {
+    as?: "summary" | "button";
     /** Må settes dersom du ikke bruker CoreToggle. Verdien skal være IDen til innholdet du ekspanderer. */
     "aria-controls"?: string;
     /** Må settes dersom du ikke bruker CoreToggle. IDen her skal brukes som verdien til aria-labelledby på innholdet du ekspanderer. */
@@ -30,6 +31,7 @@ export interface ExpandButtonProps extends WithChildren {
 }
 
 export const ExpandButton = ({
+    as = "button",
     className,
     children,
     density,
@@ -40,11 +42,15 @@ export const ExpandButton = ({
 }: ExpandButtonProps): JSX.Element => {
     const ContentWrapper = hideLabel ? ScreenReaderOnly : React.Fragment;
     const pointingDown = expandDirection === "down" ? !isExpanded : isExpanded;
+
+    const Tag = as;
+    const type = Tag === "button" ? "button" : undefined;
+
     return (
-        <button
+        <Tag
             aria-expanded={isExpanded}
             data-testid="jkl-expand-button"
-            type="button"
+            type={type}
             className={cx("jkl-expand-button", className, {
                 "jkl-expand-button--expanded": isExpanded,
                 "jkl-expand-button--icon-only": !children,
@@ -58,6 +64,6 @@ export const ExpandButton = ({
                 </ContentWrapper>
             )}
             <ArrowVerticalAnimated className="jkl-expand-button__arrow" pointingDown={pointingDown} />
-        </button>
+        </Tag>
     );
 };

--- a/packages/expand-button-react/src/ExpandSection.test.tsx
+++ b/packages/expand-button-react/src/ExpandSection.test.tsx
@@ -36,8 +36,8 @@ describe("Expand", () => {
         render(<ExpandSectionExample />);
         screen.getByText("Vis den skjulte seksjonen");
 
-        const contentToggle = screen.getByTestId("jkl-expand-section__content-wrapper");
-        expect(contentToggle).toHaveProperty("hidden", true);
+        const detailsWrapper = screen.getByTestId("jkl-expand-section__wrapper");
+        expect(detailsWrapper).toHaveProperty("open", false);
     });
 
     it("should render the expand button expanded with the isExpanded prop set to true", () => {
@@ -49,8 +49,8 @@ describe("Expand", () => {
         );
         screen.getByText("Skjult seksjon");
 
-        const contentToggle = screen.getByTestId("jkl-expand-section__content-wrapper");
-        expect(contentToggle).toHaveProperty("hidden", false);
+        const detailsWrapper = screen.getByTestId("jkl-expand-section__wrapper");
+        expect(detailsWrapper).toHaveProperty("open", true);
     });
 
     it("should trigger onClick handler on click and expand the content", async () => {
@@ -63,8 +63,8 @@ describe("Expand", () => {
 
         expect(onClickSpy).toHaveBeenCalledTimes(1);
 
-        const contentToggle = screen.getByTestId("jkl-expand-section__content-wrapper");
-        expect(contentToggle).toHaveProperty("hidden", false);
+        const detailsWrapper = screen.getByTestId("jkl-expand-section__wrapper");
+        expect(detailsWrapper).toHaveProperty("open", true);
     });
 });
 

--- a/packages/expand-button-react/src/ExpandSection.tsx
+++ b/packages/expand-button-react/src/ExpandSection.tsx
@@ -52,8 +52,14 @@ export const ExpandSection = ({
     };
 
     return (
-        <div className={cx("jkl-expand-section", className)} {...rest}>
+        <details
+            open={isExpanded ? true : undefined}
+            className={cx("jkl-expand-section", className)}
+            data-testid="jkl-expand-section__wrapper"
+            {...rest}
+        >
             <ExpandButton
+                as={"summary"}
                 {...expandButtonProps}
                 id={buttonId}
                 aria-controls={contentId}
@@ -66,14 +72,12 @@ export const ExpandSection = ({
             <div
                 id={contentId}
                 ref={elementRef}
-                data-testid="jkl-expand-section__content-wrapper"
                 className="jkl-expand-section__content-wrapper"
-                hidden={!expanded}
                 role="group"
                 aria-labelledby={buttonId}
             >
                 <div className="jkl-expand-section__content">{children}</div>
             </div>
-        </div>
+        </details>
     );
 };

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -32,6 +32,7 @@
     transition: transform $_animation-timing, border $_animation-timing;
     min-width: unset;
     position: relative;
+    display: block;
 
     &::after {
         $_expand-button-border-width: jkl.rem(1px);


### PR DESCRIPTION
Gjort om ExpandSection til å bruke `<details>` og `<summary>` elementer slik at det ved bruk i en applikasjon som benytter SSR (feks via Remix eller Next) også vil ha funksjonalitet på plass før JS har lastet og React er mounted.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil


