### PR TITLE
fix: navTabs uses aria-selected to find active tab

### DIFF
--- a/packages/tabs-react/documentation/Example.tsx
+++ b/packages/tabs-react/documentation/Example.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { DevExample } from "../../../doc-utils";
+import { NavTabsExample, navTabsExampleCode, navTabsExampleKnobs } from "./NavTabsExample";
 import { TabsExample, tabsExampleCode, tabsExampleKnobs } from "./TabsExample";
 import "../../tabs/tabs.scss";
 
 export default function Example() {
     return (
         <>
+            <h2 className="jkl-heading-2">Tabs</h2>
             <DevExample component={TabsExample} knobs={tabsExampleKnobs} codeExample={tabsExampleCode} />
+            <h2 className="jkl-heading-2">NavTabs</h2>
+            <DevExample component={NavTabsExample} knobs={navTabsExampleKnobs} codeExample={navTabsExampleCode} />
         </>
     );
 }

--- a/packages/tabs-react/documentation/NavTabsExample.tsx
+++ b/packages/tabs-react/documentation/NavTabsExample.tsx
@@ -1,0 +1,65 @@
+import React, { FC, MouseEvent, useEffect, useMemo, useState } from "react";
+import { CodeExample, ExampleComponentProps, ExampleKnobsProps } from "../../../doc-utils";
+import { NavTab, NavTabs } from "../src";
+
+export const navTabsExampleKnobs: ExampleKnobsProps = {};
+
+export const NavTabsExample: FC<ExampleComponentProps> = () => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    const tabs = useMemo(
+        () => [
+            { href: "#/eksempler", children: "Eksempler" },
+            { href: "#/bruk", children: "Bruk" },
+            { href: "#/tekst", children: "Tekst" },
+            { href: "#/spec", children: "Design spec" },
+            { href: "#/kode", children: "Kode" },
+        ],
+        [],
+    );
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+        const selectedIndex = tabs.findIndex((tab) => tab.href === window.location.hash);
+
+        setSelectedIndex(selectedIndex !== -1 ? selectedIndex : 0);
+    }, [tabs]);
+
+    return (
+        <NavTabs>
+            {tabs.map((tab, index) => (
+                <NavTab
+                    key={index}
+                    {...tab}
+                    aria-selected={selectedIndex === index}
+                    onClick={(e: MouseEvent) => {
+                        setSelectedIndex(index);
+                    }}
+                />
+            ))}
+        </NavTabs>
+    );
+};
+
+export const navTabsExampleCode: CodeExample = () => `
+<NavTabs>
+    {/* Sett aria-selected til true for den nåværende routen. */}
+    <NavTab aria-selected={true} href="/eksempler">
+        Eksempler
+    </NavTab>
+    <NavTab aria-selected={false} href="/bruk">
+        Bruk
+    </NavTab>
+    <NavTab aria-selected={false} href="/tekst">
+        Tekst
+    </NavTab>
+    <NavTab aria-selected={false} href="/spec">
+        Design Spec
+    </NavTab>
+    <NavTab aria-selected={false} href="/kode">
+        Kode
+    </NavTab>
+</NavTabs>
+`;

--- a/packages/tabs-react/src/NavTabs.tsx
+++ b/packages/tabs-react/src/NavTabs.tsx
@@ -23,6 +23,13 @@ export const NavTabs = ({
     const tablistRef = useRef<HTMLDivElement>(null);
     const activeRef = useRef<HTMLElement>(null);
 
+    const selectedIndex = React.Children.toArray(children).findIndex((navTab) => {
+        if (!React.isValidElement(navTab)) {
+            return false;
+        }
+        return navTab.props["aria-selected"] === true;
+    });
+
     useEffect(() => {
         if (tablistRef.current) {
             setTabsRect(tablistRef.current.getBoundingClientRect());
@@ -30,36 +37,18 @@ export const NavTabs = ({
         if (activeRef.current) {
             setActiveRect(activeRef.current.getBoundingClientRect());
         }
-    }, [density]);
-
-    const path = typeof window !== "undefined" ? window?.location?.pathname : "";
-    useEffect(() => {
-        if (scrollRef.current) {
-            const currentTab = scrollRef.current.querySelector(`[href="${path}"]`);
-            if (currentTab) {
-                setActiveRect(currentTab.getBoundingClientRect());
-            }
-        }
-    }, [path]);
-
-    // Scroll fanelisten og posisjoner markøren i tilfelle direktelink eller refresh
-    useEffect(() => {
-        if (scrollRef.current) {
-            let currentTab = scrollRef.current.querySelector(`[href="${path}"]`);
-            if (currentTab) {
-                const rect = currentTab.getBoundingClientRect();
-                scrollRef.current.scrollTo(rect.x, 0);
-                // Rekalkuler rect etter scroll
-                setActiveRect(currentTab.getBoundingClientRect());
-            }
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [selectedIndex, density]);
 
     return (
         <div {...rest} data-layout-density={density} className={cn("jkl-tabs", className)} ref={scrollRef}>
             <div role="tablist" aria-label={ariaLabel} ref={tablistRef} className="jkl-tablist">
-                {children}
+                {React.Children.map(children, (child, index) => {
+                    return React.isValidElement(child)
+                        ? React.cloneElement<any>(child, {
+                              ref: selectedIndex === index ? activeRef : undefined,
+                          })
+                        : null;
+                })}
                 <span
                     className="jkl-tablist__indicator"
                     style={{


### PR DESCRIPTION
Previously the NavTabs component only considered location.path which does not work with hash URLs

BREAKING CHANGE:
If you are not providing aria-selected to the active tab, either because you silenced the TS warning or are not using TS the active component will no longer have an underline

ISSUES CLOSED: #3863

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
