### PR TITLE
fix: bruk bedre typer for maskeringsfunksjoner for skjema

### DIFF
--- a/packages/formatters-util/src/index.ts
+++ b/packages/formatters-util/src/index.ts
@@ -2,13 +2,7 @@ export type { FormatNumberOptions } from "./util/formatNumber";
 export { formatNumber } from "./util/formatNumber";
 export { parseNumber } from "./util/parseNumber";
 export type { Formatter, RegisterWithMaskOptions } from "./util/registerWithMask";
-export {
-    registerWithMasks,
-    registerWithFodselsnummerMask,
-    registerWithKontonummerMask,
-    registerWithKortnummerMask,
-    registerWithTelefonnummerMask,
-} from "./util/registerWithMask";
+export { registerWithMasks } from "./util/registerWithMask";
 
 export { formatAvstand } from "./avstand/formatAvstand";
 export { formatBytes } from "./bytes/formatBytes";


### PR DESCRIPTION
Bruker riktigere typer fra React Hook Form for å gi typer til hjelpefunksjonene for skjemafelter med maskering

BREAKING CHANGE:
Fjerner deprecated funksjoner for å registrere skjemafelt med maske

ISSUES CLOSED: #3763

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
