### PR TITLE
fix: replace classnames with clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         }
     },
     "dependencies": {
+        "clsx": "^2.1.1",
         "fs-extra": "^11.1.1",
         "glob": "^8.1.0",
         "nodemon": "^2.0.22",

--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -40,8 +40,7 @@
         "@fremtind/jkl-accordion": "^11.2.2",
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icons-react": "^8.7.2",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "devDependencies": {
         "@fremtind/jkl-list-react": "^10.1.4"

--- a/packages/accordion-react/src/Accordion.tsx
+++ b/packages/accordion-react/src/Accordion.tsx
@@ -1,5 +1,5 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 
 export interface AccordionProps extends WithChildren {
@@ -13,7 +13,7 @@ export const Accordion: FC<AccordionProps> = ({ className, density, id, ...rest 
         <section
             role="group"
             data-testid="jkl-accordion"
-            className={cn("jkl-accordion", className)}
+            className={clsx("jkl-accordion", className)}
             data-density={density}
             id={id}
             {...rest}

--- a/packages/accordion-react/src/AccordionItem.tsx
+++ b/packages/accordion-react/src/AccordionItem.tsx
@@ -1,7 +1,7 @@
 import { WithChildren } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
 import { useAnimatedDetails } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC, useState } from "react";
 
 export interface AccordionItemProps extends WithChildren {
@@ -38,7 +38,7 @@ export const AccordionItem: FC<AccordionItemProps> = ({
         <details
             data-testid="jkl-accordion-item"
             {...rest}
-            className={cn("jkl-accordion-item", className)}
+            className={clsx("jkl-accordion-item", className)}
             ref={detailsRef}
             id={id}
         >

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -41,8 +41,7 @@
         "@fremtind/jkl-alert-message": "^9.0.10",
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icons-react": "^8.7.2",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/alert-message-react/src/AlertMessage.tsx
+++ b/packages/alert-message-react/src/AlertMessage.tsx
@@ -1,6 +1,6 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { DismissButton } from "./common/DismissButton";
 import { MessageIcon } from "./common/MessageIcon";
@@ -42,7 +42,7 @@ function alertFactory(messageType: messageTypes): React.FC<Props> {
                 role={role}
                 {...rest}
                 id={alertId}
-                className={cn("jkl-alert-message", "jkl-alert-message--" + messageType, className, {
+                className={clsx("jkl-alert-message", "jkl-alert-message--" + messageType, className, {
                     "jkl-alert-message--dismissed": dismissed,
                 })}
                 data-density={density}

--- a/packages/breadcrumb-react/package.json
+++ b/packages/breadcrumb-react/package.json
@@ -37,8 +37,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-breadcrumb": "^5.0.10",
-        "@fremtind/jkl-core": "^13.5.0",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-core": "^13.5.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/breadcrumb-react/src/Breadcrumb.tsx
+++ b/packages/breadcrumb-react/src/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { BreadcrumbItemProps } from "./BreadcrumbItem";
 
@@ -11,7 +11,7 @@ export interface BreadcrumbProps extends WithChildren {
 export const Breadcrumb = ({ className, children, density, ...rest }: BreadcrumbProps): JSX.Element => {
     const numberOfChildren = React.Children.count(children);
     return (
-        <nav aria-label="Sti" className={cn("jkl-breadcrumb", className)} data-layout-density={density} {...rest}>
+        <nav aria-label="Sti" className={clsx("jkl-breadcrumb", className)} data-layout-density={density} {...rest}>
             <ol className="jkl-breadcrumb__list">
                 {React.Children.map(children, (child, index) => {
                     const isLastElement = index + 1 === numberOfChildren;

--- a/packages/breadcrumb-react/src/BreadcrumbItem.tsx
+++ b/packages/breadcrumb-react/src/BreadcrumbItem.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { AnchorHTMLAttributes } from "react";
 
 export interface BreadcrumbItemProps extends WithChildren {
@@ -13,7 +13,7 @@ export interface BreadcrumbItemProps extends WithChildren {
 
 export const BreadcrumbItem = ({ className, children, isLastElement, ...rest }: BreadcrumbItemProps): JSX.Element => {
     return (
-        <li className={cn("jkl-breadcrumb__item", className)} {...rest}>
+        <li className={clsx("jkl-breadcrumb__item", className)} {...rest}>
             {React.Children.map(children, (child) => {
                 if (React.isValidElement<AnchorHTMLAttributes<HTMLAnchorElement>>(child)) {
                     return React.cloneElement<AnchorHTMLAttributes<HTMLAnchorElement>>(child, {

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -44,8 +44,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-loader-react": "^12.0.11",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "devDependencies": {
         "@fremtind/jkl-toggle-switch-react": "^13.1.10"

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -1,7 +1,7 @@
 import type { PolymorphicRef } from "@fremtind/jkl-core";
 import { Loader } from "@fremtind/jkl-loader-react";
 import { useAriaLiveRegion } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ButtonHTMLAttributes, type TouchEvent, useCallback } from "react";
 import type { ButtonComponent, ButtonProps } from "./types";
 
@@ -53,7 +53,7 @@ export const Button = React.forwardRef(function Button<ElementType extends React
         <Component
             {...ariaLive}
             data-density={density}
-            className={cn("jkl-button", "jkl-button--" + variant, className, {
+            className={clsx("jkl-button", "jkl-button--" + variant, className, {
                 "jkl-button--icon-left": iconLeft,
                 "jkl-button--icon-right": iconRight,
             })}
@@ -65,7 +65,7 @@ export const Button = React.forwardRef(function Button<ElementType extends React
         >
             <div className="jkl-button__content">
                 <div
-                    className={cn("jkl-button__slider", {
+                    className={clsx("jkl-button__slider", {
                         "jkl-button__slider--show-loader": !!loader?.showLoader,
                     })}
                 >

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -39,8 +39,7 @@
         "@fremtind/jkl-card": "^11.2.1",
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-image-react": "^6.0.11",
-        "@fremtind/jkl-tag-react": "^5.2.12",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-tag-react": "^5.2.12"
     },
     "devDependencies": {
         "@fremtind/jkl-constants-util": "^3.0.58"

--- a/packages/card-react/src/Card.tsx
+++ b/packages/card-react/src/Card.tsx
@@ -1,6 +1,6 @@
 import { Button, type ButtonVariant } from "@fremtind/jkl-button-react";
 import { WithOptionalChildren } from "@fremtind/jkl-core";
-import classNames from "classnames";
+import clsx from "clsx";
 import React, { MouseEventHandler, FC } from "react";
 
 type Action = {
@@ -33,7 +33,7 @@ interface Props extends WithOptionalChildren {
  * Se https://jokul.fremtind.no/komponenter/card for informasjon om bruk
  */
 export const Card: FC<Props> = ({ title, children, className, media, action, dark, clickable }) => {
-    const componentClassName = classNames("jkl-card", className, {
+    const componentClassName = clsx("jkl-card", className, {
         "jkl-card--dark": dark,
         "jkl-card--clickable": clickable,
     });

--- a/packages/card-react/src/InfoCard.tsx
+++ b/packages/card-react/src/InfoCard.tsx
@@ -1,5 +1,5 @@
 import { WithChildren, Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 import { PaddingOptions, SpacingStep } from "./types";
 import { getPaddingStyles } from "./utils";
@@ -15,8 +15,8 @@ export interface InfoCardProps extends PaddingOptions, WithChildren {
 }
 
 export const InfoCard: FC<InfoCardProps> = ({ title, children, density, className, padding = "l", ...rest }) => (
-    <div {...rest} className={cn("jkl-info-card", className)} data-density={density}>
-        <div className={cn("jkl-info-card__content-wrapper")} style={getPaddingStyles(padding)}>
+    <div {...rest} className={clsx("jkl-info-card", className)} data-density={density}>
+        <div className={clsx("jkl-info-card__content-wrapper")} style={getPaddingStyles(padding)}>
             {title && <p className="jkl-info-card__title">{title}</p>}
             {children}
         </div>

--- a/packages/card-react/src/NavCard.tsx
+++ b/packages/card-react/src/NavCard.tsx
@@ -1,7 +1,7 @@
 import { WithChildren, Density } from "@fremtind/jkl-core";
 import { Image, ImageProps } from "@fremtind/jkl-image-react";
 import { ErrorTag, InfoTag, SuccessTag, Tag, TagProps, WarningTag } from "@fremtind/jkl-tag-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ElementType, FC, AnchorHTMLAttributes } from "react";
 import { PaddingOptions } from "./types";
 import { getPaddingStyles } from "./utils";
@@ -78,7 +78,7 @@ export const NavCard: FC<NavCardProps> = React.forwardRef<HTMLAnchorElement, Nav
     const tagArr = !tag ? undefined : Array.isArray(tag) ? tag : [tag];
 
     return (
-        <Component ref={ref} className={cn("jkl-nav-card", className)} data-density={density} {...rest}>
+        <Component ref={ref} className={clsx("jkl-nav-card", className)} data-density={density} {...rest}>
             {image && <Image className="jkl-nav-card__image" {...image} />}
             <div className="jkl-nav-card__content" style={getPaddingStyles(padding)}>
                 {tagArr && (
@@ -89,7 +89,9 @@ export const NavCard: FC<NavCardProps> = React.forwardRef<HTMLAnchorElement, Nav
                     </div>
                 )}
                 <div>
-                    <p className={cn("jkl-nav-card__link", external ? "jkl-nav-card__link--external" : "")}>{title}</p>
+                    <p className={clsx("jkl-nav-card__link", external ? "jkl-nav-card__link--external" : "")}>
+                        {title}
+                    </p>
                     {description && <p className="jkl-nav-card__description jkl-spacing-xs--top">{description}</p>}
                 </div>
                 {children}

--- a/packages/card-react/src/TaskCard.tsx
+++ b/packages/card-react/src/TaskCard.tsx
@@ -1,5 +1,5 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 import { PaddingOptions } from "./types";
 import { getPaddingStyles } from "./utils";
@@ -35,7 +35,7 @@ export const TaskCard: FC<TaskCardProps> = ({
     ...rest
 }) => (
     <div
-        className={cn("jkl-task-card", className, {
+        className={clsx("jkl-task-card", className, {
             // Vi bruker kun background hvis bgColor ikke er satt, for å ikke bryte eksisterende kode
             [`jkl-task-card--${background}`]: !bgColor,
             [`jkl-task-card--${bgColor}`]: !!bgColor,

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -40,8 +40,7 @@
     "dependencies": {
         "@fremtind/jkl-checkbox": "^11.0.7",
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "devDependencies": {
         "@fremtind/jkl-input-group-react": "^3.0.30"

--- a/packages/checkbox-react/src/Checkbox.tsx
+++ b/packages/checkbox-react/src/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { DataTestAutoId, Density } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     ReactNode,
     forwardRef,
@@ -57,7 +57,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
 
     return (
         <div
-            className={cn("jkl-checkbox", className, {
+            className={clsx("jkl-checkbox", className, {
                 "jkl-checkbox--inline": inline,
                 "jkl-checkbox--error": invalid,
             })}

--- a/packages/combobox-react/package.json
+++ b/packages/combobox-react/package.json
@@ -44,8 +44,7 @@
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-select-react": "^14.1.33",
         "@fremtind/jkl-tag-react": "^5.2.12",
-        "@fremtind/jkl-tooltip-react": "^4.2.21",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-tooltip-react": "^4.2.21"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/combobox-react/src/Combobox.tsx
+++ b/packages/combobox-react/src/Combobox.tsx
@@ -5,7 +5,7 @@ import { InputGroup, InputGroupProps, type LabelProps } from "@fremtind/jkl-inpu
 import { useId, useAnimatedHeight, useListNavigation } from "@fremtind/jkl-react-hooks";
 import { Tag } from "@fremtind/jkl-tag-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@fremtind/jkl-tooltip-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     FC,
     useEffect,
@@ -368,7 +368,7 @@ export const Combobox: FC<ComboboxProps> = ({
             id={inputId}
             ref={componentRootElementRef}
             data-testid="jkl-combobox"
-            className={cn("jkl-combobox", className, {
+            className={clsx("jkl-combobox", className, {
                 "jkl-combobox--invalid": !!errorLabel || invalid,
                 "jkl-combobox--menu-open": showMenu,
                 "jkl-combobox--menu-closed": !showMenu && hasSelection,
@@ -382,7 +382,7 @@ export const Combobox: FC<ComboboxProps> = ({
             density={density}
             render={(inputProps) => (
                 <div
-                    className={cn("jkl-combobox__wrapper", { "jkl-combobox__wrapper--active-value": hasSelection })}
+                    className={clsx("jkl-combobox__wrapper", { "jkl-combobox__wrapper--active-value": hasSelection })}
                     style={{ width }}
                     tabIndex={-1}
                     onFocus={handleFocus}

--- a/packages/contact-information-react/package.json
+++ b/packages/contact-information-react/package.json
@@ -38,8 +38,7 @@
     "dependencies": {
         "@fremtind/jkl-contact-information": "^2.0.10",
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-formatters-util": "^5.1.14",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-formatters-util": "^5.1.14"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/contact-information-react/src/ContactInformation.tsx
+++ b/packages/contact-information-react/src/ContactInformation.tsx
@@ -1,6 +1,6 @@
 import { DataTestAutoId, Density, Link, WithChildren, NavLink, WithOptionalChildren } from "@fremtind/jkl-core";
 import { formatTelefonnummer } from "@fremtind/jkl-formatters-util";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { HTMLAttributes, FC, ReactNode } from "react";
 
 export interface FooterProps extends DataTestAutoId, HTMLAttributes<HTMLElement> {
@@ -10,7 +10,7 @@ export interface FooterProps extends DataTestAutoId, HTMLAttributes<HTMLElement>
 
 export const ContactInformation: FC<FooterProps> = ({ headingComponent, className, density, children, ...rest }) => {
     return (
-        <div className={cn("jkl-contact-info", className)} data-density={density} {...rest}>
+        <div className={clsx("jkl-contact-info", className)} data-density={density} {...rest}>
             {headingComponent}
             {children}
         </div>

--- a/packages/content-toggle-react/package.json
+++ b/packages/content-toggle-react/package.json
@@ -39,8 +39,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-content-toggle": "^6.0.10",
-        "@fremtind/jkl-core": "^13.5.0",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-core": "^13.5.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/content-toggle-react/src/ContentToggle.tsx
+++ b/packages/content-toggle-react/src/ContentToggle.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ReactNode, FC, useState, useEffect } from "react";
 
 export interface ContentToggleProps extends WithChildren {
@@ -32,7 +32,7 @@ export const ContentToggle: FC<ContentToggleProps> = ({
     }, [showSecondary, initialShowSecondary]);
 
     return (
-        <span {...rest} className={cn("jkl-content-toggle", `jkl-content-toggle--${variant}`, className)}>
+        <span {...rest} className={clsx("jkl-content-toggle", `jkl-content-toggle--${variant}`, className)}>
             <span
                 className="jkl-content-toggle__slider"
                 data-show={showSecondary ? "second" : "first"}

--- a/packages/contextual-menu-react/package.json
+++ b/packages/contextual-menu-react/package.json
@@ -42,7 +42,6 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-toggle-switch": "^13.1.1",
-        "classnames": "^2.3.2",
         "framer-motion": "^7.10.3"
     },
     "devDependencies": {

--- a/packages/contextual-menu-react/src/ContextualMenu.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenu.tsx
@@ -23,7 +23,7 @@ import {
 } from "@floating-ui/react";
 import { type DataTestAutoId, WithChildren } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import React, { type ButtonHTMLAttributes, forwardRef, type ReactNode, useEffect, useRef, useState } from "react";
 import * as ReactIs from "react-is";
@@ -185,7 +185,7 @@ const ContextualMenuComponent = forwardRef<HTMLButtonElement, ContextualMenuProp
                             returnFocus={!isNested}
                         >
                             <motion.div
-                                className={cn("jkl jkl-contextual-menu", className)}
+                                className={clsx("jkl jkl-contextual-menu", className)}
                                 data-theme={theme}
                                 data-layout-density={density}
                                 role="menu"

--- a/packages/contextual-menu-react/src/ContextualMenuDivider.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenuDivider.tsx
@@ -1,8 +1,10 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type HTMLAttributes, type FC } from "react";
 
 export const ContextualMenuDivider: FC<HTMLAttributes<HTMLHRElement>> = (props) => {
     const { className, ...hrProps } = props;
 
-    return <hr className={cn("jkl-contextual-menu-divider", className)} {...hrProps} />;
+    return <hr className={clsx("jkl-contextual-menu-divider", className)} {...hrProps} />;
 };
+
+//kan vi ikke bare lage en divider komponent som importeres inn istedenfor en dedikert hr komponent under forskjellige komponenter? :) -Maria

--- a/packages/contextual-menu-react/src/ContextualMenuItem.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenuItem.tsx
@@ -1,5 +1,5 @@
 import { ArrowNorthEastIcon, ChevronRightIcon } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ButtonHTMLAttributes, forwardRef, ReactNode } from "react";
 
 export interface ContextualMenuItemProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
@@ -23,7 +23,13 @@ export const ContextualMenuItem = forwardRef<HTMLButtonElement, ContextualMenuIt
     const { className, children, icon, expandable = false, external = false, ...rest } = props;
 
     return (
-        <button ref={ref} type="button" role="menuitem" className={cn("jkl-contextual-menu-item", className)} {...rest}>
+        <button
+            ref={ref}
+            type="button"
+            role="menuitem"
+            className={clsx("jkl-contextual-menu-item", className)}
+            {...rest}
+        >
             {icon && <span className="jkl-contextual-menu-item__icon">{icon}</span>}
             <div className="jkl-contextual-menu-item__content">
                 {children}

--- a/packages/contextual-menu-react/src/ContextualMenuItemCheckbox.tsx
+++ b/packages/contextual-menu-react/src/ContextualMenuItemCheckbox.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from "@fremtind/jkl-icons-react";
 import { useSwipeGesture, type SwipeChangeHandler } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     forwardRef,
     type HTMLAttributes,
@@ -74,7 +74,7 @@ export const ContextualMenuItemCheckbox = forwardRef<HTMLDivElement, ContextualM
             {...rest}
             role="menuitemcheckbox"
             aria-checked={checked}
-            className={cn("jkl-contextual-menu-item", "jkl-contextual-menu-item--checkbox", className)}
+            className={clsx("jkl-contextual-menu-item", "jkl-contextual-menu-item--checkbox", className)}
             {...gestureHandlers}
             onKeyDown={handleKeyDown}
         >

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,9 +46,6 @@
     "bugs": {
         "url": "https://github.com/fremtind/jokul/issues"
     },
-    "dependencies": {
-        "classnames": "^2.3.2"
-    },
     "devDependencies": {
         "change-case": "^4.1.2",
         "style-dictionary": "^3.8.0"

--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { AnchorHTMLAttributes, FC } from "react";
 
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -7,7 +7,7 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 
 export const Link: FC<LinkProps> = ({ external = false, className = "", children, ...rest }) => (
     <a
-        className={cn("jkl-link", className, {
+        className={clsx("jkl-link", className, {
             "jkl-link--external": external,
         })}
         {...rest}

--- a/packages/core/src/components/NavLink.tsx
+++ b/packages/core/src/components/NavLink.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { AnchorHTMLAttributes, FC } from "react";
 
 export interface NavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -8,7 +8,7 @@ export interface NavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 
 export const NavLink: FC<NavLinkProps> = ({ active = false, back = false, className, children, ...rest }) => (
     <a
-        className={cn(
+        className={clsx(
             "jkl-nav-link",
             {
                 "jkl-nav-link--active": active,

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -44,7 +44,6 @@
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-select-react": "^14.1.33",
         "@fremtind/jkl-text-input-react": "^15.1.2",
-        "classnames": "^2.3.2",
         "date-fns": "^2.30.0"
     },
     "devDependencies": {

--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -2,7 +2,7 @@ import { CalendarIcon } from "@fremtind/jkl-icons-react";
 import { InputGroup } from "@fremtind/jkl-input-group-react";
 import { useAnimatedHeight, useClickOutside, useFocusOutside, useKeyListener } from "@fremtind/jkl-react-hooks";
 import { BaseTextInput } from "@fremtind/jkl-text-input-react";
-import cn from "classnames";
+import clsx from "clsx";
 import startOfDay from "date-fns/startOfDay";
 import React, {
     ChangeEvent,
@@ -261,7 +261,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>((props, 
     return (
         <InputGroup
             id={id}
-            className={cn("jkl-datepicker", className, {
+            className={clsx("jkl-datepicker", className, {
                 "jkl-datepicker--open": showCalendar,
             })}
             {...rest}

--- a/packages/datepicker-react/src/internal/Calendar.tsx
+++ b/packages/datepicker-react/src/internal/Calendar.tsx
@@ -1,7 +1,7 @@
 import { Density } from "@fremtind/jkl-core";
 import { ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon } from "@fremtind/jkl-icons-react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, useCallback, useEffect, useReducer, useRef } from "react";
 import { flushSync } from "react-dom";
 import type { YearsToShow } from "../types";
@@ -350,7 +350,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>((props, ref) =
         <div
             ref={ref}
             id={id}
-            className={cn("jkl-calendar", {
+            className={clsx("jkl-calendar", {
                 "jkl-calendar--hidden": hidden,
             })}
             data-testid="jkl-calendar"

--- a/packages/description-list-react/package.json
+++ b/packages/description-list-react/package.json
@@ -48,8 +48,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-description-list": "^8.0.10",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-description-list": "^8.0.10"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/description-list-react/src/DescriptionList.tsx
+++ b/packages/description-list-react/src/DescriptionList.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import classnames from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 
 export interface DescriptionListProps extends WithChildren {
@@ -8,7 +8,7 @@ export interface DescriptionListProps extends WithChildren {
 
 export const DescriptionList: FC<DescriptionListProps> = ({ children, className, ...rest }) => {
     return (
-        <dl {...rest} className={classnames("jkl-description-list", className)}>
+        <dl {...rest} className={clsx("jkl-description-list", className)}>
             {children}
         </dl>
     );
@@ -20,7 +20,7 @@ export interface DescriptionTermProps extends WithChildren {
 
 export const DescriptionTerm: FC<DescriptionTermProps> = ({ children, className, ...rest }) => {
     return (
-        <dt {...rest} className={classnames("jkl-description-list__term", className)}>
+        <dt {...rest} className={clsx("jkl-description-list__term", className)}>
             {children}
         </dt>
     );
@@ -32,7 +32,7 @@ export interface DescriptionDetailProps extends WithChildren {
 
 export const DescriptionDetail: FC<DescriptionDetailProps> = ({ children, className, ...rest }) => {
     return (
-        <dd {...rest} className={classnames("jkl-description-list__detail", className)}>
+        <dd {...rest} className={clsx("jkl-description-list__detail", className)}>
             {children}
         </dd>
     );

--- a/packages/expand-button-react/package.json
+++ b/packages/expand-button-react/package.json
@@ -39,8 +39,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-expand-button": "^7.0.1",
         "@fremtind/jkl-icons-react": "^8.7.2",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/expand-button-react/src/ExpandButton.tsx
+++ b/packages/expand-button-react/src/ExpandButton.tsx
@@ -1,6 +1,6 @@
 import { Density, ScreenReaderOnly, WithChildren } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { ForwardedRef } from "react";
 
 export type ExpandDirection = "up" | "down";
@@ -55,7 +55,7 @@ export const ExpandButton = React.forwardRef(
                 aria-expanded={isExpanded}
                 data-testid="jkl-expand-button"
                 type={type}
-                className={cx("jkl-expand-button", className, {
+                className={clsx("jkl-expand-button", className, {
                     "jkl-expand-button--expanded": isExpanded,
                     "jkl-expand-button--icon-only": !children,
                 })}

--- a/packages/expand-button-react/src/ExpandSection.tsx
+++ b/packages/expand-button-react/src/ExpandSection.tsx
@@ -1,6 +1,6 @@
 import { Density } from "@fremtind/jkl-core";
 import { UseAnimatedHeightOptions, useAnimatedDetails } from "@fremtind/jkl-react-hooks";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { ReactNode, useEffect, useState } from "react";
 import type { ExpandButtonProps } from "./ExpandButton";
 import { ExpandButton } from "./ExpandButton";
@@ -53,7 +53,7 @@ export const ExpandSection = ({
     return (
         <details
             data-testid={"jkl-expand-section"}
-            className={cx("jkl-expand-section", className)}
+            className={clsx("jkl-expand-section", className)}
             {...rest}
             ref={detailsRef}
         >

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -46,8 +46,7 @@
         "@fremtind/jkl-radio-button-react": "^11.1.54",
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-text-input-react": "^15.1.2",
-        "@fremtind/jkl-validators-util": "^3.0.0",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-validators-util": "^3.0.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/feedback-react/src/FeedbackSuccess.tsx
+++ b/packages/feedback-react/src/FeedbackSuccess.tsx
@@ -1,9 +1,9 @@
 import { SuccessMessageBox, MessageBoxProps } from "@fremtind/jkl-message-box-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 
 export const FeedbackSuccess: FC<MessageBoxProps> = ({ children, className, ...rest }) => (
-    <SuccessMessageBox className={cn("jkl-feedback__fade-in", className)} {...rest} aria-live="polite">
+    <SuccessMessageBox className={clsx("jkl-feedback__fade-in", className)} {...rest} aria-live="polite">
         {children}
     </SuccessMessageBox>
 );

--- a/packages/feedback-react/src/main-question/MainQuestion.tsx
+++ b/packages/feedback-react/src/main-question/MainQuestion.tsx
@@ -1,6 +1,6 @@
 import { PrimaryButton, TertiaryButton } from "@fremtind/jkl-button-react";
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ReactNode, useEffect, FC, ComponentProps } from "react";
 import { Feedback } from "../Feedback";
 import { useFeedbackContext } from "../feedbackContext";
@@ -57,7 +57,7 @@ export const MainQuestion: FC<Props> = ({
                     <MainQuestionComp label={label} options={options} helpLabel={helpLabel} />
                     <div
                         ref={submitWrapperRef}
-                        className={cn({
+                        className={clsx({
                             "jkl-feedback__submit-wrapper": true,
                             "jkl-feedback__submit-wrapper--hidden": currentValue === undefined,
                         })}

--- a/packages/file-input-react/package.json
+++ b/packages/file-input-react/package.json
@@ -44,8 +44,7 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-input-group-react": "^3.0.30",
         "@fremtind/jkl-progress-bar-react": "^6.0.10",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/file-input-react/src/File.tsx
+++ b/packages/file-input-react/src/File.tsx
@@ -4,7 +4,7 @@ import { IconButton } from "@fremtind/jkl-icon-button-react";
 import { CloseIcon } from "@fremtind/jkl-icons-react";
 import { SupportLabel } from "@fremtind/jkl-input-group-react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC, MouseEvent } from "react";
 import { useFileInputContext } from "./internal/fileInputContext";
 import { Thumbnail } from "./internal/Thumbnail";
@@ -36,7 +36,7 @@ export const File: FC<FileProps> = (props) => {
     const f = (
         <div
             id={id}
-            className={cn("jkl-file", {
+            className={clsx("jkl-file", {
                 "jkl-file--error": supportLabelType === "error",
                 "jkl-file--warning": supportLabelType === "warning",
             })}

--- a/packages/file-input-react/src/FileInput.tsx
+++ b/packages/file-input-react/src/FileInput.tsx
@@ -1,6 +1,6 @@
 import type { Density } from "@fremtind/jkl-core";
 import { FieldGroup, type FieldGroupProps } from "@fremtind/jkl-input-group-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 import { Dropzone } from "./internal/Dropzone";
 import { FileInputContextProvider } from "./internal/fileInputContext";
@@ -55,7 +55,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>((props, re
         return (
             <FileInputContextProvider context={{ accept, onChange, maxSizeBytes }}>
                 <FieldGroup
-                    className={cn("jkl-file-input", "jkl-file-input--small", className, {
+                    className={clsx("jkl-file-input", "jkl-file-input--small", className, {
                         "jkl-file-input--has-files": hasFiles,
                     })}
                     data-layout-density={density ? density : "compact"}
@@ -76,7 +76,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>((props, re
     return (
         <FileInputContextProvider context={{ accept, onChange, maxSizeBytes }}>
             <FieldGroup
-                className={cn("jkl-file-input", className, {
+                className={clsx("jkl-file-input", className, {
                     "jkl-file-input--has-files": hasFiles,
                 })}
                 data-layout-density={density}

--- a/packages/file-input-react/src/internal/Dropzone.tsx
+++ b/packages/file-input-react/src/internal/Dropzone.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, useState } from "react";
 import { FileInputFile } from "../types";
 import { useFileInputContext } from "./fileInputContext";
@@ -21,7 +21,7 @@ export const Dropzone = forwardRef<HTMLDivElement, DropzoneProps>((props, ref) =
         <div
             {...rest}
             ref={ref}
-            className={cn("jkl-file-input__dropzone", onDragClassName)}
+            className={clsx("jkl-file-input__dropzone", onDragClassName)}
             onDragEnter={(e) => {
                 setOnDragClassName("jkl-file-input__dropzone--enter");
                 e.preventDefault();

--- a/packages/file-input-react/src/internal/Thumbnail.tsx
+++ b/packages/file-input-react/src/internal/Thumbnail.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 import { FileInputFileState } from "../types";
 
@@ -13,7 +13,7 @@ export interface ThumbnailProps {
 export const Thumbnail: FC<ThumbnailProps> = (props) => {
     const { fileName, fileType, path, file, state } = props;
 
-    const classNames = cn("jkl-file__thumbnail", {
+    const classNames = clsx("jkl-file__thumbnail", {
         "jkl-file__thumbnail--selected": state === "SELECTED",
         "jkl-file__thumbnail--uploading": state === "UPLOADING",
     });

--- a/packages/footer-react/package.json
+++ b/packages/footer-react/package.json
@@ -39,8 +39,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-footer": "^6.0.10",
         "@fremtind/jkl-formatters-util": "^5.1.14",
-        "@fremtind/jkl-logo-react": "^13.1.1",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-logo-react": "^13.1.1"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/footer-react/src/Footer.tsx
+++ b/packages/footer-react/src/Footer.tsx
@@ -1,5 +1,5 @@
 import { DataTestAutoId, Density, Link } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { HTMLAttributes, FC, ElementType, MouseEventHandler } from "react";
 
 export interface FooterLink<T = HTMLAnchorElement> {
@@ -31,7 +31,7 @@ export const Footer: FC<FooterProps> = ({
     ...rest
 }) => {
     return (
-        <footer className={cn("jkl-footer", className)} data-density={density} {...rest}>
+        <footer className={clsx("jkl-footer", className)} data-density={density} {...rest}>
             <p className="jkl-footer__description">{heading}</p>
             {links && (
                 <div className="jkl-footer__links">

--- a/packages/hamburger-react/package.json
+++ b/packages/hamburger-react/package.json
@@ -40,8 +40,7 @@
         "@fremtind/jkl-content-toggle-react": "^6.0.11",
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-hamburger": "^13.0.10",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -1,6 +1,6 @@
 import { ContentToggle } from "@fremtind/jkl-content-toggle-react";
 import { Density } from "@fremtind/jkl-core";
-import classnames from "classnames";
+import clsx from "clsx";
 import React from "react";
 
 export interface HamburgerProps {
@@ -47,12 +47,12 @@ export const Hamburger = ({
     actionLabel,
     ...rest
 }: HamburgerProps): JSX.Element => {
-    const componentClassname = classnames("jkl-hamburger", className, {
+    const componentClassname = clsx("jkl-hamburger", className, {
         "jkl-hamburger--label-before": actionLabel?.position === "before",
         "jkl-hamburger--label-after": actionLabel && actionLabel.position !== "before",
     });
 
-    const labelClassname = classnames("jkl-hamburger__label", {
+    const labelClassname = clsx("jkl-hamburger__label", {
         "jkl-hamburger__label--animated": actionLabel?.animated,
     });
 

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -41,8 +41,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-icon-button": "^4.0.12",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-icon-button": "^4.0.12"
     },
     "devDependencies": {
         "@fremtind/jkl-icons-react": "^8.7.2",

--- a/packages/icon-button-react/src/IconButton.tsx
+++ b/packages/icon-button-react/src/IconButton.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ButtonHTMLAttributes, forwardRef } from "react";
 
 export interface IconButtonProps extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
@@ -12,7 +12,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props,
         <button
             ref={ref}
             type="button"
-            className={cn("jkl-icon-button", className)}
+            className={clsx("jkl-icon-button", className)}
             data-testid="jkl-icon-button"
             data-density={density}
             {...rest}

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -40,8 +40,7 @@
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icons": "^9.1.4",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/icons-react/src/IconFactory.tsx
+++ b/packages/icons-react/src/IconFactory.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { SVGAttributes } from "react";
 import { IconProps, IconVariant } from "./icons/types";
 
@@ -25,7 +25,7 @@ export const makeIconComponent = (variants: IconVariants) => {
         const El = as;
         return (
             <El
-                className={cn(className, "jkl-icon", `jkl-icon--${variant}`, { "jkl-icon--bold": bold })}
+                className={clsx(className, "jkl-icon", `jkl-icon--${variant}`, { "jkl-icon--bold": bold })}
                 aria-hidden="true"
                 style={style}
                 data-testid={testId}

--- a/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowHorizontalAnimated.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type FC } from "react";
 import { ArrowLeftIcon } from "../icons/arrow-left/ArrowLeftIcon";
 import { ArrowRightIcon } from "../icons/arrow-right/ArrowRightIcon";
@@ -20,7 +20,7 @@ export const ArrowHorizontalAnimated: FC<ArrowHorizontalAnimatedProps> = ({
 }) => (
     <div
         {...rest}
-        className={cn(
+        className={clsx(
             "jkl-icon",
             "jkl-icon--animated",
             `jkl-icon--${variant}`,

--- a/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/ArrowVerticalAnimated.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type FC } from "react";
 import { ArrowDownIcon } from "../icons/arrow-down/ArrowDownIcon";
 import { ArrowUpIcon } from "../icons/arrow-up/ArrowUpIcon";
@@ -20,7 +20,7 @@ export const ArrowVerticalAnimated: FC<ArrowVerticalAnimatedProps> = ({
 }) => (
     <div
         {...rest}
-        className={cn(
+        className={clsx(
             "jkl-icon",
             "jkl-icon--animated",
             `jkl-icon--${variant}`,

--- a/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
+++ b/packages/icons-react/src/animated-icons/PlusRemoveAnimated.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type FC } from "react";
 import { PlusIcon } from "../icons/plus/PlusIcon";
 import { type IconVariant } from "../icons/types";
@@ -19,12 +19,18 @@ export const PlusRemoveAnimated: FC<PlusRemoveAnimatedProps> = ({
 }) => (
     <div
         {...rest}
-        className={cn("jkl-icon", "jkl-icon--animated", `jkl-icon--${variant}`, { "jkl-icon--bold": bold }, className)}
+        className={clsx(
+            "jkl-icon",
+            "jkl-icon--animated",
+            `jkl-icon--${variant}`,
+            { "jkl-icon--bold": bold },
+            className,
+        )}
     >
         <PlusIcon
             variant={variant}
             bold={bold}
-            className={cn("jkl-icons-animated__plus", `jkl-icons-animated__plus--${isPlus ? "plus" : "close"}`)}
+            className={clsx("jkl-icons-animated__plus", `jkl-icons-animated__plus--${isPlus ? "plus" : "close"}`)}
         />
     </div>
 );

--- a/packages/icons-react/src/icons/green-check/GreenCheck.tsx
+++ b/packages/icons-react/src/icons/green-check/GreenCheck.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC, SVGAttributes } from "react";
 
 /*
@@ -11,7 +11,7 @@ export const GreenCheck: FC<SVGAttributes<SVGElement>> = (props) => (
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         {...props}
-        className={cn(props.className, "jkl-icon--green-check")}
+        className={clsx(props.className, "jkl-icon--green-check")}
     >
         <circle cx="12" cy="12" r="10" />
         <path

--- a/packages/icons-react/src/icons/red-cross/RedCross.tsx
+++ b/packages/icons-react/src/icons/red-cross/RedCross.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC, SVGAttributes } from "react";
 
 /*
@@ -11,7 +11,7 @@ export const RedCross: FC<SVGAttributes<SVGElement>> = (props) => (
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         {...props}
-        className={cn(props.className, "jkl-icon--red-cross")}
+        className={clsx(props.className, "jkl-icon--red-cross")}
     >
         <circle cx="12" cy="12" r="10" />
         <path d="m15.71 7.23 1.06 1.06-8.48 8.48-1.06-1.06 8.48-8.48Z" />

--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -45,8 +45,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-image": "^6.0.10",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/image-react/src/Image.tsx
+++ b/packages/image-react/src/Image.tsx
@@ -1,5 +1,5 @@
 import { useElementDimensions } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 import { useImageLoadingStatus } from "./useImageLoadingStatus";
 
@@ -22,7 +22,7 @@ export const Image: FC<ImageProps> = ({ className, placeholder, alt, ...imagePro
     return (
         <div
             ref={containerRef}
-            className={cn("jkl-image", className, {
+            className={clsx("jkl-image", className, {
                 "jkl-image--loading": !imageLoaded,
             })}
         >

--- a/packages/input-group-react/package.json
+++ b/packages/input-group-react/package.json
@@ -41,8 +41,7 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-input-group": "^3.0.11",
         "@fremtind/jkl-react-hooks": "^12.0.11",
-        "@fremtind/jkl-tooltip-react": "^4.2.21",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-tooltip-react": "^4.2.21"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/input-group-react/src/FieldGroup.tsx
+++ b/packages/input-group-react/src/FieldGroup.tsx
@@ -1,7 +1,7 @@
 import type { Density, DataTestAutoId } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
 import { PopupTip, type PopupTipProps } from "@fremtind/jkl-tooltip-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { FC, FieldsetHTMLAttributes } from "react";
 import { Label, type LabelProps } from "./Label";
 import { SupportLabel, type SupportLabelProps } from "./SupportLabel";
@@ -44,7 +44,7 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
     return (
         <fieldset
             id={uid}
-            className={cn("jkl-field-group", className)}
+            className={clsx("jkl-field-group", className)}
             data-testautoid={testAutoId}
             {...rest}
             aria-describedby={describedBy}

--- a/packages/input-group-react/src/InputGroup.tsx
+++ b/packages/input-group-react/src/InputGroup.tsx
@@ -1,7 +1,7 @@
 import { type WithOptionalChildren, type Density, type DataTestAutoId } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
 import { PopupTip, type PopupTipProps } from "@fremtind/jkl-tooltip-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, type CSSProperties, type ReactNode } from "react";
 import { Label, type LabelProps } from "./Label";
 import { SupportLabel, type SupportLabelProps } from "./SupportLabel";
@@ -76,7 +76,7 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, re
     return (
         <div
             ref={ref}
-            className={cn(className, "jkl-input-group", {
+            className={clsx(className, "jkl-input-group", {
                 "jkl-input-group--inline": inline,
             })}
             data-density={density}

--- a/packages/input-group-react/src/Label.tsx
+++ b/packages/input-group-react/src/Label.tsx
@@ -1,5 +1,5 @@
 import type { WithChildren, Density } from "@fremtind/jkl-core";
-import classNames from "classnames";
+import clsx from "clsx";
 import React, { type CSSProperties, type FC } from "react";
 
 export type LabelVariant = "small" | "medium" | "large";
@@ -25,7 +25,7 @@ export const Label: FC<LabelProps> = ({
     className = "",
     ...rest
 }) => {
-    const labelClassNames = classNames("jkl-label", className, {
+    const labelClassNames = clsx("jkl-label", className, {
         [`jkl-label--${variant}`]: variant,
         "jkl-label--sr-only": srOnly,
     });

--- a/packages/input-group-react/src/SupportLabel.tsx
+++ b/packages/input-group-react/src/SupportLabel.tsx
@@ -1,6 +1,6 @@
 import { type Density } from "@fremtind/jkl-core";
 import { ErrorIcon, SuccessIcon, WarningIcon } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type FC, type ReactNode } from "react";
 
 export type SupportLabelType = "help" | "error" | "warning" | "success";
@@ -82,7 +82,7 @@ export const SupportLabel: FC<SupportLabelProps> = ({
     const isSuccess = labelType === "success";
 
     const componentClassName = hasLabel
-        ? cn("jkl-form-support-label", className, {
+        ? clsx("jkl-form-support-label", className, {
               "jkl-form-support-label--sr-only": srOnly,
               "jkl-form-support-label--help": isHelp,
               "jkl-form-support-label--error": isError,

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -41,8 +41,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-list": "^10.2.4",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-list": "^10.2.4"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/list-react/src/List.tsx
+++ b/packages/list-react/src/List.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 
 export interface ListProps extends WithChildren {
@@ -14,7 +14,7 @@ function makeListComponent(listType: ValidLists): FC<ListProps> {
 
         return (
             <C
-                className={cx("jkl-list", className, {
+                className={clsx("jkl-list", className, {
                     "jkl-list--ordered": listType === "ordered",
                 })}
                 data-testid="jkl-list"

--- a/packages/list-react/src/ListItem.tsx
+++ b/packages/list-react/src/ListItem.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { FC } from "react";
 
 export interface ListItemProps extends WithChildren {
@@ -12,7 +12,7 @@ function makeListItem(listItemType: ValidListItems): FC<ListItemProps> {
     const ListItem: FC<ListItemProps> = ({ className, children, ...rest }) => {
         return (
             <li
-                className={cx("jkl-list__item", className, {
+                className={clsx("jkl-list__item", className, {
                     "jkl-list__item--iconed": listItemType !== "normal",
                     "jkl-list__item--check": listItemType === "check",
                     "jkl-list__item--cross": listItemType === "cross",

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -38,8 +38,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-loader": "^11.0.10",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-loader": "^11.0.10"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/loader-react/src/Loader.tsx
+++ b/packages/loader-react/src/Loader.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import clsx from "clsx";
 import React, { AriaRole } from "react";
 import { useDelayedRender } from "./useDelayedRender";
 
@@ -33,7 +33,7 @@ export const Loader = ({
         return null;
     }
 
-    const componentClassName = classNames("jkl-loader", className, {
+    const componentClassName = clsx("jkl-loader", className, {
         "jkl-loader--medium": variant === "medium",
         "jkl-loader--small": variant === "small",
         "jkl-loader--inline": inline,

--- a/packages/loader-react/src/skeletons/SkeletonAnimation.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonAnimation.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { AriaRole, HTMLProps, ReactNode } from "react";
 import { useDelayedRender } from "../useDelayedRender";
 
@@ -32,7 +32,7 @@ export const SkeletonAnimation = ({
 
     return (
         <div
-            className={cn("jkl-skeleton-animation", className)}
+            className={clsx("jkl-skeleton-animation", className)}
             aria-busy="true"
             aria-label={textDescription}
             {...rest}

--- a/packages/loader-react/src/skeletons/SkeletonCheckboxGroup.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonCheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { SkeletonElement, SkeletonElementProps } from "./SkeletonElement";
 import { SkeletonLabel, SkeletonLabelProps } from "./SkeletonLabel";
@@ -22,7 +22,7 @@ export const SkeletonCheckboxGroup = ({
 }: SkeletonCheckboxGroupProps) => {
     const compact = density === "compact";
     return (
-        <div className={cn("jkl-skeleton-input", className)} {...rest}>
+        <div className={clsx("jkl-skeleton-input", className)} {...rest}>
             <SkeletonLabel density={density} {...labelProps} />
             {Array.from(Array(checkboxes)).map((_, index) => (
                 <div key={`jkl-skeleton-checkbox-${index}`} className="jkl-skeleton-input__checkbox">

--- a/packages/loader-react/src/skeletons/SkeletonElement.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonElement.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { HTMLProps } from "react";
 
 export interface SkeletonElementProps extends Pick<HTMLProps<HTMLDivElement>, "style"> {
@@ -11,7 +11,7 @@ export interface SkeletonElementProps extends Pick<HTMLProps<HTMLDivElement>, "s
 export const SkeletonElement = ({ shape = "rect", width, height, style, className, ...rest }: SkeletonElementProps) => {
     return (
         <div
-            className={cn("jkl-skeleton-element", `jkl-skeleton-element--${shape}`, className)}
+            className={clsx("jkl-skeleton-element", `jkl-skeleton-element--${shape}`, className)}
             style={{ width, height, ...style }}
             {...rest}
         />

--- a/packages/loader-react/src/skeletons/SkeletonInput.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonInput.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { SkeletonElement, SkeletonElementProps } from "./SkeletonElement";
 import { SkeletonLabel, SkeletonLabelProps } from "./SkeletonLabel";
@@ -14,7 +14,7 @@ export interface SkeletonInputProps {
 export const SkeletonInput = ({ className, density, labelProps, inputProps, ...rest }: SkeletonInputProps) => {
     const compact = density === "compact";
     return (
-        <div className={cn("jkl-skeleton-input", className)} {...rest}>
+        <div className={clsx("jkl-skeleton-input", className)} {...rest}>
             <SkeletonLabel density={density} {...labelProps} />
             <SkeletonElement width={compact ? 301 : 316} height={compact ? 32 : 48} {...inputProps} />
         </div>

--- a/packages/loader-react/src/skeletons/SkeletonRadioButtonGroup.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonRadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { SkeletonElement, SkeletonElementProps } from "./SkeletonElement";
 import { SkeletonLabel, SkeletonLabelProps } from "./SkeletonLabel";
@@ -22,7 +22,7 @@ export const SkeletonRadioButtonGroup = ({
 }: SkeletonRadioButtonGroupProps) => {
     const compact = density === "compact";
     return (
-        <div className={cn("jkl-skeleton-input", className)} {...rest}>
+        <div className={clsx("jkl-skeleton-input", className)} {...rest}>
             <SkeletonLabel density={density} {...labelProps} />
             {Array.from(Array(radioButtons)).map((_, index) => (
                 <div key={`jkl-skeleton-checkbox-${index}`} className="jkl-skeleton-input__checkbox">

--- a/packages/loader-react/src/skeletons/SkeletonTable.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonTable.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { HTMLProps, ReactNode } from "react";
 
 export interface SkeletonTableProps extends Pick<HTMLProps<HTMLDivElement>, "style"> {
@@ -12,7 +12,7 @@ export interface SkeletonTableProps extends Pick<HTMLProps<HTMLDivElement>, "sty
 export const SkeletonTable = ({ className, density, width, style, ...rest }: SkeletonTableProps) => {
     return (
         <div
-            className={cn("jkl-skeleton-table", className)}
+            className={clsx("jkl-skeleton-table", className)}
             style={{ width, ...style }}
             {...rest}
             data-density={density}
@@ -26,7 +26,7 @@ export interface SkeletonTableHeaderProps {
 }
 
 export const SkeletonTableHeader = ({ className, ...rest }: SkeletonTableHeaderProps) => {
-    return <div className={cn("jkl-skeleton-table__header", className)} {...rest} />;
+    return <div className={clsx("jkl-skeleton-table__header", className)} {...rest} />;
 };
 
 export interface SkeletonTableRowProps {
@@ -35,5 +35,5 @@ export interface SkeletonTableRowProps {
 }
 
 export const SkeletonTableRow = ({ className, ...rest }: SkeletonTableRowProps) => {
-    return <div className={cn("jkl-skeleton-table__row", className)} {...rest} />;
+    return <div className={clsx("jkl-skeleton-table__row", className)} {...rest} />;
 };

--- a/packages/loader-react/src/skeletons/SkeletonTextArea.tsx
+++ b/packages/loader-react/src/skeletons/SkeletonTextArea.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { SkeletonElement, SkeletonElementProps } from "./SkeletonElement";
 import { SkeletonLabel, SkeletonLabelProps } from "./SkeletonLabel";
@@ -14,7 +14,7 @@ export interface SkeletonTextAreaProps {
 export const SkeletonTextArea = ({ className, density, labelProps, inputProps, ...rest }: SkeletonTextAreaProps) => {
     const compact = density === "compact";
     return (
-        <div className={cn("jkl-skeleton-input", className)} {...rest} data-density={density}>
+        <div className={clsx("jkl-skeleton-input", className)} {...rest} data-density={density}>
             <SkeletonLabel density={density} {...labelProps} />
             <SkeletonElement width={compact ? 301 : 316} height={compact ? 148 : 168} {...inputProps} />
         </div>

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -39,8 +39,7 @@
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-logo": "^11.0.10",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/logo-react/src/Logo.tsx
+++ b/packages/logo-react/src/Logo.tsx
@@ -1,5 +1,5 @@
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { CSSProperties } from "react";
 
 export interface LogoProps {
@@ -30,7 +30,7 @@ export const Logo = ({
     return (
         <svg
             {...rest}
-            className={cn("jkl-logo", className, {
+            className={clsx("jkl-logo", className, {
                 "jkl-logo--animated": animated,
                 "jkl-logo--symbol-only": isSymbol,
                 "jkl-logo--centered": centered && isSymbol,

--- a/packages/logo-react/src/LogoStamp.tsx
+++ b/packages/logo-react/src/LogoStamp.tsx
@@ -1,6 +1,6 @@
 import { WithChildren } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { CSSProperties, useRef } from "react";
 import { useTextSpinner } from "./useTextSpinner";
 
@@ -37,7 +37,7 @@ export const LogoStamp = ({
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 512 512"
             aria-labelledby={uniqueId}
-            className={cn("jkl-logo-stamp", className, {
+            className={clsx("jkl-logo-stamp", className, {
                 "jkl-logo-stamp--animated": animated,
             })}
             data-rotate={animated && (visible || hasAnimated)}

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -41,8 +41,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-message-box": "^9.0.11",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/message-box-react/src/FormErrorMessageBox.tsx
+++ b/packages/message-box-react/src/FormErrorMessageBox.tsx
@@ -1,5 +1,5 @@
 import { useAnimatedHeight } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, useEffect, useRef } from "react";
 import { MessageBoxProps, ErrorMessageBox } from "./MessageBox";
 
@@ -34,7 +34,7 @@ export const FormErrorMessageBox = forwardRef<HTMLDivElement, FormErrorMessageBo
         const hasNewErrors = errors.length > previousErrors.current.length;
 
         return (
-            <div ref={forwardedRef} className={cn("jkl-form-error-message-box", className)} {...rest}>
+            <div ref={forwardedRef} className={clsx("jkl-form-error-message-box", className)} {...rest}>
                 <ErrorMessageBox
                     {...defaultMessageBoxProps}
                     {...messageBoxProps}

--- a/packages/message-box-react/src/MessageBox.tsx
+++ b/packages/message-box-react/src/MessageBox.tsx
@@ -1,7 +1,7 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
 import { ErrorIcon, InfoIcon, SuccessIcon, WarningIcon } from "@fremtind/jkl-icons-react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { AriaRole, forwardRef } from "react";
 import { DismissButton } from "./DismissButton";
 
@@ -61,7 +61,7 @@ function messageFactory(messageType: messageTypes) {
                 {...rest}
                 id={id}
                 ref={ref}
-                className={cn("jkl-message-box", "jkl-message-box--" + messageType, className, {
+                className={clsx("jkl-message-box", "jkl-message-box--" + messageType, className, {
                     "jkl-message-box--full": fullWidth,
                     "jkl-message-box--dismissed": dismissed,
                 })}

--- a/packages/modal-react/package.json
+++ b/packages/modal-react/package.json
@@ -41,7 +41,6 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-modal": "^2.1.9",
         "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2",
         "prop-types": "^15.8.1",
         "react-a11y-dialog": "^6.2.0"
     },

--- a/packages/modal-react/src/Modal.tsx
+++ b/packages/modal-react/src/Modal.tsx
@@ -1,7 +1,7 @@
 import type { WithOptionalChildren } from "@fremtind/jkl-core";
 import { IconButton, type IconButtonProps } from "@fremtind/jkl-icon-button-react";
 import { CloseIcon } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 import { ModalConfig } from "./useModal";
 
@@ -23,7 +23,7 @@ type BaseModalProps = Omit<ModalProps, "padding" | "component">;
  */
 export const ModalContainer = forwardRef<HTMLDivElement, ModalConfig["container"] & BaseModalProps>(
     ({ className, ...rest }, ref) => {
-        return <div className={cn("jkl-modal-container", className)} {...rest} ref={ref} />;
+        return <div className={clsx("jkl-modal-container", className)} {...rest} ref={ref} />;
     },
 );
 ModalContainer.displayName = "ModalContainer";
@@ -42,7 +42,7 @@ type ModalOverlayProps = ModalConfig["overlay"] &
 export const ModalOverlay = forwardRef<HTMLDivElement, ModalOverlayProps>(
     ({ className, transparent, ...rest }, ref) => (
         <div
-            className={cn("jkl-modal-overlay", className, {
+            className={clsx("jkl-modal-overlay", className, {
                 "jkl-modal-overlay--transparent": transparent,
             })}
             {...rest}
@@ -60,7 +60,7 @@ export const Modal = forwardRef<HTMLElement, ModalConfig["modal"] & ModalProps>(
         const C = component || "div";
         return (
             <C
-                className={cn("jkl jkl-modal", className)}
+                className={clsx("jkl jkl-modal", className)}
                 style={
                     {
                         "--jkl-modal-padding": padding ? `var(--jkl-spacing-${padding})` : undefined,
@@ -79,7 +79,7 @@ Modal.displayName = "Modal";
  * Ment å brukes med `useModal`.
  */
 export const ModalHeader = forwardRef<HTMLDivElement, BaseModalProps>(({ className, ...rest }, ref) => (
-    <div className={cn("jkl-modal-header", className)} {...rest} ref={ref} />
+    <div className={clsx("jkl-modal-header", className)} {...rest} ref={ref} />
 ));
 ModalHeader.displayName = "ModalHeader";
 
@@ -87,7 +87,7 @@ ModalHeader.displayName = "ModalHeader";
  * Ment å brukes med `useModal`.
  */
 export const ModalTitle = forwardRef<HTMLParagraphElement, ModalConfig["title"] & BaseModalProps>(
-    ({ className, ...rest }, ref) => <p className={cn("jkl-modal-title", className)} {...rest} ref={ref} />,
+    ({ className, ...rest }, ref) => <p className={clsx("jkl-modal-title", className)} {...rest} ref={ref} />,
 );
 ModalTitle.displayName = "ModalTitle";
 
@@ -98,7 +98,7 @@ export const ModalCloseButton = forwardRef<
     HTMLButtonElement,
     Omit<ModalConfig["closeButton"], "onClick"> & BaseModalProps & IconButtonProps
 >(({ className, ...rest }, ref) => (
-    <IconButton className={cn("jkl-modal-close", className)} data-testautoid="jkl-modal-close" {...rest} ref={ref}>
+    <IconButton className={clsx("jkl-modal-close", className)} data-testautoid="jkl-modal-close" {...rest} ref={ref}>
         <CloseIcon variant="medium" />
     </IconButton>
 ));
@@ -108,7 +108,7 @@ ModalCloseButton.displayName = "ModalCloseButton";
  * Ment å brukes med `useModal`.
  */
 export const ModalBody = forwardRef<HTMLDivElement, BaseModalProps>(({ className, ...rest }, ref) => (
-    <div className={cn("jkl-modal-body", className)} {...rest} ref={ref} />
+    <div className={clsx("jkl-modal-body", className)} {...rest} ref={ref} />
 ));
 ModalBody.displayName = "ModalBody";
 
@@ -116,6 +116,6 @@ ModalBody.displayName = "ModalBody";
  * Ment å brukes med `useModal`.
  */
 export const ModalActions = forwardRef<HTMLDivElement, BaseModalProps>(({ className, ...rest }, ref) => (
-    <div className={cn("jkl-modal-actions", className)} {...rest} ref={ref} />
+    <div className={clsx("jkl-modal-actions", className)} {...rest} ref={ref} />
 ));
 ModalActions.displayName = "ModalActions";

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -42,8 +42,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-input-group-react": "^3.0.30",
         "@fremtind/jkl-radio-button": "^10.1.10",
-        "@fremtind/jkl-react-hooks": "^12.0.11",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-react-hooks": "^12.0.11"
     },
     "devDependencies": {
         "@fremtind/jkl-formatters-util": "^5.1.14"

--- a/packages/radio-button-react/src/BaseRadioButton.tsx
+++ b/packages/radio-button-react/src/BaseRadioButton.tsx
@@ -1,6 +1,6 @@
 import { Density } from "@fremtind/jkl-core";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ChangeEventHandler, forwardRef } from "react";
 import { RadioButtonProps } from "./RadioButton";
 
@@ -18,7 +18,7 @@ export const BaseRadioButton = forwardRef<HTMLInputElement, BaseRadioButtonProps
 
     return (
         <div
-            className={cn("jkl-radio-button", className, {
+            className={clsx("jkl-radio-button", className, {
                 "jkl-radio-button--inline": inline,
                 "jkl-radio-button--error": invalid,
             })}

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -43,8 +43,7 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-input-group-react": "^3.0.30",
         "@fremtind/jkl-react-hooks": "^12.0.11",
-        "@fremtind/jkl-select": "^11.1.10",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-select": "^11.1.10"
     },
     "devDependencies": {
         "@fremtind/jkl-accordion-react": "^11.1.5",

--- a/packages/select-react/src/NativeSelect.tsx
+++ b/packages/select-react/src/NativeSelect.tsx
@@ -1,7 +1,7 @@
 import { type ValuePair, getValuePair } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
 import { InputGroup, type InputGroupProps } from "@fremtind/jkl-input-group-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, SelectHTMLAttributes } from "react";
 
 export interface NativeSelectProps extends Omit<InputGroupProps, "children">, SelectHTMLAttributes<HTMLSelectElement> {
@@ -55,7 +55,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>((pr
         <InputGroup
             {...inputGroupProps}
             data-testid="jkl-select"
-            className={cn("jkl-select", className, {
+            className={clsx("jkl-select", className, {
                 "jkl-select--inline": inline,
                 "jkl-select--invalid": !!errorLabel || invalid,
             })}
@@ -63,7 +63,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>((pr
                 <div className="jkl-select__outer-wrapper" style={{ width }}>
                     <select
                         ref={ref}
-                        className={cn("jkl-select__button", selectClassName, {
+                        className={clsx("jkl-select__button", selectClassName, {
                             "jkl-select__button--active-value": !!value,
                         })}
                         defaultValue={value ? undefined : ""}

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -3,7 +3,7 @@ import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
 import { InputGroup, type LabelProps } from "@fremtind/jkl-input-group-react";
 import { InputGroupProps } from "@fremtind/jkl-input-group-react/src";
 import { useId, useAnimatedHeight, usePreviousValue, useListNavigation } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     FocusEvent,
     forwardRef,
@@ -439,7 +439,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             <InputGroup
                 ref={componentRootElementRef}
                 data-testid="jkl-select"
-                className={cn("jkl-select", className, {
+                className={clsx("jkl-select", className, {
                     "jkl-select--inline": inline,
                     "jkl-select--open": dropdownIsShown && visibleItems.some((item) => item.visible),
                     "jkl-select--no-value": !hasSelectedValue,
@@ -493,7 +493,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
                             hidden={showSearchInputField}
                             type="button"
                             name={`${name}-btn`}
-                            className={cn("jkl-select__button", {
+                            className={clsx("jkl-select__button", {
                                 "jkl-select__button--active-value": !!selectedValue,
                             })}
                             data-testid="jkl-select__button"

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,7 +1,7 @@
 import { ValuePair, getValuePair, DataTestAutoId, Density } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
 import { InputGroup, type LabelProps } from "@fremtind/jkl-input-group-react";
-import { InputGroupProps } from "@fremtind/jkl-input-group-react/src";
+import { InputGroupProps } from "@fremtind/jkl-input-group-react";
 import { useId, useAnimatedHeight, usePreviousValue, useListNavigation } from "@fremtind/jkl-react-hooks";
 import clsx from "clsx";
 import React, {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,7 +1,6 @@
 import { ValuePair, getValuePair, DataTestAutoId, Density } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
-import { InputGroup, type LabelProps } from "@fremtind/jkl-input-group-react";
-import { InputGroupProps } from "@fremtind/jkl-input-group-react";
+import { InputGroup, type LabelProps, type InputGroupProps } from "@fremtind/jkl-input-group-react";
 import { useId, useAnimatedHeight, usePreviousValue, useListNavigation } from "@fremtind/jkl-react-hooks";
 import clsx from "clsx";
 import React, {

--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -38,8 +38,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^13.5.0",
-        "@fremtind/jkl-summary-table": "^10.0.10",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-summary-table": "^10.0.10"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/summary-table-react/src/SummaryTable.tsx
+++ b/packages/summary-table-react/src/SummaryTable.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { ReactNode, FC } from "react";
 
 export interface Props {
@@ -11,7 +11,7 @@ export interface Props {
 
 export const SummaryTable: FC<Props> = ({ className, caption, header, body, footer, ...rest }) => {
     return (
-        <table {...rest} className={cn("jkl-summary-table", className)}>
+        <table {...rest} className={clsx("jkl-summary-table", className)}>
             {caption && <caption className="jkl-sr-only">{caption}</caption>}
 
             <thead className="jkl-sr-only">

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -44,8 +44,7 @@
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-select-react": "^14.1.33",
         "@fremtind/jkl-table": "^9.1.2",
-        "@fremtind/jkl-text-input-react": "^15.1.2",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-text-input-react": "^15.1.2"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/table-react/src/ExpandableTableRow.tsx
+++ b/packages/table-react/src/ExpandableTableRow.tsx
@@ -1,5 +1,5 @@
 import { useAnimatedHeight, useId } from "@fremtind/jkl-react-hooks";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, useEffect, useState } from "react";
 import { ExpandableTableRowController, ExpandableTableRowControllerProps } from "./ExpandableTableRowController";
 import type { TableRowProps } from "./TableRow";
@@ -51,11 +51,11 @@ const ExpandableTableRow = forwardRef<HTMLTableRowElement, ExpandableTableRowPro
         setIsOpen(newIsOpen);
     };
 
-    const tableRowClassName = cx("jkl-table-row--expandable", className, {
+    const tableRowClassName = clsx("jkl-table-row--expandable", className, {
         ["jkl-table-row--expanded"]: isOpen,
         ["jkl-expandable-table-row--clickable-external"]: clickable,
     });
-    const childWrapperClassName = cx("jkl-expandable-table-row__expanded-row", {
+    const childWrapperClassName = clsx("jkl-expandable-table-row__expanded-row", {
         ["jkl-expandable-table-row__expanded-row--expanded"]: isOpen,
     });
 

--- a/packages/table-react/src/ExpandableTableRowController.tsx
+++ b/packages/table-react/src/ExpandableTableRowController.tsx
@@ -1,5 +1,5 @@
 import { ExpandButton } from "@fremtind/jkl-expand-button-react";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 import type { TableCellProps } from "./TableCell";
 import { TableCell } from "./TableCell";
@@ -27,7 +27,7 @@ const ExpandableTableRowController = forwardRef<HTMLTableCellElement, Expandable
 
         return (
             <TableCell
-                className={cx(
+                className={clsx(
                     "jkl-table-cell--expand",
                     { ["jkl-table-cell--expand-without-text"]: !children },
                     className,
@@ -36,7 +36,7 @@ const ExpandableTableRowController = forwardRef<HTMLTableCellElement, Expandable
                 ref={ref}
             >
                 <ExpandButton
-                    className={cx("jkl-table-row-expand-button", {
+                    className={clsx("jkl-table-row-expand-button", {
                         ["jkl-table-row-expand-button--expanded"]: isOpen,
                     })}
                     id={id}

--- a/packages/table-react/src/Table.tsx
+++ b/packages/table-react/src/Table.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, TableHTMLAttributes } from "react";
 import { TableContextProvider } from "./tableContext";
 
@@ -16,7 +16,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
         return (
             <TableContextProvider state={{ density, collapseToList }}>
                 <table
-                    className={cx("jkl-table", className, {
+                    className={clsx("jkl-table", className, {
                         ["jkl-table--full-width"]: fullWidth,
                         ["jkl-table--collapse-to-list"]: collapseToList,
                     })}

--- a/packages/table-react/src/TableCaption.tsx
+++ b/packages/table-react/src/TableCaption.tsx
@@ -1,4 +1,4 @@
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, HTMLAttributes } from "react";
 
 export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElement> {
@@ -8,7 +8,11 @@ export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElemen
 
 const TableCaption = forwardRef<HTMLTableCaptionElement, TableCaptionProps>(({ srOnly = true, ...rest }, ref) => {
     return (
-        <caption className={cx("jkl-table-caption", { ["jkl-table-caption--sr-only"]: srOnly })} {...rest} ref={ref} />
+        <caption
+            className={clsx("jkl-table-caption", { ["jkl-table-caption--sr-only"]: srOnly })}
+            {...rest}
+            ref={ref}
+        />
     );
 });
 

--- a/packages/table-react/src/TableCell.tsx
+++ b/packages/table-react/src/TableCell.tsx
@@ -1,5 +1,5 @@
 import { Density } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, TdHTMLAttributes } from "react";
 import { useTableContext } from "./tableContext";
 
@@ -22,7 +22,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
         const { density: contextDensity } = useTableContext();
         return (
             <td
-                className={cx("jkl-table-cell", className, {
+                className={clsx("jkl-table-cell", className, {
                     ["jkl-table-cell--align-right"]: align === "right",
                     ["jkl-table-cell--align-center"]: align === "center",
                     ["jkl-table-cell--vertical-align-center"]: verticalAlign === "center",

--- a/packages/table-react/src/TableFooter.tsx
+++ b/packages/table-react/src/TableFooter.tsx
@@ -1,4 +1,4 @@
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, HTMLAttributes } from "react";
 import { TableSectionContextProvider } from "./tableSectionContext";
 
@@ -7,7 +7,7 @@ export interface TableFooterProps extends HTMLAttributes<HTMLTableSectionElement
 const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>(({ className, ...rest }, ref) => {
     return (
         <TableSectionContextProvider state={{ isTableHead: false, isTableBody: false, isTableFooter: true }}>
-            <tfoot className={cx("jkl-table-foot", className)} {...rest} ref={ref} />
+            <tfoot className={clsx("jkl-table-foot", className)} {...rest} ref={ref} />
         </TableSectionContextProvider>
     );
 });

--- a/packages/table-react/src/TableHead.tsx
+++ b/packages/table-react/src/TableHead.tsx
@@ -1,4 +1,4 @@
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, HTMLAttributes } from "react";
 import { TableSectionContextProvider } from "./tableSectionContext";
 
@@ -11,7 +11,7 @@ const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(({ classNa
     return (
         <TableSectionContextProvider state={{ isTableHead: true, isTableBody: false, isTableFooter: false }}>
             <thead
-                className={cx("jkl-table-head", className, {
+                className={clsx("jkl-table-head", className, {
                     ["jkl-table-head--sr-only"]: srOnly,
                     ["jkl-table-head--sticky"]: sticky,
                 })}

--- a/packages/table-react/src/TableHeader.tsx
+++ b/packages/table-react/src/TableHeader.tsx
@@ -1,6 +1,6 @@
 import { Density } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, MouseEventHandler, ThHTMLAttributes } from "react";
 import { useTableContext } from "./tableContext";
 import { TableSortProps } from "./utils";
@@ -46,7 +46,7 @@ const TableHeader = forwardRef<HTMLTableCellElement, TableHeaderProps>((props, r
 
     return (
         <th
-            className={cn("jkl-table-header", className, {
+            className={clsx("jkl-table-header", className, {
                 ["jkl-table-header--bold"]: bold,
                 ["jkl-table-header--align-right"]: align === "right",
                 ["jkl-table-header--align-center"]: align === "center",
@@ -62,7 +62,7 @@ const TableHeader = forwardRef<HTMLTableCellElement, TableHeaderProps>((props, r
             {children}
             {sortable && (
                 <div
-                    className={cn("jkl-table-header__arrows", {
+                    className={clsx("jkl-table-header__arrows", {
                         "jkl-table-header__arrows--active": Boolean(sortable.direction),
                     })}
                 >

--- a/packages/table-react/src/TablePagination.tsx
+++ b/packages/table-react/src/TablePagination.tsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@fremtind/jkl-icons-react";
 import { useId } from "@fremtind/jkl-react-hooks";
 import { NativeSelect } from "@fremtind/jkl-select-react";
 import { TextInput } from "@fremtind/jkl-text-input-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     forwardRef,
     useCallback,
@@ -151,7 +151,7 @@ export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
 
     return (
         <div
-            className={cn("jkl-table-pagination", className)}
+            className={clsx("jkl-table-pagination", className)}
             {...rest}
             id={id}
             data-density={density || contextDensity}
@@ -243,7 +243,7 @@ const PaginationPages: FC<{
                 {Array.from({ length: numberOfPages }).map((_, i) => (
                     <li key={`${id}-page-${i}`}>
                         <button
-                            className={cn("jkl-table-pagination__page", {
+                            className={clsx("jkl-table-pagination__page", {
                                 "jkl-table-pagination__page--active": activePage === i,
                             })}
                             type="button"
@@ -336,7 +336,7 @@ const PaginationPageButton: FC<{
     onClick: MouseEventHandler;
 }> = ({ isActive, number, onClick, ...rest }) => (
     <button
-        className={cn("jkl-table-pagination__page", {
+        className={clsx("jkl-table-pagination__page", {
             "jkl-table-pagination__page--active": isActive,
         })}
         type="button"

--- a/packages/table-react/src/TableRow.tsx
+++ b/packages/table-react/src/TableRow.tsx
@@ -1,4 +1,4 @@
-import cx from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, HTMLAttributes, useEffect, useState } from "react";
 import { useTableContext } from "./tableContext";
 import { useTableSectionContext } from "./tableSectionContext";
@@ -42,7 +42,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(({ className, cl
                     }
                 }}
                 data-testid="jkl-clickable-table-row"
-                className={cx("jkl-table-row", "jkl-table-row--clickable", className, {
+                className={clsx("jkl-table-row", "jkl-table-row--clickable", className, {
                     ["jkl-table-row--clicked"]: clickable?.markClickedRows && clicked,
                 })}
                 aria-label="Klikkbar rad"
@@ -58,7 +58,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(({ className, cl
     }
 
     return (
-        <tr className={cx("jkl-table-row", className)} {...rest} ref={ref} data-density={density}>
+        <tr className={clsx("jkl-table-row", className)} {...rest} ref={ref} data-density={density}>
             {children}
         </tr>
     );

--- a/packages/tabs-react/package.json
+++ b/packages/tabs-react/package.json
@@ -39,7 +39,6 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-tabs": "^5.0.11",
-        "classnames": "^2.3.2",
         "nanoid": "^3.3.6"
     },
     "peerDependencies": {

--- a/packages/tabs-react/src/NavTab.tsx
+++ b/packages/tabs-react/src/NavTab.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type ElementType, forwardRef, useCallback, type AnchorHTMLAttributes } from "react";
 
 export interface NavTabProps<T extends object = Record<string, unknown>>
@@ -90,7 +90,7 @@ export const NavTab = forwardRef<HTMLAnchorElement, NavTabProps>((props, ref) =>
             {...componentProps}
             role="tab"
             aria-selected={selected}
-            className={cn("jkl-tab", className)}
+            className={clsx("jkl-tab", className)}
             onKeyDown={handleOnKeyDown}
             // En faneliste skal være én fokuserbar gruppe.
             // Piltaster brukes for å veksle mellom faner.

--- a/packages/tabs-react/src/NavTabs.tsx
+++ b/packages/tabs-react/src/NavTabs.tsx
@@ -1,5 +1,5 @@
 import type { Density, WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { useEffect, useRef, useState } from "react";
 
 export interface NavTabsProps extends WithChildren {
@@ -40,7 +40,7 @@ export const NavTabs = ({
     }, [selectedIndex, density]);
 
     return (
-        <div {...rest} data-layout-density={density} className={cn("jkl-tabs", className)} ref={scrollRef}>
+        <div {...rest} data-layout-density={density} className={clsx("jkl-tabs", className)} ref={scrollRef}>
             <div role="tablist" aria-label={ariaLabel} ref={tablistRef} className="jkl-tablist">
                 {React.Children.map(children, (child, index) => {
                     return React.isValidElement(child)

--- a/packages/tabs-react/src/Tab.tsx
+++ b/packages/tabs-react/src/Tab.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React from "react";
 
 export interface TabProps extends WithChildren {
@@ -12,7 +12,7 @@ export interface TabProps extends WithChildren {
  * Docs: https://jokul.fremtind.no/komponenter/tabs
  */
 export const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
-    const classes = cx("jkl-tab", props.className);
+    const classes = clsx("jkl-tab", props.className);
 
     return <button role="tab" type="button" ref={ref} {...props} className={classes} />;
 });

--- a/packages/tabs-react/src/TabList.tsx
+++ b/packages/tabs-react/src/TabList.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTabsContext } from "./tabsContext";
 
@@ -66,7 +66,7 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
     }, []);
 
     return (
-        <div role="tablist" ref={tabsRef} {...rest} className={cn("jkl-tablist", className)}>
+        <div role="tablist" ref={tabsRef} {...rest} className={clsx("jkl-tablist", className)}>
             {React.Children.map(children, (tab, tabIndex) => {
                 const isActive = activeIndex === tabIndex;
 

--- a/packages/tabs-react/src/TabPanel.tsx
+++ b/packages/tabs-react/src/TabPanel.tsx
@@ -1,5 +1,5 @@
 import { WithChildren } from "@fremtind/jkl-core";
-import cx from "classnames";
+import clsx from "clsx";
 import React from "react";
 
 export interface TabPanelProps extends WithChildren {
@@ -12,7 +12,7 @@ export interface TabPanelProps extends WithChildren {
  * Docs: https://jokul.fremtind.no/komponenter/tabs
  */
 export const TabPanel = ({ children, ...props }: TabPanelProps) => {
-    const classes = cx("jkl-tabpanel", props.className);
+    const classes = clsx("jkl-tabpanel", props.className);
 
     return (
         <div role="tabpanel" {...props} className={classes}>

--- a/packages/tabs-react/src/Tabs.tsx
+++ b/packages/tabs-react/src/Tabs.tsx
@@ -1,6 +1,6 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
 import { usePreviousValue } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import { nanoid } from "nanoid";
 import React, { useState, useCallback, useEffect } from "react";
 import { InjectedProps, TabListProps } from "./TabList";
@@ -82,7 +82,7 @@ export const Tabs = ({ onChange, defaultTab, density, ...props }: TabsProps) => 
 
     return (
         <TabsContextProvider state={{ density }}>
-            <div {...props} className={cn("jkl-tabs", props.className)} data-density={density}>
+            <div {...props} className={clsx("jkl-tabs", props.className)} data-density={density}>
                 {renderTabList()}
                 {renderTabPanels()}
             </div>

--- a/packages/tag-react/package.json
+++ b/packages/tag-react/package.json
@@ -41,8 +41,7 @@
         "@fremtind/jkl-core": "^13.5.0",
         "@fremtind/jkl-icon-button-react": "^4.0.33",
         "@fremtind/jkl-icons-react": "^8.7.2",
-        "@fremtind/jkl-tag": "^5.0.10",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-tag": "^5.0.10"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/tag-react/src/Tag.tsx
+++ b/packages/tag-react/src/Tag.tsx
@@ -1,7 +1,7 @@
 import { Density } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
 import { CloseIcon } from "@fremtind/jkl-icons-react";
-import cx from "classnames";
+import clsx from "clsx";
 import React, { ButtonHTMLAttributes, FC, HTMLAttributes, MouseEventHandler } from "react";
 
 export interface DismissAction extends Exclude<ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> {
@@ -34,7 +34,7 @@ function getDisplayName(variant?: Variant) {
 function tagFactory(variant?: Variant) {
     const Tag: FC<TagProps> = ({ className, density, dismissAction, children, ...rest }) => (
         <span
-            className={cx(
+            className={clsx(
                 "jkl-tag",
                 {
                     "jkl-tag--info": variant === "info",

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -49,7 +49,6 @@
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-text-input": "^12.1.10",
         "@fremtind/jkl-tooltip-react": "^4.2.21",
-        "classnames": "^2.3.2",
         "downshift": "^7.6.0",
         "match-sorter": "^6.3.1"
     },

--- a/packages/text-input-react/src/BaseTextInput.tsx
+++ b/packages/text-input-react/src/BaseTextInput.tsx
@@ -1,7 +1,7 @@
 import { Density } from "@fremtind/jkl-core";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
 import type { IconProps } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, {
     type CSSProperties,
     forwardRef,
@@ -84,7 +84,7 @@ export const BaseTextInput = forwardRef<HTMLInputElement, BaseTextInputProps>((p
             <input
                 aria-invalid={ariaInvalid}
                 ref={ref}
-                className={cn("jkl-text-input__input", className, {
+                className={clsx("jkl-text-input__input", className, {
                     "jkl-text-input__input--align-right": align === "right",
                 })}
                 maxLength={maxLength}
@@ -95,7 +95,7 @@ export const BaseTextInput = forwardRef<HTMLInputElement, BaseTextInputProps>((p
             {action && (
                 <IconButton
                     density={density}
-                    className={cn("jkl-text-input-action-button", action.className)}
+                    className={clsx("jkl-text-input-action-button", action.className)}
                     title={action.label}
                     onClick={action.onClick}
                     onFocus={action.onFocus}

--- a/packages/text-input-react/src/TextArea.tsx
+++ b/packages/text-input-react/src/TextArea.tsx
@@ -1,5 +1,5 @@
 import { InputGroup, type InputGroupProps } from "@fremtind/jkl-input-group-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 import { BaseTextArea, BaseTextAreaProps } from "./BaseTextArea";
 
@@ -34,7 +34,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
     const textAreaProps = { autoExpand, counter, startOpen };
     return (
         <InputGroup
-            className={cn("jkl-text-area", className, {
+            className={clsx("jkl-text-area", className, {
                 "jkl-text-area--start-open": startOpen,
                 "jkl-text-area--auto-expand": autoExpand,
             })}

--- a/packages/text-input-react/src/TextInput.tsx
+++ b/packages/text-input-react/src/TextInput.tsx
@@ -1,5 +1,5 @@
 import { InputGroup, InputGroupProps } from "@fremtind/jkl-input-group-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 import { BaseTextInput, BaseTextInputProps } from "./BaseTextInput";
 
@@ -36,7 +36,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
     return (
         <InputGroup
             {...inputGroupProps}
-            className={cn(className, "jkl-text-input", {
+            className={clsx(className, "jkl-text-input", {
                 "jkl-text-input--inline": inline,
             })}
             data-testid="jkl-text-input"

--- a/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
+++ b/packages/text-input-react/src/autosuggest/BaseAutosuggest.tsx
@@ -1,6 +1,6 @@
 import { InputGroup } from "@fremtind/jkl-input-group-react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import Downshift, { type DownshiftProps } from "downshift";
 import React, { type ReactNode } from "react";
 import { type CommonProps } from "./Autosuggest";
@@ -69,7 +69,7 @@ function BaseAutosuggest<T>({
                     <InputGroup
                         {...getRootProps()}
                         label={label}
-                        className={cn("jkl-autosuggest", className)}
+                        className={clsx("jkl-autosuggest", className)}
                         density={density}
                         labelProps={{
                             variant,
@@ -86,7 +86,7 @@ function BaseAutosuggest<T>({
                             <>
                                 {leadText && (
                                     <p
-                                        className={cn("jkl-spacing-l--bottom", {
+                                        className={clsx("jkl-spacing-l--bottom", {
                                             "jkl-body": density !== "compact",
                                             "jkl-small": density === "compact",
                                         })}

--- a/packages/text-input-react/src/autosuggest/Menu.tsx
+++ b/packages/text-input-react/src/autosuggest/Menu.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import clsx from "clsx";
 import { PropGetters } from "downshift";
 import React, { ReactNode } from "react";
 
@@ -47,7 +47,7 @@ function Menu<T>({
                         <li
                             {...getItemProps({
                                 item,
-                                className: cn("jkl-autosuggest__item", {
+                                className: clsx("jkl-autosuggest__item", {
                                     "jkl-autosuggest__item--active": index === highlightedIndex,
                                 }),
                             })}

--- a/packages/toast-react/package.json
+++ b/packages/toast-react/package.json
@@ -43,8 +43,7 @@
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-toast": "^2.1.9",
         "@react-aria/toast": "^3.0.0-beta.1",
-        "@react-stately/toast": "^3.0.0-beta.0",
-        "classnames": "^2.2.6"
+        "@react-stately/toast": "^3.0.0-beta.0"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/toast-react/src/Toast.tsx
+++ b/packages/toast-react/src/Toast.tsx
@@ -4,7 +4,7 @@ import { Countdown } from "@fremtind/jkl-progress-bar-react";
 import { useBrowserPreferences } from "@fremtind/jkl-react-hooks";
 import { type AriaToastProps, useToast } from "@react-aria/toast";
 import { QueuedToast, type ToastState } from "@react-stately/toast";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { useEffect, useRef } from "react";
 import { ToastContent, ToastOptions } from "./types";
 
@@ -54,7 +54,7 @@ export function Toast<T extends ToastContent>({ className, state, ...props }: To
         <div
             {...toastProps}
             ref={ref}
-            className={cn(
+            className={clsx(
                 "jkl-toast",
                 {
                     "jkl-toast--info": props.toast.variant === "info",

--- a/packages/toast-react/src/ToastRegion.tsx
+++ b/packages/toast-react/src/ToastRegion.tsx
@@ -1,6 +1,6 @@
 import { type AriaToastRegionProps, useToastRegion } from "@react-aria/toast";
 import { useToastQueue, type ToastState, ToastQueue } from "@react-stately/toast";
-import cn from "classnames";
+import clsx from "clsx";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Toast } from "./Toast";
@@ -17,7 +17,7 @@ function Region<T extends ToastContent>({ placement, state, ...props }: ToastReg
 
     return (
         <div
-            className={cn("jkl", "jkl-toast-region", {
+            className={clsx("jkl", "jkl-toast-region", {
                 "jkl-toast-region--left": placement === "left",
             })}
         >

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -43,8 +43,7 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-input-group-react": "^3.0.30",
         "@fremtind/jkl-react-hooks": "^12.0.11",
-        "@fremtind/jkl-toggle-switch": "^13.1.1",
-        "classnames": "^2.3.2"
+        "@fremtind/jkl-toggle-switch": "^13.1.1"
     },
     "peerDependencies": {
         "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",

--- a/packages/toggle-switch-react/src/ToggleSlider.tsx
+++ b/packages/toggle-switch-react/src/ToggleSlider.tsx
@@ -1,6 +1,6 @@
 import { Density, WithChildren } from "@fremtind/jkl-core";
 import { useId, useSwipeGesture } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { useState, Fragment, useRef, FC, MouseEventHandler } from "react";
 import { type ToggleChangeHandler } from "./ToggleSwitch";
 import { usePillStyles } from "./usePillStyles";
@@ -55,14 +55,14 @@ export const ToggleSlider: FC<Props> = ({
     return (
         <fieldset
             {...rest}
-            className={cn("jkl-toggle-slider", className)}
+            className={clsx("jkl-toggle-slider", className)}
             aria-labelledby={legendId}
             data-testid="jkl-toggle-slider"
             data-density={density}
         >
             <div
                 id={legendId}
-                className={cn("jkl-toggle-slider__legend", {
+                className={clsx("jkl-toggle-slider__legend", {
                     "jkl-toggle-slider__legend--sr-only": hideLegend,
                 })}
             >
@@ -82,7 +82,7 @@ export const ToggleSlider: FC<Props> = ({
                             onChange={() => {}}
                         />
                         <label
-                            className={cn("jkl-toggle-slider__label", {
+                            className={clsx("jkl-toggle-slider__label", {
                                 "jkl-toggle-slider__label--selected": label === currentLabel,
                             })}
                             ref={label === currentLabel ? activeRef : undefined}

--- a/packages/toggle-switch-react/src/ToggleSwitch.tsx
+++ b/packages/toggle-switch-react/src/ToggleSwitch.tsx
@@ -1,7 +1,7 @@
 import { Density } from "@fremtind/jkl-core";
 import { CheckIcon } from "@fremtind/jkl-icons-react";
 import { useId, useSwipeGesture, type SwipeChangeHandler } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { type ButtonHTMLAttributes, type MouseEventHandler, forwardRef } from "react";
 
 export type ToggleChangeHandler<T extends HTMLElement> = SwipeChangeHandler<T>;
@@ -55,7 +55,7 @@ export const ToggleSwitch = forwardRef<HTMLButtonElement, ToggleProps>(
 
         return (
             <button
-                className={cn("jkl-toggle-switch", className)}
+                className={clsx("jkl-toggle-switch", className)}
                 id={uid}
                 ref={ref}
                 aria-pressed={pressed}

--- a/packages/tooltip-react/package.json
+++ b/packages/tooltip-react/package.json
@@ -42,7 +42,6 @@
         "@fremtind/jkl-icons-react": "^8.7.2",
         "@fremtind/jkl-react-hooks": "^12.0.11",
         "@fremtind/jkl-tooltip": "^4.1.9",
-        "classnames": "^2.3.2",
         "framer-motion": "^7.10.3"
     },
     "peerDependencies": {

--- a/packages/tooltip-react/src/PopupTip.tsx
+++ b/packages/tooltip-react/src/PopupTip.tsx
@@ -1,5 +1,5 @@
 import { QuestionIcon } from "@fremtind/jkl-icons-react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { useState, type FC, type ReactNode, HTMLProps, FocusEventHandler } from "react";
 import { Tooltip, type TooltipProps } from "./Tooltip";
 import { TooltipContent } from "./TooltipContent";
@@ -36,7 +36,7 @@ export const PopupTip: FC<PopupTipProps> = ({ content, triggerProps, ...tooltipP
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     type="button"
-                    className={cn("jkl-tooltip-question-button", triggerProps?.className)}
+                    className={clsx("jkl-tooltip-question-button", triggerProps?.className)}
                 >
                     <QuestionIcon bold={isBold} />
                     <span className="jkl-sr-only">Vis hjelpetekst</span>

--- a/packages/tooltip-react/src/TooltipContent.tsx
+++ b/packages/tooltip-react/src/TooltipContent.tsx
@@ -1,6 +1,6 @@
 import { type Placement, useMergeRefs, FloatingPortal } from "@floating-ui/react";
 import { useId } from "@fremtind/jkl-react-hooks";
-import cn from "classnames";
+import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import React, { HTMLProps, forwardRef } from "react";
 import { useTooltipContext } from "./Tooltip";
@@ -88,7 +88,7 @@ export const TooltipContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElemen
                             transition={{ ease: "easeOut", duration: 0.25 }}
                             data-placement={placement}
                             aria-live={triggerOn === "click" ? "assertive" : undefined}
-                            className={cn("jkl-tooltip-content", className)}
+                            className={clsx("jkl-tooltip-content", className)}
                             {...getFloatingProps({ ...props, id: contentId })}
                             style={{ ...floatingStyles }}
                             data-theme={theme}

--- a/packages/tooltip-react/src/TooltipTrigger.tsx
+++ b/packages/tooltip-react/src/TooltipTrigger.tsx
@@ -1,5 +1,5 @@
 import { useMergeRefs } from "@floating-ui/react";
-import cn from "classnames";
+import clsx from "clsx";
 import React, { forwardRef, type HTMLProps } from "react";
 import { useTooltipContext } from "./Tooltip";
 
@@ -30,7 +30,7 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(fu
                 "aria-label": ariaLabel,
                 ...children.props,
                 ...props,
-                className: cn(children.props.className, className),
+                className: clsx(children.props.className, className),
                 "data-tooltip-shown": isOpen,
                 style: { ...children.props.style },
                 tabIndex: triggerOn === "click" ? 0 : undefined,
@@ -46,7 +46,7 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(fu
         <button
             data-tooltip-shown={isOpen}
             {...getReferenceProps({
-                className: cn(className, "jkl-tooltip-trigger"),
+                className: clsx(className, "jkl-tooltip-trigger"),
                 // Sørg for at vi ikke sender inn skjemaer ved klikk på knappen
                 type: "button",
                 ref,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ importers:
       '@typescript-eslint/parser': ^5.59.9
       autoprefixer: ^10.4.14
       browserslist: ^4.21.7
+      clsx: ^2.1.1
       commitizen: ^4.3.0
       cssnano: ^6.0.1
       cssnano-preset-lite: ^3.0.0
@@ -98,6 +99,7 @@ importers:
       tiny-glob: ^0.2.9
       typescript: ^5.0.4
     dependencies:
+      clsx: 2.1.1
       fs-extra: 11.1.1
       glob: 8.1.0
       nodemon: 2.0.22
@@ -218,15 +220,13 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-list-react': ^10.1.4
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-accordion': link:../accordion
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-accordion': 11.2.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
     devDependencies:
-      '@fremtind/jkl-list-react': link:../list-react
+      '@fremtind/jkl-list-react': 10.1.4
 
   packages/alert-message:
     specifiers:
@@ -240,13 +240,11 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-alert-message': link:../alert-message
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-alert-message': 9.0.10
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/breadcrumb:
     specifiers:
@@ -258,11 +256,9 @@ importers:
     specifiers:
       '@fremtind/jkl-breadcrumb': ^5.0.10
       '@fremtind/jkl-core': ^13.5.0
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-breadcrumb': link:../breadcrumb
-      '@fremtind/jkl-core': link:../core
-      classnames: 2.3.2
+      '@fremtind/jkl-breadcrumb': 5.0.10
+      '@fremtind/jkl-core': 13.5.0
 
   packages/browserslist-config-jkl:
     specifiers: {}
@@ -281,16 +277,14 @@ importers:
       '@fremtind/jkl-loader-react': ^12.0.11
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-toggle-switch-react': ^13.1.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-button': link:../button
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-loader-react': link:../loader-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-button': 12.1.0
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-loader-react': 12.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
     devDependencies:
-      '@fremtind/jkl-toggle-switch-react': link:../toggle-switch-react
+      '@fremtind/jkl-toggle-switch-react': 13.1.10
 
   packages/card:
     specifiers:
@@ -306,16 +300,14 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-image-react': ^6.0.11
       '@fremtind/jkl-tag-react': ^5.2.12
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-button-react': link:../button-react
-      '@fremtind/jkl-card': link:../card
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-image-react': link:../image-react
-      '@fremtind/jkl-tag-react': link:../tag-react
-      classnames: 2.3.2
+      '@fremtind/jkl-button-react': 15.1.2
+      '@fremtind/jkl-card': 11.2.1
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-image-react': 6.0.11
+      '@fremtind/jkl-tag-react': 5.2.12
     devDependencies:
-      '@fremtind/jkl-constants-util': link:../constants-util
+      '@fremtind/jkl-constants-util': 3.0.58
 
   packages/checkbox:
     specifiers:
@@ -329,14 +321,12 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-checkbox': link:../checkbox
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-checkbox': 11.0.7
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-react-hooks': 12.0.11
     devDependencies:
-      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-input-group-react': 3.0.30
 
   packages/combobox:
     specifiers:
@@ -355,18 +345,16 @@ importers:
       '@fremtind/jkl-select-react': ^14.1.33
       '@fremtind/jkl-tag-react': ^5.2.12
       '@fremtind/jkl-tooltip-react': ^4.2.21
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-combobox': link:../combobox
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-select-react': link:../select-react
-      '@fremtind/jkl-tag-react': link:../tag-react
-      '@fremtind/jkl-tooltip-react': link:../tooltip-react
-      classnames: 2.3.2
+      '@fremtind/jkl-combobox': 2.2.8
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-select-react': 14.1.33
+      '@fremtind/jkl-tag-react': 5.2.12
+      '@fremtind/jkl-tooltip-react': 4.2.21
 
   packages/constants-util:
     specifiers:
@@ -387,12 +375,10 @@ importers:
       '@fremtind/jkl-contact-information': ^2.0.10
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-formatters-util': ^5.1.14
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-contact-information': link:../contact-information
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-formatters-util': link:../formatters-util
-      classnames: 2.3.2
+      '@fremtind/jkl-contact-information': 2.0.10
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-formatters-util': 5.1.14
 
   packages/content-toggle:
     specifiers:
@@ -404,11 +390,9 @@ importers:
     specifiers:
       '@fremtind/jkl-content-toggle': ^6.0.10
       '@fremtind/jkl-core': ^13.5.0
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-content-toggle': link:../content-toggle
-      '@fremtind/jkl-core': link:../core
-      classnames: 2.3.2
+      '@fremtind/jkl-content-toggle': 6.0.10
+      '@fremtind/jkl-core': 13.5.0
 
   packages/contextual-menu:
     specifiers:
@@ -425,19 +409,17 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-toggle-switch': ^13.1.1
-      classnames: ^2.3.2
       framer-motion: ^7.10.3
     dependencies:
       '@floating-ui/react': 0.24.2
-      '@fremtind/jkl-contextual-menu': link:../contextual-menu
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-toggle-switch': link:../toggle-switch
-      classnames: 2.3.2
+      '@fremtind/jkl-contextual-menu': 2.1.7
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-toggle-switch': 13.1.1
       framer-motion: 7.10.3
     devDependencies:
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icon-button-react': 4.0.33
 
   packages/cookie-consent:
     specifiers:
@@ -466,10 +448,7 @@ importers:
   packages/core:
     specifiers:
       change-case: ^4.1.2
-      classnames: ^2.3.2
       style-dictionary: ^3.8.0
-    dependencies:
-      classnames: 2.3.2
     devDependencies:
       change-case: 4.1.2
       style-dictionary: 3.8.0
@@ -494,17 +473,15 @@ importers:
       '@fremtind/jkl-select-react': ^14.1.33
       '@fremtind/jkl-text-input-react': ^15.1.2
       '@jest/globals': ^29.5.0
-      classnames: ^2.3.2
       date-fns: ^2.30.0
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-datepicker': link:../datepicker
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-select-react': link:../select-react
-      '@fremtind/jkl-text-input-react': link:../text-input-react
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-datepicker': 12.1.11
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-select-react': 14.1.33
+      '@fremtind/jkl-text-input-react': 15.1.2
       date-fns: 2.30.0
     devDependencies:
       '@jest/globals': 29.5.0
@@ -519,11 +496,9 @@ importers:
     specifiers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-description-list': ^8.0.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-description-list': link:../description-list
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-description-list': 8.0.10
 
   packages/expand-button:
     specifiers:
@@ -537,13 +512,11 @@ importers:
       '@fremtind/jkl-expand-button': ^7.0.1
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-expand-button': link:../expand-button
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-expand-button': 7.0.1
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/feedback:
     specifiers:
@@ -563,19 +536,17 @@ importers:
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-text-input-react': ^15.1.2
       '@fremtind/jkl-validators-util': ^3.0.0
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-button-react': link:../button-react
-      '@fremtind/jkl-checkbox-react': link:../checkbox-react
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-feedback': link:../feedback
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-message-box-react': link:../message-box-react
-      '@fremtind/jkl-radio-button-react': link:../radio-button-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-text-input-react': link:../text-input-react
-      '@fremtind/jkl-validators-util': link:../validators-util
-      classnames: 2.3.2
+      '@fremtind/jkl-button-react': 15.1.2
+      '@fremtind/jkl-checkbox-react': 11.1.23
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-feedback': 13.0.10
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-message-box-react': 11.1.16
+      '@fremtind/jkl-radio-button-react': 11.1.54
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-text-input-react': 15.1.2
+      '@fremtind/jkl-validators-util': 3.0.0
 
   packages/file-input:
     specifiers:
@@ -594,18 +565,16 @@ importers:
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-progress-bar-react': ^6.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-button-react': link:../button-react
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-file-input': link:../file-input
-      '@fremtind/jkl-formatters-util': link:../formatters-util
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-progress-bar-react': link:../progress-bar-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-button-react': 15.1.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-file-input': 2.0.11
+      '@fremtind/jkl-formatters-util': 5.1.14
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-progress-bar-react': 6.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/footer:
     specifiers:
@@ -619,13 +588,11 @@ importers:
       '@fremtind/jkl-footer': ^6.0.10
       '@fremtind/jkl-formatters-util': ^5.1.14
       '@fremtind/jkl-logo-react': ^13.1.1
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-footer': link:../footer
-      '@fremtind/jkl-formatters-util': link:../formatters-util
-      '@fremtind/jkl-logo-react': link:../logo-react
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-footer': 6.0.10
+      '@fremtind/jkl-formatters-util': 5.1.14
+      '@fremtind/jkl-logo-react': 13.1.1
 
   packages/formatters-util:
     specifiers:
@@ -656,13 +623,11 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-hamburger': ^13.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-content-toggle-react': link:../content-toggle-react
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-hamburger': link:../hamburger
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-content-toggle-react': 6.0.11
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-hamburger': 13.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/icon-button:
     specifiers:
@@ -676,14 +641,12 @@ importers:
       '@fremtind/jkl-icon-button': ^4.0.12
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-toggle-switch-react': ^13.1.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button': link:../icon-button
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button': 4.0.12
     devDependencies:
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-toggle-switch-react': link:../toggle-switch-react
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-toggle-switch-react': 13.1.10
 
   packages/icons:
     specifiers:
@@ -696,12 +659,10 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-icons': ^9.1.4
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons': link:../icons
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons': 9.1.4
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/image:
     specifiers:
@@ -713,11 +674,9 @@ importers:
     specifiers:
       '@fremtind/jkl-image': ^6.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-image': link:../image
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-image': 6.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/input-group:
     specifiers:
@@ -732,14 +691,12 @@ importers:
       '@fremtind/jkl-input-group': ^3.0.11
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-tooltip-react': ^4.2.21
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group': link:../input-group
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-tooltip-react': link:../tooltip-react
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group': 3.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-tooltip-react': 4.2.21
 
   packages/list:
     specifiers:
@@ -751,11 +708,9 @@ importers:
     specifiers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-list': ^10.2.4
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-list': link:../list
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-list': 10.2.4
 
   packages/loader:
     specifiers:
@@ -767,11 +722,9 @@ importers:
     specifiers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-loader': ^11.0.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-loader': link:../loader
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-loader': 11.0.10
 
   packages/logo:
     specifiers:
@@ -784,12 +737,10 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-logo': ^11.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-logo': link:../logo
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-logo': 11.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/message-box:
     specifiers:
@@ -803,13 +754,11 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-message-box': ^9.0.11
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-message-box': link:../message-box
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-message-box': 9.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
 
   packages/modal:
     specifiers:
@@ -824,16 +773,14 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-modal': ^2.1.9
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
       prop-types: ^15.8.1
       react-a11y-dialog: ^6.2.0
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-modal': link:../modal
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-modal': 2.1.9
+      '@fremtind/jkl-react-hooks': 12.0.11
       prop-types: 15.8.1
       react-a11y-dialog: 6.2.0_prop-types@15.8.1
 
@@ -862,15 +809,13 @@ importers:
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-radio-button': ^10.1.10
       '@fremtind/jkl-react-hooks': ^12.0.11
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-radio-button': link:../radio-button
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-radio-button': 10.1.10
+      '@fremtind/jkl-react-hooks': 12.0.11
     devDependencies:
-      '@fremtind/jkl-formatters-util': link:../formatters-util
+      '@fremtind/jkl-formatters-util': 5.1.14
 
   packages/react-hooks:
     specifiers:
@@ -894,17 +839,15 @@ importers:
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-select': ^11.1.10
-      classnames: ^2.3.2
       react-hook-form: ^7.44.3
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-select': link:../select
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-select': 11.1.10
     devDependencies:
-      '@fremtind/jkl-accordion-react': link:../accordion-react
+      '@fremtind/jkl-accordion-react': 11.1.5
       react-hook-form: 7.44.3
 
   packages/stylelint-config-jkl:
@@ -930,11 +873,9 @@ importers:
     specifiers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-summary-table': ^10.0.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-summary-table': link:../summary-table
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-summary-table': 10.0.10
 
   packages/table:
     specifiers:
@@ -952,17 +893,15 @@ importers:
       '@fremtind/jkl-select-react': ^14.1.33
       '@fremtind/jkl-table': ^9.1.2
       '@fremtind/jkl-text-input-react': ^15.1.2
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-expand-button-react': link:../expand-button-react
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-select-react': link:../select-react
-      '@fremtind/jkl-table': link:../table
-      '@fremtind/jkl-text-input-react': link:../text-input-react
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-expand-button-react': 7.0.5
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-select-react': 14.1.33
+      '@fremtind/jkl-table': 9.1.2
+      '@fremtind/jkl-text-input-react': 15.1.2
 
   packages/tabs:
     specifiers:
@@ -975,13 +914,11 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-tabs': ^5.0.11
-      classnames: ^2.3.2
       nanoid: ^3.3.6
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-tabs': link:../tabs
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-tabs': 5.0.11
       nanoid: 3.3.6
 
   packages/tag:
@@ -996,13 +933,11 @@ importers:
       '@fremtind/jkl-icon-button-react': ^4.0.33
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-tag': ^5.0.10
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-tag': link:../tag
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-tag': 5.0.10
 
   packages/text-input:
     specifiers:
@@ -1019,18 +954,16 @@ importers:
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-text-input': ^12.1.10
       '@fremtind/jkl-tooltip-react': ^4.2.21
-      classnames: ^2.3.2
       downshift: ^7.6.0
       match-sorter: ^6.3.1
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-text-input': link:../text-input
-      '@fremtind/jkl-tooltip-react': link:../tooltip-react
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-text-input': 12.1.10
+      '@fremtind/jkl-tooltip-react': 4.2.21
       downshift: 7.6.0
       match-sorter: 6.3.1
 
@@ -1050,17 +983,15 @@ importers:
       '@fremtind/jkl-toast': ^2.1.9
       '@react-aria/toast': ^3.0.0-beta.1
       '@react-stately/toast': ^3.0.0-beta.0
-      classnames: ^2.2.6
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icon-button-react': link:../icon-button-react
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-progress-bar-react': link:../progress-bar-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-toast': link:../toast
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-progress-bar-react': 6.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-toast': 2.1.9
       '@react-aria/toast': 3.0.0-beta.1
       '@react-stately/toast': 3.0.0-beta.0
-      classnames: 2.3.2
 
   packages/toggle-switch:
     specifiers:
@@ -1075,14 +1006,12 @@ importers:
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-toggle-switch': ^13.1.1
-      classnames: ^2.3.2
     dependencies:
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-input-group-react': link:../input-group-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-toggle-switch': link:../toggle-switch
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-toggle-switch': 13.1.1
 
   packages/tooltip:
     specifiers:
@@ -1097,15 +1026,13 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-tooltip': ^4.1.9
-      classnames: ^2.3.2
       framer-motion: ^7.10.3
     dependencies:
       '@floating-ui/react': 0.24.2
-      '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': link:../icons-react
-      '@fremtind/jkl-react-hooks': link:../react-hooks
-      '@fremtind/jkl-tooltip': link:../tooltip
-      classnames: 2.3.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-tooltip': 4.1.9
       framer-motion: 7.10.3
 
   packages/validators-util:
@@ -3229,12 +3156,10 @@ packages:
     requiresBuild: true
     dependencies:
       '@emotion/memoize': 0.7.4
-    dev: false
     optional: true
 
   /@emotion/memoize/0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
-    dev: false
     optional: true
 
   /@esbuild/android-arm/0.19.2:
@@ -3491,13 +3416,11 @@ packages:
 
   /@floating-ui/core/1.2.6:
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
-    dev: false
 
   /@floating-ui/dom/1.2.9:
     resolution: {integrity: sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==}
     dependencies:
       '@floating-ui/core': 1.2.6
-    dev: false
 
   /@floating-ui/react-dom/2.0.0:
     resolution: {integrity: sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==}
@@ -3506,7 +3429,6 @@ packages:
       react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 1.2.9
-    dev: false
 
   /@floating-ui/react/0.24.2:
     resolution: {integrity: sha512-8sdLmcC85J6M2H0AL8yOQuiWD4T0gNMSLpuJjmXyEA6ndfmxXR0hwKFkczB4xRNFhKbwoQeuh8z561HE2vOdZw==}
@@ -3517,7 +3439,6 @@ packages:
       '@floating-ui/react-dom': 2.0.0
       aria-hidden: 1.2.3
       tabbable: 6.1.2
-    dev: false
 
   /@formatjs/ecma402-abstract/1.15.0:
     resolution: {integrity: sha512-7bAYAv0w4AIao9DNg0avfOLTCPE9woAgs6SpXuMq11IN3A+l+cq8ghczwqSZBM11myvPSJA7vLn72q0rJ0QK6Q==}
@@ -3551,6 +3472,737 @@ packages:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
       tslib: 2.5.3
+    dev: false
+
+  /@fremtind/jkl-accordion-react/11.1.5:
+    resolution: {integrity: sha512-S/UTTdHw+cvOH1GodRDidwx4d2vBQbmWMBE0DVthvUJjerEBH+UmNcyOc491RLehQVjlvq1YZGRh7P+8fGWfeQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-accordion': 11.2.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: true
+
+  /@fremtind/jkl-accordion/11.2.2:
+    resolution: {integrity: sha512-B6i9umOYVwiacxPck1r6iwSAupLaBs/e6sMXEnRbZLS54jVyWRf94ATZnXnWX9tY2cUrC/H1UBtAtEV/k90j2w==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-alert-message/9.0.10:
+    resolution: {integrity: sha512-DyCMr/+Xsnn9FpLxvITNc6BsqtTG/fFFmarIbfc6HqVZ7Y858eTFz0FE1tkl8a6DkuPx9tsFCTZnrNEGhBziQA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-breadcrumb/5.0.10:
+    resolution: {integrity: sha512-eVRFZBpJnsc48W+sARwA1IqHbmxuataZjdbHAoemHz4ae8Lh1sVjtniQ7SXc4NpHJTtVMtcql1EVXhxDPQGFow==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-button-react/15.1.2:
+    resolution: {integrity: sha512-c5HwaG0h/LZ1l202C1g5b9tcOD7G/ItC6HhCekUAB1avuck7yv8M2jYjGg9ooXdj6RrO3RTZpXfV0ZRrm8G0jw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-button': 12.1.0
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-loader-react': 12.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-button/12.1.0:
+    resolution: {integrity: sha512-uEWPxcM4aRF12zhfZ8igw7CuQbBz7GMHIGgsliPQ0HE/MZEfTaS4aVTrxNQIe8RptovUNYBF9YXxfIqhWMMHiw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-card/11.2.1:
+    resolution: {integrity: sha512-2XCAcW9a8TIj3d1K3HwXovWiD+Fm5sH/DnluKYawB1qsrePh+tBs2gT/2gjYORgka/iYMTS2Zp0ItojAubdNjA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-checkbox-react/11.1.23:
+    resolution: {integrity: sha512-QGEsGUf1Mqx7h3pTD8o6kNRar+TbZ6zENZ/YnD3T4n1dkr8oI8IRnlCBlfRmj29GOZDakhiw/N/C5PdiPd3GJA==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-checkbox': 11.0.7
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-checkbox/11.0.7:
+    resolution: {integrity: sha512-45J+94ZoDtbf7KXAx2CF2gIjejxkpLb71jefGhDHPRcOPwxLG/4SmOcSndetRe4bgEv3Wh9wzljR3/Uy1U3dTw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-combobox/2.2.8:
+    resolution: {integrity: sha512-auy41b97Hn509oRuIY2dNIbHnGBgEL69Ti0i3mw8vFMtFFqX49uXCB61XqguDjoKT8oM9NhJ2OsR96LripwosA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-constants-util/3.0.58:
+    resolution: {integrity: sha512-uepnZ+uYhij5X72B1m7YMmvnhHrXEILLRzp9Rq1Dlwnup8Xw6DgJxt9jr4vpaOmhEjRid54TZIoEKowiYkoiHQ==}
+
+  /@fremtind/jkl-contact-information/2.0.10:
+    resolution: {integrity: sha512-6/0dsbySpBkFXCCtUqveZt3f0w96LNrwaBHzaEDI/pQ/pwXhAo++KRhxYx09kcNZiwPjHdbQljJiz7fvES2OFA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-content-toggle-react/6.0.11:
+    resolution: {integrity: sha512-vwdidmQpyeeVP0FNlxJKaBCajZmkVj2B85F3BDN54d8q4K3lEtjkL30F3ZMPcIEWOXPNtFAAslA7vMX3UZ0jnQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-content-toggle': 6.0.10
+      '@fremtind/jkl-core': 13.5.0
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-content-toggle/6.0.10:
+    resolution: {integrity: sha512-c3YoxauNahu3XTUVfJVDxkAPwKi8t1OqoW4sf1tDajIGv+EG/hWrh4ufU2gJZSBpCqHLWdi+IVjCuqge5rzUGA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-contextual-menu/2.1.7:
+    resolution: {integrity: sha512-5zBov+FlkFA/n4NCBCjniek+1K3r9E/DGypWtJUHprDwG9TgIYIB5bN9B1LPtVgz3H/KjUCGNbMN6AA+RMOEDA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-core/13.5.0:
+    resolution: {integrity: sha512-6RFzzR7RHY/l6joGdBq5dmh0WIHBYkYjYTrGmey7Xnb1NiZCkZmL5FFZfCzMnFskierYlyS3EK1p9+u5jP721A==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      classnames: 2.3.2
+
+  /@fremtind/jkl-datepicker/12.1.11:
+    resolution: {integrity: sha512-CZwlpATRP9Ey9a/Diq8A8kHzemjwq5mAwJHD5Urc/41Jcp2oLaSD/L+O/MpARUf0Yfrof93DLSIX1In0SLtLqg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-select': 11.1.10
+      '@fremtind/jkl-text-input': 12.1.10
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-description-list/8.0.10:
+    resolution: {integrity: sha512-yD7tfpkl8fDvyXWQwHcbrmtlViMVCh0aSiuK7bWfG2pDzYuOe4qOvLRAUcyzmAu40dtmyIohFT9z9rJq5l7+KA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-expand-button-react/7.0.5:
+    resolution: {integrity: sha512-0D0F+noMROxS1+p5mLaEGaCmWAUQ0CVwqs4ikAeID+LbPv4R3DAOtroAFTlyoCgyojQLW2cxjxrBSsvrwLxU9g==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-expand-button': 7.0.1
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-expand-button/7.0.1:
+    resolution: {integrity: sha512-yx+Iwjcgu9H611DErr4dfZDInP2xwKuOxHGTepnqJqz+Y4cmkatmRIR2Ndj1t7+u0C4H43IAx4xzToHqFAInzg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-feedback/13.0.10:
+    resolution: {integrity: sha512-Rw87FGw8tRGywQnXg9iw1mZzAUMlPM3i49F1w27JgnAJ56OgJim+la5JZAB74NUiy0ja2yP9kB88d72Ud5Sulg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-file-input/2.0.11:
+    resolution: {integrity: sha512-KNOIxeQxmyf1yThV5Bkea9Cg+I75axkvhvLcyY+XteDkJUfpTKyv0WCPpmm/4uFO15N5n8cibTSOScK06veTgg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-footer/6.0.10:
+    resolution: {integrity: sha512-PccD4t/xvnb5LyoUnroGzu3x8WSkUyxKY6npjJ5MSoRsnEnbX/Kpbniw28PrB0LlM/sg0BAamURN68e1zRXwzw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-formatters-util/5.1.14:
+    resolution: {integrity: sha512-Pxtfv1heCuaDpX6sV/puHWoQijGimuiKJAvhTu4wFqf4wg7ond1u1y1iIEQ3l3/iAUj0iAYIl8icRYTR6NJ/mw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-constants-util': 3.0.58
+      '@fremtind/jkl-core': 13.5.0
+
+  /@fremtind/jkl-hamburger/13.0.10:
+    resolution: {integrity: sha512-OJo6Reb1OJbu6QU+8O0V2uRHMn53BgHN8O0Viv3pkPomhQxAx0mAh1e1VQqFa607w4hAplpE/Jtbk2cP+geXhA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-icon-button-react/4.0.33:
+    resolution: {integrity: sha512-noxMyJdA6gAH+w2sladnNarv7kB6PAojjKDpvBT0TEGD08w4A6ZBH3Ju/aVpT4C21k2ru3Vpl5zfZYh+/GUOmg==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button': 4.0.12
+      classnames: 2.3.2
+
+  /@fremtind/jkl-icon-button/4.0.12:
+    resolution: {integrity: sha512-S4pLm1ISxdANz+/X3hRYuMoaA1Px9ikM5+NyhBFJvZpam5652YqgiB+LmPefIFbcP7ODroHlpnRcs4XLchPmNQ==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-icons-react/8.7.2:
+    resolution: {integrity: sha512-2jiOclp53N5TSBwE6o+Mv+ufTetFZcBcbPTvrs89ZtVTbe1wzXytrB+NurVdOc6iO+KSjlp9B8SGcV6xdVBEgw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons': 9.1.4
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+
+  /@fremtind/jkl-icons/9.1.4:
+    resolution: {integrity: sha512-H8o1VT7V+CG93zoZdphjH/K3Z58oKUbgL7fBAK2ATPuawVuE3yDXxnjO9SmaMyEnGfiiy/oDr8Rb3lb41OaKaw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-image-react/6.0.11:
+    resolution: {integrity: sha512-yxYEBIvbCi2UZiDeAkURNnVdw1ftolmOkBbtYeYrBu2KKf7b1z03hqmKLo6hrsqmTxTQtib7M5Qu7I7EOncAEw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-image': 6.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-image/6.0.10:
+    resolution: {integrity: sha512-OUKjyAMRr3JRu+ITyUsz0rpdZM2f63NXiL2XagikQwM7oMMCvXXemlBlJSLSlZrgfeaQFfEmo8NFzRzoZfcWtQ==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-input-group-react/3.0.30:
+    resolution: {integrity: sha512-bzXELPiQYNTekFbwE/NEN8owXY9+IjNmY6Xnx4G6cIDoGillgH1K3+yCNk6F/7xwIC+Wk/YO+TAVulIK3y0aMA==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group': 3.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-tooltip-react': 4.2.21
+      classnames: 2.3.2
+
+  /@fremtind/jkl-input-group/3.0.11:
+    resolution: {integrity: sha512-InqRVRvwAlz5u718o46bYP5KSFMZi5VvHmJtuZX+tB4hQlxFI5I37OQiu73Y/DMnjy56C/EVxmByA+rpEEk01A==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-list-react/10.1.4:
+    resolution: {integrity: sha512-BFJQYGbzHoiqNttNW+shXtdAWpw4Hbiu4k5oF7i30xLasixFpZrPkZQexQQZhtX0lHjm1PeB72DDGnJYwatDqQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-list': 10.2.4
+      classnames: 2.3.2
+    dev: true
+
+  /@fremtind/jkl-list/10.2.4:
+    resolution: {integrity: sha512-ra8i/q7q9UqCto0pGMnD1vH+SeIPw19wXUkhbxaDdx9oTLnybGDyi6ZPXFFGI+L/xzTNrgLTekPl9IeXwXhdQA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-loader-react/12.0.11:
+    resolution: {integrity: sha512-wk7peQ7yckipGjj7HcLBf4xiP9nUcTKdW65Nq3DXf2onefBDVJsZzk3mJxCkMS/F7lpsFOMU00ujBwPWV6c0qw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-loader': 11.0.10
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-loader/11.0.10:
+    resolution: {integrity: sha512-VbgZ+0myfWwyd25iNM2p/oB0r3Vl/ldb8uvrTj4LWCLbkYzw44fyNPkK9+q4PaXUAnz/VsK+a26nYUOXxM09aA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-logo-react/13.1.1:
+    resolution: {integrity: sha512-RSkakWuVh2edFcAD+Djes1Jv4h65RUJ9WZU2Fgd5hbN+XpvHX0ZBULeGk1NIpOhPBjAyNGzadyBlQFPAlXz+og==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-logo': 11.0.10
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-logo/11.0.10:
+    resolution: {integrity: sha512-Dts4wkW8V1D64OSk1E5n++HncDeUACwnhqYF4fHrl3Zqyiu2BlDvis7Q9L1YNZjSiMJ7pIUMYuy2MyDAHGcTQQ==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-message-box-react/11.1.16:
+    resolution: {integrity: sha512-4B218sVmazpJuwzfxe7puv/tn6FrK8b7LltlVSaAp5WUJ9AjmGhHdRQDgJlQFx7WKJ3M5Lpn/W5QjU1bLc6ruA==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-message-box': 9.0.11
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-message-box/9.0.11:
+    resolution: {integrity: sha512-h+VwuIcl14pgDq7pMZ8FfdqDPyuNCbmXiDWshIuI9OAkRQNDCeNRtn3BTHDwrNj4uJ44zSI21Yvjn+eJZItw4g==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-modal/2.1.9:
+    resolution: {integrity: sha512-gL4ZnfK88lwha8q90B2+GD9dQvSpde68WdHyo79t2vi54pZsqS8MWumbUCOFPVXv1eJ20XG58+L17rrm7kToAg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-progress-bar-react/6.0.10:
+    resolution: {integrity: sha512-Qz8OLF4gDcvMEPVSW7UvUcWhTwcXXaZF6E8rLjuANnAOfq+ijHf4ge6pYmb8qqVyMo60cgOywsls2Cyt2xwCqQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-progress-bar': 6.0.10
+    dev: false
+
+  /@fremtind/jkl-progress-bar/6.0.10:
+    resolution: {integrity: sha512-oxlHbyob/3VQ6P4FvKSsIk/ZGY9u6n2T5HaxB22vV0CaiUexaOwY/zEpxt7OtKVX/H2tRB0R/xI8Mzl7ng8QBQ==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-radio-button-react/11.1.54:
+    resolution: {integrity: sha512-JyDDBm0FTKD+gEuQ8tDgKEa8iI8Wd6KYRGH2+yVVMlFf+SPptM+5r2qKm5Bxe6vQTt/3kjoQG/dy9PECJ01ePA==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-radio-button': 10.1.10
+      '@fremtind/jkl-react-hooks': 12.0.11
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-radio-button/10.1.10:
+    resolution: {integrity: sha512-Ym3rrpk+A+QnJ379RAeCWoa2VF2ToY5WZWZdIOAv9Tgq2oHJr4L8QwviTKq7e8zQ80+SU40c6s77MIxGQS+Shw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-react-hooks/12.0.11:
+    resolution: {integrity: sha512-LaglMSM2nvmGUClvUGGUyxTlPCMf9tctPL0DiTSFnNYxgxENrnCeipZ/AZ8Juj0vQfYEPOcHUifFXSTp2bgkYw==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      nanoid: 3.3.6
+
+  /@fremtind/jkl-select-react/14.1.33:
+    resolution: {integrity: sha512-Nvc5yK0erilIqUbcD6n65xKNXeImC2TNtQV0F1EVEtuTVo0ScwAWXlg7Z5EOXqxPYKAZtk10WSdRhU6excG3YQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-select': 11.1.10
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-select/11.1.10:
+    resolution: {integrity: sha512-ZzmulWfr9Gq+Pi928+0dHCoOQGkWAqkfhEX9I8pjabU5TXIllHQadLT+r6Nj2J06srepKTYHyeLh+G+4w+hu+g==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-summary-table/10.0.10:
+    resolution: {integrity: sha512-tcZHUFyBMn4dJz4vrhw5mlbenClVWHtvJnuBtit/IsOthRnsYxovjFhx3bLm8t4PmHYlGR+Uy8j4Cd4GhTWIqw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-table/9.1.2:
+    resolution: {integrity: sha512-Q6zh+YDGQDTpwLXLDr81Pzvgv9DEX5nAkW43ZKRZ+CCBCE2iVmPQ63C3T/axanY1UPfE0EJUrGDq5kD9R2PXuw==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-tabs/5.0.11:
+    resolution: {integrity: sha512-aEVkZyiB0FavYAMOVcWmmgQYX2j43bsiFnxmRBEIuMIJ6p22/l8gnwWrNQV1Dcr9uaOvld56xlqayKzyoEkgXA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-tag-react/5.2.12:
+    resolution: {integrity: sha512-7KRs64RrTryup8n/G9wuBIz0dV6UwhbbZs2v5NfttGzH7Kxg1v7H/0wCWROWZeGRipQXWdmnKeoxhsvRtNv6ng==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-tag': 5.0.10
+      classnames: 2.3.2
+    dev: false
+
+  /@fremtind/jkl-tag/5.0.10:
+    resolution: {integrity: sha512-MYOsCKEbWWpmT8NR/LqSVSp2zZoFV1Moluoi4tN58jyCe3laAOnTUOABRcGJxcb4Hf58nWWPjMhAf3AWq5XTIA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-text-input-react/15.1.2:
+    resolution: {integrity: sha512-m/VxNiUrYdcrdaqenB95LGBs/FPr5QO/jR9EjbalHSltExrmMxW8Q+sgfnTuXRJFSsYZdLwrjzqxm889jxVrJQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-text-input': 12.1.10
+      '@fremtind/jkl-tooltip-react': 4.2.21
+      classnames: 2.3.2
+      downshift: 7.6.0
+      match-sorter: 6.3.1
+    dev: false
+
+  /@fremtind/jkl-text-input/12.1.10:
+    resolution: {integrity: sha512-J/JeleCTzeaoEq8YztERveJ+yzFm1Fgba+GVU3gpDtVpxYDHj4ust7Elq+JhmCS43PFH8tEZHsRutyiblB82Wg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-toast/2.1.9:
+    resolution: {integrity: sha512-2SA8jMDdpXujUN6c+KduwCGv410/bisQvL0OwkinNRGw1g6PDeQL531dvLhc+BVnlS+RhNKWqN72Q1NyIMH2eg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+    dev: false
+
+  /@fremtind/jkl-toggle-switch-react/13.1.10:
+    resolution: {integrity: sha512-fFI3N29Hi2MQ/a2GnxVmcfNqlzPybiJxujL0vq5b+A0fYoBFEkkvLPEnvEHaYSFDR/y/ywhI0pdfgfEAM7VgpQ==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-toggle-switch': 13.1.1
+      classnames: 2.3.2
+    dev: true
+
+  /@fremtind/jkl-toggle-switch/13.1.1:
+    resolution: {integrity: sha512-ZwohynpF+c8gPIvEtWWByNn9Uhd+QNb27xb4K0ewGCfxRwF5unHeIf2nyEzv6YwhZ/y+xzF7ZvrPQNjf4THBEg==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-tooltip-react/4.2.21:
+    resolution: {integrity: sha512-k0azmmJV814z+BrYuZHlRiTGneum5PUs+6vdRTPrKF3UO8vNoJ5t74+bYvqrloI9RRo0RUdrqYEl12g7iXUqwg==}
+    peerDependencies:
+      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
+      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@floating-ui/react': 0.24.2
+      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-icons-react': 8.7.2
+      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-tooltip': 4.1.9
+      classnames: 2.3.2
+      framer-motion: 7.10.3
+
+  /@fremtind/jkl-tooltip/4.1.9:
+    resolution: {integrity: sha512-8NsFzPflw5AuNtI65WjExOn2r7npoOf+4sQ6OmzUZYcw9gsw1eTX0VBLToJxvxSK5L0boYLgHlrzVSJ1UXCstA==}
+    dependencies:
+      '@fremtind/jkl-core': 13.5.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  /@fremtind/jkl-validators-util/3.0.0:
+    resolution: {integrity: sha512-bkXecEtR2+ZVcbcoLJCsVa+BHAw+82fIpe7it4U/yA5XiT6IBYC5oaVfDSN6RPUiDprjRc3Wzx0eACY9IaPMOg==}
     dev: false
 
   /@frsource/base64/1.0.4:
@@ -4430,7 +5082,6 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
-    dev: false
 
   /@motionone/dom/10.16.2:
     resolution: {integrity: sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==}
@@ -4440,15 +5091,13 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.4.0
-    dev: false
+      tslib: 2.5.3
 
   /@motionone/easing/10.15.1:
     resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
     dependencies:
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
-    dev: false
 
   /@motionone/generators/10.15.1:
     resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
@@ -4456,11 +5105,9 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
-    dev: false
 
   /@motionone/types/10.15.1:
     resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
-    dev: false
 
   /@motionone/utils/10.15.1:
     resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
@@ -4468,7 +5115,6 @@ packages:
       '@motionone/types': 10.15.1
       hey-listen: 1.0.8
       tslib: 2.5.3
-    dev: false
 
   /@msgpackr-extract/msgpackr-extract-darwin-arm64/3.0.2:
     resolution: {integrity: sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==}
@@ -6883,7 +7529,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.5.3
-    dev: false
 
   /aria-query/5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -8124,7 +8769,6 @@ packages:
 
   /classnames/2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-    dev: false
 
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -8287,6 +8931,11 @@ packages:
 
   /clsx/1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /clsx/2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
     dev: false
 
@@ -11618,7 +12267,6 @@ packages:
       tslib: 2.4.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-    dev: false
 
   /framer-motion/7.10.3_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-k2ccYeZNSpPg//HTaqrU+4pRq9f9ZpaaN7rr0+Rx5zA4wZLbk547wtDzge2db1sB+1mnJ6r59P4xb+aEIi/W+w==}
@@ -13423,7 +14071,6 @@ packages:
 
   /hey-listen/1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
-    dev: false
 
   /highlight.js/10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -21448,7 +22095,6 @@ packages:
 
   /tabbable/6.1.2:
     resolution: {integrity: sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==}
-    dev: false
 
   /table/6.8.1:
     resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
@@ -21876,7 +22522,6 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
 
   /tslib/2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,12 +221,12 @@ importers:
       '@fremtind/jkl-list-react': ^10.1.4
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-accordion': 11.2.2
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-accordion': link:../accordion
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
     devDependencies:
-      '@fremtind/jkl-list-react': 10.1.4
+      '@fremtind/jkl-list-react': link:../list-react
 
   packages/alert-message:
     specifiers:
@@ -241,10 +241,10 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-alert-message': 9.0.10
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-alert-message': link:../alert-message
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/breadcrumb:
     specifiers:
@@ -257,8 +257,8 @@ importers:
       '@fremtind/jkl-breadcrumb': ^5.0.10
       '@fremtind/jkl-core': ^13.5.0
     dependencies:
-      '@fremtind/jkl-breadcrumb': 5.0.10
-      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-breadcrumb': link:../breadcrumb
+      '@fremtind/jkl-core': link:../core
 
   packages/browserslist-config-jkl:
     specifiers: {}
@@ -278,13 +278,13 @@ importers:
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-toggle-switch-react': ^13.1.10
     dependencies:
-      '@fremtind/jkl-button': 12.1.0
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-loader-react': 12.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-button': link:../button
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-loader-react': link:../loader-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
     devDependencies:
-      '@fremtind/jkl-toggle-switch-react': 13.1.10
+      '@fremtind/jkl-toggle-switch-react': link:../toggle-switch-react
 
   packages/card:
     specifiers:
@@ -301,13 +301,13 @@ importers:
       '@fremtind/jkl-image-react': ^6.0.11
       '@fremtind/jkl-tag-react': ^5.2.12
     dependencies:
-      '@fremtind/jkl-button-react': 15.1.2
-      '@fremtind/jkl-card': 11.2.1
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-image-react': 6.0.11
-      '@fremtind/jkl-tag-react': 5.2.12
+      '@fremtind/jkl-button-react': link:../button-react
+      '@fremtind/jkl-card': link:../card
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-image-react': link:../image-react
+      '@fremtind/jkl-tag-react': link:../tag-react
     devDependencies:
-      '@fremtind/jkl-constants-util': 3.0.58
+      '@fremtind/jkl-constants-util': link:../constants-util
 
   packages/checkbox:
     specifiers:
@@ -322,11 +322,11 @@ importers:
       '@fremtind/jkl-input-group-react': ^3.0.30
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-checkbox': 11.0.7
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-checkbox': link:../checkbox
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-react-hooks': link:../react-hooks
     devDependencies:
-      '@fremtind/jkl-input-group-react': 3.0.30
+      '@fremtind/jkl-input-group-react': link:../input-group-react
 
   packages/combobox:
     specifiers:
@@ -346,15 +346,15 @@ importers:
       '@fremtind/jkl-tag-react': ^5.2.12
       '@fremtind/jkl-tooltip-react': ^4.2.21
     dependencies:
-      '@fremtind/jkl-combobox': 2.2.8
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-select-react': 14.1.33
-      '@fremtind/jkl-tag-react': 5.2.12
-      '@fremtind/jkl-tooltip-react': 4.2.21
+      '@fremtind/jkl-combobox': link:../combobox
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-select-react': link:../select-react
+      '@fremtind/jkl-tag-react': link:../tag-react
+      '@fremtind/jkl-tooltip-react': link:../tooltip-react
 
   packages/constants-util:
     specifiers:
@@ -376,9 +376,9 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-formatters-util': ^5.1.14
     dependencies:
-      '@fremtind/jkl-contact-information': 2.0.10
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-formatters-util': 5.1.14
+      '@fremtind/jkl-contact-information': link:../contact-information
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-formatters-util': link:../formatters-util
 
   packages/content-toggle:
     specifiers:
@@ -391,8 +391,8 @@ importers:
       '@fremtind/jkl-content-toggle': ^6.0.10
       '@fremtind/jkl-core': ^13.5.0
     dependencies:
-      '@fremtind/jkl-content-toggle': 6.0.10
-      '@fremtind/jkl-core': 13.5.0
+      '@fremtind/jkl-content-toggle': link:../content-toggle
+      '@fremtind/jkl-core': link:../core
 
   packages/contextual-menu:
     specifiers:
@@ -412,14 +412,14 @@ importers:
       framer-motion: ^7.10.3
     dependencies:
       '@floating-ui/react': 0.24.2
-      '@fremtind/jkl-contextual-menu': 2.1.7
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-toggle-switch': 13.1.1
+      '@fremtind/jkl-contextual-menu': link:../contextual-menu
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-toggle-switch': link:../toggle-switch
       framer-motion: 7.10.3
     devDependencies:
-      '@fremtind/jkl-icon-button-react': 4.0.33
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
 
   packages/cookie-consent:
     specifiers:
@@ -475,13 +475,13 @@ importers:
       '@jest/globals': ^29.5.0
       date-fns: ^2.30.0
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-datepicker': 12.1.11
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-select-react': 14.1.33
-      '@fremtind/jkl-text-input-react': 15.1.2
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-datepicker': link:../datepicker
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-select-react': link:../select-react
+      '@fremtind/jkl-text-input-react': link:../text-input-react
       date-fns: 2.30.0
     devDependencies:
       '@jest/globals': 29.5.0
@@ -497,8 +497,8 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-description-list': ^8.0.10
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-description-list': 8.0.10
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-description-list': link:../description-list
 
   packages/expand-button:
     specifiers:
@@ -513,10 +513,10 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-expand-button': 7.0.1
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-expand-button': link:../expand-button
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/feedback:
     specifiers:
@@ -537,16 +537,16 @@ importers:
       '@fremtind/jkl-text-input-react': ^15.1.2
       '@fremtind/jkl-validators-util': ^3.0.0
     dependencies:
-      '@fremtind/jkl-button-react': 15.1.2
-      '@fremtind/jkl-checkbox-react': 11.1.23
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-feedback': 13.0.10
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-message-box-react': 11.1.16
-      '@fremtind/jkl-radio-button-react': 11.1.54
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-text-input-react': 15.1.2
-      '@fremtind/jkl-validators-util': 3.0.0
+      '@fremtind/jkl-button-react': link:../button-react
+      '@fremtind/jkl-checkbox-react': link:../checkbox-react
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-feedback': link:../feedback
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-message-box-react': link:../message-box-react
+      '@fremtind/jkl-radio-button-react': link:../radio-button-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-text-input-react': link:../text-input-react
+      '@fremtind/jkl-validators-util': link:../validators-util
 
   packages/file-input:
     specifiers:
@@ -566,15 +566,15 @@ importers:
       '@fremtind/jkl-progress-bar-react': ^6.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-button-react': 15.1.2
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-file-input': 2.0.11
-      '@fremtind/jkl-formatters-util': 5.1.14
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-progress-bar-react': 6.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-button-react': link:../button-react
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-file-input': link:../file-input
+      '@fremtind/jkl-formatters-util': link:../formatters-util
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-progress-bar-react': link:../progress-bar-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/footer:
     specifiers:
@@ -589,10 +589,10 @@ importers:
       '@fremtind/jkl-formatters-util': ^5.1.14
       '@fremtind/jkl-logo-react': ^13.1.1
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-footer': 6.0.10
-      '@fremtind/jkl-formatters-util': 5.1.14
-      '@fremtind/jkl-logo-react': 13.1.1
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-footer': link:../footer
+      '@fremtind/jkl-formatters-util': link:../formatters-util
+      '@fremtind/jkl-logo-react': link:../logo-react
 
   packages/formatters-util:
     specifiers:
@@ -624,10 +624,10 @@ importers:
       '@fremtind/jkl-hamburger': ^13.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-content-toggle-react': 6.0.11
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-hamburger': 13.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-content-toggle-react': link:../content-toggle-react
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-hamburger': link:../hamburger
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/icon-button:
     specifiers:
@@ -642,11 +642,11 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-toggle-switch-react': ^13.1.10
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button': 4.0.12
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button': link:../icon-button
     devDependencies:
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-toggle-switch-react': 13.1.10
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-toggle-switch-react': link:../toggle-switch-react
 
   packages/icons:
     specifiers:
@@ -660,9 +660,9 @@ importers:
       '@fremtind/jkl-icons': ^9.1.4
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons': 9.1.4
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons': link:../icons
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/image:
     specifiers:
@@ -675,8 +675,8 @@ importers:
       '@fremtind/jkl-image': ^6.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-image': 6.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-image': link:../image
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/input-group:
     specifiers:
@@ -692,11 +692,11 @@ importers:
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-tooltip-react': ^4.2.21
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group': 3.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-tooltip-react': 4.2.21
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group': link:../input-group
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-tooltip-react': link:../tooltip-react
 
   packages/list:
     specifiers:
@@ -709,8 +709,8 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-list': ^10.2.4
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-list': 10.2.4
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-list': link:../list
 
   packages/loader:
     specifiers:
@@ -723,8 +723,8 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-loader': ^11.0.10
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-loader': 11.0.10
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-loader': link:../loader
 
   packages/logo:
     specifiers:
@@ -738,9 +738,9 @@ importers:
       '@fremtind/jkl-logo': ^11.0.10
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-logo': 11.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-logo': link:../logo
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/message-box:
     specifiers:
@@ -755,10 +755,10 @@ importers:
       '@fremtind/jkl-message-box': ^9.0.11
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-message-box': 9.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-message-box': link:../message-box
+      '@fremtind/jkl-react-hooks': link:../react-hooks
 
   packages/modal:
     specifiers:
@@ -776,11 +776,11 @@ importers:
       prop-types: ^15.8.1
       react-a11y-dialog: ^6.2.0
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-modal': 2.1.9
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-modal': link:../modal
+      '@fremtind/jkl-react-hooks': link:../react-hooks
       prop-types: 15.8.1
       react-a11y-dialog: 6.2.0_prop-types@15.8.1
 
@@ -810,12 +810,12 @@ importers:
       '@fremtind/jkl-radio-button': ^10.1.10
       '@fremtind/jkl-react-hooks': ^12.0.11
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-radio-button': 10.1.10
-      '@fremtind/jkl-react-hooks': 12.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-radio-button': link:../radio-button
+      '@fremtind/jkl-react-hooks': link:../react-hooks
     devDependencies:
-      '@fremtind/jkl-formatters-util': 5.1.14
+      '@fremtind/jkl-formatters-util': link:../formatters-util
 
   packages/react-hooks:
     specifiers:
@@ -841,13 +841,13 @@ importers:
       '@fremtind/jkl-select': ^11.1.10
       react-hook-form: ^7.44.3
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-select': 11.1.10
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-select': link:../select
     devDependencies:
-      '@fremtind/jkl-accordion-react': 11.1.5
+      '@fremtind/jkl-accordion-react': link:../accordion-react
       react-hook-form: 7.44.3
 
   packages/stylelint-config-jkl:
@@ -874,8 +874,8 @@ importers:
       '@fremtind/jkl-core': ^13.5.0
       '@fremtind/jkl-summary-table': ^10.0.10
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-summary-table': 10.0.10
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-summary-table': link:../summary-table
 
   packages/table:
     specifiers:
@@ -894,14 +894,14 @@ importers:
       '@fremtind/jkl-table': ^9.1.2
       '@fremtind/jkl-text-input-react': ^15.1.2
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-expand-button-react': 7.0.5
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-select-react': 14.1.33
-      '@fremtind/jkl-table': 9.1.2
-      '@fremtind/jkl-text-input-react': 15.1.2
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-expand-button-react': link:../expand-button-react
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-select-react': link:../select-react
+      '@fremtind/jkl-table': link:../table
+      '@fremtind/jkl-text-input-react': link:../text-input-react
 
   packages/tabs:
     specifiers:
@@ -916,9 +916,9 @@ importers:
       '@fremtind/jkl-tabs': ^5.0.11
       nanoid: ^3.3.6
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-tabs': 5.0.11
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-tabs': link:../tabs
       nanoid: 3.3.6
 
   packages/tag:
@@ -934,10 +934,10 @@ importers:
       '@fremtind/jkl-icons-react': ^8.7.2
       '@fremtind/jkl-tag': ^5.0.10
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-tag': 5.0.10
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-tag': link:../tag
 
   packages/text-input:
     specifiers:
@@ -957,13 +957,13 @@ importers:
       downshift: ^7.6.0
       match-sorter: ^6.3.1
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-text-input': 12.1.10
-      '@fremtind/jkl-tooltip-react': 4.2.21
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-text-input': link:../text-input
+      '@fremtind/jkl-tooltip-react': link:../tooltip-react
       downshift: 7.6.0
       match-sorter: 6.3.1
 
@@ -984,12 +984,12 @@ importers:
       '@react-aria/toast': ^3.0.0-beta.1
       '@react-stately/toast': ^3.0.0-beta.0
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-progress-bar-react': 6.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-toast': 2.1.9
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icon-button-react': link:../icon-button-react
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-progress-bar-react': link:../progress-bar-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-toast': link:../toast
       '@react-aria/toast': 3.0.0-beta.1
       '@react-stately/toast': 3.0.0-beta.0
 
@@ -1007,11 +1007,11 @@ importers:
       '@fremtind/jkl-react-hooks': ^12.0.11
       '@fremtind/jkl-toggle-switch': ^13.1.1
     dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-toggle-switch': 13.1.1
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-input-group-react': link:../input-group-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-toggle-switch': link:../toggle-switch
 
   packages/tooltip:
     specifiers:
@@ -1029,10 +1029,10 @@ importers:
       framer-motion: ^7.10.3
     dependencies:
       '@floating-ui/react': 0.24.2
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-tooltip': 4.1.9
+      '@fremtind/jkl-core': link:../core
+      '@fremtind/jkl-icons-react': link:../icons-react
+      '@fremtind/jkl-react-hooks': link:../react-hooks
+      '@fremtind/jkl-tooltip': link:../tooltip
       framer-motion: 7.10.3
 
   packages/validators-util:
@@ -3156,10 +3156,12 @@ packages:
     requiresBuild: true
     dependencies:
       '@emotion/memoize': 0.7.4
+    dev: false
     optional: true
 
   /@emotion/memoize/0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    dev: false
     optional: true
 
   /@esbuild/android-arm/0.19.2:
@@ -3416,11 +3418,13 @@ packages:
 
   /@floating-ui/core/1.2.6:
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
+    dev: false
 
   /@floating-ui/dom/1.2.9:
     resolution: {integrity: sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==}
     dependencies:
       '@floating-ui/core': 1.2.6
+    dev: false
 
   /@floating-ui/react-dom/2.0.0:
     resolution: {integrity: sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==}
@@ -3429,6 +3433,7 @@ packages:
       react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 1.2.9
+    dev: false
 
   /@floating-ui/react/0.24.2:
     resolution: {integrity: sha512-8sdLmcC85J6M2H0AL8yOQuiWD4T0gNMSLpuJjmXyEA6ndfmxXR0hwKFkczB4xRNFhKbwoQeuh8z561HE2vOdZw==}
@@ -3439,6 +3444,7 @@ packages:
       '@floating-ui/react-dom': 2.0.0
       aria-hidden: 1.2.3
       tabbable: 6.1.2
+    dev: false
 
   /@formatjs/ecma402-abstract/1.15.0:
     resolution: {integrity: sha512-7bAYAv0w4AIao9DNg0avfOLTCPE9woAgs6SpXuMq11IN3A+l+cq8ghczwqSZBM11myvPSJA7vLn72q0rJ0QK6Q==}
@@ -3472,737 +3478,6 @@ packages:
     resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
     dependencies:
       tslib: 2.5.3
-    dev: false
-
-  /@fremtind/jkl-accordion-react/11.1.5:
-    resolution: {integrity: sha512-S/UTTdHw+cvOH1GodRDidwx4d2vBQbmWMBE0DVthvUJjerEBH+UmNcyOc491RLehQVjlvq1YZGRh7P+8fGWfeQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-accordion': 11.2.2
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: true
-
-  /@fremtind/jkl-accordion/11.2.2:
-    resolution: {integrity: sha512-B6i9umOYVwiacxPck1r6iwSAupLaBs/e6sMXEnRbZLS54jVyWRf94ATZnXnWX9tY2cUrC/H1UBtAtEV/k90j2w==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-alert-message/9.0.10:
-    resolution: {integrity: sha512-DyCMr/+Xsnn9FpLxvITNc6BsqtTG/fFFmarIbfc6HqVZ7Y858eTFz0FE1tkl8a6DkuPx9tsFCTZnrNEGhBziQA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-breadcrumb/5.0.10:
-    resolution: {integrity: sha512-eVRFZBpJnsc48W+sARwA1IqHbmxuataZjdbHAoemHz4ae8Lh1sVjtniQ7SXc4NpHJTtVMtcql1EVXhxDPQGFow==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-button-react/15.1.2:
-    resolution: {integrity: sha512-c5HwaG0h/LZ1l202C1g5b9tcOD7G/ItC6HhCekUAB1avuck7yv8M2jYjGg9ooXdj6RrO3RTZpXfV0ZRrm8G0jw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-button': 12.1.0
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-loader-react': 12.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-button/12.1.0:
-    resolution: {integrity: sha512-uEWPxcM4aRF12zhfZ8igw7CuQbBz7GMHIGgsliPQ0HE/MZEfTaS4aVTrxNQIe8RptovUNYBF9YXxfIqhWMMHiw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-card/11.2.1:
-    resolution: {integrity: sha512-2XCAcW9a8TIj3d1K3HwXovWiD+Fm5sH/DnluKYawB1qsrePh+tBs2gT/2gjYORgka/iYMTS2Zp0ItojAubdNjA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-checkbox-react/11.1.23:
-    resolution: {integrity: sha512-QGEsGUf1Mqx7h3pTD8o6kNRar+TbZ6zENZ/YnD3T4n1dkr8oI8IRnlCBlfRmj29GOZDakhiw/N/C5PdiPd3GJA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-checkbox': 11.0.7
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-checkbox/11.0.7:
-    resolution: {integrity: sha512-45J+94ZoDtbf7KXAx2CF2gIjejxkpLb71jefGhDHPRcOPwxLG/4SmOcSndetRe4bgEv3Wh9wzljR3/Uy1U3dTw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-combobox/2.2.8:
-    resolution: {integrity: sha512-auy41b97Hn509oRuIY2dNIbHnGBgEL69Ti0i3mw8vFMtFFqX49uXCB61XqguDjoKT8oM9NhJ2OsR96LripwosA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-constants-util/3.0.58:
-    resolution: {integrity: sha512-uepnZ+uYhij5X72B1m7YMmvnhHrXEILLRzp9Rq1Dlwnup8Xw6DgJxt9jr4vpaOmhEjRid54TZIoEKowiYkoiHQ==}
-
-  /@fremtind/jkl-contact-information/2.0.10:
-    resolution: {integrity: sha512-6/0dsbySpBkFXCCtUqveZt3f0w96LNrwaBHzaEDI/pQ/pwXhAo++KRhxYx09kcNZiwPjHdbQljJiz7fvES2OFA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-content-toggle-react/6.0.11:
-    resolution: {integrity: sha512-vwdidmQpyeeVP0FNlxJKaBCajZmkVj2B85F3BDN54d8q4K3lEtjkL30F3ZMPcIEWOXPNtFAAslA7vMX3UZ0jnQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-content-toggle': 6.0.10
-      '@fremtind/jkl-core': 13.5.0
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-content-toggle/6.0.10:
-    resolution: {integrity: sha512-c3YoxauNahu3XTUVfJVDxkAPwKi8t1OqoW4sf1tDajIGv+EG/hWrh4ufU2gJZSBpCqHLWdi+IVjCuqge5rzUGA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-contextual-menu/2.1.7:
-    resolution: {integrity: sha512-5zBov+FlkFA/n4NCBCjniek+1K3r9E/DGypWtJUHprDwG9TgIYIB5bN9B1LPtVgz3H/KjUCGNbMN6AA+RMOEDA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-core/13.5.0:
-    resolution: {integrity: sha512-6RFzzR7RHY/l6joGdBq5dmh0WIHBYkYjYTrGmey7Xnb1NiZCkZmL5FFZfCzMnFskierYlyS3EK1p9+u5jP721A==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      classnames: 2.3.2
-
-  /@fremtind/jkl-datepicker/12.1.11:
-    resolution: {integrity: sha512-CZwlpATRP9Ey9a/Diq8A8kHzemjwq5mAwJHD5Urc/41Jcp2oLaSD/L+O/MpARUf0Yfrof93DLSIX1In0SLtLqg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-select': 11.1.10
-      '@fremtind/jkl-text-input': 12.1.10
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-description-list/8.0.10:
-    resolution: {integrity: sha512-yD7tfpkl8fDvyXWQwHcbrmtlViMVCh0aSiuK7bWfG2pDzYuOe4qOvLRAUcyzmAu40dtmyIohFT9z9rJq5l7+KA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-expand-button-react/7.0.5:
-    resolution: {integrity: sha512-0D0F+noMROxS1+p5mLaEGaCmWAUQ0CVwqs4ikAeID+LbPv4R3DAOtroAFTlyoCgyojQLW2cxjxrBSsvrwLxU9g==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-expand-button': 7.0.1
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-expand-button/7.0.1:
-    resolution: {integrity: sha512-yx+Iwjcgu9H611DErr4dfZDInP2xwKuOxHGTepnqJqz+Y4cmkatmRIR2Ndj1t7+u0C4H43IAx4xzToHqFAInzg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-feedback/13.0.10:
-    resolution: {integrity: sha512-Rw87FGw8tRGywQnXg9iw1mZzAUMlPM3i49F1w27JgnAJ56OgJim+la5JZAB74NUiy0ja2yP9kB88d72Ud5Sulg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-file-input/2.0.11:
-    resolution: {integrity: sha512-KNOIxeQxmyf1yThV5Bkea9Cg+I75axkvhvLcyY+XteDkJUfpTKyv0WCPpmm/4uFO15N5n8cibTSOScK06veTgg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-footer/6.0.10:
-    resolution: {integrity: sha512-PccD4t/xvnb5LyoUnroGzu3x8WSkUyxKY6npjJ5MSoRsnEnbX/Kpbniw28PrB0LlM/sg0BAamURN68e1zRXwzw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-formatters-util/5.1.14:
-    resolution: {integrity: sha512-Pxtfv1heCuaDpX6sV/puHWoQijGimuiKJAvhTu4wFqf4wg7ond1u1y1iIEQ3l3/iAUj0iAYIl8icRYTR6NJ/mw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-constants-util': 3.0.58
-      '@fremtind/jkl-core': 13.5.0
-
-  /@fremtind/jkl-hamburger/13.0.10:
-    resolution: {integrity: sha512-OJo6Reb1OJbu6QU+8O0V2uRHMn53BgHN8O0Viv3pkPomhQxAx0mAh1e1VQqFa607w4hAplpE/Jtbk2cP+geXhA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-icon-button-react/4.0.33:
-    resolution: {integrity: sha512-noxMyJdA6gAH+w2sladnNarv7kB6PAojjKDpvBT0TEGD08w4A6ZBH3Ju/aVpT4C21k2ru3Vpl5zfZYh+/GUOmg==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button': 4.0.12
-      classnames: 2.3.2
-
-  /@fremtind/jkl-icon-button/4.0.12:
-    resolution: {integrity: sha512-S4pLm1ISxdANz+/X3hRYuMoaA1Px9ikM5+NyhBFJvZpam5652YqgiB+LmPefIFbcP7ODroHlpnRcs4XLchPmNQ==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-icons-react/8.7.2:
-    resolution: {integrity: sha512-2jiOclp53N5TSBwE6o+Mv+ufTetFZcBcbPTvrs89ZtVTbe1wzXytrB+NurVdOc6iO+KSjlp9B8SGcV6xdVBEgw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons': 9.1.4
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-
-  /@fremtind/jkl-icons/9.1.4:
-    resolution: {integrity: sha512-H8o1VT7V+CG93zoZdphjH/K3Z58oKUbgL7fBAK2ATPuawVuE3yDXxnjO9SmaMyEnGfiiy/oDr8Rb3lb41OaKaw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-image-react/6.0.11:
-    resolution: {integrity: sha512-yxYEBIvbCi2UZiDeAkURNnVdw1ftolmOkBbtYeYrBu2KKf7b1z03hqmKLo6hrsqmTxTQtib7M5Qu7I7EOncAEw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-image': 6.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-image/6.0.10:
-    resolution: {integrity: sha512-OUKjyAMRr3JRu+ITyUsz0rpdZM2f63NXiL2XagikQwM7oMMCvXXemlBlJSLSlZrgfeaQFfEmo8NFzRzoZfcWtQ==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-input-group-react/3.0.30:
-    resolution: {integrity: sha512-bzXELPiQYNTekFbwE/NEN8owXY9+IjNmY6Xnx4G6cIDoGillgH1K3+yCNk6F/7xwIC+Wk/YO+TAVulIK3y0aMA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group': 3.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-tooltip-react': 4.2.21
-      classnames: 2.3.2
-
-  /@fremtind/jkl-input-group/3.0.11:
-    resolution: {integrity: sha512-InqRVRvwAlz5u718o46bYP5KSFMZi5VvHmJtuZX+tB4hQlxFI5I37OQiu73Y/DMnjy56C/EVxmByA+rpEEk01A==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-list-react/10.1.4:
-    resolution: {integrity: sha512-BFJQYGbzHoiqNttNW+shXtdAWpw4Hbiu4k5oF7i30xLasixFpZrPkZQexQQZhtX0lHjm1PeB72DDGnJYwatDqQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-list': 10.2.4
-      classnames: 2.3.2
-    dev: true
-
-  /@fremtind/jkl-list/10.2.4:
-    resolution: {integrity: sha512-ra8i/q7q9UqCto0pGMnD1vH+SeIPw19wXUkhbxaDdx9oTLnybGDyi6ZPXFFGI+L/xzTNrgLTekPl9IeXwXhdQA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-loader-react/12.0.11:
-    resolution: {integrity: sha512-wk7peQ7yckipGjj7HcLBf4xiP9nUcTKdW65Nq3DXf2onefBDVJsZzk3mJxCkMS/F7lpsFOMU00ujBwPWV6c0qw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-loader': 11.0.10
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-loader/11.0.10:
-    resolution: {integrity: sha512-VbgZ+0myfWwyd25iNM2p/oB0r3Vl/ldb8uvrTj4LWCLbkYzw44fyNPkK9+q4PaXUAnz/VsK+a26nYUOXxM09aA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-logo-react/13.1.1:
-    resolution: {integrity: sha512-RSkakWuVh2edFcAD+Djes1Jv4h65RUJ9WZU2Fgd5hbN+XpvHX0ZBULeGk1NIpOhPBjAyNGzadyBlQFPAlXz+og==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-logo': 11.0.10
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-logo/11.0.10:
-    resolution: {integrity: sha512-Dts4wkW8V1D64OSk1E5n++HncDeUACwnhqYF4fHrl3Zqyiu2BlDvis7Q9L1YNZjSiMJ7pIUMYuy2MyDAHGcTQQ==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-message-box-react/11.1.16:
-    resolution: {integrity: sha512-4B218sVmazpJuwzfxe7puv/tn6FrK8b7LltlVSaAp5WUJ9AjmGhHdRQDgJlQFx7WKJ3M5Lpn/W5QjU1bLc6ruA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-message-box': 9.0.11
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-message-box/9.0.11:
-    resolution: {integrity: sha512-h+VwuIcl14pgDq7pMZ8FfdqDPyuNCbmXiDWshIuI9OAkRQNDCeNRtn3BTHDwrNj4uJ44zSI21Yvjn+eJZItw4g==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-modal/2.1.9:
-    resolution: {integrity: sha512-gL4ZnfK88lwha8q90B2+GD9dQvSpde68WdHyo79t2vi54pZsqS8MWumbUCOFPVXv1eJ20XG58+L17rrm7kToAg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-progress-bar-react/6.0.10:
-    resolution: {integrity: sha512-Qz8OLF4gDcvMEPVSW7UvUcWhTwcXXaZF6E8rLjuANnAOfq+ijHf4ge6pYmb8qqVyMo60cgOywsls2Cyt2xwCqQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-progress-bar': 6.0.10
-    dev: false
-
-  /@fremtind/jkl-progress-bar/6.0.10:
-    resolution: {integrity: sha512-oxlHbyob/3VQ6P4FvKSsIk/ZGY9u6n2T5HaxB22vV0CaiUexaOwY/zEpxt7OtKVX/H2tRB0R/xI8Mzl7ng8QBQ==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-radio-button-react/11.1.54:
-    resolution: {integrity: sha512-JyDDBm0FTKD+gEuQ8tDgKEa8iI8Wd6KYRGH2+yVVMlFf+SPptM+5r2qKm5Bxe6vQTt/3kjoQG/dy9PECJ01ePA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-radio-button': 10.1.10
-      '@fremtind/jkl-react-hooks': 12.0.11
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-radio-button/10.1.10:
-    resolution: {integrity: sha512-Ym3rrpk+A+QnJ379RAeCWoa2VF2ToY5WZWZdIOAv9Tgq2oHJr4L8QwviTKq7e8zQ80+SU40c6s77MIxGQS+Shw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-react-hooks/12.0.11:
-    resolution: {integrity: sha512-LaglMSM2nvmGUClvUGGUyxTlPCMf9tctPL0DiTSFnNYxgxENrnCeipZ/AZ8Juj0vQfYEPOcHUifFXSTp2bgkYw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      nanoid: 3.3.6
-
-  /@fremtind/jkl-select-react/14.1.33:
-    resolution: {integrity: sha512-Nvc5yK0erilIqUbcD6n65xKNXeImC2TNtQV0F1EVEtuTVo0ScwAWXlg7Z5EOXqxPYKAZtk10WSdRhU6excG3YQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-select': 11.1.10
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-select/11.1.10:
-    resolution: {integrity: sha512-ZzmulWfr9Gq+Pi928+0dHCoOQGkWAqkfhEX9I8pjabU5TXIllHQadLT+r6Nj2J06srepKTYHyeLh+G+4w+hu+g==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-summary-table/10.0.10:
-    resolution: {integrity: sha512-tcZHUFyBMn4dJz4vrhw5mlbenClVWHtvJnuBtit/IsOthRnsYxovjFhx3bLm8t4PmHYlGR+Uy8j4Cd4GhTWIqw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-table/9.1.2:
-    resolution: {integrity: sha512-Q6zh+YDGQDTpwLXLDr81Pzvgv9DEX5nAkW43ZKRZ+CCBCE2iVmPQ63C3T/axanY1UPfE0EJUrGDq5kD9R2PXuw==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-tabs/5.0.11:
-    resolution: {integrity: sha512-aEVkZyiB0FavYAMOVcWmmgQYX2j43bsiFnxmRBEIuMIJ6p22/l8gnwWrNQV1Dcr9uaOvld56xlqayKzyoEkgXA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-tag-react/5.2.12:
-    resolution: {integrity: sha512-7KRs64RrTryup8n/G9wuBIz0dV6UwhbbZs2v5NfttGzH7Kxg1v7H/0wCWROWZeGRipQXWdmnKeoxhsvRtNv6ng==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-tag': 5.0.10
-      classnames: 2.3.2
-    dev: false
-
-  /@fremtind/jkl-tag/5.0.10:
-    resolution: {integrity: sha512-MYOsCKEbWWpmT8NR/LqSVSp2zZoFV1Moluoi4tN58jyCe3laAOnTUOABRcGJxcb4Hf58nWWPjMhAf3AWq5XTIA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-text-input-react/15.1.2:
-    resolution: {integrity: sha512-m/VxNiUrYdcrdaqenB95LGBs/FPr5QO/jR9EjbalHSltExrmMxW8Q+sgfnTuXRJFSsYZdLwrjzqxm889jxVrJQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icon-button-react': 4.0.33
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-text-input': 12.1.10
-      '@fremtind/jkl-tooltip-react': 4.2.21
-      classnames: 2.3.2
-      downshift: 7.6.0
-      match-sorter: 6.3.1
-    dev: false
-
-  /@fremtind/jkl-text-input/12.1.10:
-    resolution: {integrity: sha512-J/JeleCTzeaoEq8YztERveJ+yzFm1Fgba+GVU3gpDtVpxYDHj4ust7Elq+JhmCS43PFH8tEZHsRutyiblB82Wg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-toast/2.1.9:
-    resolution: {integrity: sha512-2SA8jMDdpXujUN6c+KduwCGv410/bisQvL0OwkinNRGw1g6PDeQL531dvLhc+BVnlS+RhNKWqN72Q1NyIMH2eg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-    dev: false
-
-  /@fremtind/jkl-toggle-switch-react/13.1.10:
-    resolution: {integrity: sha512-fFI3N29Hi2MQ/a2GnxVmcfNqlzPybiJxujL0vq5b+A0fYoBFEkkvLPEnvEHaYSFDR/y/ywhI0pdfgfEAM7VgpQ==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-input-group-react': 3.0.30
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-toggle-switch': 13.1.1
-      classnames: 2.3.2
-    dev: true
-
-  /@fremtind/jkl-toggle-switch/13.1.1:
-    resolution: {integrity: sha512-ZwohynpF+c8gPIvEtWWByNn9Uhd+QNb27xb4K0ewGCfxRwF5unHeIf2nyEzv6YwhZ/y+xzF7ZvrPQNjf4THBEg==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-tooltip-react/4.2.21:
-    resolution: {integrity: sha512-k0azmmJV814z+BrYuZHlRiTGneum5PUs+6vdRTPrKF3UO8vNoJ5t74+bYvqrloI9RRo0RUdrqYEl12g7iXUqwg==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@floating-ui/react': 0.24.2
-      '@fremtind/jkl-core': 13.5.0
-      '@fremtind/jkl-icons-react': 8.7.2
-      '@fremtind/jkl-react-hooks': 12.0.11
-      '@fremtind/jkl-tooltip': 4.1.9
-      classnames: 2.3.2
-      framer-motion: 7.10.3
-
-  /@fremtind/jkl-tooltip/4.1.9:
-    resolution: {integrity: sha512-8NsFzPflw5AuNtI65WjExOn2r7npoOf+4sQ6OmzUZYcw9gsw1eTX0VBLToJxvxSK5L0boYLgHlrzVSJ1UXCstA==}
-    dependencies:
-      '@fremtind/jkl-core': 13.5.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react
-      - react-dom
-
-  /@fremtind/jkl-validators-util/3.0.0:
-    resolution: {integrity: sha512-bkXecEtR2+ZVcbcoLJCsVa+BHAw+82fIpe7it4U/yA5XiT6IBYC5oaVfDSN6RPUiDprjRc3Wzx0eACY9IaPMOg==}
     dev: false
 
   /@frsource/base64/1.0.4:
@@ -5082,6 +4357,7 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
+    dev: false
 
   /@motionone/dom/10.16.2:
     resolution: {integrity: sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==}
@@ -5092,12 +4368,14 @@ packages:
       '@motionone/utils': 10.15.1
       hey-listen: 1.0.8
       tslib: 2.5.3
+    dev: false
 
   /@motionone/easing/10.15.1:
     resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
     dependencies:
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
+    dev: false
 
   /@motionone/generators/10.15.1:
     resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
@@ -5105,9 +4383,11 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       tslib: 2.5.3
+    dev: false
 
   /@motionone/types/10.15.1:
     resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
+    dev: false
 
   /@motionone/utils/10.15.1:
     resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
@@ -5115,6 +4395,7 @@ packages:
       '@motionone/types': 10.15.1
       hey-listen: 1.0.8
       tslib: 2.5.3
+    dev: false
 
   /@msgpackr-extract/msgpackr-extract-darwin-arm64/3.0.2:
     resolution: {integrity: sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==}
@@ -7529,6 +6810,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.5.3
+    dev: false
 
   /aria-query/5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -8769,6 +8051,7 @@ packages:
 
   /classnames/2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
+    dev: false
 
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -12267,6 +11550,7 @@ packages:
       tslib: 2.4.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
+    dev: false
 
   /framer-motion/7.10.3_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-k2ccYeZNSpPg//HTaqrU+4pRq9f9ZpaaN7rr0+Rx5zA4wZLbk547wtDzge2db1sB+1mnJ6r59P4xb+aEIi/W+w==}
@@ -14071,6 +13355,7 @@ packages:
 
   /hey-listen/1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+    dev: false
 
   /highlight.js/10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -22095,6 +21380,7 @@ packages:
 
   /tabbable/6.1.2:
     resolution: {integrity: sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==}
+    dev: false
 
   /table/6.8.1:
     resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
@@ -22522,6 +21808,7 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
 
   /tslib/2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

- Alle komponent pakker har fått classnames pakken avinstallert
- clsx er installert i root, her må vi teste litt hva som fungerer og ikke. Fin overgang til reisen å samle alle komponenter til én pakke
- Rettet opp noen skriveleifer her og der
- classnames pakken er på ca 1,2k kb, clsx er på 239 kb
- cn og cx erstattet med clsx i koden i alle komponenter

Denne PR'en burde vi ta en felles gjennomgang på og idémyldre litt hvordan vi vil angripe oppgaven å gå fra mange pakker til én komponentpakke og proper tree shaking :)

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
