### PR TITLE
Oppdater fokusstiler i accordion

### DIFF
--- a/packages/accordion/accordion.scss
+++ b/packages/accordion/accordion.scss
@@ -58,9 +58,8 @@
 }
 
 .jkl-accordion-item {
+    @include jkl.motion("exit", "snappy", border-top-color, border-bottom-color);
     @include jkl.reset-outline;
-    @include jkl.motion("exit", "snappy");
-    transition-property: border-top-color, border-bottom-color;
 
     &:nth-child(n) {
         @include hover;
@@ -93,13 +92,8 @@
 
     &__title {
         @include jkl.use-font-variables("jkl-accordion-title");
-        @include jkl.reset-outline;
 
-        &::-webkit-details-marker {
-            display: none;
-        }
         list-style: none;
-
         color: var(--jkl-color);
         background-color: transparent;
         position: relative;
@@ -107,6 +101,12 @@
         text-align: left;
         width: 100%;
         box-sizing: border-box;
+
+        @include jkl.reset-outline;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
 
         &:hover {
             cursor: pointer;
@@ -122,7 +122,7 @@
         }
 
         html:not([data-mousenavigation]) &:focus {
-            box-shadow: inset 0 0 0 2px var(--jkl-accordion-focus);
+            @include jkl.focus-outline($offset: -2px);
         }
     }
 

--- a/packages/core/jkl/_motion.scss
+++ b/packages/core/jkl/_motion.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "sass:list";
 
 // Oppdater verdier i motion.ts også
 $_easings: (
@@ -41,7 +42,7 @@ $_timings: (
     @if map.has-key($timings, $mode) {
         @return map.get($timings, $mode);
     } @else {
-        @error 'Unable to find a mode for #{$mode}';
+        @error 'Unable to find a timing named #{$mode} in our supported timings';
     }
 }
 
@@ -49,9 +50,13 @@ $_timings: (
 /// Se også `timing`- og `easing`-funksjonene.
 /// @param {"standard" | "entrance" | "exit" | "easeInBounceOut" | "focus"} $name [standard] - Navn på easingen du ønsker verdien til
 /// @param {"energetic" | "snappy" | "productive" | "expressive" | "lazy"} $mode [productive] - Navn på timingen du ønsker verdien til
+/// @param $properties - Kommaseparert liste over egenskapene du ønsker å animere
 /// @see easing
 /// @see timing
-@mixin motion($name: "standard", $mode: "productive") {
+@mixin motion($name: "standard", $mode: "productive", $properties...) {
     transition-timing-function: easing($name);
     transition-duration: timing($mode);
+    @if list.length($properties) > 0 {
+        transition-property: $properties;
+    }
 }

--- a/packages/core/jkl/_ornaments.scss
+++ b/packages/core/jkl/_ornaments.scss
@@ -19,3 +19,8 @@
     content: $content / ""; // Tom alternativ tekst
     alt: " "; // WebKit-alternativ, fases ut når varianten fra speccen er støttet
 }
+
+@mixin focus-outline($offset: 2px, $thickness: 2px) {
+    outline: $thickness solid var(--jkl-color-border-action);
+    outline-offset: $offset;
+}


### PR DESCRIPTION
- Legger til en hjelpe-mixin i `core` for å generere standardisert fokusindikator med `outline`
- Oppdaterer `Accordion` til å bruke nny fokusindikator
- Omrokkerer stiler i henhold til ny standard i Sass (closes #4020)

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
