### PR TITLE
fix: riktig visning av hoverstate for linklist

### DIFF
--- a/packages/list-react/documentation/LinkListExample.tsx
+++ b/packages/list-react/documentation/LinkListExample.tsx
@@ -4,16 +4,16 @@ import { LinkList } from "../src";
 export const OrderedLinkListExample: FC = () => (
     <LinkList variant="ordered">
         <LinkList.Item>
-            <LinkList.Link>SpareBank 1</LinkList.Link>
+            <LinkList.Link href="/">SpareBank 1</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>DNB</LinkList.Link>
+            <LinkList.Link href="/">DNB</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>LOfavør</LinkList.Link>
+            <LinkList.Link href="/">LOfavør</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>Norsk Sykepleierforbund</LinkList.Link>
+            <LinkList.Link href="/">Norsk Sykepleierforbund</LinkList.Link>
         </LinkList.Item>
     </LinkList>
 );
@@ -38,19 +38,19 @@ export const orderedLinkListExample = () => `
 export const UnorderedLinkListExample: FC = () => (
     <LinkList variant="unordered">
         <LinkList.Item>
-            <LinkList.Link>Ledige stillinger</LinkList.Link>
+            <LinkList.Link href="/">Ledige stillinger</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>Hvorfor Fremtind?</LinkList.Link>
+            <LinkList.Link href="/">Hvorfor Fremtind?</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>Fordeler og goder</LinkList.Link>
+            <LinkList.Link href="/">Fordeler og goder</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>Kultur</LinkList.Link>
+            <LinkList.Link href="/">Kultur</LinkList.Link>
         </LinkList.Item>
         <LinkList.Item>
-            <LinkList.Link>Teknologi</LinkList.Link>
+            <LinkList.Link href="/">Teknologi</LinkList.Link>
         </LinkList.Item>
     </LinkList>
 );

--- a/packages/list/_link-list.scss
+++ b/packages/list/_link-list.scss
@@ -9,33 +9,22 @@
 }
 
 .jkl-link-list {
+    --border-color: var(--jkl-color-border-separator);
+
     display: flex;
     flex-direction: column;
     width: 100%;
     padding: 0;
     margin: 0;
-    border-bottom: 1.44px solid var(--jkl-color-border-separator);
+    border-bottom: jkl.rem(1px) solid var(--border-color);
     height: min-content;
     counter-reset: link-list;
-
-    --color: var(--jkl-color);
 
     @media (hover: hover) {
         &:has(:focus-visible),
         &:has(:hover) {
-            --color: var(--jkl-color-border-separator);
-
-            .jkl-link-list-link::before {
-                color: var(--color);
-            }
-
-            .jkl-link-list-link:has(:focus-visible),
-            .jkl-link-list-link:hover {
-                --color: var(--jkl-color);
-
-                &::before {
-                    color: var(--color);
-                }
+            .jkl-link-list-link:not(:hover):not(:focus-visible) {
+                --text-color: var(--jkl-color-border-separator);
             }
         }
     }
@@ -47,37 +36,40 @@
 }
 
 .jkl-link-list-link {
+    --text-color: var(--jkl-color-text-default);
+    --icon-background: transparent;
+
     display: flex;
     justify-content: space-between;
     gap: var(--jkl-spacing-16);
     padding: var(--jkl-link-list-padding) 0;
-    border-top: 1.44px solid var(--jkl-color-border-separator);
+    border-top: jkl.rem(1px) solid var(--border-color);
     width: 100%;
     text-decoration: none;
-    color: var(--color);
+    color: var(--text-color);
     cursor: pointer;
 
-    &,
-    & svg {
-        @include jkl.motion("standard", "productive");
-        transition-property: color, border-color, background-color;
+    @include jkl.motion("standard", "productive");
+    transition-property: color, border-color;
+
+    &:hover,
+    &:focus-visible {
+        --icon-background: var(--jkl-color-background-interactive-selected);
     }
 
-    .jkl-link-list--unordered & {
-        svg {
-            border-radius: 50%;
-        }
-
-        &:hover,
-        &:focus {
-            svg {
-                background-color: var(--jkl-color-background-interactive-selected);
-            }
-        }
+    &:focus-visible {
+        --border-color: transparent;
+        z-index: 1;
+        @include jkl.focus-outline(0);
     }
 
     &__arrow {
         align-self: center;
+        border-radius: 100%;
+        background-color: var(--icon-background);
+
+        @include jkl.motion("standard", "productive");
+        transition-property: color, background-color;
     }
 
     .jkl-link-list--ordered & {
@@ -91,7 +83,7 @@
             content: counter(link-list, decimal-leading-zero);
 
             @include jkl.use-font-family("Fremtind Grotesk Mono");
-            color: var(--jkl-color-text-interactive);
+            color: var(--text-color);
             font-size: var(--jkl-small-font-size);
         }
     }


### PR DESCRIPTION
Fikser en bug der hoverindikator  i LinkListble endret etter bytte til Material Symbols. Legger også til fokusring for elementene i LinkList.

closes #4057 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
