### PR TITLE
fix: make sure IconButtons have a default type of "button"

### DIFF
--- a/packages/text-input-react/src/BaseTextInput.tsx
+++ b/packages/text-input-react/src/BaseTextInput.tsx
@@ -74,6 +74,7 @@ export const BaseTextInput = forwardRef<HTMLInputElement, BaseTextInputProps>((p
         width,
         ...rest
     } = props;
+
     return (
         <div
             className="jkl-text-input-wrapper"
@@ -100,7 +101,7 @@ export const BaseTextInput = forwardRef<HTMLInputElement, BaseTextInputProps>((p
                     onFocus={action.onFocus}
                     onBlur={action.onBlur}
                     ref={action.buttonRef}
-                    type={action.type}
+                    type={action.type || "button"}
                 >
                     {action.icon}
                 </IconButton>


### PR DESCRIPTION
If no type is provided we end up having a key for "type" set to undefined and when the IconButton spreads
its rest-props to the button element it overwrites any previously set value, effectively removing it

ISSUES CLOSED: #3776

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))

