### PR TITLE
feat: eksporter base text area og typer

### DIFF
--- a/packages/text-input-react/src/index.ts
+++ b/packages/text-input-react/src/index.ts
@@ -1,6 +1,7 @@
 import type { AutosuggestProps } from "./autosuggest";
 import { Autosuggest } from "./autosuggest";
 
+export { BaseTextArea, type BaseTextAreaProps } from "./BaseTextArea";
 export { BaseTextInput, type BaseTextInputProps } from "./BaseTextInput";
 export { TextArea, type TextAreaProps } from "./TextArea";
 export { TextInput, type TextInputProps } from "./TextInput";


### PR DESCRIPTION
Sørger for å eksportere BaseTextArea og typer for props, på samme måte som for BaseTextInput

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
