### PR TITLE
chore: legg til lintregel for intern import i jokul

### DIFF
--- a/packages/jokul/.eslintrc.cjs
+++ b/packages/jokul/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+    extends: "../../.eslintrc.js",
+    rules: {
+        "no-restricted-imports": [
+            "error",
+            {
+                patterns: [
+                    {
+                        group: ["@fremtind/jkl-*"],
+                        message: "Alle Jøkul-pakker skal importeres fra innad i @fremtind/jokul",
+                    },
+                ],
+            },
+        ],
+    },
+};


### PR DESCRIPTION
Legger til en regel i ESLint for å catche importer av eksterne Jøkul-komponenter i `@fremtind/jokul`. De er lette å overse når man flytter kode, og kan komme seg gjennom bygget siden pakkene eksisterer lokalt i monorepoet.

## 🎯 Sjekkliste

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
