### PR TITLE
fix: revert display for animated icons

### DIFF
--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -34,6 +34,10 @@
         display: flex;
         align-items: center;
         @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
+
+        &--animated {
+            display: revert;
+        }
     }
 
     &:hover {


### PR DESCRIPTION
While flexbox fixed the alignment for regular IconButtons it breaks it for the animated ones

ISSUES CLOSED: #3837

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
