### PR TITLE
fix: gi smileys og radio buttons i feedback unike ider

### DIFF
--- a/packages/feedback-react/src/questions/RadioQuestion.tsx
+++ b/packages/feedback-react/src/questions/RadioQuestion.tsx
@@ -1,5 +1,5 @@
 import { RadioButton, RadioButtonGroup } from "@fremtind/jkl-radio-button-react";
-import React, { ChangeEventHandler, useEffect, useMemo, useRef } from "react";
+import React, { ChangeEventHandler, useEffect, useId, useMemo, useRef } from "react";
 import { useFollowUpContext } from "../followup/followupContext";
 import { useMainQuestionContext } from "../main-question/mainQuestionContext";
 import { QuestionProps } from "../types";
@@ -8,6 +8,7 @@ export const RadioQuestion: React.FC<QuestionProps> = ({ label, name, options, h
     const followupContext = useFollowUpContext();
     const feedbackContext = useMainQuestionContext();
     const context = followupContext || feedbackContext;
+    const id = useId();
 
     const numOptions = options?.length || 0;
 
@@ -40,7 +41,7 @@ export const RadioQuestion: React.FC<QuestionProps> = ({ label, name, options, h
         <RadioButtonGroup
             legend={label}
             labelProps={{ variant: "large" }}
-            name={name || label}
+            name={`${id}-${name || label}`}
             inline={numOptions < 3}
             value={selectedValue || ""}
             onChange={handleChange}
@@ -49,7 +50,7 @@ export const RadioQuestion: React.FC<QuestionProps> = ({ label, name, options, h
             {options?.map((option, i) => (
                 <RadioButton
                     ref={i === 0 ? ref : undefined}
-                    key={`${name || label}${option.value}`}
+                    key={`${id}-${name || label}-${option.value}`}
                     label={option.label}
                     value={String(option.value)}
                 />

--- a/packages/feedback-react/src/questions/SmileyQuestion.tsx
+++ b/packages/feedback-react/src/questions/SmileyQuestion.tsx
@@ -1,5 +1,5 @@
 import { FieldGroup } from "@fremtind/jkl-input-group-react";
-import React, { Fragment, ChangeEventHandler, useMemo } from "react";
+import React, { Fragment, ChangeEventHandler, useMemo, useId } from "react";
 import { useFollowUpContext } from "../followup/followupContext";
 import { useMainQuestionContext } from "../main-question/mainQuestionContext";
 import { FeedbackOption, QuestionProps } from "../types";
@@ -17,8 +17,10 @@ export const SmileyQuestion: React.FC<QuestionProps> = ({
     const followupContext = useFollowUpContext();
     const feedbackContext = useMainQuestionContext();
     const context = followupContext || feedbackContext;
+    const id = useId();
 
     const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+        console.log(e.target.value);
         const option = options?.find((option) => option.value.toString() === e.target.value);
         context?.setCurrentValue(option);
     };
@@ -45,14 +47,14 @@ export const SmileyQuestion: React.FC<QuestionProps> = ({
                     <Fragment key={option.value}>
                         <input
                             className="jkl-sr-only"
-                            id={`${name}-${option.value}`}
-                            name={name}
+                            id={`${id}-${name}-${option.value}`}
+                            name={`${id}-${name}`}
                             type="radio"
                             value={option.value}
                             onChange={handleChange}
                             checked={selectedValue === option.value}
                         />
-                        <label className="jkl-feedback-smiley-option" htmlFor={`${name}-${option.value}`}>
+                        <label className="jkl-feedback-smiley-option" htmlFor={`${id}-${name}-${option.value}`}>
                             <span className="jkl-sr-only">{option.label}</span>
                             {getSmiley(Number(option.value))}
                         </label>


### PR DESCRIPTION
Fikser en bug der Feedback med smileys eller radio buttons kunne sette verdien til hverandre dersom man hadde flere instanser på samme side.

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
