### PR TITLE
fix: no longer default button type to "button"

### DIFF
--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -52,13 +52,17 @@ Knappene våre har et hierarki. Når brukeren har flere knapper å velge mellom,
 
 Knappetekster skal være så enkle og korte som mulig og skal oppfordre til handling. Bruk helst bare to ord:
 
-<Button variant="primary" className="jkl-spacing-xl--right">
-    Send inn
-</Button>
-<Button className="jkl-spacing-xl--right">Lagre</Button>
-<Button variant="tertiary" className="jkl-spacing-xl--right">
-    Avbryt
-</Button>
+<form>
+    <Button variant="primary" className="jkl-spacing-xl--right">
+        Send inn
+    </Button>
+    <Button type="button" className="jkl-spacing-xl--right">
+        Lagre
+    </Button>
+    <Button type="button" variant="tertiary" className="jkl-spacing-xl--right">
+        Avbryt
+    </Button>
+</form>
 
 ## Knapper rendret som andre elementer
 

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -18,7 +18,6 @@ export const Button = React.forwardRef(function Button<ElementType extends React
         loader,
         iconLeft,
         iconRight,
-        type = as === "button" ? "button" : undefined,
         variant = "secondary",
         ...rest
     } = props;
@@ -60,7 +59,6 @@ export const Button = React.forwardRef(function Button<ElementType extends React
             disabled={as === "button" ? loader?.showLoader : undefined}
             onTouchStart={handleTouch}
             {...rest}
-            type={type}
             ref={ref}
         >
             <div className="jkl-button__content">


### PR DESCRIPTION
this is in line with how the default <button> element behaves

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
