### PR TITLE
Bytt til semantiske fargevariabler i de fleste komponentene

### DIFF
--- a/packages/breadcrumb/breadcrumb.scss
+++ b/packages/breadcrumb/breadcrumb.scss
@@ -5,11 +5,11 @@
     a[aria-current] {
         text-decoration: none;
         background-image: none;
-        color: var(--jkl-color);
+        color: var(--jkl-color-text-interactive);
 
         &:hover {
             cursor: default;
-            color: var(--jkl-link-color);
+            color: var(--jkl-color-text-interactive-hover);
             background-image: none;
         }
     }
@@ -23,12 +23,12 @@
     }
 
     &__item {
-        margin-bottom: jkl.$spacing-xs;
+        margin-bottom: jkl.$spacing-8;
         white-space: nowrap;
     }
 
     &__item-separator {
-        padding-left: jkl.$spacing-xs;
-        padding-right: jkl.$spacing-xs;
+        padding-left: jkl.$spacing-8;
+        padding-right: jkl.$spacing-8;
     }
 }

--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -3,68 +3,26 @@
 @use "@fremtind/jkl-core/jkl";
 @use "@fremtind/jkl-core/jkl/colors";
 
-@include jkl.light-mode-variables {
-    --jkl-checkbox-color: #{jkl.$color-granitt};
-    --jkl-checkbox-background-color: #{jkl.$color-snohvit};
-    --jkl-checkbox-focus-color: #{jkl.$color-granitt};
-    --jkl-checkbox-focus-background-color: #{jkl.$color-hvit};
-    --jkl-checkbox-error-background-color: #{jkl.$color-feil};
-    --jkl-checkbox-error-check-color: #{jkl.$color-granitt};
-    --jkl-checkbox-disabled-color: #{jkl.$color-stein};
-    --jkl-checkbox-box-default-color: #{jkl.$color-stein};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-checkbox-color: #{jkl.$color-snohvit};
-    --jkl-checkbox-background-color: transparent;
-    --jkl-checkbox-focus-color: #{jkl.$color-snohvit};
-    --jkl-checkbox-focus-background-color: #{jkl.$color-skifer};
-    --jkl-checkbox-error-background-color: #{jkl.$color-feil};
-    --jkl-checkbox-error-check-color: #{jkl.$color-granitt};
-    --jkl-checkbox-disabled-color: #{jkl.$color-stein};
-    --jkl-checkbox-box-default-color: #{jkl.$color-svaberg};
-}
-
 @include jkl.comfortable-density-variables {
     @include jkl.declare-font-variables("jkl-checkbox", "body");
 
-    $_checkbox-height: jkl.rem(48px);
-    $_checkbox-box-size: jkl.rem(24px);
-    $_checkbox-line-height: jkl.rem(32px);
-
-    --jkl-checkbox-height: #{$_checkbox-height};
-    --jkl-checkbox-box-size: #{$_checkbox-box-size};
-    --jkl-checkbox-line-height: #{$_checkbox-line-height};
-    --jkl-checkbox-mark-margin: #{jkl.rem(11px)} #{jkl.$spacing-xs} #{jkl.rem(8px)} 0;
-    --jkl-checkbox-text-translate: translate3d(0, #{jkl.rem(1px)}, 0);
-    --jkl-checkbox-text-margin: #{(($_checkbox-height - $_checkbox-line-height) * 0.5)} 0;
+    --jkl-checkbox-height: #{jkl.rem(48px)};
+    --jkl-checkbox-box-size: #{jkl.rem(24px)};
+    --jkl-checkbox-line-height: #{jkl.rem(32px)};
 
     @include jkl.small-device {
-        $_checkbox-height--mobile: jkl.rem(40px);
-        $_checkbox-box-size--mobile: jkl.rem(24px);
-        $_checkbox-line-height--mobile: jkl.rem(28px);
-
-        --jkl-checkbox-height: #{$_checkbox-height--mobile};
-        --jkl-checkbox-box-size: #{$_checkbox-box-size--mobile};
-        --jkl-checkbox-line-height: #{$_checkbox-line-height--mobile};
-        --jkl-checkbox-text-translate: translate3d(0, 0, 0);
-        --jkl-checkbox-text-margin: #{(($_checkbox-height--mobile - $_checkbox-line-height--mobile) * 0.5)} 0;
+        --jkl-checkbox-height: #{jkl.rem(40px)};
+        --jkl-checkbox-box-size: #{jkl.rem(24px)};
+        --jkl-checkbox-line-height: #{jkl.rem(28px)};
     }
 }
 
 @include jkl.compact-density-variables {
     @include jkl.declare-font-variables("jkl-checkbox", "small");
 
-    $_checkbox-height--compact: jkl.rem(28px);
-    $_checkbox-box-size--compact: jkl.rem(18px);
-    $_checkbox-line-height--compact: jkl.rem(24px);
-
-    --jkl-checkbox-height: #{$_checkbox-height--compact};
-    --jkl-checkbox-box-size: #{$_checkbox-box-size--compact};
-    --jkl-checkbox-line-height: #{$_checkbox-line-height--compact};
-    --jkl-checkbox-mark-margin: #{jkl.rem(5px)} #{jkl.$spacing-xs} #{jkl.rem(4px)} 0;
-    --jkl-checkbox-text-translate: translate3d(0, 0, 0);
-    --jkl-checkbox-text-margin: #{(($_checkbox-height--compact - $_checkbox-line-height--compact) * 0.5)} 0;
+    --jkl-checkbox-height: #{jkl.rem(28px)};
+    --jkl-checkbox-box-size: #{jkl.rem(18px)};
+    --jkl-checkbox-line-height: #{jkl.rem(24px)};
 }
 
 $_checkbox-checked-animation-name: jkl-checkbox-checked-#{string.unique-id()};
@@ -98,12 +56,17 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
 }
 
 .jkl-checkbox {
+    --box-color: var(--jkl-color-border-action);
+    --check-color: var(--jkl-color-border-action);
+    --text-color: var(--jkl-color-text-default);
+    --background-color: transparent;
+
     @include jkl.use-font-variables("jkl-checkbox");
 
     display: flex;
     flex-wrap: wrap;
     min-height: var(--jkl-checkbox-height);
-    color: var(--jkl-checkbox-color);
+    color: var(--text-color);
     position: relative;
 
     &__input {
@@ -134,8 +97,8 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
             color: var(--jkl-checkbox-focus-color);
 
             & > .jkl-checkbox__mark {
+                --background-color: var(--jkl-color-background-input-focus);
                 @include jkl.focus-outline;
-                background-color: var(--jkl-checkbox-focus-background-color);
             }
         }
 
@@ -152,35 +115,21 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         cursor: pointer;
         flex-shrink: 0;
 
-        &:hover {
-            color: var(--jkl-checkbox-focus-color);
-
+        &:hover,
+        &:active {
             .jkl-checkbox__mark {
-                outline: 1px solid currentColor;
-
-                @include jkl.forced-colors-mode {
-                    &::before {
-                        border: 2px solid ButtonText;
-                        position: absolute;
-                        inset: jkl.rem(-1px) jkl.rem(-1px) jkl.rem(-1px) jkl.rem(-1px);
-                    }
-                }
+                outline: 1px solid var(--box-color);
             }
         }
 
         &:active {
-            color: var(--jkl-checkbox-color);
-
-            .jkl-checkbox__mark {
-                outline: 1px solid currentColor;
-                background-color: var(--jkl-checkbox-focus-background-color);
-            }
+            --background-color: var(--jkl-color-background-input-focus);
         }
     }
 
     &__text {
-        margin: var(--jkl-checkbox-text-margin);
-        transform: var(--jkl-checkbox-text-translate);
+        margin: calc((var(--jkl-checkbox-height) - var(--jkl-checkbox-line-height)) * 0.5) 0;
+        translate: 0 jkl.rem(1px);
 
         @include jkl.motion;
         transition-property: color;
@@ -192,14 +141,16 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         height: var(--jkl-checkbox-box-size);
         width: var(--jkl-checkbox-box-size);
 
-        margin: var(--jkl-checkbox-mark-margin);
+        margin-block: calc((var(--jkl-checkbox-height) - var(--jkl-checkbox-box-size)) * 0.5);
+        margin-inline-end: var(--jkl-spacing-8);
         align-self: flex-start;
         flex-shrink: 0; // Don't allow the mark to shrink in case of really long text
 
         outline: none;
         border-radius: 0; // fixes rounded corners in iOS Safari
-        border: 1px solid currentColor;
-
+        border: 1px solid;
+        border-color: var(--box-color);
+        background-color: var(--background-color);
         @include jkl.motion;
         transition-property: background-color;
 
@@ -223,7 +174,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
             height: 58%;
             transform: rotate(45deg);
 
-            border: solid jkl.rem(2px) currentColor;
+            border: solid jkl.rem(2px) var(--check-color);
             border-left-width: 0;
             border-top-width: 0;
 
@@ -251,7 +202,7 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
             display: block;
             width: var(--width);
 
-            border-bottom: solid var(--thickness) currentColor;
+            border-bottom: solid var(--thickness) var(--check-color);
 
             opacity: 0;
             @include jkl.motion;
@@ -267,20 +218,12 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
         display: inline-flex;
 
         &:not(:last-of-type) {
-            margin-right: jkl.$spacing-l;
+            margin-right: jkl.$spacing-24;
         }
     }
 
     &--error {
-        .jkl-checkbox__mark,
-        & > .jkl-checkbox__label:active > .jkl-checkbox__mark,
-        & > .jkl-checkbox__input:focus-visible + .jkl-checkbox__label > .jkl-checkbox__mark {
-            background-color: var(--jkl-checkbox-error-background-color);
-        }
-
-        .jkl-checkbox__indeterminate-mark::after,
-        .jkl-checkbox__check-mark::after {
-            border-color: var(--jkl-checkbox-error-check-color);
-        }
+        --background-color: var(--jkl-color-background-alert-error);
+        --check-color: var(--jkl-color-text-on-alert);
     }
 }

--- a/packages/contextual-menu/_contextual-menu-divider.scss
+++ b/packages/contextual-menu/_contextual-menu-divider.scss
@@ -1,16 +1,8 @@
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-contextual-menu-divider-color: #{jkl.$color-svaberg};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-contextual-menu-divider-color: #{jkl.$color-stein};
-}
-
 .jkl-contextual-menu-divider {
     width: 100%;
     margin-block: 0;
     border: none;
-    border-bottom: jkl.rem(1px) solid var(--jkl-contextual-menu-divider-color);
+    border-bottom: jkl.rem(1px) solid var(--jkl-color-border-separator);
 }

--- a/packages/contextual-menu/_contextual-menu-item.scss
+++ b/packages/contextual-menu/_contextual-menu-item.scss
@@ -1,17 +1,5 @@
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-contextual-menu-item-hover-background-color: #{jkl.$color-dis};
-    --jkl-contextual-menu-item-focus-background-color: #{jkl.$color-varde};
-    --jkl-contextual-menu-item-disabled-color: #{jkl.$color-svaberg};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-contextual-menu-item-hover-background-color: #{jkl.$color-stein};
-    --jkl-contextual-menu-item-focus-background-color: #{jkl.$color-fjellgra};
-    --jkl-contextual-menu-item-disabled-color: #{jkl.$color-stein};
-}
-
 @include jkl.comfortable-density-variables {
     --jkl-contextual-menu-item-height: #{jkl.rem(48px)};
     --jkl-contextual-menu-item-padding: #{jkl.$spacing-8} #{jkl.$spacing-24};
@@ -25,8 +13,10 @@
 }
 
 .jkl-contextual-menu-item {
-    background-color: transparent;
-    color: var(--jkl-color);
+    --background-color: var(--jkl-color-background-interactive);
+
+    background-color: var(--background-color);
+    color: var(--jkl-color-text-default);
     cursor: pointer;
 
     box-sizing: border-box;
@@ -68,11 +58,8 @@
         flex-shrink: 0;
     }
 
-    html[data-mousenavigation] &:hover {
-        background-color: var(--jkl-contextual-menu-item-hover-background-color);
-    }
-
-    &:focus {
-        background-color: var(--jkl-contextual-menu-item-focus-background-color);
+    &:hover,
+    &:focus-visible {
+        --background-color: var(--jkl-color-background-interactive-hover);
     }
 }

--- a/packages/contextual-menu/contextual-menu.scss
+++ b/packages/contextual-menu/contextual-menu.scss
@@ -4,25 +4,22 @@
 @use "contextual-menu-divider";
 
 @include jkl.light-mode-variables {
-    --jkl-contextual-menu-bg-color: #{jkl.$color-hvit};
-    --jkl-contextual-menu-trigger-focus-color: #{jkl.$color-granitt};
     --jkl-contextual-menu-border: none;
 }
 
 @include jkl.dark-mode-variables {
-    --jkl-contextual-menu-bg-color: #{jkl.$color-svart};
-    --jkl-contextual-menu-trigger-focus-color: #{jkl.$color-snohvit};
     --jkl-contextual-menu-border: 2px solid #{jkl.$color-snohvit};
 }
 
 .jkl-contextual-menu {
+    background-color: var(--jkl-color-background-container-high);
+
     width: 100%;
     max-width: jkl.rem(336px);
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     flex-wrap: nowrap;
-    background-color: var(--jkl-contextual-menu-bg-color);
     box-shadow: 0 jkl.rem(4px) jkl.rem(20px) rgb(49 48 48 / 20%);
     border-radius: jkl.rem(2px);
     border: var(--jkl-contextual-menu-border);

--- a/packages/core/jkl/_legacy-tokens.scss
+++ b/packages/core/jkl/_legacy-tokens.scss
@@ -1,5 +1,5 @@
 // Do not edit directly
-// Generated on Wed, 22 Nov 2023 09:07:30 GMT
+// Generated on Fri, 06 Sep 2024 19:24:11 GMT
 
 $color-svart: #000000;
 $color-granitt: #1b1917;

--- a/packages/core/jkl/_tokens.scss
+++ b/packages/core/jkl/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 19 Jun 2024 10:02:18 GMT
+ * Generated on Fri, 06 Sep 2024 19:24:11 GMT
  */
 
 $color-brand-snohvit: #f9f9f9;
@@ -119,6 +119,8 @@ $color-background-page-variant: var(--jkl-color-background-page-variant);
 $color-background-container: var(--jkl-color-background-container);
 $color-background-container-low: var(--jkl-color-background-container-low);
 $color-background-container-high: var(--jkl-color-background-container-high);
+$color-background-container-inverted: var(--jkl-color-background-container-inverted);
+$color-background-container-subdued: var(--jkl-color-background-container-subdued);
 $color-background-input-base: var(--jkl-color-background-input-base);
 $color-background-input-focus: var(--jkl-color-background-input-focus);
 $color-background-action: var(--jkl-color-background-action);
@@ -143,3 +145,4 @@ $color-border-input-focus: var(--jkl-color-border-input-focus);
 $color-border-separator: var(--jkl-color-border-separator);
 $color-border-separator-strong: var(--jkl-color-border-separator-strong);
 $color-border-separator-hover: var(--jkl-color-border-separator-hover);
+$color-border-subdued: var(--jkl-color-border-subdued);

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 19 Jun 2024 10:02:18 GMT
+ * Generated on Fri, 06 Sep 2024 19:24:11 GMT
  */
 
 export default {
@@ -49,6 +49,14 @@ export default {
                 light: "#FFFFFF",
                 dark: "#313030",
             },
+            containerInverted: {
+                light: "#1B1917",
+                dark: "#F9F9F9",
+            },
+            containerSubdued: {
+                light: "#C8C5C3",
+                dark: "#636060",
+            },
             input: {
                 base: {
                     light: "transparent",
@@ -73,7 +81,7 @@ export default {
             },
             interactiveSelected: {
                 light: "#E0DBD4",
-                dark: "#444141",
+                dark: "#636060",
             },
             alert: {
                 neutral: {
@@ -152,6 +160,10 @@ export default {
             separatorHover: {
                 light: "#1B1917",
                 dark: "#F9F9F9",
+            },
+            subdued: {
+                light: "#C8C5C3",
+                dark: "#636060",
             },
         },
         svart: "#000",

--- a/packages/core/styles/_color-tokens.scss
+++ b/packages/core/styles/_color-tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 22 Nov 2023 09:07:30 GMT
+ * Generated on Fri, 06 Sep 2024 19:24:11 GMT
  */
 
 @use "../jkl";
@@ -11,6 +11,8 @@
     --jkl-color-background-container: #{jkl.$color-brand-snohvit};
     --jkl-color-background-container-low: #{jkl.$color-brand-dis};
     --jkl-color-background-container-high: #{jkl.$color-brand-hvit};
+    --jkl-color-background-container-inverted: #{jkl.$color-brand-granitt};
+    --jkl-color-background-container-subdued: #{jkl.$color-brand-svaberg};
     --jkl-color-background-input-base: rgba(0, 0, 0, 0);
     --jkl-color-background-input-focus: #{jkl.$color-brand-hvit};
     --jkl-color-background-action: #{jkl.$color-brand-granitt};
@@ -35,6 +37,7 @@
     --jkl-color-border-separator: #{jkl.$color-brand-svaberg};
     --jkl-color-border-separator-strong: #{jkl.$color-brand-stein};
     --jkl-color-border-separator-hover: #{jkl.$color-brand-granitt};
+    --jkl-color-border-subdued: #{jkl.$color-brand-svaberg};
 }
 @include jkl.dark-mode-variables {
     --jkl-color-background-page: #{jkl.$color-brand-granitt};
@@ -42,12 +45,14 @@
     --jkl-color-background-container: #{jkl.$color-brand-skifer};
     --jkl-color-background-container-low: #{jkl.$color-brand-svart};
     --jkl-color-background-container-high: #{jkl.$color-brand-skifer};
+    --jkl-color-background-container-inverted: #{jkl.$color-brand-snohvit};
+    --jkl-color-background-container-subdued: #{jkl.$color-brand-stein};
     --jkl-color-background-input-base: rgba(0, 0, 0, 0);
     --jkl-color-background-input-focus: #{jkl.$color-brand-skifer};
     --jkl-color-background-action: #{jkl.$color-brand-snohvit};
     --jkl-color-background-interactive: rgba(0, 0, 0, 0);
     --jkl-color-background-interactive-hover: #{jkl.$color-brand-fjellgra};
-    --jkl-color-background-interactive-selected: #{jkl.$color-brand-fjellgra};
+    --jkl-color-background-interactive-selected: #{jkl.$color-brand-stein};
     --jkl-color-background-alert-neutral: #{jkl.$color-brand-varde};
     --jkl-color-background-alert-info: #{jkl.$color-functional-info-dark};
     --jkl-color-background-alert-success: #{jkl.$color-functional-success-dark};
@@ -66,4 +71,5 @@
     --jkl-color-border-separator: #{jkl.$color-brand-stein};
     --jkl-color-border-separator-strong: #{jkl.$color-brand-svaberg};
     --jkl-color-border-separator-hover: #{jkl.$color-brand-snohvit};
+    --jkl-color-border-subdued: #{jkl.$color-brand-stein};
 }

--- a/packages/core/styles/_legacy-tokens.scss
+++ b/packages/core/styles/_legacy-tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 22 Nov 2023 09:07:30 GMT
+ * Generated on Fri, 06 Sep 2024 19:24:11 GMT
  */
 
 :root {

--- a/packages/core/styles/_tokens.scss
+++ b/packages/core/styles/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 22 Nov 2023 09:07:30 GMT
+ * Generated on Fri, 06 Sep 2024 19:24:11 GMT
  */
 
 :root {

--- a/packages/core/tokens.less
+++ b/packages/core/tokens.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 22 Nov 2023 09:07:30 GMT
+// Generated on Fri, 06 Sep 2024 19:24:11 GMT
 
 @color-brand-snohvit: #f9f9f9;
 @color-brand-varde: #e0dbd4;
@@ -31,6 +31,10 @@
 @color-background-container-low-dark: #000000;
 @color-background-container-high-light: #ffffff;
 @color-background-container-high-dark: #313030;
+@color-background-container-inverted-light: #1b1917;
+@color-background-container-inverted-dark: #f9f9f9;
+@color-background-container-subdued-light: #c8c5c3;
+@color-background-container-subdued-dark: #636060;
 @color-background-input-base-light: #000000;
 @color-background-input-base-dark: #000000;
 @color-background-input-focus-light: #ffffff;
@@ -42,7 +46,7 @@
 @color-background-interactive-hover-light: #ece9e5;
 @color-background-interactive-hover-dark: #444141;
 @color-background-interactive-selected-light: #e0dbd4;
-@color-background-interactive-selected-dark: #444141;
+@color-background-interactive-selected-dark: #636060;
 @color-background-alert-neutral-light: #e0dbd4;
 @color-background-alert-neutral-dark: #e0dbd4;
 @color-background-alert-info-light: #d3d3f6;
@@ -79,6 +83,8 @@
 @color-border-separator-strong-dark: #c8c5c3;
 @color-border-separator-hover-light: #1b1917;
 @color-border-separator-hover-dark: #f9f9f9;
+@color-border-subdued-light: #c8c5c3;
+@color-border-subdued-dark: #636060;
 @color-svart: #000000;
 @color-granitt: #1b1917;
 @color-skifer: #313030;
@@ -110,6 +116,8 @@
 @spacing-64: 4rem;
 @spacing-104: 6.5rem;
 @spacing-168: 10.5rem;
+@icon-weight-normal: 300;
+@icon-weight-bold: 500;
 @typography-weight-normal: 400;
 @typography-weight-bold: 700;
 @typography-font-size-16: 1rem;

--- a/packages/core/tokens/color/color.semantic.tokens.json
+++ b/packages/core/tokens/color/color.semantic.tokens.json
@@ -41,6 +41,22 @@
                     "value": "{color.brand.skifer.value}"
                 }
             },
+            "container-inverted": {
+                "light": {
+                    "value": "{color.brand.granitt.value}"
+                },
+                "dark": {
+                    "value": "{color.brand.snohvit.value}"
+                }
+            },
+            "container-subdued": {
+                "light": {
+                    "value": "{color.brand.svaberg.value}"
+                },
+                "dark": {
+                    "value": "{color.brand.stein.value}"
+                }
+            },
             "input": {
                 "base": {
                     "light": {
@@ -88,7 +104,7 @@
                     "value": "{color.brand.varde.value}"
                 },
                 "dark": {
-                    "value": "{color.brand.fjellgra.value}"
+                    "value": "{color.brand.stein.value}"
                 }
             },
             "alert": {
@@ -239,6 +255,14 @@
                 },
                 "dark": {
                     "value": "{color.brand.snohvit.value}"
+                }
+            },
+            "subdued": {
+                "light": {
+                    "value": "{color.brand.svaberg.value}"
+                },
+                "dark": {
+                    "value": "{color.brand.stein.value}"
                 }
             }
         }

--- a/packages/expand-button/expand-button.scss
+++ b/packages/expand-button/expand-button.scss
@@ -1,18 +1,6 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-expand-button-text-color: #{jkl.$color-granitt};
-    --jkl-expand-button-focus-color: #{jkl.$color-granitt};
-    --jkl-expand-button-hover-color: #{jkl.$color-stein};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-expand-button-text-color: #{jkl.$color-snohvit};
-    --jkl-expand-button-focus-color: #{jkl.$color-snohvit};
-    --jkl-expand-button-hover-color: #{jkl.$color-svaberg};
-}
-
 @mixin _expanded-arrow($px) {
     .jkl-expand-button__arrow {
         transform: translateY(jkl.rem($px));
@@ -20,13 +8,15 @@
 }
 
 .jkl-expand-button {
+    --color: var(--jkl-color-text-interactive);
+
     $_animation-timing: jkl.timing("snappy") jkl.easing("focus");
     $_focus-ring-width: jkl.rem(2px);
     list-style: none;
 
     background-color: transparent;
     cursor: pointer;
-    color: var(--jkl-expand-button-text-color);
+    color: var(--color);
     padding: 0;
     transition: transform $_animation-timing, border $_animation-timing;
     min-width: unset;
@@ -40,14 +30,14 @@
 
     &:focus-visible {
         border: none;
-        color: var(--jkl-expand-button-focus-color);
 
         @include jkl.focus-outline;
         @include _expanded-arrow(3px);
     }
 
+    &:focus-visible,
     &:hover {
-        color: var(--jkl-expand-button-hover-color);
+        --color: var(--jkl-color-text-interactive-hover);
     }
 
     &--expanded {

--- a/packages/feedback/feedback.scss
+++ b/packages/feedback/feedback.scss
@@ -6,18 +6,6 @@ $_smiley-size: jkl.rem(40px);
 $_smileys-max-width: $_smiley-size * 9; // 5 smileys med fire like store mellomrom
 $_show-animation-name: jkl-show-#{string.unique-id()};
 
-@include jkl.light-mode-variables {
-    --jkl-feedback-step-color: #{jkl.$color-stein};
-    --jkl-feedback-smiley-color: #{jkl.$color-stein};
-    --jkl-feedback-smiley-color-hover: #{jkl.$color-granitt};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-feedback-step-color: #{jkl.$color-svaberg};
-    --jkl-feedback-smiley-color: #{jkl.$color-svaberg};
-    --jkl-feedback-smiley-color-hover: #{jkl.$color-snohvit};
-}
-
 @keyframes #{$_show-animation-name} {
     from {
         transform: translate3d(0, 0.5rem, 0);
@@ -39,8 +27,8 @@ $_show-animation-name: jkl-show-#{string.unique-id()};
     }
 
     &__step-counter {
-        color: var(--jkl-feedback-step-color);
-        margin-bottom: jkl.$spacing-m;
+        color: var(--jkl-color-text-subdued);
+        margin-bottom: jkl.$spacing-16;
         @include jkl.text-style("body");
     }
 
@@ -50,7 +38,7 @@ $_show-animation-name: jkl-show-#{string.unique-id()};
 }
 
 .jkl-feedback-smileys {
-    margin-top: jkl.$spacing-xs;
+    margin-top: jkl.$spacing-8;
     display: flex;
     justify-content: space-between;
     width: 100%;
@@ -65,7 +53,7 @@ $_show-animation-name: jkl-show-#{string.unique-id()};
     cursor: pointer;
     height: $_smiley-size;
     width: $_smiley-size;
-    color: var(--jkl-feedback-smiley-color);
+    color: var(--jkl-color-text-subdued);
     transform: translate3d(0, 0, 0);
 
     @include jkl.motion;
@@ -95,11 +83,11 @@ $_show-animation-name: jkl-show-#{string.unique-id()};
     }
 
     &:hover {
-        color: var(--jkl-feedback-smiley-color-hover);
+        color: var(--jkl-color-text-default);
     }
 
     input:checked + & {
-        color: var(--jkl-feedback-smiley-color-hover);
+        color: var(--jkl-color-text-default);
         transform: translate3d(0, -20%, 0);
 
         &::before {

--- a/packages/file-input/file-input.scss
+++ b/packages/file-input/file-input.scss
@@ -1,20 +1,6 @@
 @use "@fremtind/jkl-core/jkl";
 @use "./file";
 
-@include jkl.light-mode-variables {
-    --jkl-file-input-color: var(--jkl-color);
-    --jkl-file-input-dropzone-background-color: #{jkl.$color-snohvit};
-    --jkl-file-input-dropzone-background-color-enter: #{jkl.$color-hvit};
-    --jkl-file-input-dropzone-border-color: #{jkl.$color-fjellgra};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-file-input-color: var(--jkl-color);
-    --jkl-file-input-dropzone-background-color: #{jkl.$color-granitt};
-    --jkl-file-input-dropzone-background-color-enter: #{jkl.$color-svart};
-    --jkl-file-input-dropzone-border-color: #{jkl.$color-varde};
-}
-
 @include jkl.comfortable-density-variables {
     @include jkl.declare-font-variables("jkl-file-input-drag", "heading-2");
     @include jkl.declare-font-variables("jkl-file-size-hint", "small");
@@ -38,7 +24,10 @@
 
 .jkl-file-input {
     &__dropzone {
-        border: var(--jkl-file-input-dropzone-border-color) 1px dashed;
+        --border-color: var(--jkl-color-border-input);
+        --background-color: transparent;
+
+        border: var(--border-color) 1px dashed;
         border-radius: jkl.rem(4px);
         padding: var(--jkl-file-input-dropzone-padding);
         display: flex;
@@ -49,10 +38,11 @@
         gap: var(--jkl-file-input-dropzone-gap);
         @include jkl.motion("standard", "productive");
         transition-property: background-color;
-        background-color: transparent;
+        background-color: var(--background-color);
 
         &--enter {
-            background-color: var(--jkl-file-input-dropzone-background-color-enter);
+            --border-color: var(--jkl-color-border-input-focus);
+            --background-color: var(--jkl-color-background-container-high);
             border-style: solid;
         }
 
@@ -76,9 +66,7 @@
             .jkl-button {
                 transform: scale(1.05);
 
-                &::after {
-                    box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-button-focus-color);
-                }
+                @include jkl.focus-outline;
 
                 &:active {
                     transform: scale(1);
@@ -93,7 +81,7 @@
 
     &__max-size-text {
         @include jkl.use-font-variables("jkl-file-size-hint");
-        color: var(--jkl-file-input-color);
+        color: var(--jkl-color-text-subdued);
     }
 
     &__files {

--- a/packages/input-group/_labels.scss
+++ b/packages/input-group/_labels.scss
@@ -1,18 +1,6 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-label-color: #{jkl.$color-granitt};
-    --jkl-label-support-color: #{jkl.$color-stein};
-    --jkl-label-error-color: #{jkl.$color-granitt};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-label-color: #{jkl.$color-snohvit};
-    --jkl-label-support-color: #{jkl.$color-svaberg};
-    --jkl-label-error-color: #{jkl.$color-snohvit};
-}
-
 .jkl-dormant-form-support-label {
     display: none;
     opacity: 0;
@@ -38,12 +26,14 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
 }
 
 .jkl-form-support-label {
+    --color: var(--jkl-color-text-subdued);
+
     @include jkl.use-font-variables("jkl-form-support-label");
     @include jkl.motion("standard", "lazy");
 
     display: flex;
     margin: var(--jkl-form-support-label-margin);
-    color: var(--jkl-label-support-color);
+    color: var(--color);
     transition-property: color;
     transition-delay: jkl.timing("productive");
 
@@ -59,7 +49,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
     &--error,
     &--warning,
     &--success {
-        color: var(--jkl-label-error-color);
+        --color: var(--jkl-color-text-default);
 
         .jkl-form-support-label__icon {
             animation: jkl.timing("lazy") cubic-bezier(0, 0, 0.3, 1) jkl.timing("expressive")
@@ -99,7 +89,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
 .jkl-label {
     display: block;
     margin-left: initial;
-    color: var(--jkl-label-color);
+    color: var(--jkl-color-text-default);
 
     &--small {
         @include jkl.use-font-variables("jkl-label-small");

--- a/packages/message-box/message-box.scss
+++ b/packages/message-box/message-box.scss
@@ -1,22 +1,13 @@
 @charset "UTF-8";
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
-@use "@fremtind/jkl-core/jkl/colors";
 
 $_dismiss-animation-duration: jkl.timing("lazy");
 $_message-width: jkl.rem(560px);
 $_message-width--compact: jkl.rem(440px);
 
 $_dismiss-animation-name: jkl-dismiss-#{string.unique-id()};
-$_dismiss-focus-border-color: jkl.$color-granitt;
 $_dismiss-hover-color: jkl.$color-stein;
-
-$_text-color: jkl.$color-granitt;
-$_bg-color--default: jkl.$color-snohvit;
-$_bg-color--suksess: colors.varslingsfarge("suksess");
-$_bg-color--feil: colors.varslingsfarge("feil");
-$_bg-color--info: colors.varslingsfarge("info");
-$_bg-color--advarsel: colors.varslingsfarge("advarsel");
 
 @include jkl.comfortable-density-variables {
     @include jkl.declare-font-variables("jkl-message-box-message", "body");
@@ -49,11 +40,14 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
 }
 
 .jkl-message-box {
+    --background-color: var(--jkl-color-background-alert-neutral);
+    --text-color: var(--jkl-color-text-on-alert);
+
     width: 100%;
     max-width: $_message-width;
     padding: var(--jkl-message-box-padding);
-    background-color: $_bg-color--default;
-    color: $_text-color;
+    background-color: var(--background-color);
+    color: var(--text-color);
     border-radius: jkl.rem(4px);
     box-sizing: border-box;
 
@@ -96,7 +90,6 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
         margin-left: var(--jkl-message-box-gap);
 
         background-color: transparent;
-        border-radius: jkl.rem(3px);
         padding: 0;
         cursor: pointer;
 
@@ -121,15 +114,8 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
             @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
         }
 
-        &:focus {
-            @include jkl.keyboard-navigation {
-                outline: 2px solid $_dismiss-focus-border-color;
-
-                @include jkl.forced-colors-mode {
-                    outline: 2px solid ButtonText;
-                    outline-offset: 2px;
-                }
-            }
+        &:focus-visible {
+            @include jkl.focus-outline(0);
         }
     }
 
@@ -138,19 +124,19 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
     }
 
     &--info {
-        background-color: $_bg-color--info;
+        --background-color: var(--jkl-color-background-alert-info);
     }
 
     &--warning {
-        background-color: $_bg-color--advarsel;
+        --background-color: var(--jkl-color-background-alert-warning);
     }
 
     &--error {
-        background-color: $_bg-color--feil;
+        --background-color: var(--jkl-color-background-alert-error);
     }
 
     &--success {
-        background-color: $_bg-color--suksess;
+        --background-color: var(--jkl-color-background-alert-success);
     }
 
     &--dismissed {
@@ -190,5 +176,5 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
 }
 
 .jkl-form-error-message-box {
-    padding-bottom: jkl.$spacing-xl;
+    padding-bottom: jkl.$spacing-40;
 }

--- a/packages/modal/modal.scss
+++ b/packages/modal/modal.scss
@@ -1,16 +1,6 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-modal-overlay-color: rgba(27 25 23 / 80%);
-    --jkl-modal-background-color: #{jkl.$color-hvit};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-modal-overlay-color: rgba(27 25 23 / 80%);
-    --jkl-modal-background-color: #{jkl.$color-skifer};
-}
-
 @include jkl.comfortable-density-variables {
     @include jkl.declare-font-variables("jkl-modal-body", "body");
     @include jkl.declare-font-variables("jkl-modal-title", "heading-3");
@@ -54,7 +44,7 @@
 }
 
 .jkl-modal-overlay {
-    background-color: var(--jkl-modal-overlay-color);
+    background-color: rgba(27 25 23 / 80%);
 }
 
 .jkl-modal {
@@ -62,7 +52,7 @@
     z-index: jkl.$z-index--modal;
     position: relative;
 
-    background-color: var(--jkl-modal-background-color);
+    background-color: var(--jkl-color-background-container-high);
     border-radius: jkl.rem(2px);
     box-shadow: jkl.$shadow-task-card;
 

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -36,6 +36,7 @@
         "dev": "run-p dev:*"
     },
     "dependencies": {
+        "@fremtind/jkl-core": "^14.3.0",
         "@fremtind/jkl-progress-bar": "^6.0.17"
     },
     "peerDependencies": {

--- a/packages/progress-bar/progress-bar.scss
+++ b/packages/progress-bar/progress-bar.scss
@@ -1,30 +1,22 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-progress-background-color: #{jkl.$color-dis};
-    --jkl-progress-tracker-color: #{jkl.$color-stein};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-progress-background-color: #{jkl.$color-stein};
-    --jkl-progress-tracker-color: #{jkl.$color-dis};
-}
-
 .jkl-progress-bar,
 .jkl-countdown {
-    --jkl-progress-bar-height: #{jkl.rem(4px)};
+    --track-color: var(--jkl-color-border-separator);
+    --bar-color: var(--jkl-color-border-input-focus);
+    --bar-height: #{jkl.rem(4px)};
 
-    background-color: var(--jkl-progress-background-color);
+    background-color: var(--track-color);
     border-radius: jkl.rem(100px);
-    height: var(--jkl-progress-bar-height);
+    height: var(--bar-height);
     width: 100%;
     overflow: hidden;
 
     &__tracker {
         display: block;
-        height: var(--jkl-progress-bar-height);
-        background-color: var(--jkl-progress-tracker-color);
+        height: var(--bar-height);
+        background-color: var(--bar-color);
     }
 
     @include jkl.forced-colors-mode {

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -6,26 +6,6 @@
 $_radio-button-dot-padding: jkl.rem(4px);
 $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
 
-@include jkl.light-mode-variables {
-    --jkl-radio-button-color: #{jkl.$color-granitt};
-    --jkl-radio-button-background-color: #{jkl.$color-snohvit};
-    --jkl-radio-button-focus-color: #{jkl.$color-granitt};
-    --jkl-radio-button-focus-background-color: #{jkl.$color-hvit};
-    --jkl-radio-button-error-background-color: #{jkl.$color-feil};
-    --jkl-radio-button-error-dot-color: #{jkl.$color-granitt};
-    --jkl-radio-button-default-color: #{jkl.$color-stein};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-radio-button-color: #{jkl.$color-snohvit};
-    --jkl-radio-button-background-color: transparent;
-    --jkl-radio-button-focus-color: #{jkl.$color-snohvit};
-    --jkl-radio-button-focus-background-color: #{jkl.$color-svart};
-    --jkl-radio-button-error-background-color: #{jkl.$color-feil};
-    --jkl-radio-button-error-dot-color: #{jkl.$color-granitt};
-    --jkl-radio-button-default-color: #{jkl.$color-svaberg};
-}
-
 @include jkl.comfortable-density-variables {
     $_radio-button-height: jkl.rem(48px);
     $_radio-button-line-height: jkl.rem(32px);
@@ -85,9 +65,14 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
 }
 
 .jkl-radio-button {
+    --ring-color: var(--jkl-color-border-action);
+    --dot-color: transparent;
+    --background-color: transparent;
+    --text-color: var(--jkl-color-text-default);
+
     display: flex;
     min-height: var(--jkl-radio-button-height);
-    color: var(--jkl-radio-button-color);
+    color: var(--text-color);
     position: relative;
 
     @include jkl.reset-outline;
@@ -102,36 +87,33 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         // Checked state
         &:checked {
             + .jkl-radio-button__label > .jkl-radio-button__dot::after {
+                --dot-color: var(--jkl-color-border-action);
                 animation: $_radio-button-dot-animation-name jkl.timing("productive") ease;
-                background-color: currentColor;
 
                 @include jkl.forced-colors-mode {
                     background-color: ButtonText;
                 }
             }
 
-            .jkl-radio-button--error & + .jkl-radio-button__label > .jkl-radio-button__dot::after {
-                background-color: var(--jkl-radio-button-error-dot-color);
+            .jkl-radio-button--error & + .jkl-radio-button__label {
+                --background-color: var(--jkl-color-background-alert-error);
+                --dot-color: var(--jkl-color-text-on-alert);
             }
         }
 
         // Focused state
         &:focus-visible {
             + .jkl-radio-button__label {
-                color: var(--jkl-radio-button-focus-color);
+                --background-color: var(--jkl-color-background-input-focus);
 
                 & > .jkl-radio-button__dot {
-                    background-color: var(--jkl-radio-button-focus-background-color);
                     @include jkl.focus-outline;
                 }
+            }
 
-                & > .jkl-radio-button__dot::before {
-                    box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-radio-button-focus-color);
-
-                    @include jkl.forced-colors-mode {
-                        border: 4px double ButtonText;
-                    }
-                }
+            .jkl-radio-button--error & + .jkl-radio-button__label {
+                --background-color: var(--jkl-color-background-alert-error);
+                --dot-color: var(--jkl-color-text-on-alert);
             }
         }
     }
@@ -144,33 +126,13 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         @include jkl.use-font-variables("jkl-radio-button-label");
 
         // Hovered state
-        &:hover {
-            color: var(--jkl-radio-button-focus-color);
-
-            & > .jkl-radio-button__dot {
-                box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) currentColor;
-
-                @include jkl.forced-colors-mode {
-                    &::before {
-                        border: 2px solid ButtonText;
-                        position: absolute;
-                        inset: jkl.rem(-1px) jkl.rem(-1px) jkl.rem(-1px) jkl.rem(-1px);
-                    }
-                }
-            }
+        &:hover > .jkl-radio-button__dot {
+            outline: 1px solid var(--ring-color);
         }
 
         // Active state
-        &:active {
-            color: var(--jkl-radio-button-color);
-
-            & > .jkl-radio-button__dot {
-                box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
-
-                &::after {
-                    transform: scale(0.9);
-                }
-            }
+        &:active > .jkl-radio-button__dot &::after {
+            scale: 0.9;
         }
     }
 
@@ -178,15 +140,16 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         display: inline-block;
         position: relative;
         box-sizing: border-box;
-        height: var(--jkl-radio-button-size);
-        width: var(--jkl-radio-button-size);
         margin: var(--jkl-radio-button-dot-margin);
         flex-shrink: 0;
 
+        height: var(--jkl-radio-button-size);
+        width: var(--jkl-radio-button-size);
         border-radius: 50%;
-        box-shadow: inset 0 0 0 jkl.rem(1px) currentColor, 0 0 0 jkl.rem(1px) transparent;
+        border: jkl.rem(1px) solid var(--ring-color);
+        background-color: var(--background-color);
 
-        transition-property: background-color, box-shadow;
+        transition-property: background-color, outline;
         @include jkl.motion;
 
         /* Inner dot */
@@ -194,20 +157,18 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
             content: "";
 
             position: absolute;
-            left: $_radio-button-dot-padding;
-            top: $_radio-button-dot-padding;
+            left: 50%;
+            top: 50%;
+            translate: -50% -50%;
+            scale: 1;
+
             height: var(--jkl-radio-button-dot-size);
             width: var(--jkl-radio-button-dot-size);
             border-radius: 50%;
-            transform: scale(1);
+            background-color: var(--dot-color);
 
             transition-property: transform;
             @include jkl.motion;
-
-            @include jkl.forced-colors-mode {
-                top: jkl.rem(3px);
-                left: jkl.rem(3px);
-            }
         }
 
         @include jkl.forced-colors-mode {
@@ -223,24 +184,13 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
     }
 
     &--error {
-        .jkl-radio-button__dot {
-            background-color: var(--jkl-radio-button-error-background-color);
-        }
+        --background-color: var(--jkl-color-background-alert-error);
     }
 
     &--inline {
         display: inline-flex;
         margin-top: unset;
         margin-right: jkl.$spacing-l;
-    }
-
-    @include jkl.small-device {
-        .jkl-radio-button__dot::after {
-            @include jkl.forced-colors-mode {
-                top: jkl.rem(2.35px);
-                left: jkl.rem(2px);
-            }
-        }
     }
 
     + .jkl-form-support-label {

--- a/packages/system-message/system-message.scss
+++ b/packages/system-message/system-message.scss
@@ -8,12 +8,6 @@ $_dismiss-animation-duration: jkl.timing("lazy");
 $_dismiss-focus-border-color: jkl.$color-granitt;
 $_dismiss-hover-color: jkl.$color-stein;
 
-$_bg-color--default: jkl.$color-snohvit;
-$_bg-color--suksess: colors.varslingsfarge("suksess");
-$_bg-color--feil: colors.varslingsfarge("feil");
-$_bg-color--info: colors.varslingsfarge("info");
-$_bg-color--advarsel: colors.varslingsfarge("advarsel");
-
 @include jkl.comfortable-density-variables {
     --jkl-system-message-icon-height: #{jkl.rem(24px)};
     --jkl-system-message-icon-padding: #{jkl.rem(3px)} 0 0 0;
@@ -35,9 +29,12 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
 }
 
 .jkl-system-message {
+    --background-color: var(--jkl-color-background-alert-neutral);
+    --text-color: var(--jkl-color-text-on-alert);
+
     width: 100%;
-    background-color: $_bg-color--default;
-    color: jkl.$color-granitt;
+    background-color: var(--background-color);
+    color: var(--text-color);
     box-sizing: border-box;
 
     &__content {
@@ -115,19 +112,19 @@ $_bg-color--advarsel: colors.varslingsfarge("advarsel");
     }
 
     &--info {
-        background-color: $_bg-color--info;
+        --background-color: var(--jkl-color-background-alert-info);
     }
 
     &--warning {
-        background-color: $_bg-color--advarsel;
+        --background-color: var(--jkl-color-background-alert-warning);
     }
 
     &--error {
-        background-color: $_bg-color--feil;
+        --background-color: var(--jkl-color-background-alert-error);
     }
 
     &--success {
-        background-color: $_bg-color--suksess;
+        --background-color: var(--jkl-color-background-alert-success);
     }
 
     @include jkl.forced-colors-mode {

--- a/packages/tabs/tabs.scss
+++ b/packages/tabs/tabs.scss
@@ -1,30 +1,19 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-@include jkl.light-mode-variables {
-    --jkl-tab-text-color: #{jkl.$color-granitt};
-    --jkl-tab-indicator-color: #{jkl.$color-granitt};
-    --jkl-tab-hover-color: #{jkl.$color-stein};
-    --jkl-tab-focus-border-color: #{jkl.$color-granitt};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-tab-text-color: #{jkl.$color-snohvit};
-    --jkl-tab-indicator-color: #{jkl.$color-snohvit};
-    --jkl-tab-hover-color: #{jkl.$color-svaberg};
-    --jkl-tab-focus-border-color: #{jkl.$color-snohvit};
-}
-
 @include jkl.comfortable-density-variables {
-    @include jkl.declare-font-variables("jkl-tab", "body");
+    --jkl-tab-padding: var(--jkl-spacing-8) var(--jkl-spacing-40) var(--jkl-spacing-12) var(--jkl-spacing-2);
 
-    --jkl-tab-padding: #{jkl.$spacing-xs} #{jkl.$spacing-xl} #{jkl.$spacing-s} #{jkl.$spacing-3xs};
+    @include jkl.declare-font-variables("jkl-tab", "body");
+    @include jkl.small-device {
+        --jkl-tab-padding: var(--jkl-spacing-8) var(--jkl-spacing-24) var(--jkl-spacing-12) var(--jkl-spacing-2);
+    }
 }
 
 @include jkl.compact-density-variables {
     @include jkl.declare-font-variables("jkl-tab", "small");
 
-    --jkl-tab-padding: #{jkl.$spacing-3xs} #{jkl.rem(32px)} #{jkl.$spacing-2xs} 0;
+    --jkl-tab-padding: var(--jkl-spacing-2) var(--jkl-spacing-32) var(--jkl-spacing-4) 0;
 }
 
 .jkl-tabs {
@@ -40,19 +29,23 @@
 }
 
 .jkl-tablist {
+    --text-color: var(--jkl-color-text-interactive);
+    --line-color: var(--jkl-color-border-separator);
+    --indicator-color: var(--jkl-color-border-separator-hover);
+
     position: relative;
     display: inline-flex;
     flex-direction: row;
     padding: 0;
     margin: 0;
-    border-bottom: 1px jkl.$color-svaberg solid;
+    border-bottom: 1px solid var(--line-color);
     min-width: fit-content;
     width: 100%;
 
     &__indicator {
         position: absolute;
         height: 2px;
-        background-color: var(--jkl-tab-indicator-color);
+        background-color: var(--indicator-color);
         @include jkl.motion("standard", "lazy");
         transition-property: left, width;
         will-change: left, width;
@@ -69,24 +62,21 @@
 
 .jkl-tab {
     @include jkl.use-font-variables("jkl-tab");
-    color: var(--jkl-tab-text-color);
+    color: var(--text-color);
     padding: var(--jkl-tab-padding);
     border: none;
     background-color: transparent;
     cursor: pointer;
     position: relative;
-    scroll-margin-inline-start: jkl.$spacing-m;
+    scroll-margin-inline-start: var(--jkl-spacing-16);
     scroll-snap-align: start;
     text-decoration: none;
     white-space: nowrap;
+
     @include jkl.reset-outline;
 
-    @include jkl.small-device {
-        padding: #{jkl.$spacing-8} #{jkl.$spacing-24} #{jkl.$spacing-12} #{jkl.$spacing-2};
-    }
-
     &:hover {
-        color: var(--jkl-tab-hover-color);
+        --text-color: var(--jkl-color-text-interactive-hover);
     }
 
     &:focus-visible {

--- a/packages/tag/tag.scss
+++ b/packages/tag/tag.scss
@@ -2,17 +2,6 @@
 @use "@fremtind/jkl-core/jkl";
 @use "@fremtind/jkl-core/jkl/colors";
 
-$_tag-background-color: jkl.$color-varde;
-$_tag-text-color: jkl.$color-granitt;
-
-$_dismiss-focus-border-color: jkl.$color-granitt;
-$_dismiss-hover-color: jkl.$color-stein;
-
-$_tag-background-color--success: colors.varslingsfarge("suksess");
-$_tag-background-color--error: colors.varslingsfarge("feil");
-$_tag-background-color--info: colors.varslingsfarge("info");
-$_tag-background-color--warning: colors.varslingsfarge("advarsel");
-
 @include jkl.comfortable-density-variables {
     --jkl-tag-padding: var(--jkl-spacing-4) var(--jkl-spacing-8);
     --jkl-tag-dismiss-margin: 0;
@@ -26,9 +15,12 @@ $_tag-background-color--warning: colors.varslingsfarge("advarsel");
 }
 
 .jkl-tag {
+    --background-color: var(--jkl-color-background-alert-neutral);
+    --text-color: var(--jkl-color-text-on-alert);
+
     @include jkl.text-style("heading-5");
-    background-color: $_tag-background-color;
-    color: $_tag-text-color;
+    background-color: var(--background-color);
+    color: var(--text-color);
     border-radius: jkl.rem(4px);
     display: inline-flex;
     align-items: center;
@@ -37,19 +29,19 @@ $_tag-background-color--warning: colors.varslingsfarge("advarsel");
     gap: var(--jkl-tag-gap);
 
     &--info {
-        background-color: $_tag-background-color--info;
+        --background-color: var(--jkl-color-background-alert-info);
     }
 
     &--warning {
-        background-color: $_tag-background-color--warning;
+        --background-color: var(--jkl-color-background-alert-warning);
     }
 
     &--error {
-        background-color: $_tag-background-color--error;
+        --background-color: var(--jkl-color-background-alert-error);
     }
 
     &--success {
-        background-color: $_tag-background-color--success;
+        --background-color: var(--jkl-color-background-alert-success);
     }
 
     @include jkl.forced-colors-mode {

--- a/packages/toast-react/src/Toast.tsx
+++ b/packages/toast-react/src/Toast.tsx
@@ -65,7 +65,6 @@ export function Toast<T extends ToastContent>({ className, state, ...props }: To
                 className,
             )}
             data-animation={props.toast.animation}
-            data-theme={props.toast.variant ? "light" : undefined}
             onAnimationEnd={() => {
                 // Remove the toast when the exiting animation completes.
                 if (props.toast.animation === "exiting") {

--- a/packages/toast/toast.scss
+++ b/packages/toast/toast.scss
@@ -3,16 +3,6 @@
 @use "@fremtind/jkl-core/jkl";
 @use "@fremtind/jkl-core/jkl/colors";
 
-@include jkl.light-mode-variables {
-    --jkl-toast-color: #{jkl.$color-granitt};
-    --jkl-toast-background-color: #{jkl.$color-hvit};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-toast-color: #{jkl.$color-snohvit};
-    --jkl-toast-background-color: #{jkl.$color-skifer};
-}
-
 @include jkl.comfortable-density-variables {
     --jkl-toast-padding: #{jkl.$spacing-16};
 
@@ -53,8 +43,11 @@
 }
 
 .jkl-toast {
-    color: var(--jkl-toast-color);
-    background-color: var(--jkl-toast-background-color);
+    --background-color: var(--jkl-color-background-container-high);
+    --text-color: var(--jkl-color-text-default);
+
+    color: var(--text-color);
+    background-color: var(--background-color);
     border-radius: 4px;
     box-sizing: border-box;
     display: grid;
@@ -82,12 +75,13 @@
     }
 
     &__progress {
-        --jkl-progress-background-color: transparent;
         grid-area: progress;
         margin-bottom: jkl.$spacing-16;
         margin-inline: calc(-1 * var(--jkl-toast-padding)); // Motvirk padding for å gå kant i kant.
 
         .jkl-countdown {
+            --bar-color: var(--text-color);
+            --track-color: transparent;
             border-radius: 0;
         }
     }
@@ -142,20 +136,27 @@
         }
     }
 
+    &--info,
+    &--warning,
+    &--error,
+    &--success {
+        --text-color: var(--jkl-color-text-on-alert);
+    }
+
     &--info {
-        background-color: colors.varslingsfarge("info");
+        --background-color: var(--jkl-color-background-alert-info);
     }
 
     &--warning {
-        background-color: colors.varslingsfarge("advarsel");
+        --background-color: var(--jkl-color-background-alert-warning);
     }
 
     &--error {
-        background-color: colors.varslingsfarge("feil");
+        --background-color: var(--jkl-color-background-alert-error);
     }
 
     &--success {
-        background-color: colors.varslingsfarge("suksess");
+        --background-color: var(--jkl-color-background-alert-success);
     }
 
     @include jkl.forced-colors-mode {

--- a/packages/toggle-switch/toggle-switch.scss
+++ b/packages/toggle-switch/toggle-switch.scss
@@ -9,8 +9,6 @@
     --jkl-toggle-switch-height: #{jkl.rem(28px)};
     --jkl-toggle-switch-width: #{jkl.rem(48px)};
     --jkl-toggle-switch-knob-size: #{jkl.rem(20px)};
-    --jkl-toggle-switch-border-width: #{jkl.rem(1px)};
-    --jkl-toggle-switch-padding: #{jkl.rem(4px)};
     --jkl-toggle-switch-indicator-spacing: 0;
     --jkl-toggle-switch-help-label-spacing: var(--jkl-spacing-2);
 }
@@ -21,49 +19,23 @@
     --jkl-toggle-switch-height: #{jkl.rem(20px)};
     --jkl-toggle-switch-width: #{jkl.rem(36px)};
     --jkl-toggle-switch-knob-size: #{jkl.rem(12px)};
-    --jkl-toggle-switch-border-width: #{jkl.rem(1px)};
-    --jkl-toggle-switch-padding: #{jkl.rem(4px)};
     --jkl-toggle-switch-indicator-spacing: #{jkl.rem(-2px)};
     --jkl-toggle-switch-help-label-spacing: 0;
 }
 
-@include jkl.light-mode-variables {
-    --jkl-toggle-switch-border: #{jkl.$color-granitt};
-    --jkl-toggle-switch-background: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-knob-border: #{jkl.$color-granitt};
-    --jkl-toggle-switch-knob-background: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-knob-background--on: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-indicator-color: transparent;
-    --jkl-toggle-switch-indicator-color--on: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-border--disabled: #{jkl.$color-svaberg};
-    --jkl-toggle-switch-knob-border--disabled: #{jkl.$color-svaberg};
-    --jkl-toggle-switch-knob-background--disabled: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-border--disabled-on: #{jkl.$color-svaberg};
-    --jkl-toggle-switch-knob-border--disabled-on: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-knob-background--disabled-on: #{jkl.$color-snohvit};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-toggle-switch-border: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-background: #{jkl.$color-skifer};
-    --jkl-toggle-switch-knob-border: #{jkl.$color-snohvit};
-    --jkl-toggle-switch-knob-background: #{jkl.$color-skifer};
-    --jkl-toggle-switch-knob-background--on: #{jkl.$color-granitt};
-    --jkl-toggle-switch-indicator-color: transparent;
-    --jkl-toggle-switch-indicator-color--on: #{jkl.$color-granitt};
-    --jkl-toggle-switch-border--disabled: #{jkl.$color-stein};
-    --jkl-toggle-switch-knob-border--disabled: #{jkl.$color-stein};
-    --jkl-toggle-switch-knob-background--disabled: #{jkl.$color-skifer};
-    --jkl-toggle-switch-border--disabled-on: #{jkl.$color-stein};
-    --jkl-toggle-switch-knob-border--disabled-on: #{jkl.$color-granitt};
-    --jkl-toggle-switch-knob-background--disabled-on: #{jkl.$color-granitt};
-}
-
 .jkl-toggle-switch {
-    --jkl-toggle-switch-knob-position: 0;
+    --border-width: #{jkl.rem(1px)};
+    --switch-padding: #{jkl.rem(4px)};
+    --knob-position: 0;
+    --switch-border-color: var(--jkl-color-border-action);
+    --indicator-color: var(--jkl-color-background-container-high);
+    --knob-border-color: var(--jkl-color-border-action);
+    --knob-color: var(--jkl-color-background-container-high);
+    --text-color: var(--jkl-color-text-default);
+    --icon-color: var(--jkl-color-text-inverted);
 
     background: transparent;
-    color: var(--jkl-color);
+    color: var(--text-color);
     padding: 0;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
@@ -85,28 +57,23 @@
 
     &[aria-pressed="true"],
     [aria-checked="true"] > & {
-        --jkl-toggle-switch-background: var(--jkl-toggle-switch-border);
-        --jkl-toggle-switch-knob-border: var(--jkl-toggle-switch-knob-background);
-        --jkl-toggle-switch-knob-background: var(--jkl-toggle-switch-knob-background--on);
-        --jkl-toggle-switch-indicator-color: var(--jkl-toggle-switch-indicator-color--on);
-        --jkl-toggle-switch-knob-position: calc(
-            var(--jkl-toggle-switch-width) - var(--jkl-toggle-switch-knob-size) - var(--jkl-toggle-switch-padding) * 2
+        --indicator-color: var(--jkl-color-background-container-inverted);
+        --knob-color: var(--jkl-color-text-inverted);
+        --knob-position: calc(
+            var(--jkl-toggle-switch-width) - var(--jkl-toggle-switch-knob-size) - var(--switch-padding) * 2
         );
     }
 
     &[disabled] {
         cursor: revert;
-        color: var(--jkl-color-text-subdued);
 
-        --jkl-toggle-switch-border: var(--jkl-toggle-switch-border--disabled);
-        --jkl-toggle-switch-knob-border: var(--jkl-toggle-switch-knob-border--disabled);
-        --jkl-toggle-switch-knob-background: var(--jkl-toggle-switch-knob-background--disabled);
+        --text-color: var(--jkl-color-text-subdued);
+        --switch-border-color: var(--jkl-color-border-subdued);
+        --knob-border-color: var(--jkl-color-border-subdued);
 
         &[aria-pressed="true"],
         [aria-checked="true"] > & {
-            --jkl-toggle-switch-border: var(--jkl-toggle-switch-border--disabled-on);
-            --jkl-toggle-switch-knob-border: var(--jkl-toggle-switch-knob-border--disabled-on);
-            --jkl-toggle-switch-knob-background: var(--jkl-toggle-switch-knob-background--disabled-on);
+            --indicator-color: var(--jkl-color-border-subdued);
         }
     }
 }
@@ -120,18 +87,18 @@
     height: var(--jkl-toggle-switch-height);
     width: var(--jkl-toggle-switch-width);
     border-radius: 9999px;
-    box-shadow: inset 0 0 0 var(--jkl-toggle-switch-border-width) var(--jkl-toggle-switch-border);
+    border: var(--border-width) solid var(--switch-border-color);
     overflow: hidden;
     user-select: none;
-    padding: var(--jkl-toggle-switch-padding);
-    background-color: var(--jkl-toggle-switch-background);
+    padding: var(--switch-padding);
+    background-color: var(--indicator-color);
     pointer-events: none;
 
     @include jkl.forced-colors-mode {
         border: jkl.rem(1px) solid ButtonText;
     }
 
-    &:focus-visible {
+    .jkl-toggle-switch:focus-visible & {
         @include jkl.focus-outline;
     }
 
@@ -140,19 +107,19 @@
         box-sizing: border-box;
         height: var(--jkl-toggle-switch-knob-size);
         width: var(--jkl-toggle-switch-knob-size);
-        color: var(--jkl-toggle-switch-indicator-color);
+        color: var(--icon-color);
 
         @include jkl.motion;
-        transition-property: transform;
-        transform: translateX(var(--jkl-toggle-switch-knob-position));
+        transition-property: translate;
+        translate: var(--knob-position);
     }
 
     &__knob {
         position: absolute;
         inset: 0;
         border-radius: 9999px;
-        border: var(--jkl-toggle-switch-border-width) solid var(--jkl-toggle-switch-knob-border);
-        background-color: var(--jkl-toggle-switch-knob-background);
+        border: var(--border-width) solid var(--knob-border-color);
+        background-color: var(--knob-color);
     }
 
     &__indicator {

--- a/packages/tooltip/tooltip.scss
+++ b/packages/tooltip/tooltip.scss
@@ -6,20 +6,6 @@ $_tooltip-arrow-height: jkl.rem(8px);
 $_focus-ring-distance: jkl.rem(-1px); // Negativ margin for å unngå subpixel mellomrom mellom border og box-shadow
 $_focus-ring-width: jkl.rem(2px);
 
-@include jkl.light-mode-variables {
-    --jkl-tooltip-button-color: #{jkl.$color-granitt};
-    --jkl-tooltip-active-button-color: #{jkl.$color-stein};
-    --jkl-tooltip-bg-color: #{jkl.$color-granitt};
-    --jkl-tooltip-text-color: #{jkl.$color-snohvit};
-}
-
-@include jkl.dark-mode-variables {
-    --jkl-tooltip-button-color: #{jkl.$color-snohvit};
-    --jkl-tooltip-active-button-color: #{jkl.$color-svaberg};
-    --jkl-tooltip-bg-color: #{jkl.$color-snohvit};
-    --jkl-tooltip-text-color: #{jkl.$color-granitt};
-}
-
 @include jkl.comfortable-density-variables {
     --jkl-tooltip-size: #{jkl.rem(24px)};
     --jkl-tooltip-content-padding: #{jkl.$spacing-m};
@@ -50,9 +36,12 @@ $_focus-ring-width: jkl.rem(2px);
 }
 
 .jkl-tooltip-content {
+    --background-color: var(--jkl-color-background-container-inverted);
+    --text-color: var(--jkl-color-text-inverted);
+
     @include jkl.text-style("small");
-    background-color: var(--jkl-tooltip-bg-color);
-    color: var(--jkl-tooltip-text-color);
+    background-color: var(--background-color);
+    color: var(--text-color);
     display: inline-block;
     min-width: min-content;
     max-width: min(jkl.rem(310px), 100%); // 10px mindre enn smaleste støttede skjerm
@@ -83,7 +72,7 @@ $_focus-ring-width: jkl.rem(2px);
     &__arrow {
         overflow: hidden;
         position: absolute;
-        background-color: var(--jkl-tooltip-bg-color);
+        background-color: var(--background-color);
         transform: rotate(45deg);
         height: $_tooltip-arrow-height * 2;
         width: $_tooltip-arrow-height * 2;
@@ -95,6 +84,8 @@ $_focus-ring-width: jkl.rem(2px);
 }
 
 .jkl-tooltip-question-button {
+    --button-color: var(--jkl-color-text-interactive);
+
     @include jkl.motion("exit", "snappy");
     transition-property: color;
     cursor: pointer;
@@ -102,13 +93,13 @@ $_focus-ring-width: jkl.rem(2px);
     padding: 0;
     display: inline-flex;
     align-items: center;
-    color: var(--jkl-tooltip-button-color);
+    color: var(--button-color);
     transform: translateY(max(0.16em, jkl.rem(4px))); // Cap på 4px
     font-size: 1.2em;
 
     @include jkl.reset-outline;
 
     &:hover {
-        color: var(--jkl-tooltip-active-button-color);
+        --button-color: var(--jkl-color-text-interactive-hover);
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,8 +833,10 @@ importers:
 
   packages/progress-bar-react:
     specifiers:
+      '@fremtind/jkl-core': ^14.3.0
       '@fremtind/jkl-progress-bar': ^6.0.17
     dependencies:
+      '@fremtind/jkl-core': link:../core
       '@fremtind/jkl-progress-bar': link:../progress-bar
 
   packages/radio-button:
@@ -3905,8 +3907,8 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@fremtind/jkl-core/14.2.2:
-    resolution: {integrity: sha512-4vakA1THQn4/+xfzVPwlnIml6am5tB33t+2LGK3BCbYCJTFwtMRe3Qeianev/yWQuwdUUT7pnjkpsJGy1bZHyQ==}
+  /@fremtind/jkl-core/14.3.0:
+    resolution: {integrity: sha512-FhrqG96hdfayObPnWfZMLbuZQyXoEj/lNrEUOUojTD60sp/AZ/DLYQ3aQHWaTX+jheHwmdftz8+7WMHCiofogA==}
     peerDependencies:
       '@types/react': ^16.8.6 || ^17.0.0 || ^18.0.0
       '@types/react-dom': ^16.8.6 || ^17.0.0 || ^18.0.0
@@ -3919,7 +3921,7 @@ packages:
   /@fremtind/jkl-icons/9.1.5:
     resolution: {integrity: sha512-JDn9qAWTc68CI0Ua41MJ7/NOcOQBHr8T0mr2Qcwd1nTJPVuNRD7X+RHNs54bMykugp24hq+xbPGQWShOnb6qSQ==}
     dependencies:
-      '@fremtind/jkl-core': 14.2.2
+      '@fremtind/jkl-core': 14.3.0
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'


### PR DESCRIPTION
- Legger til tre manglende semantiske fargevariabler, og retter opp verdien til én
- Bytter til å bruke semantiske variabler for farger i de fleste komponenter

Det er ikke byttet til semantiske variabler i
- utgående komponenter
- komponenter som bruker eller likner på TextInput (de er kompliserte nok til å ta i egen PR)

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
