### PR TITLE
docs: merk hamburger-komponenten som deprecated

### DIFF
--- a/packages/hamburger-react/src/Hamburger.tsx
+++ b/packages/hamburger-react/src/Hamburger.tsx
@@ -38,6 +38,10 @@ export interface HamburgerProps {
     };
 }
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ * Bruk heller `HamburgerIcon` fra ikonpakka https://jokul.fremtind.no/komponenter/icons/
+ */
 export const Hamburger = ({
     "aria-label": ariaLabel = "Hovedmeny",
     isOpen,

--- a/packages/hamburger/hamburger.scss
+++ b/packages/hamburger/hamburger.scss
@@ -38,6 +38,8 @@ $_hamburger-line-height: jkl.rem(2px);
     --jkl-hamburger-expanded-hover-scale: scale3d(1.1, 1, 1);
 }
 
+/// @deprecated Denne komponenten bør ikke lenger brukes. Bruk heller
+/// HamburgerIcon fra ikonpakka
 .jkl-hamburger {
     @include jkl.reset-outline;
     cursor: pointer;


### PR DESCRIPTION
ISSUES CLOSED: #3948

Sørg for at `Hamburger`-komponenten er merket som deprecated i kode før vi fjerner den fra repet. Da blir det lettere å se at den ikke skal brukes. Når dette er merget, og siste versjon av pakken er publisert, kan vi slette komponenten fra repoet (se #3950).