### PR TITLE
fix: oppdater til siste versjon av ikonene i list-react

### DIFF
--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@fremtind/jkl-core": "^14.1.0",
-        "@fremtind/jkl-icons-react": "^8.7.2",
+        "@fremtind/jkl-icons-react": "^9.1.0",
         "@fremtind/jkl-list": "^10.3.0",
         "classnames": "^2.3.2"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -772,12 +772,12 @@ importers:
   packages/list-react:
     specifiers:
       '@fremtind/jkl-core': ^14.1.0
-      '@fremtind/jkl-icons-react': ^8.7.2
+      '@fremtind/jkl-icons-react': ^9.1.0
       '@fremtind/jkl-list': ^10.3.0
       classnames: ^2.3.2
     dependencies:
       '@fremtind/jkl-core': link:../core
-      '@fremtind/jkl-icons-react': 8.7.4
+      '@fremtind/jkl-icons-react': link:../icons-react
       '@fremtind/jkl-list': link:../list
       classnames: 2.3.2
 
@@ -3951,20 +3951,7 @@ packages:
       react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
     dependencies:
       classnames: 2.5.1
-
-  /@fremtind/jkl-icons-react/8.7.4:
-    resolution: {integrity: sha512-lHO+8F/phYBauQoURQKC552qbaSZ39IBS/zx33nfB2zn0n6jOhJtUK0TjSA1A4gcQYzTOiTsEktwaVQ2ZvEPnA==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 14.1.0
-      '@fremtind/jkl-icons': 9.1.5
-      '@fremtind/jkl-react-hooks': 12.1.2
-      classnames: 2.5.1
-    dev: false
+    dev: true
 
   /@fremtind/jkl-icons/9.1.5:
     resolution: {integrity: sha512-JDn9qAWTc68CI0Ua41MJ7/NOcOQBHr8T0mr2Qcwd1nTJPVuNRD7X+RHNs54bMykugp24hq+xbPGQWShOnb6qSQ==}
@@ -3975,18 +3962,7 @@ packages:
       - '@types/react-dom'
       - react
       - react-dom
-
-  /@fremtind/jkl-react-hooks/12.1.2:
-    resolution: {integrity: sha512-NHnooJSHSrmfzQhRt2OaiJRQlvckqjhSD565WrNllSGG5BHAPriAKOwEb/iszU5CVcjB6pSIGlALBH2bDc3+rw==}
-    peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
-      '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
-      react: ^16.8.6 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@fremtind/jkl-core': 14.1.0
-      nanoid: 3.3.7
-    dev: false
+    dev: true
 
   /@frsource/base64/1.0.4:
     resolution: {integrity: sha512-IphM1ro1cvV5CqJWzX/LvPJcUE26cwgt/zMtBdssvTrfSNhh9KjfS2VXTA8SivkvPHK1DsdPnoMoXitmx8c3Cg==}
@@ -7309,7 +7285,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.7.18
-      vite: 5.4.2
+      vite: 5.4.2_qly2xqze27fzfdjycmqvs326c4
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -14331,7 +14307,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.17.4
+      uglify-js: 3.19.2
     dev: true
 
   /hard-rejection/2.1.0:
@@ -23232,8 +23208,8 @@ packages:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
     dev: false
 
-  /uglify-js/3.17.4:
-    resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
+  /uglify-js/3.19.2:
+    resolution: {integrity: sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
`list-react`-pakken avhenger av en gammel versjon av ikonene, noe som kan føre til konflikter dersom man bruker begge pakkene i samme prosjekt.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
