### PR TITLE
fix: referer til jkl-klasser i stedet for elementer

### DIFF
--- a/packages/table-react/src/TableFooter.tsx
+++ b/packages/table-react/src/TableFooter.tsx
@@ -1,12 +1,13 @@
+import cx from "classnames";
 import React, { forwardRef, HTMLAttributes } from "react";
 import { TableSectionContextProvider } from "./tableSectionContext";
 
 export interface TableFooterProps extends HTMLAttributes<HTMLTableSectionElement> {}
 
-const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>((props, ref) => {
+const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>(({ className, ...rest }, ref) => {
     return (
         <TableSectionContextProvider state={{ isTableHead: false, isTableBody: false, isTableFooter: true }}>
-            <tfoot {...props} ref={ref} />
+            <tfoot className={cx("jkl-table-foot", className)} {...rest} ref={ref} />
         </TableSectionContextProvider>
     );
 });

--- a/packages/table/_table-row.scss
+++ b/packages/table/_table-row.scss
@@ -20,12 +20,12 @@ $_focus-ring-width: jkl.rem(2px);
 .jkl-table-row {
     border-bottom: solid $_border-size var(--jkl-table-row-border-color);
 
-    thead > & {
+    .jkl-table-head > & {
         border-bottom: solid $_border-size var(--jkl-table-row-hover-border-color);
     }
 
     /* stylelint-disable-next-line selector-not-notation */
-    :not(thead, tfoot) > & {
+    :not(.jkl-table-head, .jkl-table-foot) > & {
         border-top: solid $_border-size transparent; // Unngår vertikal shift ved hover i collapsed mobilvisning
 
         &:hover {
@@ -48,13 +48,13 @@ $_focus-ring-width: jkl.rem(2px);
         border-bottom: solid $_border-size var(--jkl-table-row-border-color);
     }
 
-    .jkl-table--collapse-to-list > thead > & {
+    .jkl-table--collapse-to-list > .jkl-table-head > & {
         @include jkl.small-device {
             @include _responsive-table-head;
         }
     }
 
-    .jkl-table--collapse-to-list[data-collapse] > thead > & {
+    .jkl-table--collapse-to-list[data-collapse] > .jkl-table-head > & {
         @include _responsive-table-head;
     }
 
@@ -67,17 +67,17 @@ $_focus-ring-width: jkl.rem(2px);
         }
     }
 
-    .jkl-table--collapse-to-list :not(thead) > & {
+    .jkl-table--collapse-to-list :not(.jkl-table-head) > & {
         @include jkl.small-device {
             @include _responsive-table-row;
         }
     }
 
-    .jkl-table--collapse-to-list[data-collapse] :not(thead) > & {
+    .jkl-table--collapse-to-list[data-collapse] :not(.jkl-table-head) > & {
         @include _responsive-table-row;
     }
 
-    .jkl-table--collapse-to-list[data-collapse] :not(thead) > &.jkl-table-row--expandable {
+    .jkl-table--collapse-to-list[data-collapse] :not(.jkl-table-head) > &.jkl-table-row--expandable {
         transition-property: border, padding;
         @include jkl.motion;
 
@@ -116,13 +116,13 @@ $_focus-ring-width: jkl.rem(2px);
         border-bottom: solid $_border-size var(--jkl-table-row-hover-border-color);
     }
 
-    .jkl-table--collapse-to-list :not(thead) > &:hover {
+    .jkl-table--collapse-to-list :not(.jkl-table-head) > &:hover {
         @include jkl.small-device {
             @include _responsive-table-row--hover;
         }
     }
 
-    .jkl-table--collapse-to-list[data-collapse] :not(thead) > &:hover {
+    .jkl-table--collapse-to-list[data-collapse] :not(.jkl-table-head) > &:hover {
         @include _responsive-table-row--hover;
     }
 
@@ -138,13 +138,13 @@ $_focus-ring-width: jkl.rem(2px);
             border-bottom: double $_border-size var(--jkl-table-row-hover-border-color);
         }
 
-        .jkl-table--collapse-to-list :not(thead) > &:hover {
+        .jkl-table--collapse-to-list :not(.jkl-table-head) > &:hover {
             @include jkl.small-device {
                 @include _responsive-table-row--hover;
             }
         }
 
-        .jkl-table--collapse-to-list[data-collapse] :not(thead) > &:hover {
+        .jkl-table--collapse-to-list[data-collapse] :not(.jkl-table-head) > &:hover {
             @include _responsive-table-row--hover;
         }
 


### PR DESCRIPTION
tabell-rader har en del funksjonalitet knyttet til thead. disse referansene er fjernet til fordel for .jkl-table-head for å kunne gjenbruke utseendet til en tabell, uten at det nødvendigvis er en HTML-table

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
