### PR TITLE
Ny komponent: GhostButton ✨

### DIFF
--- a/packages/button-react/documentation/Anchors.tsx
+++ b/packages/button-react/documentation/Anchors.tsx
@@ -5,7 +5,7 @@ import "./style.scss";
 
 export const Anchors: React.FC<ExampleComponentProps> = () => {
     return (
-        <div className="jkl-button-example" style={{ textAlign: "center" }}>
+        <div className="jkl-button-example">
             <div>
                 <Button as="a" variant="primary" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Send inn

--- a/packages/button-react/documentation/Anchors.tsx
+++ b/packages/button-react/documentation/Anchors.tsx
@@ -5,20 +5,25 @@ import "./style.scss";
 
 export const Anchors: React.FC<ExampleComponentProps> = () => {
     return (
-        <div className="jkl-button-example">
+        <div className="jkl-button-example" style={{ textAlign: "center" }}>
             <div>
                 <Button as="a" variant="primary" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Send inn
                 </Button>
             </div>
             <div>
-                <Button as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
+                <Button variant="secondary" as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Lagre
                 </Button>
             </div>
             <div>
                 <Button variant="tertiary" as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Avbryt
+                </Button>
+            </div>
+            <div>
+                <Button variant="ghost" as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
+                    Vis mer
                 </Button>
             </div>
         </div>

--- a/packages/button-react/documentation/Anchors.tsx
+++ b/packages/button-react/documentation/Anchors.tsx
@@ -1,24 +1,25 @@
 import React from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
+import { Button } from "../src";
 import "./style.scss";
 
 export const Anchors: React.FC<ExampleComponentProps> = () => {
     return (
         <div className="jkl-button-example">
             <div>
-                <a className="jkl-button jkl-button--primary" href="/komponenter/buttons#knapper-som-er-lenker">
+                <Button as="a" variant="primary" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Send inn
-                </a>
+                </Button>
             </div>
             <div>
-                <a className="jkl-button jkl-button--secondary" href="/komponenter/buttons#knapper-som-er-lenker">
+                <Button as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Lagre
-                </a>
+                </Button>
             </div>
             <div>
-                <a className="jkl-button jkl-button--tertiary" href="/komponenter/buttons#knapper-som-er-lenker">
+                <Button variant="tertiary" as="a" href="/komponenter/buttons#knapper-rendret-som-andre-elementer">
                     Avbryt
-                </a>
+                </Button>
             </div>
         </div>
     );
@@ -26,27 +27,30 @@ export const Anchors: React.FC<ExampleComponentProps> = () => {
 
 export const AnchorsCode = `
 <div>
-    <a
-        className="jkl-button jkl-button--primary"
-        href="/komponenter/buttons#knapper-som-er-lenker"
+    <Button
+        variant="primary"
+        as="a"
+        href="/komponenter/buttons#knapper-rendret-som-andre-elementer"
     >
         Send inn
-    </a>
+    </Button>
 </div>
 <div>
-    <a
-        className="jkl-button jkl-button--secondary"
-        href="/komponenter/buttons#knapper-som-er-lenker"
+    <Button
+        variant="secondary" // Kan unnlates, secondary er standard variant
+        as="a"
+        href="/komponenter/buttons#knapper-rendret-som-andre-elementer"
     >
         Lagre
-    </a>
+    </Button>
 </div>
 <div>
-    <a
-        className="jkl-button jkl-button--tertiary"
-        href="/komponenter/buttons#knapper-som-er-lenker"
+    <Button
+        variant="tertiary"
+        as="a"
+        href="/komponenter/buttons#knapper-rendret-som-andre-elementer"
     >
         Avbryt
-    </a>
+    </Button>
 </div>
 `;

--- a/packages/button-react/documentation/ButtonExample.tsx
+++ b/packages/button-react/documentation/ButtonExample.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ExampleComponentProps, ExampleKnobsProps } from "../../../doc-utils";
+import { Ghost } from "./Ghost";
 import { Primary } from "./Primary";
 import { Secondary } from "./Secondary";
 import { Tertiary } from "./Tertiary";
@@ -27,6 +28,9 @@ export const ButtonExample: React.FC<ExampleComponentProps> = ({ boolValues, cho
             </div>
             <div>
                 <Tertiary boolValues={boolValues} choiceValues={choiceValues} />
+            </div>
+            <div>
+                <Ghost boolValues={boolValues} choiceValues={choiceValues} />
             </div>
         </div>
     );

--- a/packages/button-react/documentation/Ghost.tsx
+++ b/packages/button-react/documentation/Ghost.tsx
@@ -1,0 +1,30 @@
+import { ChevronDownIcon } from "@fremtind/jkl-icons-react";
+import React, { useState } from "react";
+import { ExampleComponentProps } from "../../../doc-utils";
+import { Button } from "../src";
+
+export const Ghost: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
+    const [showLoader] = useState(false);
+    const loader = { showLoader: showLoader || !!boolValues?.["isLoading"], textDescription: "Laster innhold" };
+
+    return (
+        <Button
+            variant="ghost"
+            loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
+            className="jkl-spacing-l--right"
+            iconRight={<ChevronDownIcon bold />}
+        >
+            Ola Nordmann
+        </Button>
+    );
+};
+
+export const ghostCode = (): string => `
+<Button
+    variant="ghost"
+    className="jkl-spacing-l--right"
+    iconRight={<ChevronDownIcon bold />}
+>
+    Ola Nordmann
+</Button>
+`;

--- a/packages/button-react/documentation/Primary.tsx
+++ b/packages/button-react/documentation/Primary.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
-import { PrimaryButton } from "../src";
+import { Button } from "../src";
 
 export const Primary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
@@ -20,7 +20,8 @@ export const Primary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVal
     };
 
     return (
-        <PrimaryButton
+        <Button
+            variant="primary"
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
             onClick={simulateLoading}
@@ -28,12 +29,13 @@ export const Primary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVal
             iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon /> : null}
         >
             Lagre og send inn
-        </PrimaryButton>
+        </Button>
     );
 };
 
 export const primaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
-<PrimaryButton
+<Button
+    variant="primary"
     loader={${
         !!boolValues?.["withLoader"]
             ? `{
@@ -50,5 +52,5 @@ export const primaryCode = ({ boolValues, choiceValues }: ExampleComponentProps)
     }}
 >
     Lagre og send inn
-</PrimaryButton>
+</Button>
 `;

--- a/packages/button-react/documentation/Secondary.tsx
+++ b/packages/button-react/documentation/Secondary.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
-import { SecondaryButton } from "../src";
+import { Button } from "../src";
 
 export const Secondary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
@@ -20,7 +20,7 @@ export const Secondary: React.FC<ExampleComponentProps> = ({ boolValues, choiceV
     };
 
     return (
-        <SecondaryButton
+        <Button
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
             onClick={simulateLoading}
@@ -28,12 +28,12 @@ export const Secondary: React.FC<ExampleComponentProps> = ({ boolValues, choiceV
             iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon /> : null}
         >
             Lagre
-        </SecondaryButton>
+        </Button>
     );
 };
 
 export const secondaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
-<SecondaryButton
+<Button
     loader={${
         !!boolValues?.["withLoader"]
             ? `{
@@ -50,5 +50,5 @@ export const secondaryCode = ({ boolValues, choiceValues }: ExampleComponentProp
     }}
 >
     Lagre
-</SecondaryButton>
+</Button>
 `;

--- a/packages/button-react/documentation/Tertiary.tsx
+++ b/packages/button-react/documentation/Tertiary.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
-import { TertiaryButton } from "../src";
+import { Button } from "../src";
 
 export const Tertiary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
@@ -20,7 +20,8 @@ export const Tertiary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVa
     };
 
     return (
-        <TertiaryButton
+        <Button
+            variant="tertiary"
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
             onClick={simulateLoading}
@@ -28,12 +29,13 @@ export const Tertiary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVa
             iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon bold /> : null}
         >
             Avbryt
-        </TertiaryButton>
+        </Button>
     );
 };
 
 export const tertiaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
-<TertiaryButton
+<Button
+    variant="tertiary"
     loader={${
         !!boolValues?.["withLoader"]
             ? `{
@@ -52,5 +54,5 @@ export const tertiaryCode = ({ boolValues, choiceValues }: ExampleComponentProps
     }}
 >
     Avbryt
-</TertiaryButton>
+</Button>
 `;

--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -12,7 +12,7 @@ import { Tertiary, tertiaryCode } from "./Tertiary";
 import { Anchors, AnchorsCode } from "./Anchors";
 import { buttonExampleKnobs } from "./ButtonExample";
 
-import { PrimaryButton, SecondaryButton, TertiaryButton } from "../src";
+import { Button } from "../src";
 
 <Ingress>
     Knapper starter en handling. Teksten på knappen forteller hva som vil skje når brukeren klikker på den.
@@ -47,13 +47,33 @@ De tre knappene har et hierarki. Når brukeren har flere knapper å velge mellom
 
 Knappetekster skal være så enkle og korte som mulig og skal oppfordre til handling. Bruk helst bare to ord:
 
-<PrimaryButton className="jkl-spacing-xl--right">Send inn</PrimaryButton>
-<SecondaryButton className="jkl-spacing-xl--right">Lagre</SecondaryButton>
-<TertiaryButton className="jkl-spacing-xl--right">Avbryt</TertiaryButton>
+<Button variant="primary" className="jkl-spacing-xl--right">
+    Send inn
+</Button>
+<Button className="jkl-spacing-xl--right">Lagre</Button>
+<Button variant="tertiary" className="jkl-spacing-xl--right">
+    Avbryt
+</Button>
 
-## Knapper som er lenker
+## Knapper rendret som andre elementer
 
-Avhengig av situasjonen kan det hende en knapp teknisk sett er et `<a />`-element. Jøkul støtter å ha knappeklasser på `<a />`.
+I noen tilfeller representerer en knapp et annet semantisk element, for eksempel en lenke. Knappekomponentene i Jøkul er derfor _polymorfe_, og kan ta inn en React-komponent eller et HTML-element den skal rendre ut.
+
+```tsx
+// Rendrer en vanlig HTML-lenke til gitt href:
+<Button type="primary" as="a" href="/order">
+    Bestill nå
+</Button>;
+
+// Rendrer en Remix-lenke som bruker rammeverkets ruting:
+import { Link } from "@remix-run/react";
+
+<Button as={Link} to="/products">
+    Se alle produkter
+</Button>;
+```
+
+Knappen tar automatisk imot riktige props og riktig `ref` for komponenten som sendes inn, slik at du får typesikkerhet.
 
 <ComponentExample component={Anchors} codeExample={AnchorsCode} />
 

--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -9,6 +9,7 @@ keywords: primary secondary tertiary primær sekundær tertiær
 import { Primary, primaryCode } from "./Primary";
 import { Secondary, secondaryCode } from "./Secondary";
 import { Tertiary, tertiaryCode } from "./Tertiary";
+import { Ghost, ghostCode } from "./Ghost";
 import { Anchors, AnchorsCode } from "./Anchors";
 import { buttonExampleKnobs } from "./ButtonExample";
 
@@ -35,13 +36,17 @@ import { Button } from "../src";
 
 <ComponentExample title="TertiaryButton" component={Tertiary} knobs={buttonExampleKnobs} codeExample={tertiaryCode} />
 
+**Ghost-knapp:** brukes til sekundære handlinger som å åpne menyer. Bruk den gjerne som triggerelement for [ContextualMenu](/komponenter/contextualmenu)
+
+<ComponentExample title="GhostButton" component={Ghost} codeExample={ghostCode} />
+
 ## Lastemodus
 
 Hvis du skal bruke lastemodus i knappen må du sørge for at `@fremtind/jkl-loader/loader.min.css` er lastet inn i klienten.
 
 ## Knappetyper
 
-De tre knappene har et hierarki. Når brukeren har flere knapper å velge mellom, skal vi kun ha én primærknapp.
+Knappene våre har et hierarki. Når brukeren har flere knapper å velge mellom, skal vi kun ha én primærknapp.
 
 ## Tekst på knapper
 

--- a/packages/button-react/documentation/style.scss
+++ b/packages/button-react/documentation/style.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    align-items: center;
     width: 100%;
 
     > *:not(:last-child) {

--- a/packages/button-react/src/BaseButton.tsx
+++ b/packages/button-react/src/BaseButton.tsx
@@ -1,6 +1,0 @@
-import React, { forwardRef } from "react";
-import { Props } from "./types";
-
-export const BaseButton = forwardRef<HTMLButtonElement, Props>((props, ref) => <button {...props} ref={ref} />);
-
-BaseButton.displayName = "BaseButton";

--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -2,31 +2,25 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import React, { useState } from "react";
-import { PrimaryButton, SecondaryButton, TertiaryButton } from ".";
-
-const buttonVariants = [
-    { name: "primary", component: PrimaryButton },
-    { name: "secondary", component: SecondaryButton },
-    { name: "tertiary", component: TertiaryButton },
-];
+import { Button } from "./Button";
+import { buttonVariants } from "./types";
 
 describe("Button", () => {
     buttonVariants.map((buttonVariant) => {
-        it(`renders the ${buttonVariant.name} button correctly`, () => {
-            const { name, component: Button } = buttonVariant;
+        it(`renders the ${buttonVariant} button correctly`, () => {
             render(
-                <Button data-testid={name} onClick={() => {}}>
-                    {name}
+                <Button variant={buttonVariant} data-testid={buttonVariant} onClick={() => {}}>
+                    {buttonVariant}
                 </Button>,
             );
 
-            expect(screen.getByTestId(name)).toHaveClass(`jkl-button--${name}`);
+            expect(screen.getByTestId(buttonVariant)).toHaveClass(`jkl-button--${buttonVariant}`);
         });
     });
 
     it("calls the onClick handler when clicked", async () => {
         const clickHandler = jest.fn();
-        render(<PrimaryButton onClick={clickHandler}>I am groot!</PrimaryButton>);
+        render(<Button onClick={clickHandler}>I am groot!</Button>);
 
         const button = screen.getByText("I am groot!");
 
@@ -39,9 +33,9 @@ describe("Button", () => {
 
     it("applies passed classNames", () => {
         render(
-            <PrimaryButton data-testid="test" className="test-class" onClick={() => {}}>
+            <Button data-testid="test" className="test-class" onClick={() => {}}>
                 test
-            </PrimaryButton>,
+            </Button>,
         );
 
         expect(screen.getByTestId("test")).toHaveClass("test-class");
@@ -49,9 +43,9 @@ describe("Button", () => {
 
     it("applies compact mode", () => {
         render(
-            <PrimaryButton data-testid="test" density="compact" onClick={() => {}}>
+            <Button data-testid="test" density="compact" onClick={() => {}}>
                 test
-            </PrimaryButton>,
+            </Button>,
         );
 
         expect(screen.getByTestId("test")).toHaveAttribute("data-density", "compact");
@@ -77,13 +71,14 @@ describe("Button", () => {
                     >
                         Increment
                     </button>
-                    <PrimaryButton
+                    <Button
+                        variant="primary"
                         onClick={() => {
                             props.onClick(counter);
                         }}
                     >
                         Submit form
-                    </PrimaryButton>
+                    </Button>
                 </div>
             );
         }
@@ -105,19 +100,21 @@ describe("Button", () => {
 
 describe("a11y", () => {
     buttonVariants.map((buttonVariant) => {
-        it(`${buttonVariant.name} should be a11y compliant`, async () => {
-            const { name, component: Button } = buttonVariant;
-            const { container } = render(<Button onClick={() => {}}>{name}</Button>);
+        it(`${buttonVariant} should be a11y compliant`, async () => {
+            const { container } = render(
+                <Button variant={buttonVariant} onClick={() => {}}>
+                    {buttonVariant}
+                </Button>,
+            );
             const results = await axe(container);
 
             expect(results).toHaveNoViolations();
         });
 
-        it(`${buttonVariant.name} should be a11y compliant in compact mode`, async () => {
-            const { name, component: Button } = buttonVariant;
+        it(`${buttonVariant} should be a11y compliant in compact mode`, async () => {
             const { container } = render(
-                <Button density="compact" onClick={() => {}}>
-                    {name}
+                <Button variant={buttonVariant} density="compact" onClick={() => {}}>
+                    {buttonVariant}
                 </Button>,
             );
             const results = await axe(container);
@@ -126,13 +123,16 @@ describe("a11y", () => {
         });
 
         [false, true].map((showLoader) => {
-            it(`${buttonVariant.name} sets aria-hidden="${String(
+            it(`${buttonVariant} sets aria-hidden="${String(
                 !showLoader,
             )}" on loader when showLoader is ${showLoader}`, async () => {
-                const { name, component: Button } = buttonVariant;
                 render(
-                    <Button loader={{ showLoader, textDescription: "Vennligst vent" }} onClick={() => {}}>
-                        {name}
+                    <Button
+                        variant={buttonVariant}
+                        loader={{ showLoader, textDescription: "Vennligst vent" }}
+                        onClick={() => {}}
+                    >
+                        {buttonVariant}
                     </Button>,
                 );
                 const loader = screen.getByTestId("jkl-loader");

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -36,7 +36,12 @@ export const Button = React.forwardRef(function Button<ElementType extends React
                 target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
                 target.style.setProperty("--jkl-touch-ycoord", Ycoord.toPrecision(4) + "px");
                 target.classList.add("jkl-button--pressed");
-                setTimeout(() => target.classList.remove("jkl-button--pressed"), 400);
+
+                setTimeout(() => {
+                    target.classList.remove("jkl-button--pressed");
+                    target.style.removeProperty("--jkl-touch-xcoord");
+                    target.style.removeProperty("--jkl-touch-ycoord");
+                }, 400);
             }
         },
         [onTouchStart],

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -79,14 +79,28 @@ export const Button = React.forwardRef(function Button<ElementType extends React
     );
 }) as ButtonComponent;
 
-export function PrimaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
-    return <Button {...props} variant="primary" />;
+export function PrimaryButton<ElementType extends React.ElementType = "button">(
+    props: Omit<ButtonProps<ElementType>, "variant">,
+) {
+    const buttonProps = { ...props, variant: "primary" } as ButtonProps<ElementType>;
+    return <Button {...buttonProps} />;
 }
 
-export function SecondaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
-    return <Button {...props} variant="secondary" />;
+export function SecondaryButton<ElementType extends React.ElementType = "button">(
+    props: Omit<ButtonProps<ElementType>, "variant">,
+) {
+    const buttonProps = { ...props, variant: "secondary" } as ButtonProps<ElementType>;
+    return <Button {...buttonProps} />;
 }
 
 export function TertiaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
-    return <Button {...props} variant="tertiary" />;
+    const buttonProps = { ...props, variant: "tertiary" } as ButtonProps<ElementType>;
+    return <Button {...buttonProps} />;
+}
+
+export function GhostButton<ElementType extends React.ElementType = "button">(
+    props: Omit<ButtonProps<ElementType>, "variant" | "loader">,
+) {
+    const buttonProps = { ...props, variant: "ghost" } as ButtonProps<ElementType>;
+    return <Button {...buttonProps} />;
 }

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -2,7 +2,7 @@ import type { PolymorphicRef } from "@fremtind/jkl-core";
 import { Loader } from "@fremtind/jkl-loader-react";
 import { useAriaLiveRegion } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
-import React, { type TouchEvent, useCallback } from "react";
+import React, { ButtonHTMLAttributes, type TouchEvent, useCallback } from "react";
 import type { ButtonComponent, ButtonProps } from "./types";
 
 export const Button = React.forwardRef(function Button<ElementType extends React.ElementType = "button">(
@@ -85,20 +85,25 @@ export const Button = React.forwardRef(function Button<ElementType extends React
 }) as ButtonComponent;
 
 export function PrimaryButton<ElementType extends React.ElementType = "button">(
-    props: Omit<ButtonProps<ElementType>, "variant">,
+    props: Omit<ButtonProps<ElementType>, "variant" | "onClick" | "as"> &
+        Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">,
 ) {
     const buttonProps = { ...props, variant: "primary" } as ButtonProps<ElementType>;
     return <Button {...buttonProps} />;
 }
 
 export function SecondaryButton<ElementType extends React.ElementType = "button">(
-    props: Omit<ButtonProps<ElementType>, "variant">,
+    props: Omit<ButtonProps<ElementType>, "variant" | "onClick" | "as"> &
+        Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">,
 ) {
     const buttonProps = { ...props, variant: "secondary" } as ButtonProps<ElementType>;
     return <Button {...buttonProps} />;
 }
 
-export function TertiaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
+export function TertiaryButton<ElementType extends React.ElementType = "button">(
+    props: Omit<ButtonProps<ElementType>, "variant" | "onClick" | "as"> &
+        Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">,
+) {
     const buttonProps = { ...props, variant: "tertiary" } as ButtonProps<ElementType>;
     return <Button {...buttonProps} />;
 }

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -1,73 +1,92 @@
+import type { PolymorphicRef } from "@fremtind/jkl-core";
 import { Loader } from "@fremtind/jkl-loader-react";
 import { useAriaLiveRegion } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
-import React, { forwardRef, TouchEvent, useCallback } from "react";
-import { BaseButton } from "./BaseButton";
-import { Props, ValidButtons } from "./types";
-const makeButtonComponent = (buttonType: ValidButtons) => {
-    const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
-        const { children, className, density, onClick, onTouchStart, loader, iconLeft, iconRight, ...rest } = props;
+import React, { type TouchEvent, useCallback } from "react";
+import type { ButtonComponent, ButtonProps } from "./types";
 
-        const handleTouch = useCallback(
-            (event: TouchEvent<HTMLButtonElement>) => {
-                onTouchStart && onTouchStart(event);
+export const Button = React.forwardRef(function Button<ElementType extends React.ElementType = "button">(
+    props: ButtonProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const {
+        as = "button",
+        children,
+        className,
+        density,
+        onTouchStart,
+        loader,
+        iconLeft,
+        iconRight,
+        type = as === "button" ? "button" : undefined,
+        variant = "secondary",
+        ...rest
+    } = props;
 
-                const target = event.target as HTMLButtonElement;
-                if (target && event.targetTouches.length) {
-                    const Xcoord = event.targetTouches[0].clientX - target.getBoundingClientRect().x;
-                    const Ycoord = event.targetTouches[0].clientY - target.getBoundingClientRect().y;
-                    target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
-                    target.style.setProperty("--jkl-touch-ycoord", Ycoord.toPrecision(4) + "px");
-                    target.classList.add("jkl-button--pressed");
-                    setTimeout(() => target.classList.remove("jkl-button--pressed"), 400);
-                }
-            },
-            [onTouchStart],
-        );
+    const Component = as;
 
-        const ariaLive = useAriaLiveRegion(loader?.showLoader);
+    const handleTouch = useCallback(
+        (event: TouchEvent<HTMLButtonElement>) => {
+            onTouchStart && onTouchStart(event);
 
-        return (
-            <BaseButton
-                {...ariaLive}
-                data-density={density}
-                className={cn("jkl-button", "jkl-button--" + buttonType, className, {
-                    "jkl-button--icon-left": iconLeft,
-                    "jkl-button--icon-right": iconRight,
-                })}
-                disabled={loader?.showLoader}
-                onClick={onClick}
-                onTouchStart={handleTouch}
-                {...rest}
-                ref={ref}
-            >
-                <div className="jkl-button__content">
-                    <div
-                        className={cn("jkl-button__slider", {
-                            "jkl-button__slider--show-loader": !!loader?.showLoader,
-                        })}
-                    >
-                        {iconLeft && <span className="jkl-button__icon">{iconLeft}</span>}
-                        <span className="jkl-button__children">{children}</span>
-                        {iconRight && <span className="jkl-button__icon">{iconRight}</span>}
+            const target = event.target as HTMLButtonElement;
+            if (target && event.targetTouches.length) {
+                const Xcoord = event.targetTouches[0].clientX - target.getBoundingClientRect().x;
+                const Ycoord = event.targetTouches[0].clientY - target.getBoundingClientRect().y;
+                target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
+                target.style.setProperty("--jkl-touch-ycoord", Ycoord.toPrecision(4) + "px");
+                target.classList.add("jkl-button--pressed");
+                setTimeout(() => target.classList.remove("jkl-button--pressed"), 400);
+            }
+        },
+        [onTouchStart],
+    );
 
-                        {loader && (
-                            <div className="jkl-button__loader">
-                                <Loader textDescription={loader.textDescription} aria-hidden={!loader.showLoader} />
-                            </div>
-                        )}
-                    </div>
+    const ariaLive = useAriaLiveRegion(loader?.showLoader);
+
+    return (
+        <Component
+            {...ariaLive}
+            data-density={density}
+            className={cn("jkl-button", "jkl-button--" + variant, className, {
+                "jkl-button--icon-left": iconLeft,
+                "jkl-button--icon-right": iconRight,
+            })}
+            disabled={as === "button" ? loader?.showLoader : undefined}
+            onTouchStart={handleTouch}
+            {...rest}
+            type={type}
+            ref={ref}
+        >
+            <div className="jkl-button__content">
+                <div
+                    className={cn("jkl-button__slider", {
+                        "jkl-button__slider--show-loader": !!loader?.showLoader,
+                    })}
+                >
+                    {iconLeft && <span className="jkl-button__icon">{iconLeft}</span>}
+                    <span className="jkl-button__children">{children}</span>
+                    {iconRight && <span className="jkl-button__icon">{iconRight}</span>}
+
+                    {loader && (
+                        <div className="jkl-button__loader">
+                            <Loader textDescription={loader.textDescription} aria-hidden={!loader.showLoader} />
+                        </div>
+                    )}
                 </div>
-            </BaseButton>
-        );
-    });
-    Button.displayName = "BaseButton";
-    return Button;
-};
+            </div>
+        </Component>
+    );
+}) as ButtonComponent;
 
-export const PrimaryButton = makeButtonComponent("primary");
-PrimaryButton.displayName = "PrimaryButton";
-export const SecondaryButton = makeButtonComponent("secondary");
-SecondaryButton.displayName = "SecondaryButton";
-export const TertiaryButton = makeButtonComponent("tertiary");
-TertiaryButton.displayName = "TertiaryButton";
+export function PrimaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
+    return <Button {...props} variant="primary" />;
+}
+
+export function SecondaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
+    return <Button {...props} variant="secondary" />;
+}
+
+export function TertiaryButton<ElementType extends React.ElementType = "button">(props: ButtonProps<ElementType>) {
+    return <Button {...props} variant="tertiary" />;
+}

--- a/packages/button-react/src/index.ts
+++ b/packages/button-react/src/index.ts
@@ -1,8 +1,2 @@
-import { PrimaryButton, SecondaryButton, TertiaryButton } from "./Button";
-import { Props as ButtonPropsInterface } from "./types";
-
-interface ButtonProps extends ButtonPropsInterface {}
-
-export type { ButtonProps };
-
-export { PrimaryButton, SecondaryButton, TertiaryButton };
+export { Button, PrimaryButton, SecondaryButton, TertiaryButton } from "./Button";
+export type { ButtonProps, ButtonVariant } from "./types";

--- a/packages/button-react/src/types.ts
+++ b/packages/button-react/src/types.ts
@@ -1,16 +1,27 @@
-import { Density } from "@fremtind/jkl-core";
-import { ButtonHTMLAttributes, ReactNode } from "react";
+import { Density, PolymorphicPropsWithRef } from "@fremtind/jkl-core";
 
-export interface Props extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
-    density?: Density;
-    className?: string;
-    loader?: {
-        showLoader: boolean;
-        textDescription: string;
-    };
-    iconLeft?: ReactNode;
-    iconRight?: ReactNode;
-    children: ReactNode;
-}
+export const buttonVariants = ["primary", "secondary", "tertiary"] as const;
+export type ButtonVariant = (typeof buttonVariants)[number];
 
-export type ValidButtons = "primary" | "secondary" | "tertiary";
+export type ButtonProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        density?: Density;
+        /**
+         * Hvilken variant av knappen skal vises
+         * @default "secondary"
+         */
+        variant?: ButtonVariant;
+        className?: string;
+        loader?: {
+            showLoader: boolean;
+            textDescription: string;
+        };
+        iconLeft?: React.ReactNode;
+        iconRight?: React.ReactNode;
+    }
+>;
+
+export type ButtonComponent = <ElementType extends React.ElementType = "button">(
+    props: ButtonProps<ElementType>,
+) => React.ReactElement | null;

--- a/packages/button-react/src/types.ts
+++ b/packages/button-react/src/types.ts
@@ -1,6 +1,6 @@
 import { Density, PolymorphicPropsWithRef } from "@fremtind/jkl-core";
 
-export const buttonVariants = ["primary", "secondary", "tertiary"] as const;
+export const buttonVariants = ["primary", "secondary", "tertiary", "ghost"] as const;
 export type ButtonVariant = (typeof buttonVariants)[number];
 
 export type ButtonProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -137,12 +137,20 @@ a.jkl-button {
     &--ghost {
         --border-color: transparent;
         border-radius: jkl.rem(4px);
-        padding: 0 jkl.$spacing-12;
+        padding: 0 jkl.$spacing-4;
 
         html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
         html:not([data-touchnavigation]) &:hover {
             --background-color: var(--jkl-color-background-interactive-hover);
             transform: scale(1);
+        }
+
+        &.jkl-button--icon-left .jkl-button__children {
+            padding-left: var(--jkl-button-children-padding-with-icon);
+        }
+
+        &.jkl-button--icon-right .jkl-button__children {
+            padding-right: var(--jkl-button-children-padding-with-icon);
         }
     }
 

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -7,24 +7,6 @@ $_flash-animation-name: jkl-flash-#{string.unique-id()};
 $_tertiary-flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
 $_hover-elevation-distance: -0.25rem;
 
-@include jkl.light-mode-variables {
-    --jkl-button-border-color: #{jkl.$color-granitt};
-    --jkl-button-text-color: #{jkl.$color-granitt};
-    --jkl-button-background-color: transparent;
-    --jkl-button-focus-color: #{jkl.$color-granitt};
-    --jkl-button-primary-text-color: #{jkl.$color-snohvit};
-    --jkl-button-primary-background-color: #{jkl.$color-granitt};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-button-border-color: #{jkl.$color-snohvit};
-    --jkl-button-text-color: #{jkl.$color-snohvit};
-    --jkl-button-background-color: transparent;
-    --jkl-button-focus-color: #{jkl.$color-snohvit};
-    --jkl-button-primary-text-color: #{jkl.$color-granitt};
-    --jkl-button-primary-background-color: #{jkl.$color-snohvit};
-}
-
 $_button-border-width: jkl.rem(1px);
 $_focus-ring-distance: jkl.rem(4px);
 $_focus-ring-width: jkl.rem(2px);
@@ -62,10 +44,18 @@ a.jkl-button {
 }
 
 .jkl-button {
+    --border-color: var(--jkl-color-background-action);
+    --text-color: var(--jkl-color-background-action);
+    --focus-color: var(--jkl-color-background-action);
+    --background-color: transparent;
+
     @include jkl.reset-outline;
     display: inline-flex;
     box-sizing: border-box;
     justify-content: center;
+
+    background-color: var(--background-color);
+    color: var(--text-color);
 
     @include jkl.use-font-variables("jkl-button");
 
@@ -89,6 +79,11 @@ a.jkl-button {
     html:not([data-touchnavigation]) &:active,
     &:active {
         transform: scale(1);
+    }
+
+    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
+        outline: $_focus-ring-width solid var(--focus-color);
+        outline-offset: jkl.rem(2px);
     }
 
     html[data-touchnavigation] &--pressed {
@@ -121,21 +116,11 @@ a.jkl-button {
     // ********* VARIANTS *********
 
     &--primary,
-    &--secondary {
-        border: solid $_button-border-width var(--jkl-button-border-color);
+    &--secondary,
+    &--ghost {
+        border: solid $_button-border-width var(--border-color);
         border-radius: 999px;
         padding: var(--jkl-button-padding);
-
-        &::after {
-            border-radius: 99px;
-            border: solid $_focus-ring-width transparent;
-            box-shadow: none;
-            transition: box-shadow $_animation-timing;
-            content: "";
-            position: absolute;
-            inset: var(--jkl-button-focus-ring-placement) var(--jkl-button-focus-ring-placement)
-                var(--jkl-button-focus-ring-placement) var(--jkl-button-focus-ring-placement);
-        }
 
         &::before {
             content: "";
@@ -144,46 +129,41 @@ a.jkl-button {
             inset: 0;
         }
 
-        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
-            &::after {
-                box-shadow: 0 0 0 $_focus-ring-width var(--jkl-button-focus-color);
-            }
-        }
-
         html[data-touchnavigation] &.jkl-button--pressed::before {
             animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_flash-animation-name;
         }
     }
 
-    &--primary {
-        background-color: var(--jkl-button-primary-background-color);
-        color: var(--jkl-button-primary-text-color);
+    &--ghost {
+        --border-color: transparent;
+        border-radius: jkl.rem(4px);
+        padding: 0 jkl.$spacing-12;
 
-        &:hover,
         html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
-        html[data-touchnavigation] &.jkl-button--pressed {
-            background-color: var(--jkl-button-focus-color);
-            border-color: var(--jkl-button-focus-color);
+        html:not([data-touchnavigation]) &:hover {
+            --background-color: var(--jkl-color-background-interactive-hover);
+            transform: scale(1);
         }
     }
 
+    &--primary {
+        --background-color: var(--jkl-color-background-action);
+        --text-color: var(--jkl-color-text-on-action);
+    }
+
     &--secondary {
-        background-color: var(--jkl-button-background-color);
-        color: var(--jkl-button-text-color);
         transition-property: box-shadow, transform, background-color;
 
         &:hover,
         html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
         html[data-touchnavigation] &.jkl-button--pressed {
-            box-shadow: inset 0 0 0 1px var(--jkl-button-border-color), inset 0 0 0 1px var(--jkl-button-border-color);
+            box-shadow: inset 0 0 0 1px var(--border-color), inset 0 0 0 1px var(--border-color);
         }
     }
 
     &--tertiary {
-        border-bottom: solid $_button-border-width var(--jkl-button-border-color);
+        border-bottom: solid $_button-border-width var(--border-color);
         border-top: solid $_button-border-width transparent;
-        background-color: transparent;
-        color: var(--jkl-button-text-color);
         padding: var(--jkl-button-tertiary-padding);
         transition: transform $_animation-timing, border $_animation-timing;
         min-width: unset;
@@ -220,10 +200,6 @@ a.jkl-button {
         html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
             border: none;
 
-            &::after {
-                box-shadow: 0 0 0 $_focus-ring-width var(--jkl-button-focus-color);
-            }
-
             @include jkl.forced-colors-mode {
                 border: revert;
             }
@@ -232,9 +208,9 @@ a.jkl-button {
         &:hover,
         html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
         html[data-touchnavigation] &.jkl-button--pressed {
-            border-bottom-color: var(--jkl-button-focus-color);
+            border-bottom-color: var(--focus-color);
             border-bottom-width: $_focus-ring-width;
-            color: var(--jkl-button-focus-color);
+            color: var(--focus-color);
         }
     }
 
@@ -305,26 +281,26 @@ a.jkl-button {
 
 @keyframes #{$_flash-animation-name} {
     0% {
-        box-shadow: 0 0 0 0 var(--jkl-button-focus-color);
+        box-shadow: 0 0 0 0 var(--focus-color);
         opacity: 0.5;
     }
 
     100% {
-        box-shadow: 0 0 0 #{jkl.rem(16px)} var(--jkl-button-focus-color);
+        box-shadow: 0 0 0 #{jkl.rem(16px)} var(--focus-color);
         opacity: 0;
     }
 }
 
 @keyframes #{$_tertiary-flash-animation-name} {
     0% {
-        box-shadow: 0 0 0 0 var(--jkl-button-focus-color);
-        background-color: var(--jkl-button-focus-color);
+        box-shadow: 0 0 0 0 var(--focus-color);
+        background-color: var(--focus-color);
         opacity: 0.5;
     }
 
     100% {
-        box-shadow: 0 0 0 #{jkl.rem(40px)} var(--jkl-button-focus-color);
-        background-color: var(--jkl-button-focus-color);
+        box-shadow: 0 0 0 #{jkl.rem(40px)} var(--focus-color);
+        background-color: var(--focus-color);
         opacity: 0;
     }
 }

--- a/packages/card-react/src/Card.tsx
+++ b/packages/card-react/src/Card.tsx
@@ -1,12 +1,10 @@
-import { PrimaryButton, SecondaryButton, TertiaryButton } from "@fremtind/jkl-button-react";
+import { Button, type ButtonVariant } from "@fremtind/jkl-button-react";
 import { WithOptionalChildren } from "@fremtind/jkl-core";
 import classNames from "classnames";
 import React, { MouseEventHandler, FC } from "react";
 
-type validButtons = "primary" | "secondary" | "tertiary";
-
 type Action = {
-    type: validButtons;
+    type: ButtonVariant;
     name: string;
     onClick: MouseEventHandler<HTMLButtonElement>;
 };
@@ -40,20 +38,6 @@ export const Card: FC<Props> = ({ title, children, className, media, action, dar
         "jkl-card--clickable": clickable,
     });
 
-    let Button = PrimaryButton;
-    if (action) {
-        switch (action.type) {
-            case "secondary":
-                Button = SecondaryButton;
-                break;
-            case "tertiary":
-                Button = TertiaryButton;
-                break;
-            default:
-                break;
-        }
-    }
-
     return (
         <div data-testid="jkl-card" className={componentClassName}>
             {media && (
@@ -73,7 +57,9 @@ export const Card: FC<Props> = ({ title, children, className, media, action, dar
             <div className="jkl-card__children">{children}</div>
             {action && (
                 <div className="jkl-card__action">
-                    <Button onClick={action.onClick}>{action.name}</Button>
+                    <Button variant={action.type || "primary"} onClick={action.onClick}>
+                        {action.name}
+                    </Button>
                 </div>
             )}
         </div>

--- a/packages/contextual-menu-react/documentation/ContextualMenuExample.tsx
+++ b/packages/contextual-menu-react/documentation/ContextualMenuExample.tsx
@@ -1,9 +1,8 @@
-import { IconButton } from "@fremtind/jkl-icon-button-react";
-import { CopyIcon, DotsIcon, InfoIcon } from "@fremtind/jkl-icons-react";
+import { ErrorIcon, ChevronDownIcon } from "@fremtind/jkl-icons-react";
 import React, { FC } from "react";
 import { ExampleComponentProps, ExampleKnobsProps, CodeExample } from "../../../doc-utils";
+import { Button } from "../../button-react";
 import { ContextualMenu } from "../src/ContextualMenu";
-import { ContextualMenuDivider } from "../src/ContextualMenuDivider";
 import { ContextualMenuItem } from "../src/ContextualMenuItem";
 
 export const contextualMenuExampleKnobs: ExampleKnobsProps = {
@@ -26,41 +25,23 @@ export const ContextualMenuExample: FC<ExampleComponentProps> = ({ boolValues, c
         <div
             style={{
                 width: "500px",
+                textAlign: "center",
             }}
         >
             <ContextualMenu
                 id={key}
-                initialPlacement="bottom-start"
+                initialPlacement="bottom-end"
                 isOpen={isOpen}
                 keepOpenOnClickOutside={boolValues?.["Ikke lukk ved klikk utenfor"]}
                 triggerElement={
-                    <IconButton
-                        data-testid="trigger-contextual-menu"
-                        title="En kontekstuell meny med eksempelvalg for å demonstrere mulighetene i komponenten"
-                    >
-                        <DotsIcon bold />
-                    </IconButton>
+                    <Button variant="ghost" iconRight={<ChevronDownIcon bold />}>
+                        Ola Nordmann
+                    </Button>
                 }
             >
-                <ContextualMenuItem icon={<InfoIcon />}>Menyvalg 1</ContextualMenuItem>
-                <ContextualMenuItem onClick={() => console.log("Hei fra Menyvalg 2")}>Menyvalg 2</ContextualMenuItem>
-                <ContextualMenuDivider />
-                <ContextualMenu
-                    openOnHover
-                    triggerElement={
-                        <ContextualMenuItem expandable>Ekspanderende menyvalg med veldig lang tekst</ContextualMenuItem>
-                    }
-                >
-                    <ContextualMenuItem icon={<InfoIcon />}>Ekspandert menyvalg</ContextualMenuItem>
-                    <ContextualMenuItem>Ekspandert menyvalg med mer tekst</ContextualMenuItem>
-                </ContextualMenu>
-                <ContextualMenu
-                    openOnHover
-                    triggerElement={<ContextualMenuItem expandable>Ekspanderende menyvalg</ContextualMenuItem>}
-                >
-                    <ContextualMenuItem icon={<CopyIcon />}>Ekspandert menyvalg</ContextualMenuItem>
-                    <ContextualMenuItem>Ekspandert menyvalg med mer tekst</ContextualMenuItem>
-                </ContextualMenu>
+                <ContextualMenuItem>Forsikringsprofil</ContextualMenuItem>
+                <ContextualMenuItem onClick={() => console.log("Hei fra Dokumenter")}>Dokumenter</ContextualMenuItem>
+                <ContextualMenuItem icon={<ErrorIcon />}>Skadesaker</ContextualMenuItem>
             </ContextualMenu>
         </div>
     );
@@ -73,32 +54,16 @@ export const contextualMenuExampleCode: CodeExample = ({ boolValues, choiceValue
 
     return `
 <ContextualMenu
-    initialPlacement="bottom-start"${isOpen}${keepOpen}
+    initialPlacement="bottom-end"${isOpen}${keepOpen}
     triggerElement={
-        <IconButton title="En kontekstuell meny med eksempelvalg for å demonstrere mulighetene i komponenten">
-            <DotsIcon bold />
-        </IconButton>
+        <Button variant="ghost" iconRight={<ChevronDownIcon bold />}>
+            Ola Nordmann
+        </Button>
     }
 >
-    <ContextualMenuItem icon={<InfoIcon />}>Menyvalg 1</ContextualMenuItem>
-    <ContextualMenuItem onClick={() => console.log("Hei fra Menyvalg 2")}>Menyvalg 2</ContextualMenuItem>
-    <ContextualMenuDivider />
-    <ContextualMenu
-        openOnHover
-        triggerElement={
-            <ContextualMenuItem expandable>Ekspanderende menyvalg med veldig lang tekst</ContextualMenuItem>
-        }
-    >
-        <ContextualMenuItem icon={<InfoIcon />}>Ekspandert menyvalg</ContextualMenuItem>
-        <ContextualMenuItem>Ekspandert menyvalg med mer tekst</ContextualMenuItem>
-    </ContextualMenu>
-    <ContextualMenu
-        openOnHover
-        triggerElement={<ContextualMenuItem expandable>Ekspanderende menyvalg</ContextualMenuItem>}
-    >
-        <ContextualMenuItem icon={<CopyIcon />}>Ekspandert menyvalg</ContextualMenuItem>
-        <ContextualMenuItem>Ekspandert menyvalg med mer tekst</ContextualMenuItem>
-    </ContextualMenu>
+    <ContextualMenuItem>Forsikringsprofil</ContextualMenuItem>
+    <ContextualMenuItem onClick={() => console.log("Hei fra Skadesaker")}>Dokumenter</ContextualMenuItem>
+    <ContextualMenuItem icon={<ErrorIcon />}>Skadesaker</ContextualMenuItem>
 </ContextualMenu>
 `;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export type { LinkProps, NavLinkProps, ScreenReaderOnlyProps } from "./component
 export { Link, NavLink, ScreenReaderOnly } from "./components";
 export type { ColorScheme, DataTestAutoId, ValuePair, WithChildren, WithOptionalChildren } from "./types";
 export { default as tokens } from "./tokens";
+export type { PolymorphicProps, PolymorphicPropsWithRef, PolymorphicRef } from "./polymorphism";

--- a/packages/core/src/polymorphism.ts
+++ b/packages/core/src/polymorphism.ts
@@ -1,0 +1,17 @@
+type ElementTypeProp<ElementType extends React.ElementType> = {
+    as?: ElementType;
+};
+
+type PropsToOmit<ElementType extends React.ElementType, Props> = keyof (ElementTypeProp<ElementType> & Props);
+
+export type PolymorphicProps<ElementType extends React.ElementType, Props = {}> = React.PropsWithChildren<
+    Props & ElementTypeProp<ElementType>
+> &
+    Omit<React.ComponentPropsWithoutRef<ElementType>, PropsToOmit<ElementType, Props>>;
+
+export type PolymorphicRef<ElementType extends React.ElementType> = React.ComponentPropsWithRef<ElementType>["ref"];
+
+export type PolymorphicPropsWithRef<ElementType extends React.ElementType, Props = {}> = PolymorphicProps<
+    ElementType,
+    Props
+> & { ref?: PolymorphicRef<ElementType> };


### PR DESCRIPTION
Ny knappekomponent, `GhostButton`

I tillegg til å legge til ny variant av knapper, er knappekomponenten bygget om med ny/endret funksjonalitet:
- **Polymorfisme**: Du kan nå bestemme hvilket element/hvilken komponent knappen skal rendres som. Trenger du en lenke? Det får du enkelt med prop-en `as="a"`.
- **Én komponent, flere varianter**: Knappene er nå én komponent, og du velger variant med en prop: `<Button variant="primary">Lagre</Button>`. (Du kan fortsatt bruke `PrimaryButton` etc. men de er bare snarveier til `Button`)

closes #3871 

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
