### PR TITLE
feat: legg til formatterer og maske for datofelter

### DIFF
--- a/packages/formatters-util/documentation/InputMaskExample.tsx
+++ b/packages/formatters-util/documentation/InputMaskExample.tsx
@@ -1,13 +1,16 @@
-import React, { Fragment, useState, FC } from "react";
+import React, { FC, Fragment, useState } from "react";
 import { useForm } from "react-hook-form";
-import { ExampleComponentProps, CodeExample } from "../../../doc-utils";
+import { CodeExample, ExampleComponentProps } from "../../../doc-utils";
 import { PrimaryButton } from "../../../packages/button-react/src";
-import { DescriptionList, DescriptionTerm, DescriptionDetail } from "../../../packages/description-list-react/src";
+import { DatePicker } from "../../../packages/datepicker-react/src";
+import { DescriptionDetail, DescriptionList, DescriptionTerm } from "../../../packages/description-list-react/src";
 import { TextInput } from "../../../packages/text-input-react/src";
 import { registerWithMasks } from "../src";
 import "./input-mask-example.scss";
 
 interface Skjema {
+    dato: string;
+    datepicker: string;
     telefonnr: string;
     fodselsnr: string;
     kortnr: string;
@@ -21,6 +24,7 @@ export const InputMaskExample: FC<ExampleComponentProps> = () => {
     const [formData, setFormData] = useState<Skjema>();
 
     const {
+        registerWithDateMask,
         registerWithFodselsnummerMask,
         registerWithKontonummerMask,
         registerWithKortnummerMask,
@@ -32,6 +36,8 @@ export const InputMaskExample: FC<ExampleComponentProps> = () => {
     return (
         <>
             <form className="input-mask-example-form" onSubmit={form.handleSubmit(setFormData)}>
+                <TextInput label="Dato" maxLength={10} {...registerWithDateMask("dato")} />
+                <DatePicker label="Dato brukt i datovelger" {...registerWithDateMask("datepicker")} />
                 <TextInput
                     label="Telefonnummer"
                     // Husk å gi plass til mellomrommene som settes inn!

--- a/packages/formatters-util/documentation/input-mask-example.scss
+++ b/packages/formatters-util/documentation/input-mask-example.scss
@@ -1,6 +1,7 @@
 @use "@fremtind/jkl-core/jkl";
-@use "@fremtind/jkl-text-input/text-input";
 @use "@fremtind/jkl-button/button";
+@use "@fremtind/jkl-datepicker/datepicker";
+@use "@fremtind/jkl-text-input/text-input";
 
 .input-mask-example-form {
     width: 100%;

--- a/packages/formatters-util/package.json
+++ b/packages/formatters-util/package.json
@@ -41,6 +41,7 @@
     },
     "devDependencies": {
         "@fremtind/jkl-button": "^12.0.7",
+        "@fremtind/jkl-datepicker": "^12.1.9",
         "@fremtind/jkl-text-input": "^12.1.8",
         "react-hook-form": "^7.44.3"
     },

--- a/packages/formatters-util/src/date/formatDate.test.ts
+++ b/packages/formatters-util/src/date/formatDate.test.ts
@@ -1,0 +1,17 @@
+import { formatDateString } from "./formatDate";
+
+describe("formatDateString", () => {
+    it("formats 6-digit dates correctly", () => {
+        expect(formatDateString("141086")).toEqual("14.10.86");
+        expect(formatDateString("14/10/86")).toEqual("14.10.86");
+        expect(formatDateString("14.10.86")).toEqual("14.10.86");
+        expect(formatDateString("14 10 86")).toEqual("14.10.86");
+        expect(formatDateString("1 4 1 0 8 6")).toEqual("14.10.86");
+    });
+    it("formats 8-digit dates correctly", () => {
+        expect(formatDateString("14101986")).toEqual("14.10.1986");
+        expect(formatDateString("14/10/1986")).toEqual("14.10.1986");
+        expect(formatDateString("14.10.1986")).toEqual("14.10.1986");
+        expect(formatDateString("1 4 1 0 19 86")).toEqual("14.10.1986");
+    });
+});

--- a/packages/formatters-util/src/date/formatDate.ts
+++ b/packages/formatters-util/src/date/formatDate.ts
@@ -10,14 +10,13 @@ export function formatDate(date: Date): string {
 }
 
 export const DATE_REGEX = {
-    // Tillater datoer på formene DD-MM-YY og DD-MM-YYYY
+    // Tillater datoer på formene DDMMYY og DDMMYYYY
     full: /^(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])(\d{2}|\d{4})$/,
     partial: /^(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])?(\d{1,4})?$/,
 };
 
 type FormatDateStringOptions = {
     partial?: boolean;
-    separator?: "." | "-" | " " | "/";
 };
 
 export function formatDateString(input: string, options?: FormatDateStringOptions): string {
@@ -30,8 +29,5 @@ export function formatDateString(input: string, options?: FormatDateStringOption
         return input;
     }
 
-    return match
-        .slice(1)
-        .filter(Boolean)
-        .join(options?.separator || ".");
+    return match.slice(1).filter(Boolean).join(".");
 }

--- a/packages/formatters-util/src/date/formatDate.ts
+++ b/packages/formatters-util/src/date/formatDate.ts
@@ -8,3 +8,30 @@ export function formatDate(date: Date): string {
     const month = `${date.getMonth() + 1}`.padStart(2, "0");
     return `${day}.${month}.${date.getFullYear()}`;
 }
+
+export const DATE_REGEX = {
+    // Tillater datoer på formene DD-MM-YY og DD-MM-YYYY
+    full: /^(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])(\d{2}|\d{4})$/,
+    partial: /^(0[1-9]|[12][0-9]|3[01])(0[1-9]|1[0-2])?(\d{1,4})?$/,
+};
+
+type FormatDateStringOptions = {
+    partial?: boolean;
+    separator?: "." | "-" | " " | "/";
+};
+
+export function formatDateString(input: string, options?: FormatDateStringOptions): string {
+    const strippedInput = input.replace(/\D/g, "");
+    const regex = options?.partial ? DATE_REGEX.partial : DATE_REGEX.full;
+
+    const match = strippedInput.match(regex);
+
+    if (!match) {
+        return input;
+    }
+
+    return match
+        .slice(1)
+        .filter(Boolean)
+        .join(options?.separator || ".");
+}

--- a/packages/formatters-util/src/util/registerWithMask.ts
+++ b/packages/formatters-util/src/util/registerWithMask.ts
@@ -7,6 +7,7 @@ import type {
     UseFormRegisterReturn,
     UseFormReturn,
 } from "react-hook-form";
+import { formatDateString } from "../date/formatDate";
 import { formatFodselsnummer } from "../fodselsnummer/formatFodselsnummer";
 import { formatKontonummer } from "../kontonummer/formatKontonummer";
 import { formatKortnummer } from "../kortnummer/formatKortnummer";
@@ -15,6 +16,7 @@ import { formatTelefonnummer } from "../telefonnummer/formatTelefonnummer";
 import { formatNumber } from "./formatNumber";
 
 const formatters = {
+    date: formatDateString,
     fodselsnummer: formatFodselsnummer,
     kortnummer: formatKortnummer,
     kontonummer: formatKontonummer,
@@ -122,6 +124,8 @@ export const registerWithMasks = <T extends FieldValues>(form: UseFormReturn<T>)
         registerWithMask("telefonnummer")<T>(form, name, options),
     registerWithOrganisasjonsnummerMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
         registerWithMask("organisasjonsnummer")<T>(form, name, options),
+    registerWithDateMask: (name: Path<T>, options?: RegisterWithMaskOptions<T>): UseFormRegisterReturn =>
+        registerWithMask("date")<T>(form, name, options),
     registerWithNumber: (
         name: Path<T>,
         options?: RegisterWithMaskOptions<T>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,7 @@ importers:
       '@fremtind/jkl-button': ^12.0.7
       '@fremtind/jkl-constants-util': ^3.0.44
       '@fremtind/jkl-core': ^13.4.2
+      '@fremtind/jkl-datepicker': ^12.1.9
       '@fremtind/jkl-text-input': ^12.1.8
       react-hook-form: ^7.44.3
     dependencies:
@@ -639,6 +640,7 @@ importers:
       '@fremtind/jkl-core': link:../core
     devDependencies:
       '@fremtind/jkl-button': link:../button
+      '@fremtind/jkl-datepicker': link:../datepicker
       '@fremtind/jkl-text-input': link:../text-input
       react-hook-form: 7.44.3
 


### PR DESCRIPTION
Legger til en formateringsfunksjon for innskrevne datoer, som også kan brukes med `registerWithMask`. Fungerer strålende sammen med `DatePicker` for enklere innskriving av dato.

ISSUES CLOSED: #3648

https://github.com/fremtind/jokul/assets/25739615/96ce0678-b710-411f-91c3-2e78946c7a08

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
