### PR TITLE
docs: marker komponenter som deprecated

### DIFF
--- a/packages/contact-information-react/src/ContactInformation.tsx
+++ b/packages/contact-information-react/src/ContactInformation.tsx
@@ -3,6 +3,9 @@ import { formatTelefonnummer } from "@fremtind/jkl-formatters-util";
 import cn from "classnames";
 import React, { HTMLAttributes, FC, ReactNode } from "react";
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export interface FooterProps extends DataTestAutoId, HTMLAttributes<HTMLElement> {
     headingComponent: ReactNode;
     density?: Density;

--- a/packages/contact-information/contact-information.scss
+++ b/packages/contact-information/contact-information.scss
@@ -1,6 +1,9 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
+/// @deprecated Denne komponenten bør ikke lenger brukes. Bruk heller
+/// HamburgerIcon fra ikonpakka
+
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-sand};
 }

--- a/packages/contact-information/contact-information.scss
+++ b/packages/contact-information/contact-information.scss
@@ -1,8 +1,7 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes. Bruk heller
-/// HamburgerIcon fra ikonpakka
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert
 
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-sand};

--- a/packages/content-toggle-react/src/ContentToggle.tsx
+++ b/packages/content-toggle-react/src/ContentToggle.tsx
@@ -2,6 +2,10 @@ import { WithChildren } from "@fremtind/jkl-core";
 import cn from "classnames";
 import React, { ReactNode, FC, useState, useEffect } from "react";
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
+
 export interface ContentToggleProps extends WithChildren {
     /** @default "polite" */
     "aria-live"?: "polite" | "assertive" | "off";

--- a/packages/content-toggle/content-toggle.scss
+++ b/packages/content-toggle/content-toggle.scss
@@ -2,6 +2,8 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
+/// @deprecated Denne komponenten bør ikke lenger brukes.
+
 $_animation-duration: 300ms;
 $_half-animation-duration: calc(#{$_animation-duration} / 2);
 

--- a/packages/content-toggle/content-toggle.scss
+++ b/packages/content-toggle/content-toggle.scss
@@ -2,7 +2,7 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes.
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
 
 $_animation-duration: 300ms;
 $_half-animation-duration: calc(#{$_animation-duration} / 2);

--- a/packages/footer-react/src/Footer.tsx
+++ b/packages/footer-react/src/Footer.tsx
@@ -2,6 +2,10 @@ import { DataTestAutoId, Density, Link } from "@fremtind/jkl-core";
 import cn from "classnames";
 import React, { HTMLAttributes, FC, ElementType, MouseEventHandler } from "react";
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
+
 export interface FooterLink<T = HTMLAnchorElement> {
     title: string;
     href?: string;

--- a/packages/footer/footer.scss
+++ b/packages/footer/footer.scss
@@ -1,8 +1,7 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes. Bruk heller
-/// HamburgerIcon fra ikonpakka
+/// @deprecated Denne komponenten bør ikke lenger brukes.
 
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-hvit};

--- a/packages/footer/footer.scss
+++ b/packages/footer/footer.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes.
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
 
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-hvit};

--- a/packages/footer/footer.scss
+++ b/packages/footer/footer.scss
@@ -1,6 +1,9 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
+/// @deprecated Denne komponenten bør ikke lenger brukes. Bruk heller
+/// HamburgerIcon fra ikonpakka
+
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-hvit};
 }


### PR DESCRIPTION
ContactInformation, Footer og Content toggle markeres som deprecated.

Content Toggle blir kun brukt ét sted, og det er i hamburger som også har blitt fjernet :)