### PR TITLE
feat: gjør Link og NavLink til polymorfe komponenter

### DIFF
--- a/packages/core/documentation/Link.mdx
+++ b/packages/core/documentation/Link.mdx
@@ -25,6 +25,24 @@ import { NavLinkExample, navLinkExampleCode, navLinkExampleKnobs } from "./Link/
     codeExample={navLinkExampleCode}
 />
 
+## Lenker rendret som andre elementer
+
+Både ensideapplikasjoner (SPA-er) og serverrendrede applikasjoner bruker gjerne egne lenkekomponenter for å navigere mellom sider. Lenkene i Jøkul er derfor _polymorfe_ komponenter, som kan ta formen til et annet element eller en React-komponent. Som standard rendres lenkene som `<a>`-elementer;
+
+```tsx
+// Rendrer en vanlig HTML-lenke til gitt href:
+<Link href="https://www.fremtind.no">Besøk nettsidene våre</Link>;
+
+// Rendrer en Remix-lenke som bruker rammeverkets ruting:
+import { Link as RemixLink } from "@remix-run/react";
+
+<Link as={RemixLink} to="/products">
+    Se alle produkter
+</Link>;
+```
+
+Lenken tar automatisk imot riktige props og riktig `ref` for komponenten som sendes inn, slik at du får typesikkerhet.
+
 ## Bruk
 
 Vi har to typer lenker. I løpende tekst brukes vanlige lenker, mens navigasjons&shy;lenker brukes i menyer og der lenken står for seg selv. Bruk egenskapen `Back` hvis det skal indikere en navigasjon som går mot hovedretningen. Feks en tilbake til "oversikt" i en kjøpsflyt.

--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -1,17 +1,34 @@
 import cn from "classnames";
-import React, { AnchorHTMLAttributes, FC } from "react";
+import React from "react";
+import { PolymorphicPropsWithRef, PolymorphicRef } from "../polymorphism";
 
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    external?: boolean;
-}
+export type LinkProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        external?: boolean;
+    }
+>;
 
-export const Link: FC<LinkProps> = ({ external = false, className = "", children, ...rest }) => (
-    <a
-        className={cn("jkl-link", className, {
-            "jkl-link--external": external,
-        })}
-        {...rest}
-    >
-        {children}
-    </a>
-);
+export type LinkComponent = <ElementType extends React.ElementType = "a">(
+    props: LinkProps<ElementType>,
+) => React.ReactElement | null;
+
+export const Link = React.forwardRef(function Link<ElementType extends React.ElementType = "a">(
+    props: LinkProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const { external = false, className = "", children, as = "a", ...rest } = props;
+    const Component = as;
+
+    return (
+        <Component
+            ref={ref}
+            className={cn("jkl-link", className, {
+                "jkl-link--external": external,
+            })}
+            {...rest}
+        >
+            {children}
+        </Component>
+    );
+});

--- a/packages/core/src/components/NavLink.test.tsx
+++ b/packages/core/src/components/NavLink.test.tsx
@@ -23,6 +23,16 @@ describe("NavLink", () => {
         expect(getByText("Some link")).toHaveClass("jkl-nav-link--active");
     });
 
+    it("should render as the supplied element", () => {
+        const { getByText } = render(
+            <NavLink as="div" active>
+                Some link
+            </NavLink>,
+        );
+
+        expect(getByText("Some link").nodeName).toEqual("DIV");
+    });
+
     it("should get the supplied className", () => {
         const { getByText } = render(<NavLink className="my-class">Some link</NavLink>);
 

--- a/packages/core/src/components/NavLink.tsx
+++ b/packages/core/src/components/NavLink.tsx
@@ -1,23 +1,40 @@
 import cn from "classnames";
-import React, { AnchorHTMLAttributes, FC } from "react";
+import React from "react";
+import { PolymorphicPropsWithRef, PolymorphicRef } from "../polymorphism";
 
-export interface NavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    active?: boolean;
-    back?: boolean;
-}
+export type NavLinkProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        active?: boolean;
+        back?: boolean;
+    }
+>;
 
-export const NavLink: FC<NavLinkProps> = ({ active = false, back = false, className, children, ...rest }) => (
-    <a
-        className={cn(
-            "jkl-nav-link",
-            {
-                "jkl-nav-link--active": active,
-                "jkl-nav-link--back": back,
-            },
-            className,
-        )}
-        {...rest}
-    >
-        {children}
-    </a>
-);
+export type LinkComponent = <ElementType extends React.ElementType = "a">(
+    props: NavLinkProps<ElementType>,
+) => React.ReactElement | null;
+
+export const NavLink = React.forwardRef(function NavLink<ElementType extends React.ElementType = "a">(
+    props: NavLinkProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const { active = false, back = false, className, children, as = "a", ...rest } = props;
+    const Component = as;
+
+    return (
+        <Component
+            ref={ref}
+            className={cn(
+                "jkl-nav-link",
+                {
+                    "jkl-nav-link--active": active,
+                    "jkl-nav-link--back": back,
+                },
+                className,
+            )}
+            {...rest}
+        >
+            {children}
+        </Component>
+    );
+});

--- a/packages/jokul/src/components/link/Link.tsx
+++ b/packages/jokul/src/components/link/Link.tsx
@@ -1,17 +1,34 @@
 import { clsx } from "clsx";
-import React, { AnchorHTMLAttributes, FC } from "react";
+import React from "react";
+import { PolymorphicPropsWithRef, PolymorphicRef } from "../../core";
 
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    external?: boolean;
-}
+export type LinkProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        external?: boolean;
+    }
+>;
 
-export const Link: FC<LinkProps> = ({ external = false, className = "", children, ...rest }) => (
-    <a
-        className={clsx("jkl-link", className, {
-            "jkl-link--external": external,
-        })}
-        {...rest}
-    >
-        {children}
-    </a>
-);
+export type LinkComponent = <ElementType extends React.ElementType = "a">(
+    props: LinkProps<ElementType>,
+) => React.ReactElement | null;
+
+export const Link = React.forwardRef(function Link<ElementType extends React.ElementType = "a">(
+    props: LinkProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const { external = false, className = "", children, as = "a", ...rest } = props;
+    const Component = as;
+
+    return (
+        <Component
+            ref={ref}
+            className={clsx("jkl-link", className, {
+                "jkl-link--external": external,
+            })}
+            {...rest}
+        >
+            {children}
+        </Component>
+    );
+});

--- a/packages/jokul/src/components/link/NavLink.test.tsx
+++ b/packages/jokul/src/components/link/NavLink.test.tsx
@@ -23,6 +23,16 @@ describe("NavLink", () => {
         expect(getByText("Some link")).toHaveClass("jkl-nav-link--active");
     });
 
+    it("should render as the supplied element", () => {
+        const { getByText } = render(
+            <NavLink as="div" active>
+                Some link
+            </NavLink>,
+        );
+
+        expect(getByText("Some link").nodeName).toEqual("DIV");
+    });
+
     it("should get the supplied className", () => {
         const { getByText } = render(<NavLink className="my-class">Some link</NavLink>);
 

--- a/packages/jokul/src/components/link/NavLink.tsx
+++ b/packages/jokul/src/components/link/NavLink.tsx
@@ -1,23 +1,40 @@
 import { clsx } from "clsx";
-import React, { AnchorHTMLAttributes, FC } from "react";
+import React from "react";
+import { PolymorphicPropsWithRef, PolymorphicRef } from "../../core";
 
-export interface NavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    active?: boolean;
-    back?: boolean;
-}
+export type NavLinkProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        active?: boolean;
+        back?: boolean;
+    }
+>;
 
-export const NavLink: FC<NavLinkProps> = ({ active = false, back = false, className, children, ...rest }) => (
-    <a
-        className={clsx(
-            "jkl-nav-link",
-            {
-                "jkl-nav-link--active": active,
-                "jkl-nav-link--back": back,
-            },
-            className,
-        )}
-        {...rest}
-    >
-        {children}
-    </a>
-);
+export type LinkComponent = <ElementType extends React.ElementType = "a">(
+    props: NavLinkProps<ElementType>,
+) => React.ReactElement | null;
+
+export const NavLink = React.forwardRef(function NavLink<ElementType extends React.ElementType = "a">(
+    props: NavLinkProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const { active = false, back = false, className, children, as = "a", ...rest } = props;
+    const Component = as;
+
+    return (
+        <Component
+            ref={ref}
+            className={clsx(
+                "jkl-nav-link",
+                {
+                    "jkl-nav-link--active": active,
+                    "jkl-nav-link--back": back,
+                },
+                className,
+            )}
+            {...rest}
+        >
+            {children}
+        </Component>
+    );
+});


### PR DESCRIPTION
Lar Link og NavLink rendres som andre HTML-elementer eller React-komponenter, som for eksempel en Link- komponent fra et routing-bibliotek.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
