### PR TITLE
fix: handle inline elements in support labels

### DIFF
--- a/packages/datepicker-react/src/DatePicker.test.tsx
+++ b/packages/datepicker-react/src/DatePicker.test.tsx
@@ -385,26 +385,6 @@ describe("Datepicker", () => {
         expect(label).toHaveClass("jkl-label--sr-only");
     });
 
-    it("should pass density compact to all compactable child components", () => {
-        const { getByTestId, getByText } = setup(
-            <DatePicker
-                defaultValue="24.12.2019"
-                label="Hva er tid?" /* label skal være kompakt */
-                helpLabel="Tid er en flat sirkel" /* hjelpeteksten skal være kompakt */
-                density="compact"
-            />,
-        );
-
-        const label = getByText("Hva er tid?");
-        expect(label).toHaveAttribute("data-density", "compact");
-
-        const inputWrapper = getByTestId("jkl-datepicker__input-wrapper");
-        expect(inputWrapper).toHaveAttribute("data-density", "compact");
-
-        const helpText = getByText("Tid er en flat sirkel");
-        expect(helpText).toHaveAttribute("data-density", "compact");
-    });
-
     describe("after user types string", () => {
         it("should return null value for invalid string", async () => {
             const onBlur = jest.fn();

--- a/packages/input-group-react/documentation/InputGroupExample.tsx
+++ b/packages/input-group-react/documentation/InputGroupExample.tsx
@@ -17,7 +17,12 @@ export const inputGroupExampleKnobs: ExampleKnobsProps = {
 
 export const InputGroupExample: FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const helpLabel = boolValues?.["Med hjelpetekst"] ? "Fødselsnummer består av 11 siffer" : undefined;
-    const errorLabel = boolValues?.["Med feil"] ? "Du må fylle ut fødselsnummer, 11 siffer" : undefined;
+    const errorLabel = boolValues?.["Med feil"] ? (
+        <>
+            Du må fylle ut fødelsnummer eller D-nummer. Se <Link href="">guiden vår</Link> hvis du er usikker på hvordan
+            du finner D-nummer.
+        </>
+    ) : undefined;
     const labelProps = {
         variant: choiceValues?.["Variant"] as LabelVariant,
     };
@@ -52,7 +57,14 @@ export const inputGroupExampleCode: CodeExample = ({ boolValues }) => `
 <InputGroup
     label="Fødselsnummer"
     helpLabel=${boolValues?.["Med hjelpetekst"] ? `"Fødselsnummer består av 11 siffer"` : `{undefined}`}
-    errorLabel=${boolValues?.["Med feil"] ? `"Du må fylle ut fødselsnummer, 11 siffer"` : `{undefined}`}${
+    errorLabel=${
+        boolValues?.["Med feil"]
+            ? `<>
+            Du må fylle ut fødelsnummer eller D-nummer. Se <Link href="">guiden vår</Link> hvis du er usikker på hvordan
+            du finner D-nummer.
+        </>`
+            : `{undefined}`
+    }${
     boolValues?.["Med tooltip"]
         ? `
     tooltipProps={{ content: (

--- a/packages/input-group-react/src/SupportLabel.tsx
+++ b/packages/input-group-react/src/SupportLabel.tsx
@@ -98,7 +98,7 @@ export const SupportLabel: FC<SupportLabelProps> = ({
     return (
         <span id={id} className={componentClassName} {...restProps} data-density={density}>
             <Icon variant="small" className="jkl-form-support-label__icon" />
-            {errorLabel || helpLabel || label}
+            <span>{errorLabel || helpLabel || label}</span>
         </span>
     );
 };


### PR DESCRIPTION
SupportLabel uses flexbox to neatly display the text content next to the icon. This fix wraps the supplied label in a div to avoid having it participate in the parents flex layout

ISSUES CLOSED: #3892

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
