### PR TITLE
docs: flytt deprecation warnings så de synes i IntelliSense

### DIFF
--- a/packages/contact-information-react/src/ContactInformation.tsx
+++ b/packages/contact-information-react/src/ContactInformation.tsx
@@ -2,15 +2,14 @@ import { DataTestAutoId, Density, Link, WithChildren, NavLink, WithOptionalChild
 import { formatTelefonnummer } from "@fremtind/jkl-formatters-util";
 import cn from "classnames";
 import React, { HTMLAttributes, FC, ReactNode } from "react";
-
-/**
- * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
- */
 export interface FooterProps extends DataTestAutoId, HTMLAttributes<HTMLElement> {
     headingComponent: ReactNode;
     density?: Density;
 }
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const ContactInformation: FC<FooterProps> = ({ headingComponent, className, density, children, ...rest }) => {
     return (
         <div className={cn("jkl-contact-info", className)} data-density={density} {...rest}>
@@ -23,6 +22,10 @@ export const ContactInformation: FC<FooterProps> = ({ headingComponent, classNam
 interface HeadingProps extends WithOptionalChildren {
     heading?: string;
 }
+
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const ContactInformationHeading: FC<HeadingProps> = ({
     heading = "Trenger du hjelp med forsikring?",
     children,
@@ -35,14 +38,23 @@ export const ContactInformationHeading: FC<HeadingProps> = ({
     );
 };
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const Content: FC<WithChildren> = ({ children }) => {
     return <div className="jkl-contact-info__content">{children}</div>;
 };
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const InfoColumn: FC<WithChildren> = ({ children }) => {
     return <div className="jkl-contact-info__column">{children}</div>;
 };
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const PhoneColumn = ({ phone, openingHours }: { phone: string; openingHours?: string }) => {
     return (
         <InfoColumn>
@@ -54,6 +66,9 @@ export const PhoneColumn = ({ phone, openingHours }: { phone: string; openingHou
     );
 };
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const ChatAndMailColumn = ({ chat, email }: { chat?: () => void; email?: string }) => {
     return (
         <InfoColumn>
@@ -65,6 +80,9 @@ export const ChatAndMailColumn = ({ chat, email }: { chat?: () => void; email?: 
     );
 };
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const QAndAColumn = ({ qAndA }: { qAndA: () => void }) => {
     return (
         <InfoColumn>

--- a/packages/contact-information/contact-information.scss
+++ b/packages/contact-information/contact-information.scss
@@ -1,8 +1,6 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert
-
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-sand};
 }
@@ -10,6 +8,7 @@
     --jkl-footer-background-color: #{jkl.$color-granitt};
 }
 
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert
 .jkl-contact-info {
     background-color: var(--jkl-footer-background-color);
 

--- a/packages/content-toggle-react/src/ContentToggle.tsx
+++ b/packages/content-toggle-react/src/ContentToggle.tsx
@@ -2,10 +2,6 @@ import { WithChildren } from "@fremtind/jkl-core";
 import cn from "classnames";
 import React, { ReactNode, FC, useState, useEffect } from "react";
 
-/**
- * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
- */
-
 export interface ContentToggleProps extends WithChildren {
     /** @default "polite" */
     "aria-live"?: "polite" | "assertive" | "off";
@@ -16,6 +12,9 @@ export interface ContentToggleProps extends WithChildren {
     variant?: "flip" | "fade";
 }
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const ContentToggle: FC<ContentToggleProps> = ({
     "aria-live": ariaLive = "polite",
     showSecondary,

--- a/packages/content-toggle/content-toggle.scss
+++ b/packages/content-toggle/content-toggle.scss
@@ -2,8 +2,6 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
-
 $_animation-duration: 300ms;
 $_half-animation-duration: calc(#{$_animation-duration} / 2);
 
@@ -34,6 +32,7 @@ $_fade-in-animation-name: jkl-fade-in-#{string.unique-id()};
     }
 }
 
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
 .jkl-content-toggle {
     height: 1.2em;
     overflow: hidden;

--- a/packages/footer-react/src/Footer.tsx
+++ b/packages/footer-react/src/Footer.tsx
@@ -2,10 +2,6 @@ import { DataTestAutoId, Density, Link } from "@fremtind/jkl-core";
 import cn from "classnames";
 import React, { HTMLAttributes, FC, ElementType, MouseEventHandler } from "react";
 
-/**
- * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
- */
-
 export interface FooterLink<T = HTMLAnchorElement> {
     title: string;
     href?: string;
@@ -26,6 +22,9 @@ export interface FooterProps extends DataTestAutoId, HTMLAttributes<HTMLElement>
     density?: Density;
 }
 
+/**
+ * @deprecated Denne komponenten bør ikke brukes lenger, og vil ikke bli oppdatert.
+ */
 export const Footer: FC<FooterProps> = ({
     heading = "Fremtind er vår leverandør av forsikring",
     className,

--- a/packages/footer/footer.scss
+++ b/packages/footer/footer.scss
@@ -1,8 +1,6 @@
 @charset "UTF-8";
 @use "@fremtind/jkl-core/jkl";
 
-/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
-
 @include jkl.light-mode-variables {
     --jkl-footer-background-color: #{jkl.$color-hvit};
 }
@@ -10,6 +8,7 @@
     --jkl-footer-background-color: #{jkl.$color-svart};
 }
 
+/// @deprecated Denne komponenten bør ikke lenger brukes, og vil ikke bli oppdatert.
 .jkl-footer {
     background-color: var(--jkl-footer-background-color);
 


### PR DESCRIPTION
La merke til at noen av disse komponentene ikke ble merket som deprecated av VSCode, så har flyttet litt rundt på (og lagt til noen) warnings før vi sletter komponentene helt.

## 🎯 Sjekkliste

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
