### PR TITLE
fix: the button in the modal consent form submits again

### DIFF
--- a/packages/cookie-consent-react/documentation/Example.tsx
+++ b/packages/cookie-consent-react/documentation/Example.tsx
@@ -3,6 +3,7 @@ import { DevExample } from "../../../doc-utils";
 import "../../cookie-consent/cookie-consent.scss";
 import "../../button/button.scss";
 import "../../list/list.scss";
+import "../../modal/modal.scss";
 import {
     CookieConsentModalExample,
     cookieConsentModalExampleCode,

--- a/packages/cookie-consent-react/src/CookieConsentModal.tsx
+++ b/packages/cookie-consent-react/src/CookieConsentModal.tsx
@@ -198,7 +198,9 @@ export const CookieConsentModal: FC<ConsentComponentBaseProps> = ({ onAccept, ..
                         )}
                     </ModalBody>
                     <ModalActions>
-                        <PrimaryButton data-testid="jkl-cookie-consent-godta">Godta</PrimaryButton>
+                        <PrimaryButton type="submit" data-testid="jkl-cookie-consent-godta">
+                            Godta
+                        </PrimaryButton>
                     </ModalActions>
                 </Modal>
             )}


### PR DESCRIPTION
default type for buttons changed from "submit" to "button" so needs to be explicitly set now

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
