### PR TITLE
fix: sørg for at Select eksporterer riktige typedefinisjoner

### DIFF
--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -1,7 +1,6 @@
-import { ValuePair, getValuePair, DataTestAutoId, Density } from "@fremtind/jkl-core";
+import { type ValuePair, getValuePair, type DataTestAutoId, type Density } from "@fremtind/jkl-core";
 import { ArrowVerticalAnimated } from "@fremtind/jkl-icons-react";
-import { InputGroup, type LabelProps } from "@fremtind/jkl-input-group-react";
-import { InputGroupProps } from "@fremtind/jkl-input-group-react/src";
+import { InputGroup, type LabelProps, type InputGroupProps } from "@fremtind/jkl-input-group-react";
 import { useId, useAnimatedHeight, usePreviousValue, useListNavigation } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
 import React, {
@@ -36,45 +35,44 @@ interface Option extends ValuePair {
     visible: boolean;
 }
 
-export type SelectProps = InputGroupProps &
-    DataTestAutoId & {
-        id?: string;
-        name: string;
-        label: string;
-        labelProps?: Omit<LabelProps, "children" | "density" | "htmlFor" | "standAlone">;
-        items: Array<string | ValuePair>;
-        /**
-         * @default false
-         */
-        inline?: boolean;
-        /**
-         * @default "Velg"
-         */
-        defaultPrompt?: string;
-        className?: string;
-        value?: string;
-        helpLabel?: string;
-        errorLabel?: string;
-        /**
-         * @default false
-         */
-        searchable?: boolean | ((searchValue: string, searchItem: string | ValuePair) => boolean);
-        density?: Density;
-        width?: string;
-        onChange?: ChangeEventHandler;
-        onBlur?: ChangeEventHandler;
-        onFocus?: ChangeEventHandler;
-        /**
-         * Merk som ugyldig uten å sende inn en errorLabel.
-         * NB! Brukes kun i tilfeller der valideringsfeil dukker opp andre steder, for eksempel i en FieldGroup.
-         */
-        invalid?: boolean;
-        /**
-         * Hvor mange valg skal vises i listen før den begynner å scrolle.
-         * @default 5
-         */
-        maxShownOptions?: number;
-    };
+export interface SelectProps extends Omit<InputGroupProps, "children">, DataTestAutoId {
+    id?: string;
+    name: string;
+    label: string;
+    labelProps?: Omit<LabelProps, "children" | "density" | "htmlFor" | "standAlone">;
+    items: Array<string | ValuePair>;
+    /**
+     * @default false
+     */
+    inline?: boolean;
+    /**
+     * @default "Velg"
+     */
+    defaultPrompt?: string;
+    className?: string;
+    value?: string;
+    helpLabel?: string;
+    errorLabel?: string;
+    /**
+     * @default false
+     */
+    searchable?: boolean | ((searchValue: string, searchItem: string | ValuePair) => boolean);
+    density?: Density;
+    width?: string;
+    onChange?: ChangeEventHandler;
+    onBlur?: ChangeEventHandler;
+    onFocus?: ChangeEventHandler;
+    /**
+     * Merk som ugyldig uten å sende inn en errorLabel.
+     * NB! Brukes kun i tilfeller der valideringsfeil dukker opp andre steder, for eksempel i en FieldGroup.
+     */
+    invalid?: boolean;
+    /**
+     * Hvor mange valg skal vises i listen før den begynner å scrolle.
+     * @default 5
+     */
+    maxShownOptions?: number;
+}
 
 const noop = () => {
     return;


### PR DESCRIPTION
Jeg er usikker på _hvorfor_ dette er tilfelle, men det ser ut som at TypeScript ikke liker typer som er unions av importerte typer og lokale typer. I alle fall endte Select opp med å importere typedefinisjoner med inline `import()`-statements.

Ved å endre typen for `SelectProps` tilbake til et interface ser det ut som den eksporterte typen blir riktig, med referanser til importene øverst i fila.

## 🎯 Sjekkliste

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
