### PR TITLE
fix: align checkbox mot toppen for å støtte label over flere linjer

### DIFF
--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -35,7 +35,7 @@
     --jkl-checkbox-height: #{$_checkbox-height};
     --jkl-checkbox-box-size: #{$_checkbox-box-size};
     --jkl-checkbox-line-height: #{$_checkbox-line-height};
-    --jkl-checkbox-mark-margin: #{jkl.rem(8px)} #{jkl.$spacing-xs} #{jkl.rem(8px)} 0;
+    --jkl-checkbox-mark-margin: #{jkl.rem(11px)} #{jkl.$spacing-xs} #{jkl.rem(8px)} 0;
     --jkl-checkbox-text-translate: translate3d(0, #{jkl.rem(1px)}, 0);
     --jkl-checkbox-text-margin: #{(($_checkbox-height - $_checkbox-line-height) * 0.5)} 0;
 
@@ -62,7 +62,7 @@
     --jkl-checkbox-height: #{$_checkbox-height--compact};
     --jkl-checkbox-box-size: #{$_checkbox-box-size--compact};
     --jkl-checkbox-line-height: #{$_checkbox-line-height--compact};
-    --jkl-checkbox-mark-margin: #{jkl.rem(4px)} #{jkl.$spacing-xs} #{jkl.rem(4px)} 0;
+    --jkl-checkbox-mark-margin: #{jkl.rem(5px)} #{jkl.$spacing-xs} #{jkl.rem(4px)} 0;
     --jkl-checkbox-text-translate: translate3d(0, 0, 0);
     --jkl-checkbox-text-margin: #{(($_checkbox-height--compact - $_checkbox-line-height--compact) * 0.5)} 0;
 }
@@ -204,7 +204,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         width: var(--jkl-checkbox-box-size);
 
         margin: var(--jkl-checkbox-mark-margin);
-        align-self: center;
+        align-self: flex-start;
         flex-shrink: 0; // Don't allow the mark to shrink in case of really long text
 
         outline: none;


### PR DESCRIPTION
Checkbox midtstiller seg om label havner over flere linjer. Denne PRen legger checkbox mot toppen av label, så om label brekker over flere linjer holder den seg på toppen.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [X] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
