### PR TITLE
chore: bruk git clean for å rydde opp i pakker

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "2.0.0-alpha.0",
     "scripts": {
-        "clean": "lerna run clean && rimraf .nx && rimraf node_modules/",
+        "clean": "git clean -xfd",
         "build": "lerna run build",
         "build:docs": "lerna run build:docs",
         "commit": "git-cz",
@@ -124,7 +124,6 @@
         "react-syntax-highlighter": "^15.5.0",
         "replace-in-file": "^7.0.1",
         "resize-observer-polyfill": "^1.5.1",
-        "rimraf": "^4.4.1",
         "sass": "^1.77.6",
         "stylelint": "^15.7.0",
         "tiny-glob": "^0.2.9",

--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -24,7 +24,7 @@
     "browser": "./build/es/index.js",
     "types": "./build/index.d.ts",
     "scripts": {
-        "clean": "rimraf build/ node_modules/",
+        "clean": "git clean -xfd",
         "build": "vite build --config vite.build.config.mjs",
         "test": "jest --testMatch '**/accordion-react/**/*.test.+(ts|tsx|js)' --config=../../jest.config.js",
         "dev": "vite --config vite.dev.config.ts --port 3000"

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo *.css",
+        "clean": "git clean -xfd",
         "build": "node build.js",
         "build:watch": "nodemon build.js",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/alert-message-react/package.json
+++ b/packages/alert-message-react/package.json
@@ -28,7 +28,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/alert-message/package.json
+++ b/packages/alert-message/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf node_modules/ **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/breadcrumb-react/package.json
+++ b/packages/breadcrumb-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/browserslist-config-jkl/package.json
+++ b/packages/browserslist-config-jkl/package.json
@@ -17,7 +17,7 @@
         "index.js"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/",
+        "clean": "git clean -xfd",
         "test": "echo \"Error: run tests from root\" && exit 1"
     },
     "repository": {

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -30,7 +30,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -21,7 +21,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -25,7 +25,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -28,7 +28,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/combobox-react/package.json
+++ b/packages/combobox-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/constants-util/package.json
+++ b/packages/constants-util/package.json
@@ -26,7 +26,7 @@
         "@fremtind/jkl-table-react": "^11.4.20"
     },
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/contact-information-react/package.json
+++ b/packages/contact-information-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/contact-information/package.json
+++ b/packages/contact-information/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/content-toggle-react/package.json
+++ b/packages/content-toggle-react/package.json
@@ -28,7 +28,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/content-toggle/package.json
+++ b/packages/content-toggle/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/contextual-menu-react/package.json
+++ b/packages/contextual-menu-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/contextual-menu/package.json
+++ b/packages/contextual-menu/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/cookie-consent-react/package.json
+++ b/packages/cookie-consent-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
         "lib": "build"
     },
     "scripts": {
-        "clean": "rimraf node_modules/ build/ **/*.css",
+        "clean": "git clean -xfd",
         "generate:tokens": "node tokens.build.mjs",
         "build": "run-s build:*",
         "build:style": "gulp build",

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/description-list-react/package.json
+++ b/packages/description-list-react/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/fremtind/jokul.git"
     },
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/description-list/package.json
+++ b/packages/description-list/package.json
@@ -28,7 +28,7 @@
         "@fremtind/jkl-core": "^14.2.1"
     },
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/expand-button-react/package.json
+++ b/packages/expand-button-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/expand-button/package.json
+++ b/packages/expand-button/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/file-input-react/package.json
+++ b/packages/file-input-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/file-input/package.json
+++ b/packages/file-input/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/footer-react/package.json
+++ b/packages/footer-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/formatters-util/package.json
+++ b/packages/formatters-util/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -30,7 +30,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -21,7 +21,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -28,7 +28,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,7 +20,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/fremtind/jokul.git"
     },
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/input-group-react/package.json
+++ b/packages/input-group-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf .turbo/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/input-group/package.json
+++ b/packages/input-group/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -30,7 +30,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -21,7 +21,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/message-box-react/package.json
+++ b/packages/message-box-react/package.json
@@ -28,7 +28,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/modal-react/package.json
+++ b/packages/modal-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -26,7 +26,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf node_modules/ .cache/ build/ dist/ public/ **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -29,7 +29,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -20,7 +20,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -28,7 +28,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -29,7 +29,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/stylelint-config-jkl/package.json
+++ b/packages/stylelint-config-jkl/package.json
@@ -17,7 +17,7 @@
         "rules/"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ node_modules/ .stylelintcache",
+        "clean": "git clean -xfd",
         "lint": "stylelint --config=index.js 'examples/**/*.{css,scss,sass}' --cache",
         "test": "npm run lint"
     },

--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/summary-table/package.json
+++ b/packages/summary-table/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tabs-react/package.json
+++ b/packages/tabs-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tag-react/package.json
+++ b/packages/tag-react/package.json
@@ -28,7 +28,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -32,7 +32,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -22,7 +22,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toast-react/package.json
+++ b/packages/toast-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -29,7 +29,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -20,7 +20,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/tooltip-react/package.json
+++ b/packages/tooltip-react/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -17,7 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/validators-util/package.json
+++ b/packages/validators-util/package.json
@@ -27,7 +27,7 @@
         "build"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/packages/webfonts/package.json
+++ b/packages/webfonts/package.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf node_modules/ **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "dev": "echo \"Error: run dev from root\" && exit 1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,6 @@ importers:
       react-syntax-highlighter: ^15.5.0
       replace-in-file: ^7.0.1
       resize-observer-polyfill: ^1.5.1
-      rimraf: ^4.4.1
       sass: ^1.77.6
       stylelint: ^15.7.0
       tiny-glob: ^0.2.9
@@ -171,7 +170,6 @@ importers:
       react-syntax-highlighter: 15.5.0_react@18.2.0
       replace-in-file: 7.0.1
       resize-observer-polyfill: 1.5.1
-      rimraf: 4.4.1
       sass: 1.77.8
       stylelint: 15.7.0
       tiny-glob: 0.2.9
@@ -1342,7 +1340,6 @@ importers:
       react-hook-form: ^7.44.3
       react-live: ^3.2.0
       react-syntax-highlighter: ^15.5.0
-      rimraf: ^5.0.7
       typescript: ^5.2.2
       vite: ^5.2.0
       vite-plugin-dts: ^3.9.0
@@ -1407,7 +1404,6 @@ importers:
       '@types/react-syntax-highlighter': 15.5.13
       '@vitejs/plugin-react-swc': 3.7.0_vite@5.4.2
       glob: 8.1.0
-      rimraf: 5.0.10
       typescript: 5.4.2
       vite: 5.4.2
       vite-plugin-dts: 3.9.1_l4kf3v35sg5jx3vp6c2zvhh4g4
@@ -21452,13 +21448,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 9.3.5
-    dev: true
-
-  /rimraf/5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
-    dependencies:
-      glob: 10.4.5
     dev: true
 
   /rollup-plugin-node-externals/7.1.3:

--- a/portal/package.json
+++ b/portal/package.json
@@ -93,7 +93,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf node_modules/ .cache/ public/",
+        "clean": "git clean -xfd",
         "build:docs": "gatsby build",
         "build:test": "gatsby build && gatsby serve",
         "dev": "gatsby develop --host 0.0.0.0 --port 8000",

--- a/scripts/scaffold/templates/component-react/package.json
+++ b/scripts/scaffold/templates/component-react/package.json
@@ -26,7 +26,7 @@
         "*.scss"
     ],
     "scripts": {
-        "clean": "rimraf node_modules/ build/ node_modules/ ",
+        "clean": "git clean -xfd",
         "build:types": "tsc -p tsconfig-for-declarations.json",
         "build:scripts": "node ./esbuild.prod.mjs",
         "build": "run-s build:*",

--- a/scripts/scaffold/templates/component/package.json
+++ b/scripts/scaffold/templates/component/package.json
@@ -16,7 +16,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "clean": "rimraf .turbo **/*.css",
+        "clean": "git clean -xfd",
         "build": "gulp build",
         "build:watch": "gulp build:watch",
         "test": "echo \"Error: run tests from root\" && exit 1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "type": "module",
     "scripts": {
-        "clean": "rimraf build/ node_modules/",
+        "clean": "git clean -xfd",
         "build": "vite build --config vite.build.config.ts",
         "build:watch": "vite build --config vite.build.config.ts --watch",
         "typecheck": "tsc",
@@ -71,7 +71,6 @@
         "@types/react-syntax-highlighter": "^15.5.10",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "glob": "^8.1.0",
-        "rimraf": "^5.0.7",
         "typescript": "^5.2.2",
         "vite": "^5.2.0",
         "vite-plugin-dts": "^3.9.0"


### PR DESCRIPTION
Jeg er lei av å vente i fem minutter på at Lerna/NX skal rydde vekk gamle filer når man kjører `pnpm clean`. Git har et innebygget verktøy som fjerner alle filer som ikke er tracket eller er med i `.gitignore` som vi kan bruke i stedet.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
