### PR TITLE
fix: la combobox kunne brukes som controlled component

### DIFF
--- a/packages/combobox-react/src/Combobox.tsx
+++ b/packages/combobox-react/src/Combobox.tsx
@@ -103,6 +103,10 @@ export const Combobox: FC<ComboboxProps> = ({
         }
     }, [showMenu]);
 
+    useEffect(() => {
+        setSelectedValue((prev) => value || prev);
+    }, [value]);
+
     // Funksjon for å stile valgt element
     const isSelected = (option: ValuePair) => {
         if (!selectedValue) {


### PR DESCRIPTION
Fikser en bug der verdien til en ComboBox ikke kunne styres ved hjelp av value-propen

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
