### PR TITLE
fix: force remount of controls for new followups

### DIFF
--- a/packages/feedback-react/src/Feedback.test.tsx
+++ b/packages/feedback-react/src/Feedback.test.tsx
@@ -273,6 +273,52 @@ describe("Feedback", () => {
         expect(mockFn).toBeCalledTimes(1);
     });
 
+    it("clears state of second followup question (#4001)", async () => {
+        render(
+            <Feedback
+                {...PRESETS["Fant du"]}
+                followup={{
+                    questions: [
+                        {
+                            type: "text",
+                            label: "Er det noe mer du vil legge til?",
+                            name: "annet",
+                        },
+                        {
+                            type: "text",
+                            label: "Er det noe mer mer du vil legge til?",
+                            name: "mer-annet",
+                        },
+                    ],
+                    onSubmit: mockFn,
+                }}
+                onSubmit={() => null}
+            />,
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByText("Ja"));
+            await userEvent.click(screen.getByText("Send"));
+        });
+
+        await act(async () => {
+            await userEvent.click(screen.getByText("Jeg har tid!"));
+        });
+
+        await act(async () => {
+            await userEvent.type(screen.getByLabelText("Er det noe mer du vil legge til?"), "mer");
+            await userEvent.click(screen.getByText("Neste"));
+        });
+
+        await act(async () => {
+            const oldTextarea = await screen.queryByDisplayValue("mer");
+            expect(oldTextarea).not.toBeInTheDocument();
+
+            const newTextarea = await screen.queryByDisplayValue("");
+            expect(newTextarea).toBeInTheDocument();
+        });
+    });
+
     it("submits correct contact information", async () => {
         render(
             <Feedback

--- a/packages/feedback-react/src/followup/Followup.tsx
+++ b/packages/feedback-react/src/followup/Followup.tsx
@@ -72,7 +72,7 @@ export const Followup: FC<Props> = ({ questions, successMessage = defaultSuccess
                             Steg {step.number + 1} av {questions.length}
                         </p>
                         {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-                        <QuestionComponent {...questions[step.number]} autoFocus />
+                        <QuestionComponent {...questions[step.number]} autoFocus key={step.number} />
                         <div className="jkl-spacing-xl--top" aria-live="off">
                             <Button type="submit">{step.isLast ? "Send inn" : "Neste"}</Button>
                             <TertiaryButton onClick={handleAbort} className="jkl-spacing-xl--left">


### PR DESCRIPTION
Ensures that any UI state from e.g. textareas is cleared when the flow moves to a new step

Fixes #4001

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
