### PR TITLE
fix: handle Files with path set better

### DIFF
--- a/packages/file-input-react/documentation/FileInputExample.tsx
+++ b/packages/file-input-react/documentation/FileInputExample.tsx
@@ -8,7 +8,7 @@ import { File, FileInput, FileInputFile, FileInputFileState } from "../src";
 import iconBytes from "./iconBytes";
 
 export const fileInputExampleKnobs: ExampleKnobsProps = {
-    boolProps: ["Laster opp", "Med valideringsfeil", "Med feil", "Lastet opp"],
+    boolProps: ["Laster opp", "Med valideringsfeil", "Med feil", "Lastet opp", "Filer med path"],
     choiceProps: [
         {
             name: "Variant",
@@ -108,6 +108,7 @@ export const FileInputExample: FC<ExampleComponentProps> = ({ boolValues, choice
                             fileName={file.name}
                             fileType={file.type}
                             fileSize={file.size}
+                            path={boolValues?.["Filer med path"] ? `/path/fil-${index}` : undefined}
                             file={file}
                             state={demoState}
                             supportLabel={label}
@@ -215,6 +216,7 @@ return (
                         fileType={file.type}
                         fileSize={file.size}
                         file={file}
+                        path={boolValues?.["Filer med path"] ? "/path/file.ext" : undefined
                         state={state}
                         supportLabel={label}
                         supportLabelType={labelType}

--- a/packages/file-input-react/src/File.tsx
+++ b/packages/file-input-react/src/File.tsx
@@ -32,20 +32,20 @@ export const File: FC<FileProps> = (props) => {
     const context = useFileInputContext();
     const isInFileInputContext = context !== null;
 
-    const C = path ? "a" : "div";
+    const TitleComponent = path ? "a" : "div";
     const f = (
-        <C
+        <div
             id={id}
             className={cn("jkl-file", {
                 "jkl-file--error": supportLabelType === "error",
                 "jkl-file--warning": supportLabelType === "warning",
             })}
-            href={path}
-            target={path ? "_blank" : undefined}
         >
             <Thumbnail fileName={fileName} fileType={fileType} file={file} path={path} state={state} />
             <div className="jkl-file__file-info">
-                <div className="jkl-file__title">{fileName}</div>
+                <TitleComponent href={path} target={path ? "_blank" : undefined} className="jkl-file__title">
+                    {fileName}
+                </TitleComponent>
                 <p className="jkl-file__description">
                     <span>{formatBytes(fileSize)}</span>
                     <span className="jkl-file__description-slot">{children}</span>
@@ -56,7 +56,7 @@ export const File: FC<FileProps> = (props) => {
                     <CloseIcon />
                 </IconButton>
             )}
-        </C>
+        </div>
     );
 
     if (isInFileInputContext) {

--- a/packages/file-input/_file.scss
+++ b/packages/file-input/_file.scss
@@ -44,12 +44,12 @@
     gap: var(--jkl-file-gap);
     align-items: center;
 
-    &[href] {
+    a {
         cursor: pointer;
         text-decoration: none;
-        display: block;
+        color: var(--jkl-file-color);
 
-        &:hover .jkl-file__description {
+        &:hover ~ .jkl-file__description {
             @include jkl.no-grow-bold;
         }
 

--- a/packages/file-input/file-input.scss
+++ b/packages/file-input/file-input.scss
@@ -71,6 +71,20 @@
         align-items: center;
         flex-direction: column;
         flex-wrap: nowrap;
+
+        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus-within {
+            .jkl-button {
+                transform: scale(1.05);
+
+                &::after {
+                    box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-button-focus-color);
+                }
+
+                &:active {
+                    transform: scale(1);
+                }
+            }
+        }
     }
 
     &--has-files &__call-to-action {
@@ -89,20 +103,6 @@
         display: flex;
         flex-direction: column;
         gap: var(--jkl-file-list-gap);
-    }
-
-    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus-within {
-        .jkl-button {
-            transform: scale(1.05);
-
-            &::after {
-                box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-button-focus-color);
-            }
-
-            &:active {
-                transform: scale(1);
-            }
-        }
     }
 
     &--small {


### PR DESCRIPTION
First make sure that the layout remains correct when a File has the path prop set. Secondly, change the DOM structure so that the close icon that is present when onRemove prop is set can be interacted with. This means that now only the filename itself becomes a click target when the file has a path to avoid having nested interactive elements.

ISSUES CLOSED: #3891

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
