### PR TITLE
fix: legg til aria-label og tekst om skjermlesere på NavCard og Card

### DIFF
--- a/packages/card-react/src/Card.tsx
+++ b/packages/card-react/src/Card.tsx
@@ -31,6 +31,8 @@ export type CardProps<ElementType extends React.ElementType> = PolymorphicPropsW
          * Angir om kortet visuelt skal fremstå som klikkbart. Du må selv rendre
          * kortet som et klikkbart element (f.eks. `<a>` eller en `<Link>` fra
          * et ruting-bibliotek) og gi det en `href` eller `onClick`-handler.
+         * HUSK: Sett aria-label for at støtteverktøy, som skjermlesere, ikke
+         * skal lese alt innholdet i kortet.
          */
         clickable?: boolean;
     }

--- a/packages/card-react/src/NavCard.tsx
+++ b/packages/card-react/src/NavCard.tsx
@@ -78,7 +78,13 @@ export const NavCard: FC<NavCardProps> = React.forwardRef<HTMLAnchorElement, Nav
     const tagArr = !tag ? undefined : Array.isArray(tag) ? tag : [tag];
 
     return (
-        <Component ref={ref} className={cn("jkl-nav-card", className)} data-density={density} {...rest}>
+        <Component
+            ref={ref}
+            aria-label={title}
+            className={cn("jkl-nav-card", className)}
+            data-density={density}
+            {...rest}
+        >
             {image && <Image className="jkl-nav-card__image" {...image} />}
             <div className="jkl-nav-card__content" style={getPaddingStyles(padding)}>
                 {tagArr && (


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

Legger til aria-label på NavCard-komponenten, for å unngå at skjermlesere og andre støtteverktøy tar med alt innhold. I tillegg er det lagt til en tekst på clickable propen, siden det ikke er noen tittel på vanlig Card.

Lagde ikke noe issue, men det kunne jeg gjort.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
