### PR TITLE
fix: la til støtte for mellomrom mellom filtypene i accept strengen

### DIFF
--- a/packages/file-input-react/src/internal/validateFile.ts
+++ b/packages/file-input-react/src/internal/validateFile.ts
@@ -5,7 +5,8 @@ export function validateFile(file: File, accept = "", maxSizeBytes?: number): Fi
     const acceptStrings = accept
         .split(",")
         .map((s) => s.toLowerCase())
-        .map((s) => s.replaceAll("*", ""));
+        .map((s) => s.replaceAll("*", ""))
+        .map((s) => s.trim());
 
     let isValidFormat = acceptStrings.length === 0;
 


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->
Har lagt til støtte for å ha mellomrom filtypene i accept på FileInput. Valideringa tolka `accept=".png .pdf"` og `accept=".png.pdf"` forskjellig, sjølv om nettlesaren tolker dei likt.

Denne er veldig enkelt å jobbe runudt ved å kutte ut mellomrom, men kanskje nokon andre slipper litt hodebry ein vakker dag på grunn av endringen.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [X] `pnpm build` og `pnpm ci:test` gir ingen feil
