### PR TITLE
fix: switch from exporting interfaces to exporting types

### DIFF
--- a/packages/input-group-react/src/InputGroup.tsx
+++ b/packages/input-group-react/src/InputGroup.tsx
@@ -12,21 +12,22 @@ export interface InputProps {
     id?: string;
 }
 
-export interface InputGroupProps extends WithOptionalChildren, DataTestAutoId {
-    id?: string;
-    className?: string;
-    "data-testid"?: string;
-    density?: Density;
-    errorLabel?: ReactNode;
-    helpLabel?: ReactNode;
-    inline?: boolean;
-    label: ReactNode;
-    labelProps?: Omit<LabelProps, "children" | "density">;
-    supportLabelProps?: Omit<SupportLabelProps, "id" | "errorLabel" | "helpLabel" | "density">;
-    tooltipProps?: PopupTipProps;
-    style?: CSSProperties;
-    render?: (props: InputProps) => JSX.Element;
-}
+export type InputGroupProps = WithOptionalChildren &
+    DataTestAutoId & {
+        id?: string;
+        className?: string;
+        "data-testid"?: string;
+        density?: Density;
+        errorLabel?: ReactNode;
+        helpLabel?: ReactNode;
+        inline?: boolean;
+        label: ReactNode;
+        labelProps?: Omit<LabelProps, "children" | "density">;
+        supportLabelProps?: Omit<SupportLabelProps, "id" | "errorLabel" | "helpLabel" | "density">;
+        tooltipProps?: PopupTipProps;
+        style?: CSSProperties;
+        render?: (props: InputProps) => JSX.Element;
+    };
 
 export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, ref) => {
     const {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -36,44 +36,45 @@ interface Option extends ValuePair {
     visible: boolean;
 }
 
-export interface SelectProps extends InputGroupProps, DataTestAutoId {
-    id?: string;
-    name: string;
-    label: string;
-    labelProps?: Omit<LabelProps, "children" | "density" | "htmlFor" | "standAlone">;
-    items: Array<string | ValuePair>;
-    /**
-     * @default false
-     */
-    inline?: boolean;
-    /**
-     * @default "Velg"
-     */
-    defaultPrompt?: string;
-    className?: string;
-    value?: string;
-    helpLabel?: string;
-    errorLabel?: string;
-    /**
-     * @default false
-     */
-    searchable?: boolean | ((searchValue: string, searchItem: string | ValuePair) => boolean);
-    density?: Density;
-    width?: string;
-    onChange?: ChangeEventHandler;
-    onBlur?: ChangeEventHandler;
-    onFocus?: ChangeEventHandler;
-    /**
-     * Merk som ugyldig uten å sende inn en errorLabel.
-     * NB! Brukes kun i tilfeller der valideringsfeil dukker opp andre steder, for eksempel i en FieldGroup.
-     */
-    invalid?: boolean;
-    /**
-     * Hvor mange valg skal vises i listen før den begynner å scrolle.
-     * @default 5
-     */
-    maxShownOptions?: number;
-}
+export type SelectProps = InputGroupProps &
+    DataTestAutoId & {
+        id?: string;
+        name: string;
+        label: string;
+        labelProps?: Omit<LabelProps, "children" | "density" | "htmlFor" | "standAlone">;
+        items: Array<string | ValuePair>;
+        /**
+         * @default false
+         */
+        inline?: boolean;
+        /**
+         * @default "Velg"
+         */
+        defaultPrompt?: string;
+        className?: string;
+        value?: string;
+        helpLabel?: string;
+        errorLabel?: string;
+        /**
+         * @default false
+         */
+        searchable?: boolean | ((searchValue: string, searchItem: string | ValuePair) => boolean);
+        density?: Density;
+        width?: string;
+        onChange?: ChangeEventHandler;
+        onBlur?: ChangeEventHandler;
+        onFocus?: ChangeEventHandler;
+        /**
+         * Merk som ugyldig uten å sende inn en errorLabel.
+         * NB! Brukes kun i tilfeller der valideringsfeil dukker opp andre steder, for eksempel i en FieldGroup.
+         */
+        invalid?: boolean;
+        /**
+         * Hvor mange valg skal vises i listen før den begynner å scrolle.
+         * @default 5
+         */
+        maxShownOptions?: number;
+    };
 
 const noop = () => {
     return;


### PR DESCRIPTION
ISSUES CLOSED: #3855

Noe usikker på om dette løser issuet, men med lokal kopi av pakken (link fungerer ikke hos meg, heller ikke med `--global` flag, pnpm hoster ut en lang liste med feilmeldinger og så slutter hele greia å virke til jeg rydder opp manuelt). Det jeg uansett ser er at [InputGroupProps](https://github.com/fremtind/jokul/blob/7d2975a838a070a84bca31593dc0b80f8cc3db6e/packages/input-group-react/src/InputGroup.tsx#L15) deklareres som et interface men [eksporteres som en type](https://github.com/fremtind/jokul/blob/7d2975a838a070a84bca31593dc0b80f8cc3db6e/packages/input-group-react/src/index.ts#L2) så tenker det uansett er like ryddig at vi deklarerer det som en type i utgangspunktet.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->


-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
