### PR TITLE
fix: using tab with focus on an option no longer selects that option

### DIFF
--- a/packages/combobox-react/src/Combobox.tsx
+++ b/packages/combobox-react/src/Combobox.tsx
@@ -86,7 +86,7 @@ export const Combobox: FC<ComboboxProps> = ({
     const inputId = `${listId}_search-input`;
 
     const [selectedValue, setSelectedValue] = useState<Array<ComboboxValuePair>>(value || []);
-    const [isPoitingDown, setIsPointingDown] = useState<boolean>(true);
+    const [isPointingDown, setIsPointingDown] = useState<boolean>(true);
     const [showMenu, setShowMenu] = useState<boolean>(false);
     const [searchValue, setSearchValue] = useState<string>("");
     const [noResults, setNoResults] = useState(false);
@@ -339,8 +339,6 @@ export const Combobox: FC<ComboboxProps> = ({
                     if (e.shiftKey) {
                         searchRef.current.focus();
                     } else {
-                        // Mimic behaviour of Firefox and native select, where Tab selects the current item and closes the menu
-                        onItemClick(e.currentTarget.value);
                         setShowMenu(false);
                         searchRef.current.focus();
                     }
@@ -355,7 +353,7 @@ export const Combobox: FC<ComboboxProps> = ({
                 }
             }
         },
-        [setShowMenu, onItemClick, dropdownRef],
+        [setShowMenu, dropdownRef],
     );
 
     const hasSelection = selectedValue.length >= 1;
@@ -509,7 +507,7 @@ export const Combobox: FC<ComboboxProps> = ({
                                 inputRef.current?.focus();
                             }}
                         >
-                            <ArrowVerticalAnimated pointingDown={isPoitingDown} />
+                            <ArrowVerticalAnimated pointingDown={isPointingDown} />
                         </IconButton>
                     </div>
                 </div>


### PR DESCRIPTION
This makes it possible for a keyboard user to navigate past the Combobox without having to select an item

ISSUES CLOSED: #3858

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
