### PR TITLE
fix: bruk outline i stedet for box-shadow for fokusringer

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -49,7 +49,6 @@ a.jkl-button {
     --focus-color: var(--jkl-color-background-action);
     --background-color: transparent;
 
-    @include jkl.reset-outline;
     display: inline-flex;
     box-sizing: border-box;
     justify-content: center;
@@ -70,7 +69,9 @@ a.jkl-button {
     transform-origin: 50% 90%;
     transition-property: transform, background-color;
 
-    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+    @include jkl.reset-outline;
+
+    &:focus-visible,
     html:not([data-touchnavigation]) &:hover {
         transform: scale(1.05);
     }
@@ -81,9 +82,8 @@ a.jkl-button {
         transform: scale(1);
     }
 
-    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
-        outline: $_focus-ring-width solid var(--focus-color);
-        outline-offset: jkl.rem(2px);
+    &:focus-visible {
+        @include jkl.focus-outline;
     }
 
     html[data-touchnavigation] &--pressed {
@@ -139,7 +139,7 @@ a.jkl-button {
         border-radius: jkl.rem(4px);
         padding: 0 jkl.$spacing-4;
 
-        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        &:focus-visible,
         html:not([data-touchnavigation]) &:hover {
             --background-color: var(--jkl-color-background-interactive-hover);
             transform: scale(1);
@@ -163,7 +163,7 @@ a.jkl-button {
         transition-property: box-shadow, transform, background-color;
 
         &:hover,
-        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        &:focus-visible,
         html[data-touchnavigation] &.jkl-button--pressed {
             box-shadow: inset 0 0 0 1px var(--border-color), inset 0 0 0 1px var(--border-color);
         }
@@ -191,21 +191,11 @@ a.jkl-button {
             background-color: transparent;
         }
 
-        &::after {
-            border: solid $_focus-ring-width transparent;
-            box-shadow: none;
-            transition: box-shadow $_animation-timing;
-            content: "";
-            position: absolute;
-            inset: (-($_button-border-width)) (-($_button-border-width)) (-($_button-border-width))
-                (-($_button-border-width));
-        }
-
         html[data-touchnavigation] &.jkl-button--pressed::before {
             animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_tertiary-flash-animation-name;
         }
 
-        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
+        &:focus-visible {
             border: none;
 
             @include jkl.forced-colors-mode {
@@ -214,7 +204,7 @@ a.jkl-button {
         }
 
         &:hover,
-        html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus,
+        &:focus-visible,
         html[data-touchnavigation] &.jkl-button--pressed {
             border-bottom-color: var(--focus-color);
             border-bottom-width: $_focus-ring-width;
@@ -268,18 +258,8 @@ a.jkl-button {
             background-color: ButtonText;
         }
 
-        &.jkl-button--secondary::after {
-            // Selve knappen har en border, men med to borders er secondary for lik primary uten farger.
-            // Gjør så secondary har _en_ border for å differensiere visuelt i forced-colors-modus.
-            border: none;
-        }
-
         &.jkl-button--tertiary {
             outline-offset: jkl.$spacing-3xs;
-        }
-
-        &.jkl-button--tertiary,
-        &.jkl-button--tertiary::after {
             border-top-style: none;
             border-right-style: none;
             border-left-style: none;

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -130,18 +130,11 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         }
 
         // Focused state:
-        html:not([data-mousenavigation]) &:focus + .jkl-checkbox__label {
+        &:focus-visible + .jkl-checkbox__label {
             color: var(--jkl-checkbox-focus-color);
 
-            & > .jkl-checkbox__mark::before {
-                box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-checkbox-focus-color);
-
-                @include jkl.forced-colors-mode {
-                    border: 4px double ButtonText;
-                }
-            }
-
             & > .jkl-checkbox__mark {
+                @include jkl.focus-outline;
                 background-color: var(--jkl-checkbox-focus-background-color);
             }
         }
@@ -149,10 +142,6 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         // Disabled state:
         &:disabled + .jkl-checkbox__label {
             color: var(--jkl-checkbox-disabled-color);
-
-            &:hover .jkl-checkbox__mark {
-                box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
-            }
         }
     }
 
@@ -167,7 +156,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
             color: var(--jkl-checkbox-focus-color);
 
             .jkl-checkbox__mark {
-                box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) currentColor;
+                outline: 1px solid currentColor;
 
                 @include jkl.forced-colors-mode {
                     &::before {
@@ -183,7 +172,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
             color: var(--jkl-checkbox-color);
 
             .jkl-checkbox__mark {
-                box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
+                outline: 1px solid currentColor;
                 background-color: var(--jkl-checkbox-focus-background-color);
             }
         }
@@ -209,17 +198,10 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
 
         outline: none;
         border-radius: 0; // fixes rounded corners in iOS Safari
-        box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
+        border: 1px solid currentColor;
 
         @include jkl.motion;
-        transition-property: background-color, box-shadow;
-
-        // This is the basis of the focus ring
-        &::before {
-            content: "";
-            position: absolute;
-            inset: jkl.rem(-2px) jkl.rem(-2px) jkl.rem(-2px) jkl.rem(-2px);
-        }
+        transition-property: background-color;
 
         @include jkl.forced-colors-mode {
             outline: revert;
@@ -292,7 +274,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
     &--error {
         .jkl-checkbox__mark,
         & > .jkl-checkbox__label:active > .jkl-checkbox__mark,
-        html:not([data-mousenavigation]) & > .jkl-checkbox__input:focus + .jkl-checkbox__label > .jkl-checkbox__mark {
+        & > .jkl-checkbox__input:focus-visible + .jkl-checkbox__label > .jkl-checkbox__mark {
             background-color: var(--jkl-checkbox-error-background-color);
         }
 

--- a/packages/core/styles/_links.scss
+++ b/packages/core/styles/_links.scss
@@ -4,11 +4,6 @@
     background-image: linear-gradient(to bottom, $color 0%, $color 100%);
 }
 
-@mixin _link-outline {
-    outline: jkl.rem(2px) solid var(--jkl-link-active-color);
-    outline-offset: jkl.rem(2px);
-}
-
 $_right-arrow: "\2192"; // unicode right arrow
 $_left-arrow: "\2190"; // unicode left arrow
 $_north-east-arrow: "\2197"; // unicode north east arrow (up/right)
@@ -47,8 +42,8 @@ $_link-underline-thickness--focus: jkl.rem(2px);
         @include _underline-gradient(var(--jkl-link-hover-color));
     }
 
-    html:not([data-mousenavigation]) &:focus {
-        @include _link-outline;
+    &:focus-visible {
+        @include jkl.focus-outline;
         background: none;
     }
 
@@ -100,8 +95,8 @@ $_link-underline-thickness--focus: jkl.rem(2px);
         }
     }
 
-    html:not([data-mousenavigation]) &:focus {
-        @include _link-outline;
+    &:focus-visible {
+        @include jkl.focus-outline;
 
         &::after {
             padding-left: 0.7em;
@@ -135,7 +130,7 @@ $_link-underline-thickness--focus: jkl.rem(2px);
     }
 
     &:hover,
-    html:not([data-mousenavigation]) &:focus {
+    &:focus-visible {
         &::before {
             transform: translateX(-33%);
         }

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -38,26 +38,12 @@
         display: none;
     }
 
-    &::after {
-        $_expand-button-border-width: jkl.rem(1px);
-        border: solid $_focus-ring-width transparent;
-        box-shadow: none;
-        transition: box-shadow $_animation-timing;
-        content: "";
-        position: absolute;
-        inset: (-($_expand-button-border-width)) (-($_expand-button-border-width)) (-($_expand-button-border-width))
-            (-($_expand-button-border-width));
-    }
-
-    html:not([data-mousenavigation]):not([data-touchnavigation]) &:focus {
+    &:focus-visible {
         border: none;
         color: var(--jkl-expand-button-focus-color);
 
+        @include jkl.focus-outline;
         @include _expanded-arrow(3px);
-
-        &::after {
-            box-shadow: 0 0 0 $_focus-ring-width var(--jkl-expand-button-focus-color);
-        }
     }
 
     &:hover {

--- a/packages/icon-button/icon-button.scss
+++ b/packages/icon-button/icon-button.scss
@@ -20,15 +20,14 @@
 }
 
 .jkl-icon-button {
-    @include jkl.reset-outline;
-    @include jkl.motion(focus, snappy);
-
     background-color: transparent;
     cursor: pointer;
     color: inherit;
     position: relative;
     transition-property: box-shadow;
-    border-radius: jkl.rem(3px);
+
+    @include jkl.motion(focus, snappy);
+    @include jkl.reset-outline;
 
     .jkl-icon {
         display: flex;
@@ -44,25 +43,12 @@
         color: var(--jkl-icon-button-focus-color);
     }
 
-    &::after {
-        $_button-border-gap: jkl.rem(1px); // Synlig border i forced-colors
-        content: "";
-        position: absolute;
-        inset: (-($_button-border-gap)) $_button-border-gap (-($_button-border-gap)) $_button-border-gap;
-        box-shadow: none;
-    }
+    &:focus-visible {
+        color: var(--jkl-icon-button-focus-color);
 
-    @include jkl.keyboard-navigation {
-        &:focus {
-            color: var(--jkl-icon-button-focus-color);
-
-            &::after {
-                box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-icon-button-border-color);
-            }
-
-            @include jkl.forced-colors-mode {
-                border: revert;
-            }
+        @include jkl.focus-outline;
+        @include jkl.forced-colors-mode {
+            border: revert;
         }
     }
 

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -116,12 +116,13 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         }
 
         // Focused state
-        html:not([data-mousenavigation]) &:focus {
+        &:focus-visible {
             + .jkl-radio-button__label {
                 color: var(--jkl-radio-button-focus-color);
 
                 & > .jkl-radio-button__dot {
                     background-color: var(--jkl-radio-button-focus-background-color);
+                    @include jkl.focus-outline;
                 }
 
                 & > .jkl-radio-button__dot::before {
@@ -207,16 +208,6 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
                 top: jkl.rem(3px);
                 left: jkl.rem(3px);
             }
-        }
-
-        // Focus ring
-        &::before {
-            content: "";
-            position: absolute;
-            inset: jkl.rem(-2px) jkl.rem(-2px) jkl.rem(-2px) jkl.rem(-2px);
-            border-radius: 50%;
-
-            box-shadow: 0 0 0 jkl.rem(1px) transparent;
         }
 
         @include jkl.forced-colors-mode {

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -79,6 +79,7 @@
     scroll-snap-align: start;
     text-decoration: none;
     white-space: nowrap;
+    @include jkl.reset-outline;
 
     @include jkl.small-device {
         padding: #{jkl.$spacing-8} #{jkl.$spacing-24} #{jkl.$spacing-12} #{jkl.$spacing-2};
@@ -89,19 +90,7 @@
     }
 
     &:focus-visible {
-        @include jkl.reset-outline;
-
-        &::after {
-            content: "";
-            position: absolute;
-            inset: jkl.rem(2px) jkl.rem(6px) jkl.rem(1px) jkl.rem(-2px); // Hold avstand til neste fane
-            box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-tab-focus-border-color);
-        }
-
-        &:first-of-type::after {
-            // Unngå clipping hvis kant til kant med skjerm eller scroll container.
-            left: jkl.rem(2px);
-        }
+        @include jkl.focus-outline($offset: -2px);
     }
 
     &[aria-selected="true"] {

--- a/packages/toast/toast.scss
+++ b/packages/toast/toast.scss
@@ -53,7 +53,6 @@
 }
 
 .jkl-toast {
-    @include jkl.text-style("body");
     color: var(--jkl-toast-color);
     background-color: var(--jkl-toast-background-color);
     border-radius: 4px;
@@ -65,6 +64,8 @@
     max-width: min(30rem, 85vw);
     padding: var(--jkl-toast-padding);
     padding-top: 0;
+
+    @include jkl.text-style("body");
 
     @include jkl.small-device {
         grid-template-areas:
@@ -107,8 +108,8 @@
     }
 
     &__title {
-        @include jkl.text-style("heading-4");
         margin: 0 0 jkl.$spacing-4 0;
+        @include jkl.text-style("heading-4");
 
         & ~ .jkl-toast__message {
             margin-top: 0; // Unset offset satt for å aligne med ikon hvis uten tittel.
@@ -116,14 +117,12 @@
     }
 
     &__dismiss-button {
-        @include jkl.reset-outline;
         grid-area: dismiss;
         justify-self: end;
         position: relative;
         margin-left: var(--jkl-toast-gap);
 
         background-color: transparent;
-        border-radius: jkl.rem(3px);
         padding: 0;
         cursor: pointer;
 
@@ -139,17 +138,7 @@
             content: "";
             position: absolute;
             inset: var(--tap-increment) var(--tap-increment) var(--tap-increment) var(--tap-increment);
-        }
-
-        &:focus {
-            @include jkl.keyboard-navigation {
-                outline: 2px solid var(--jkl-color);
-
-                @include jkl.forced-colors-mode {
-                    outline: 2px solid ButtonText;
-                    outline-offset: 2px;
-                }
-            }
+            border-radius: jkl.rem(3px);
         }
     }
 

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -60,7 +60,8 @@
 }
 
 .jkl-toggle-switch {
-    @include jkl.reset-outline;
+    --jkl-toggle-switch-knob-position: 0;
+
     background: transparent;
     color: var(--jkl-color);
     padding: 0;
@@ -75,12 +76,12 @@
 
     @include jkl.use-font-variables("jkl-toggle");
 
+    @include jkl.reset-outline;
+
     @include jkl.forced-colors-mode {
         border-color: transparent;
         border-style: none;
     }
-
-    --jkl-toggle-switch-knob-position: 0;
 
     &[aria-pressed="true"],
     [aria-checked="true"] > & {
@@ -130,11 +131,8 @@
         border: jkl.rem(1px) solid ButtonText;
     }
 
-    :focus > & {
-        @include jkl.keyboard-navigation {
-            outline: jkl.rem(2px) solid var(--jkl-color);
-            outline-offset: jkl.rem(2px);
-        }
+    &:focus-visible {
+        @include jkl.focus-outline;
     }
 
     &__slider {


### PR DESCRIPTION
Bruker den nye mixin-en `jkl.focus-outline` for å tegne fokusringer på komponentene som har det. Bytter også over til å bruke `:focus-visible`-selektoren [fra CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) i stedet for å sjekke `keyboard-navigation`-attributten vår.

Fikser også Sass-rekkefølge i de komponentene der det er gjort endringer.

closes #4027 
closes #4028 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
