### PR TITLE
fix: gi ikonet til PopupTip stor nok trykkflate

### DIFF
--- a/packages/jokul/src/components/tooltip/styles/tooltip.scss
+++ b/packages/jokul/src/components/tooltip/styles/tooltip.scss
@@ -89,6 +89,7 @@ $_focus-ring-width: jkl.rem(2px);
     @include jkl.motion("exit", "snappy");
     transition-property: color;
     cursor: pointer;
+    position: relative;
     background-color: transparent;
     padding: 0;
     display: inline-flex;
@@ -96,10 +97,25 @@ $_focus-ring-width: jkl.rem(2px);
     color: var(--button-color);
     transform: translateY(max(0.16em, jkl.rem(4px))); // Cap på 4px
     font-size: 1.2em;
+    border-radius: 9999px;
 
     @include jkl.reset-outline;
 
     &:hover {
         --button-color: var(--jkl-color-text-interactive-hover);
+    }
+
+    &:focus-visible {
+        @include jkl.focus-outline(0);
+    }
+
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        min-width: 44px;
+        min-height: 44px;
     }
 }

--- a/packages/tooltip/tooltip.scss
+++ b/packages/tooltip/tooltip.scss
@@ -89,6 +89,7 @@ $_focus-ring-width: jkl.rem(2px);
     @include jkl.motion("exit", "snappy");
     transition-property: color;
     cursor: pointer;
+    position: relative;
     background-color: transparent;
     padding: 0;
     display: inline-flex;
@@ -96,10 +97,25 @@ $_focus-ring-width: jkl.rem(2px);
     color: var(--button-color);
     transform: translateY(max(0.16em, jkl.rem(4px))); // Cap på 4px
     font-size: 1.2em;
+    border-radius: 9999px;
 
     @include jkl.reset-outline;
 
     &:hover {
         --button-color: var(--jkl-color-text-interactive-hover);
+    }
+
+    &:focus-visible {
+        @include jkl.focus-outline(0);
+    }
+
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        min-width: 44px;
+        min-height: 44px;
     }
 }


### PR DESCRIPTION
ISSUES CLOSED: #4107

Legger til en utvidet trykkflate rundt ikonet til `PopupTip` som oppfyller tilgjengelighstekrav

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
