### PR TITLE
fix: fix sass-order in components used by doc-utils

### DIFF
--- a/doc-utils/CodeBlock/CodeBlock.scss
+++ b/doc-utils/CodeBlock/CodeBlock.scss
@@ -40,10 +40,10 @@
         padding: jkl.$spacing-xs;
         background-color: var(--language-tag-bg-color);
         color: var(--language-tag-text-color);
-        @include jkl.use-font-family("Fremtind Grotesk");
-        @include jkl.text-style("small");
         text-transform: uppercase;
         content: attr(data-language);
+        @include jkl.use-font-family("Fremtind Grotesk");
+        @include jkl.text-style("small");
     }
 
     &__code {

--- a/doc-utils/component-example.scss
+++ b/doc-utils/component-example.scss
@@ -46,12 +46,13 @@
 
         // Unngå at endring av tittel knekker visuell regresjonstest ved å skjule den
         :not([data-test-mode="e2e"]) &::before {
-            @include jkl.text-style("small");
             color: var(--component-example-header-color);
             position: absolute;
             top: jkl.$spacing-s;
             left: jkl.$spacing-m;
             content: attr(data-example-text);
+
+            @include jkl.text-style("small");
         }
 
         &[data-test-mode="e2e-screenshot"] {
@@ -75,19 +76,20 @@
     }
 
     &__example-options-header {
+        margin-bottom: jkl.$spacing-s;
+        @include jkl.text-style("small");
+
         &:not(:first-child) {
             margin-top: jkl.$spacing-l;
         }
-        @include jkl.text-style("small");
-        margin-bottom: jkl.$spacing-s;
     }
 
     &__choice-option {
         margin-top: jkl.$spacing-l;
 
         & .jkl-label.jkl-label--small {
-            @include jkl.text-style("small");
             color: jkl.$color-fjellgra;
+            @include jkl.text-style("small");
         }
     }
 

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -22,12 +22,6 @@
 .jkl-expand-button {
     $_animation-timing: jkl.timing("snappy") jkl.easing("focus");
     $_focus-ring-width: jkl.rem(2px);
-
-    @include jkl.reset-outline;
-
-    &::-webkit-details-marker {
-        display: none;
-    }
     list-style: none;
 
     background-color: transparent;
@@ -37,6 +31,12 @@
     transition: transform $_animation-timing, border $_animation-timing;
     min-width: unset;
     position: relative;
+
+    @include jkl.reset-outline;
+
+    &::-webkit-details-marker {
+        display: none;
+    }
 
     &::after {
         $_expand-button-border-width: jkl.rem(1px);
@@ -50,9 +50,10 @@
     }
 
     html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
-        @include _expanded-arrow(3px);
         border: none;
         color: var(--jkl-expand-button-focus-color);
+
+        @include _expanded-arrow(3px);
 
         &::after {
             box-shadow: 0 0 0 $_focus-ring-width var(--jkl-expand-button-focus-color);
@@ -75,12 +76,13 @@
 
     // Bevisst nøstet for høyere specificity enn icons uavhengig av importrekkefølge.
     .jkl-expand-button__arrow {
-        @include jkl.motion;
         transition-property: transform;
 
         display: inline-block;
         margin-left: jkl.$spacing-2;
         margin-bottom: -0.15em;
+
+        @include jkl.motion;
     }
 
     @include jkl.forced-colors-mode {
@@ -95,8 +97,8 @@
 
 .jkl-expand-section {
     &__content-wrapper {
-        @include jkl.motion;
         transition-property: height;
+        @include jkl.motion;
     }
 
     &__content {

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -27,8 +27,6 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
 }
 
 @include jkl.comfortable-density-variables {
-    @include jkl.declare-font-variables("jkl-radio-button-label", "body");
-
     $_radio-button-height: jkl.rem(48px);
     $_radio-button-line-height: jkl.rem(32px);
     $_radio-button-size: jkl.rem(24px);
@@ -42,6 +40,8 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
             ($_radio-button-height - $_radio-button-size) * 0.5
         )} 0;
     --jkl-radio-button-dot-size: #{$_radio-button-size - (2 * $_radio-button-dot-padding)};
+
+    @include jkl.declare-font-variables("jkl-radio-button-label", "body");
 
     @include jkl.small-device {
         $_mobile-radio-button-height: jkl.rem(40px);
@@ -59,8 +59,6 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
 }
 
 @include jkl.compact-density-variables {
-    @include jkl.declare-font-variables("jkl-radio-button-label", "small");
-
     $_compact-radio-button-height: jkl.rem(28px);
     $_compact-radio-button-size: jkl.rem(18px);
     $_compact-radio-button-line-height: jkl.rem(24px);
@@ -72,6 +70,8 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
     --jkl-radio-button-text-transform: translate3d(0, 0, 0);
     --jkl-radio-button-dot-margin: #{jkl.rem(7px)} #{jkl.$spacing-xs} #{jkl.rem(7px)} 0;
     --jkl-radio-button-dot-size: #{$_compact-radio-button-size - (2 * $_radio-button-dot-padding)};
+
+    @include jkl.declare-font-variables("jkl-radio-button-label", "small");
 }
 
 @keyframes #{$_radio-button-dot-animation-name} {
@@ -85,11 +85,12 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
 }
 
 .jkl-radio-button {
-    @include jkl.reset-outline;
     display: flex;
     min-height: var(--jkl-radio-button-height);
     color: var(--jkl-radio-button-color);
     position: relative;
+
+    @include jkl.reset-outline;
 
     &__input {
         // hide default radio button
@@ -135,10 +136,11 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
     }
 
     &__label {
-        @include jkl.use-font-variables("jkl-radio-button-label");
         cursor: pointer;
         display: flex;
         align-items: flex-start;
+
+        @include jkl.use-font-variables("jkl-radio-button-label");
 
         // Hovered state
         &:hover {
@@ -183,8 +185,8 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         border-radius: 50%;
         box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
 
-        @include jkl.motion;
         transition-property: background-color, box-shadow;
+        @include jkl.motion;
 
         /* Inner dot */
         &::after {
@@ -198,8 +200,8 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
             border-radius: 50%;
             transform: scale(1);
 
-            @include jkl.motion;
             transition-property: transform;
+            @include jkl.motion;
 
             @include jkl.forced-colors-mode {
                 top: jkl.rem(3px);

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -53,8 +53,6 @@ $_select-search-input-selection-color--inverted: color.scale(
 }
 
 @include jkl.comfortable-density-variables {
-    @include jkl.declare-font-variables("jkl-select", "body");
-
     --jkl-select-input-height: #{jkl.rem(48px)};
     --jkl-select-arrow-right: #{jkl.$spacing-8};
     --jkl-select-button-padding: #{jkl.$spacing-8} #{jkl.rem(36px)} #{jkl.$spacing-8} #{jkl.$spacing-12};
@@ -62,26 +60,29 @@ $_select-search-input-selection-color--inverted: color.scale(
     --jkl-select-native-padding: 0 #{jkl.$spacing-40} 0 #{jkl.$spacing-8};
     --jkl-select-option-padding: #{jkl.$spacing-8} #{jkl.$spacing-12};
 
+    @include jkl.declare-font-variables("jkl-select", "body");
+
     @include jkl.small-device {
         --jkl-select-input-height: #{jkl.rem(44px)};
     }
 }
 
 @include jkl.compact-density-variables {
-    @include jkl.declare-font-variables("jkl-select", "small");
-
     --jkl-select-input-height: #{jkl.rem(32px)};
     --jkl-select-arrow-right: #{jkl.rem(4px)};
     --jkl-select-button-padding: #{jkl.$spacing-4} #{jkl.$spacing-32} #{jkl.$spacing-4} #{jkl.$spacing-8};
     --jkl-select-search-input-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
     --jkl-select-native-padding: #{jkl.$spacing-4} #{jkl.$spacing-24} #{jkl.$spacing-4} #{jkl.$spacing-4};
     --jkl-select-option-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
+
+    @include jkl.declare-font-variables("jkl-select", "small");
 }
 
 .jkl-select {
-    @include jkl.reset-outline;
     display: block;
     position: relative;
+
+    @include jkl.reset-outline;
 
     & *:focus {
         outline: none;
@@ -134,7 +135,6 @@ $_select-search-input-selection-color--inverted: color.scale(
 
     &__search-input,
     &__button {
-        @include jkl.use-font-variables("jkl-select");
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -149,12 +149,14 @@ $_select-search-input-selection-color--inverted: color.scale(
         text-align: left;
         width: 100%;
 
+        transition-property: color, border-color, box-shadow;
+        @include jkl.motion;
+
+        @include jkl.use-font-variables("jkl-select");
+
         &--active-value {
             color: var(--jkl-select-text-active-value-color);
         }
-
-        @include jkl.motion;
-        transition-property: color, border-color, box-shadow;
 
         &:focus {
             border-color: var(--jkl-select-focus-color);
@@ -186,18 +188,16 @@ $_select-search-input-selection-color--inverted: color.scale(
         position: absolute;
         right: var(--jkl-select-arrow-right);
         top: 50%;
-        transform: translateY(-50%);
-
-        @include jkl.motion;
-        transition-property: transform, color;
-
         color: var(--jkl-select-arrow-color);
+
+        transform: translateY(-50%);
+        transition-property: transform, color;
+        @include jkl.motion;
+
         @include jkl.forced-colors-svg-fallback($stroke: CanvasText, $fill: CanvasText);
     }
 
     &__options-menu {
-        @include jkl.motion;
-        transition-property: height;
         position: absolute;
         left: jkl.rem(-1px);
         right: jkl.rem(-1px);
@@ -213,6 +213,9 @@ $_select-search-input-selection-color--inverted: color.scale(
         overflow-y: auto;
         // Sett makshøyde på listen til høyden av (maxShownOptions + 0.5) ganger høyden på ett enlinjes valg
         max-height: calc(calc(var(--jkl-select-max-shown-options, 5) + 0.5) * var(--jkl-select-input-height));
+
+        transition-property: height;
+        @include jkl.motion;
     }
 
     &__option-wrapper {
@@ -224,18 +227,19 @@ $_select-search-input-selection-color--inverted: color.scale(
     }
 
     &__option {
-        @include jkl.use-font-variables("jkl-select");
         color: unset;
         border: 0; // removes native styling
         width: 100%;
         background-color: inherit;
         min-height: var(--jkl-select-input-height);
         text-align: left;
-        @include jkl.motion;
         transition-property: color, background-color;
         position: relative;
         padding: var(--jkl-select-option-padding);
         cursor: pointer;
+
+        @include jkl.motion;
+        @include jkl.use-font-variables("jkl-select");
 
         /* For å unngå "dobbel" markering skrur vi av markering på hover i React-
         komponenten med data-focus="controlled". Uten dette satt vil valgene
@@ -247,10 +251,10 @@ $_select-search-input-selection-color--inverted: color.scale(
         }
 
         &-description {
-            @include jkl.text-style("small");
             color: var(--jkl-select-option-description-color);
             display: block;
             width: 100%;
+            @include jkl.text-style("small");
         }
     }
 
@@ -317,9 +321,9 @@ $_select-search-input-selection-color--inverted: color.scale(
 
             &:hover,
             &:focus {
-                @include jkl.no-grow-bold;
                 border-top: 1px solid SelectedItem;
                 border-bottom: 1px solid SelectedItem;
+                @include jkl.no-grow-bold;
             }
         }
     }


### PR DESCRIPTION
Motivation here being making it easier to track what is actually causing warnings when running the respective dev servers for other components

ISSUES CLOSED: #4017

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
