### PR TITLE
feat: legg til mulighet for å sette headers på uploads

### DIFF
--- a/packages/file-input-react/src/utils.ts
+++ b/packages/file-input-react/src/utils.ts
@@ -4,9 +4,16 @@
  * @param {string} url Endepunktet som skal lastes opp til
  * @param {FormData} data FormData med filen som skal lastes opp
  * @param progress Callback som blir kalt med oppdatert progresjon
+ * @param {Record<string, string>} headers Eventuelle headers som skal sendes
+ * med opplasingen. Her kan du f.eks. sende med CSRF-verdier.
  * @returns {T} Svaret fra endepunktet
  */
-export async function upload<T>(url: string, data: FormData, progress: (progress: number) => void): Promise<T> {
+export async function upload<T>(
+    url: string,
+    data: FormData,
+    progress: (progress: number) => void,
+    headers?: Record<string, string>,
+): Promise<T> {
     // I skrivende stund er det ikke mulig å hente progress med fetch. Derfor bruker vi XMLHttpRequest.
     const xhr = new XMLHttpRequest();
     const request = new Promise<ProgressEvent<XMLHttpRequestEventTarget>>((resolve, reject) => {
@@ -32,6 +39,11 @@ export async function upload<T>(url: string, data: FormData, progress: (progress
         });
 
         xhr.open("POST", url);
+
+        Object.entries(headers || {}).forEach(([header, value]) => {
+            xhr.setRequestHeader(header, value);
+        });
+
         xhr.send(data);
     }).then(
         (e) => {


### PR DESCRIPTION
Gjør det mulig å sette HTTP-headere på opplastingen når du bruker `upload`-hjelpefunksjonen i `FileUpload`. Dette kan være nyttig for å f.eks. sende med CRFS-tokens.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
