### PR TITLE
feat: forenkle stil og struktur i knapper og endre API

### DIFF
--- a/packages/button-react/documentation/ButtonExample.tsx
+++ b/packages/button-react/documentation/ButtonExample.tsx
@@ -7,11 +7,19 @@ import { Tertiary } from "./Tertiary";
 import "./style.scss";
 
 export const buttonExampleKnobs: ExampleKnobsProps = {
-    boolProps: ["withLoader", "isLoading"],
+    boolProps: [
+        "withLoader",
+        "isLoading",
+        "icon",
+        {
+            prop: "label",
+            defaultValue: true,
+        },
+    ],
     choiceProps: [
         {
-            name: "Ikon",
-            values: ["uten", "arrow-left", "arrow-right", "begge"],
+            name: "iconPosition",
+            values: ["left", "right"],
             defaultValue: 0,
         },
     ],

--- a/packages/button-react/documentation/Example.tsx
+++ b/packages/button-react/documentation/Example.tsx
@@ -4,7 +4,8 @@ import { ButtonExample, buttonExampleKnobs } from "./ButtonExample";
 import "../../button/button.scss";
 import "../../loader/loader.scss";
 import "./style.scss";
+import { primaryCode } from "./Primary";
 
 export default function Example() {
-    return <DevExample component={ButtonExample} knobs={buttonExampleKnobs} />;
+    return <DevExample component={ButtonExample} knobs={buttonExampleKnobs} codeExample={primaryCode} />;
 }

--- a/packages/button-react/documentation/Ghost.tsx
+++ b/packages/button-react/documentation/Ghost.tsx
@@ -2,29 +2,41 @@ import { ChevronDownIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Button } from "../src";
+import { IconPosition } from "../src/types";
 
 export const Ghost: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader] = useState(false);
     const loader = { showLoader: showLoader || !!boolValues?.["isLoading"], textDescription: "Laster innhold" };
+    const iconPosition =
+        choiceValues?.["iconPosition"] === "none" ? undefined : (choiceValues?.["iconPosition"] as IconPosition);
 
     return (
         <Button
             variant="ghost"
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
-            iconRight={<ChevronDownIcon bold />}
+            iconPosition={iconPosition as IconPosition}
+            icon={<ChevronDownIcon />}
         >
             Ola Nordmann
         </Button>
     );
 };
 
-export const ghostCode = (): string => `
+export const ghostCode = ({ choiceValues }: ExampleComponentProps): string => {
+    const iconPosition = choiceValues?.["iconPosition"] || "noIcon";
+    return `
 <Button
     variant="ghost"
     className="jkl-spacing-l--right"
-    iconRight={<ChevronDownIcon bold />}
+    icon={<ChevronDownIcon />}${
+        ["left", "right"].includes(iconPosition)
+            ? `
+    iconPosition="${iconPosition}"`
+            : ""
+    }
 >
     Ola Nordmann
 </Button>
 `;
+};

--- a/packages/button-react/documentation/Primary.tsx
+++ b/packages/button-react/documentation/Primary.tsx
@@ -1,15 +1,22 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
+import { CheckIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Button } from "../src";
+import { IconPosition } from "../src/types";
 
 export const Primary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
+    const icon = boolValues?.["icon"] || false;
     const loader = { showLoader: showLoader || !!boolValues?.["isLoading"], textDescription: "Laster innhold" };
-    const icon =
-        choiceValues?.["Ikon"] === "uten"
-            ? undefined
-            : (choiceValues?.["Ikon"] as "arrow-left" | "arrow-right" | "begge");
+    const iconPosition = (choiceValues?.["iconPosition"] || "left") as IconPosition;
+
+    const iconProps =
+        icon || !boolValues?.["label"]
+            ? {
+                  icon: <CheckIcon />,
+                  iconPosition,
+              }
+            : {};
 
     const simulateLoading = () => {
         console.log("Hello!");
@@ -23,17 +30,30 @@ export const Primary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVal
         <Button
             variant="primary"
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
-            className="jkl-spacing-l--right"
             onClick={simulateLoading}
-            iconLeft={icon === "arrow-left" || icon === "begge" ? <ArrowLeftIcon /> : null}
-            iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon /> : null}
+            {...iconProps}
         >
-            Lagre og send inn
+            {boolValues?.["label"] && "Lagre og send inn"}
         </Button>
     );
 };
 
-export const primaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
+export const primaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => {
+    const label = boolValues?.["label"]
+        ? `
+    Lagre og send inn
+`
+        : "";
+    const icon = boolValues?.["icon"] || false;
+    const iconPosition = (choiceValues?.["iconPosition"] || "left") as IconPosition;
+    const iconProps =
+        icon || !boolValues?.["label"]
+            ? `
+    icon={<CheckIcon />}
+    iconPosition="${iconPosition}"`
+            : "";
+
+    return `
 <Button
     variant="primary"
     loader={${
@@ -44,13 +64,7 @@ export const primaryCode = ({ boolValues, choiceValues }: ExampleComponentProps)
     }`
             : `false`
     }}
-    onClick={simulateLoading}
-    className="jkl-spacing-l--right"
-    iconLeft={${choiceValues?.["Ikon"] === "arrow-left" || choiceValues?.["Ikon"] === "begge" ? `<ArrowLeft />` : null}}
-    iconRight={${
-        choiceValues?.["Ikon"] === "arrow-right" || choiceValues?.["Ikon"] === "begge" ? `<ArrowRight />` : null
-    }}
->
-    Lagre og send inn
-</Button>
+    onClick={simulateLoading}${iconProps}
+>${label}</Button>
 `;
+};

--- a/packages/button-react/documentation/Secondary.tsx
+++ b/packages/button-react/documentation/Secondary.tsx
@@ -1,15 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
+import { CheckIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Button } from "../src";
+import { IconPosition } from "../src/types";
 
 export const Secondary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
     const loader = { showLoader: showLoader || !!boolValues?.["isLoading"], textDescription: "Laster innhold" };
-    const icon =
-        choiceValues?.["Ikon"] === "uten"
-            ? undefined
-            : (choiceValues?.["Ikon"] as "arrow-left" | "arrow-right" | "begge");
+    const iconPosition =
+        choiceValues?.["iconPosition"] === "none" ? undefined : (choiceValues?.["iconPosition"] as IconPosition);
 
     const simulateLoading = () => {
         console.log("Hello!");
@@ -24,15 +23,17 @@ export const Secondary: React.FC<ExampleComponentProps> = ({ boolValues, choiceV
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
             onClick={simulateLoading}
-            iconLeft={icon === "arrow-left" || icon === "begge" ? <ArrowLeftIcon /> : null}
-            iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon /> : null}
+            iconPosition={iconPosition as IconPosition}
+            icon={<CheckIcon />}
         >
             Lagre
         </Button>
     );
 };
 
-export const secondaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
+export const secondaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => {
+    const iconPosition = choiceValues?.["iconPosition"] || "noIcon";
+    return `
 <Button
     loader={${
         !!boolValues?.["withLoader"]
@@ -44,11 +45,14 @@ export const secondaryCode = ({ boolValues, choiceValues }: ExampleComponentProp
     }}
     onClick={simulateLoading}
     className="jkl-spacing-l--right"
-    iconLeft={${choiceValues?.["Ikon"] === "arrow-left" || choiceValues?.["Ikon"] === "begge" ? `<ArrowLeft />` : null}}
-    iconRight={${
-        choiceValues?.["Ikon"] === "arrow-right" || choiceValues?.["Ikon"] === "begge" ? `<ArrowRight />` : null
-    }}
+    icon={<CheckIcon />}${
+        ["left", "right"].includes(iconPosition)
+            ? `
+    iconPosition="${iconPosition}"`
+            : ""
+    }
 >
     Lagre
 </Button>
 `;
+};

--- a/packages/button-react/documentation/Tertiary.tsx
+++ b/packages/button-react/documentation/Tertiary.tsx
@@ -1,15 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@fremtind/jkl-icons-react";
+import { CloseIcon } from "@fremtind/jkl-icons-react";
 import React, { useState } from "react";
 import { ExampleComponentProps } from "../../../doc-utils";
 import { Button } from "../src";
+import { IconPosition } from "../src/types";
 
 export const Tertiary: React.FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
     const [showLoader, setShowLoader] = useState(false);
     const loader = { showLoader: showLoader || !!boolValues?.["isLoading"], textDescription: "Laster innhold" };
-    const icon =
-        choiceValues?.["Ikon"] === "uten"
-            ? undefined
-            : (choiceValues?.["Ikon"] as "arrow-left" | "arrow-right" | "begge");
+    const iconPosition =
+        choiceValues?.["iconPosition"] === "none" ? undefined : (choiceValues?.["iconPosition"] as IconPosition);
 
     const simulateLoading = () => {
         console.log("Hello!");
@@ -25,15 +24,17 @@ export const Tertiary: React.FC<ExampleComponentProps> = ({ boolValues, choiceVa
             loader={showLoader || !!boolValues?.["withLoader"] ? loader : undefined}
             className="jkl-spacing-l--right"
             onClick={simulateLoading}
-            iconLeft={icon === "arrow-left" || icon === "begge" ? <ArrowLeftIcon bold /> : null}
-            iconRight={icon === "arrow-right" || icon === "begge" ? <ArrowRightIcon bold /> : null}
+            iconPosition={iconPosition as IconPosition}
+            icon={<CloseIcon />}
         >
             Avbryt
         </Button>
     );
 };
 
-export const tertiaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => `
+export const tertiaryCode = ({ boolValues, choiceValues }: ExampleComponentProps): string => {
+    const iconPosition = choiceValues?.["iconPosition"] || "noIcon";
+    return `
 <Button
     variant="tertiary"
     loader={${
@@ -46,13 +47,14 @@ export const tertiaryCode = ({ boolValues, choiceValues }: ExampleComponentProps
     }}
     onClick={simulateLoading}
     className="jkl-spacing-l--right"
-    iconLeft={${
-        choiceValues?.["Ikon"] === "arrow-left" || choiceValues?.["Ikon"] === "begge" ? `<ArrowLeft bold/>` : null
-    }}
-    iconRight={${
-        choiceValues?.["Ikon"] === "arrow-right" || choiceValues?.["Ikon"] === "begge" ? `<ArrowRight bold/>` : null
-    }}
+    icon={<CloseIcon />}${
+        ["left", "right"].includes(iconPosition)
+            ? `
+    iconPosition="${iconPosition}"`
+            : ""
+    }
 >
     Avbryt
 </Button>
 `;
+};

--- a/packages/button-react/documentation/buttons.mdx
+++ b/packages/button-react/documentation/buttons.mdx
@@ -64,6 +64,22 @@ Knappetekster skal være så enkle og korte som mulig og skal oppfordre til hand
     </Button>
 </form>
 
+## Ikoner i knapper
+
+Knappene kan ta inn et ikon som vises til venstre eller høyre for knappeteksten. Om du ikke sender inn tekst vises kun ikonet.
+Som standard vises ikonet til venstre for knappeteksten.
+
+### Knapper med kun ikon
+
+Vær forsiktig med å bruke knapper med kun ikon, da dette krever ekstra forståelse fra brukerens side. De kan likevel være nyttige i ekspertverktøy, og i mønstre som verktøylinjer. Når du bruker en knapp med kun ikon må du huske å angi en tekstlig beskrivelse av funksjonaliteten gjennom f.eks. et <a href="/komponenter/tooltip">Tooltip</a> eller `title`-attributten.
+
+```tsx
+<Tooltip>
+    <TooltipTrigger><Button variant="ghost" icon={<PenIcon />} /></TooltipTrigger>
+    <TooltipContent>Rediger innhold</TooltipContent>
+<Tooltip/>
+```
+
 ## Knapper rendret som andre elementer
 
 I noen tilfeller representerer en knapp et annet semantisk element, for eksempel en lenke. Knappekomponentene i Jøkul er derfor _polymorfe_, og kan ta inn en React-komponent eller et HTML-element den skal rendre ut.

--- a/packages/button-react/src/Button.test.tsx
+++ b/packages/button-react/src/Button.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import React, { useState } from "react";
+import { Icon } from "../../icons-react";
 import { Button } from "./Button";
 import { buttonVariants } from "./types";
 
@@ -16,6 +17,34 @@ describe("Button", () => {
 
             expect(screen.getByTestId(buttonVariant)).toHaveClass(`jkl-button--${buttonVariant}`);
         });
+    });
+
+    it("renders correctly with left icon and label", () => {
+        render(
+            <Button variant="primary" icon={<Icon>save</Icon>}>
+                Lagre
+            </Button>,
+        );
+
+        expect(screen.getByText("Lagre")).toBeInTheDocument();
+        expect(screen.getByText("save")).toBeInTheDocument();
+    });
+
+    it("renders correctly with right icon and label", () => {
+        render(
+            <Button variant="primary" icon={<Icon>save</Icon>} iconPosition="right">
+                Lagre
+            </Button>,
+        );
+
+        expect(screen.getByText("Lagre")).toBeInTheDocument();
+        expect(screen.getByText("save")).toBeInTheDocument();
+    });
+
+    it("renders correctly with icon only", () => {
+        render(<Button variant="primary" icon={<Icon>save</Icon>} title="Lagre" />);
+
+        expect(screen.getByText("save")).toBeInTheDocument();
     });
 
     it("calls the onClick handler when clicked", async () => {

--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -16,6 +16,8 @@ export const Button = React.forwardRef(function Button<ElementType extends React
         density,
         onTouchStart,
         loader,
+        icon,
+        iconPosition = "left",
         iconLeft,
         iconRight,
         variant = "secondary",
@@ -29,7 +31,7 @@ export const Button = React.forwardRef(function Button<ElementType extends React
             onTouchStart && onTouchStart(event);
 
             const target = event.target as HTMLButtonElement;
-            if (target && event.targetTouches.length) {
+            if (target && !target.disabled && event.targetTouches.length) {
                 const Xcoord = event.targetTouches[0].clientX - target.getBoundingClientRect().x;
                 const Ycoord = event.targetTouches[0].clientY - target.getBoundingClientRect().y;
                 target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
@@ -47,37 +49,35 @@ export const Button = React.forwardRef(function Button<ElementType extends React
     );
 
     const ariaLive = useAriaLiveRegion(loader?.showLoader);
+    const showLoader = Boolean(children) && Boolean(loader?.showLoader);
 
     return (
         <Component
             {...ariaLive}
+            data-loading={showLoader}
             data-density={density}
-            className={cn("jkl-button", "jkl-button--" + variant, className, {
-                "jkl-button--icon-left": iconLeft,
-                "jkl-button--icon-right": iconRight,
-            })}
+            className={cn("jkl-button", "jkl-button--" + variant, className)}
             disabled={as === "button" ? loader?.showLoader : undefined}
             onTouchStart={handleTouch}
             {...rest}
             ref={ref}
         >
-            <div className="jkl-button__content">
-                <div
-                    className={cn("jkl-button__slider", {
-                        "jkl-button__slider--show-loader": !!loader?.showLoader,
-                    })}
-                >
-                    {iconLeft && <span className="jkl-button__icon">{iconLeft}</span>}
-                    <span className="jkl-button__children">{children}</span>
-                    {iconRight && <span className="jkl-button__icon">{iconRight}</span>}
-
-                    {loader && (
-                        <div className="jkl-button__loader">
-                            <Loader textDescription={loader.textDescription} aria-hidden={!loader.showLoader} />
-                        </div>
-                    )}
-                </div>
+            <div className="jkl-button__label">
+                {iconLeft && iconLeft}
+                {icon && iconPosition === "left" && icon}
+                {children && <span className="jkl-button__text">{children}</span>}
+                {iconRight && iconRight}
+                {icon && iconPosition === "right" && icon}
             </div>
+
+            {children && (
+                <Loader
+                    className="jkl-button__loader"
+                    variant="medium"
+                    textDescription={loader?.textDescription || "Vennligst vent"}
+                    aria-hidden={!loader?.showLoader}
+                />
+            )}
         </Component>
     );
 }) as ButtonComponent;

--- a/packages/button-react/src/types.ts
+++ b/packages/button-react/src/types.ts
@@ -2,6 +2,26 @@ import { Density, PolymorphicPropsWithRef } from "@fremtind/jkl-core";
 
 export const buttonVariants = ["primary", "secondary", "tertiary", "ghost"] as const;
 export type ButtonVariant = (typeof buttonVariants)[number];
+export type IconPosition = "left" | "right";
+
+type IconOptions<T extends React.ElementType> =
+    // Hvis ikke knappen har ikon, MÅ den ha children:
+    | {
+          iconPosition?: never;
+          icon?: never;
+          children: React.ComponentPropsWithoutRef<T>["children"];
+      }
+    | {
+          /**
+           * Plasseringen av ikonet
+           * @default "left"
+           */
+          iconPosition?: IconPosition;
+          /**
+           * Hvilket ikon som skal vises i knappen
+           */
+          icon: React.ReactElement;
+      };
 
 export type ButtonProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
     ElementType,
@@ -17,9 +37,15 @@ export type ButtonProps<ElementType extends React.ElementType> = PolymorphicProp
             showLoader: boolean;
             textDescription: string;
         };
+        /**
+         * @deprecated Bruk `icon` i kombinasjon med `iconPosition="left"`
+         */
         iconLeft?: React.ReactNode;
+        /**
+         * @deprecated Bruk `icon` i kombinasjon med `iconPosition="right"`
+         */
         iconRight?: React.ReactNode;
-    }
+    } & IconOptions<ElementType>
 >;
 
 export type ButtonComponent = <ElementType extends React.ElementType = "button">(

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -2,156 +2,144 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-$_animation-timing: jkl.timing("snappy") jkl.easing("focus");
-$_flash-animation-name: jkl-flash-#{string.unique-id()};
-$_tertiary-flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
-$_hover-elevation-distance: -0.25rem;
+$_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
 
-$_button-border-width: jkl.rem(1px);
-$_focus-ring-distance: jkl.rem(4px);
-$_focus-ring-width: jkl.rem(2px);
-
-@include jkl.comfortable-density-variables {
-    --jkl-button-font-size: var(--jkl-body-font-size);
-    --jkl-button-line-height: #{jkl.rem(48px)};
-    --jkl-button-font-weight: #{jkl.$typography-weight-bold};
-    --jkl-button-min-width: #{jkl.rem(104px)};
-    --jkl-button-padding: 0 #{jkl.$spacing-24};
-    --jkl-button-tertiary-padding: 0 #{jkl.$spacing-2};
-    --jkl-button-children-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-tertiary-padding-with-icon: 0;
-    --jkl-button-focus-ring-placement: -#{($_button-border-width + $_focus-ring-distance)};
-
-    @include jkl.small-device {
-        --jkl-button-line-height: #{jkl.rem(44px)};
-    }
+@include jkl.comfortable-density(".jkl-button") {
+    --padding-block: #{jkl.$spacing-8};
+    --padding-text: #{jkl.$spacing-24};
+    --padding-icon: #{jkl.$spacing-16};
+    --padding-icon-button: #{jkl.$spacing-8};
+    --padding-tertiary-inline: #{jkl.$spacing-4};
+    --padding-ghost-inline: #{jkl.$spacing-8};
 }
 
-@include jkl.compact-density-variables {
-    --jkl-button-font-size: var(--jkl-small-font-size);
-    --jkl-button-line-height: #{jkl.rem(32px)};
-    --jkl-button-font-weight: #{jkl.$typography-weight-bold};
-    --jkl-button-min-width: #{jkl.rem(76px)};
-    --jkl-button-padding: 0 #{jkl.$spacing-12};
-    --jkl-button-tertiary-padding: 0 #{jkl.$spacing-2};
-    --jkl-button-children-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-tertiary-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-focus-ring-placement: -#{($_button-border-width + calc($_focus-ring-distance / 2))};
-}
-
-a.jkl-button {
-    text-decoration: none;
+@include jkl.compact-density(".jkl-button") {
+    --padding-block: #{jkl.$spacing-4};
+    --padding-text: #{jkl.$spacing-12};
+    --padding-icon: #{jkl.$spacing-8};
+    --padding-icon-button: #{jkl.$spacing-4};
+    --padding-tertiary-inline: #{jkl.$spacing-2};
+    --padding-ghost-inline: #{jkl.$spacing-4};
 }
 
 .jkl-button {
-    --border-color: var(--jkl-color-background-action);
-    --text-color: var(--jkl-color-background-action);
-    --focus-color: var(--jkl-color-background-action);
+    --text-color: var(--jkl-color-text-default);
     --background-color: transparent;
+    --border-radius: 0;
+    --border-width: #{jkl.rem(1px)}; // For secondary og tertiary button
 
-    display: inline-flex;
-    box-sizing: border-box;
-    justify-content: center;
-
-    background-color: var(--background-color);
-    color: var(--text-color);
-
-    @include jkl.use-font-variables("jkl-button");
-
-    height: var(--jkl-button-line-height);
-    min-width: var(--jkl-button-min-width);
+    // button and link resets
     cursor: pointer;
     user-select: none;
-    overflow: visible;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    border: unset;
+    text-decoration: none;
+    -webkit-tap-highlight-color: transparent;
+
+    border-radius: var(--border-radius);
+    padding-inline: var(--padding-text);
+    padding-block: var(--padding-block);
     position: relative;
+    overflow: hidden;
+    max-width: 100%;
 
-    @include jkl.motion;
-    transform-origin: 50% 90%;
-    transition-property: transform, background-color;
+    @include jkl.motion("standard", "productive", scale);
 
-    @include jkl.reset-outline;
-
-    &:focus-visible,
-    html:not([data-touchnavigation]) &:hover {
-        transform: scale(1.05);
+    @include jkl.text-style("body") {
+        --jkl-icon-weight: #{jkl.$icon-weight-bold};
+        font-weight: jkl.$typography-weight-bold;
     }
 
-    html:not([data-mousenavigation]) &:active,
-    html:not([data-touchnavigation]) &:active,
-    &:active {
-        transform: scale(1);
+    &:has(.jkl-icon:first-child) {
+        padding-inline-start: var(--padding-icon);
+    }
+
+    &:has(.jkl-icon:last-child) {
+        padding-inline-end: var(--padding-icon);
+    }
+
+    &:has(.jkl-icon:first-child):has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-icon-button);
+    }
+
+    &__label {
+        @include jkl.motion("standard", "expressive", translate);
+
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: jkl.$spacing-2;
+        pointer-events: none;
+    }
+
+    &__loader {
+        @include jkl.motion("standard", "expressive", opacity, translate);
+
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        translate: -50% 350%;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    &__text {
+        // Håndter tekster som er lenger enn knappen
+        // Knappen vokser til teksten, men kan f.eks. begrenses
+        // av sidebredde på mobil
+        max-width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &[data-loading="true"] &__label {
+        translate: 0 -120%;
+    }
+
+    &[data-loading="true"] &__loader {
+        translate: -50% -50%;
+        opacity: 1;
     }
 
     &:focus-visible {
         @include jkl.focus-outline;
     }
 
-    html[data-touchnavigation] &--pressed {
-        transform: scale(0.95);
-        -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+    // Dette er elementet som viser touch-animasjon
+    &::before {
+        content: "";
+        pointer-events: none;
+        display: block;
+        position: absolute;
+        left: var(--jkl-touch-xcoord, 50%);
+        top: var(--jkl-touch-ycoord, 50%);
+        translate: -100%, -100%;
+        transform-origin: center;
+        border-radius: 9999px;
+        background-color: var(--text-color);
+        opacity: 0;
+        width: jkl.rem(16px);
+        height: jkl.rem(16px);
     }
 
-    &__content {
-        height: var(--jkl-button-line-height);
-        overflow: hidden;
+    html[data-touchnavigation] &.jkl-button--pressed::before {
+        animation: jkl.easing("focus") jkl.timing("expressive") $_flash-animation-name;
     }
-
-    &__slider {
-        @include jkl.motion;
-        transition-property: transform;
-
-        &--show-loader {
-            transform: translateY(-51%);
-        }
-    }
-
-    &__loader {
-        display: flex;
-        padding: 0;
-        align-items: center;
-        justify-content: center;
-        height: var(--jkl-button-line-height);
-    }
-
-    // ********* VARIANTS *********
 
     &--primary,
     &--secondary,
-    &--ghost {
-        border: solid $_button-border-width var(--border-color);
-        border-radius: 999px;
-        padding: var(--jkl-button-padding);
-
-        &::before {
-            content: "";
-            position: absolute;
-            border-radius: 999px;
-            inset: 0;
-        }
-
-        html[data-touchnavigation] &.jkl-button--pressed::before {
-            animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_flash-animation-name;
+    &--tertiary {
+        :not([data-touchnavigation]) &:hover {
+            scale: 1.05;
+            transform-origin: center;
         }
     }
 
-    &--ghost {
-        --border-color: transparent;
-        border-radius: jkl.rem(4px);
-        padding: 0 jkl.$spacing-4;
-
-        &:focus-visible,
-        html:not([data-touchnavigation]) &:hover {
-            --background-color: var(--jkl-color-background-interactive-hover);
-            transform: scale(1);
-        }
-
-        &.jkl-button--icon-left .jkl-button__children {
-            padding-left: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--icon-right .jkl-button__children {
-            padding-right: var(--jkl-button-children-padding-with-icon);
-        }
+    &--primary,
+    &--secondary {
+        --border-radius: 999px;
     }
 
     &--primary {
@@ -160,135 +148,56 @@ a.jkl-button {
     }
 
     &--secondary {
-        transition-property: box-shadow, transform, background-color;
-
-        &:hover,
-        &:focus-visible,
-        html[data-touchnavigation] &.jkl-button--pressed {
-            box-shadow: inset 0 0 0 1px var(--border-color), inset 0 0 0 1px var(--border-color);
-        }
-    }
-
-    &--tertiary {
-        border-bottom: solid $_button-border-width var(--border-color);
-        border-top: solid $_button-border-width transparent;
-        padding: var(--jkl-button-tertiary-padding);
-        transition: transform $_animation-timing, border $_animation-timing;
-        min-width: unset;
-
-        // Base for touch-effekt
-        &::before {
+        &::after {
             content: "";
-            pointer-events: none;
-            display: block;
             position: absolute;
-            left: var(--jkl-touch-xcoord, 50%);
-            top: var(--jkl-touch-ycoord, 50%);
-            transform: translate3d(-50%, -50%, 0);
-            border-radius: 100%;
-            width: jkl.rem(16px);
-            height: jkl.rem(16px);
-            background-color: transparent;
+            inset: 0;
+            border-radius: var(--border-radius);
+            border: var(--border-width) solid var(--text-color);
         }
+    }
 
-        html[data-touchnavigation] &.jkl-button--pressed::before {
-            animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_tertiary-flash-animation-name;
-        }
+    &--tertiary,
+    &--tertiary:has(.jkl-icon:first-child),
+    &--tertiary:has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-tertiary-inline);
 
-        &:focus-visible {
-            border: none;
-
-            @include jkl.forced-colors-mode {
-                border: revert;
-            }
+        &::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: var(--border-radius);
+            border-bottom: var(--border-width) solid var(--text-color);
         }
 
         &:hover,
-        &:focus-visible,
-        html[data-touchnavigation] &.jkl-button--pressed {
-            border-bottom-color: var(--focus-color);
-            border-bottom-width: $_focus-ring-width;
-            color: var(--focus-color);
+        &:focus-visible {
+            --border-width: #{jkl.rem(2px)};
         }
     }
 
-    &--icon-left,
-    &--icon-right {
-        .jkl-button__icon {
-            display: inline-block;
-            vertical-align: sub;
-        }
-    }
+    &--ghost,
+    &--ghost:has(.jkl-icon:first-child),
+    &--ghost:has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-ghost-inline);
+        border-radius: jkl.rem(4px);
 
-    &--icon-left {
-        padding-left: jkl.$spacing-8;
+        @include jkl.motion("standard", "productive", background-color);
 
-        .jkl-button__children {
-            padding-left: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--tertiary {
-            padding-left: var(--jkl-button-tertiary-padding-with-icon);
-        }
-    }
-
-    &--icon-right {
-        padding-right: jkl.$spacing-8;
-
-        .jkl-button__children {
-            padding-right: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--tertiary {
-            padding-right: var(--jkl-button-tertiary-padding-with-icon);
-        }
-    }
-
-    @include jkl.forced-colors-mode {
-        &.jkl-button--primary:not(a),
-        &.jkl-button--secondary:not(a),
-        &.jkl-button--primary:hover:not(a),
-        &.jkl-button--secondary:hover:not(a),
-        &.jkl-button--primary:focus:not(a),
-        &.jkl-button--secondary:focus:not(a) {
-            border-color: ButtonText;
-        }
-
-        & .jkl-loader__dot {
-            background-color: ButtonText;
-        }
-
-        &.jkl-button--tertiary {
-            outline-offset: jkl.$spacing-3xs;
-            border-top-style: none;
-            border-right-style: none;
-            border-left-style: none;
+        &:hover {
+            --background-color: var(--jkl-color-background-interactive-hover);
         }
     }
 }
 
 @keyframes #{$_flash-animation-name} {
     0% {
-        box-shadow: 0 0 0 0 var(--focus-color);
         opacity: 0.5;
+        scale: 1;
     }
 
     100% {
-        box-shadow: 0 0 0 #{jkl.rem(16px)} var(--focus-color);
         opacity: 0;
-    }
-}
-
-@keyframes #{$_tertiary-flash-animation-name} {
-    0% {
-        box-shadow: 0 0 0 0 var(--focus-color);
-        background-color: var(--focus-color);
-        opacity: 0.5;
-    }
-
-    100% {
-        box-shadow: 0 0 0 #{jkl.rem(40px)} var(--focus-color);
-        background-color: var(--focus-color);
-        opacity: 0;
+        scale: 8;
     }
 }

--- a/packages/jokul/src/components/button/Button.test.tsx
+++ b/packages/jokul/src/components/button/Button.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import React, { useState } from "react";
+import { Icon } from "../icon";
 import { Button } from "./Button";
 import { buttonVariants } from "./types";
 
@@ -16,6 +17,34 @@ describe("Button", () => {
 
             expect(screen.getByTestId(buttonVariant)).toHaveClass(`jkl-button--${buttonVariant}`);
         });
+    });
+
+    it("renders correctly with left icon and label", () => {
+        render(
+            <Button variant="primary" icon={<Icon>save</Icon>}>
+                Lagre
+            </Button>,
+        );
+
+        expect(screen.getByText("Lagre")).toBeInTheDocument();
+        expect(screen.getByText("save")).toBeInTheDocument();
+    });
+
+    it("renders correctly with right icon and label", () => {
+        render(
+            <Button variant="primary" icon={<Icon>save</Icon>} iconPosition="right">
+                Lagre
+            </Button>,
+        );
+
+        expect(screen.getByText("Lagre")).toBeInTheDocument();
+        expect(screen.getByText("save")).toBeInTheDocument();
+    });
+
+    it("renders correctly with icon only", () => {
+        render(<Button variant="primary" icon={<Icon>save</Icon>} title="Lagre" />);
+
+        expect(screen.getByText("save")).toBeInTheDocument();
     });
 
     it("calls the onClick handler when clicked", async () => {

--- a/packages/jokul/src/components/button/Button.tsx
+++ b/packages/jokul/src/components/button/Button.tsx
@@ -1,7 +1,7 @@
-import clsx from "clsx";
+import cn from "clsx";
 import React, { ButtonHTMLAttributes, type TouchEvent, useCallback } from "react";
-import type { PolymorphicRef } from "../..";
 import { useAriaLiveRegion } from "../../hooks";
+import type { PolymorphicRef } from "../../utilities";
 import { Loader } from "../loader";
 import type { ButtonComponent, ButtonProps } from "./types";
 
@@ -16,6 +16,8 @@ export const Button = React.forwardRef(function Button<ElementType extends React
         density,
         onTouchStart,
         loader,
+        icon,
+        iconPosition = "left",
         iconLeft,
         iconRight,
         variant = "secondary",
@@ -29,7 +31,7 @@ export const Button = React.forwardRef(function Button<ElementType extends React
             onTouchStart && onTouchStart(event);
 
             const target = event.target as HTMLButtonElement;
-            if (target && event.targetTouches.length) {
+            if (target && !target.disabled && event.targetTouches.length) {
                 const Xcoord = event.targetTouches[0].clientX - target.getBoundingClientRect().x;
                 const Ycoord = event.targetTouches[0].clientY - target.getBoundingClientRect().y;
                 target.style.setProperty("--jkl-touch-xcoord", Xcoord.toPrecision(4) + "px");
@@ -47,37 +49,35 @@ export const Button = React.forwardRef(function Button<ElementType extends React
     );
 
     const ariaLive = useAriaLiveRegion(loader?.showLoader);
+    const showLoader = Boolean(children) && Boolean(loader?.showLoader);
 
     return (
         <Component
             {...ariaLive}
+            data-loading={showLoader}
             data-density={density}
-            className={clsx("jkl-button", "jkl-button--" + variant, className, {
-                "jkl-button--icon-left": iconLeft,
-                "jkl-button--icon-right": iconRight,
-            })}
+            className={cn("jkl-button", "jkl-button--" + variant, className)}
             disabled={as === "button" ? loader?.showLoader : undefined}
             onTouchStart={handleTouch}
             {...rest}
             ref={ref}
         >
-            <div className="jkl-button__content">
-                <div
-                    className={clsx("jkl-button__slider", {
-                        "jkl-button__slider--show-loader": !!loader?.showLoader,
-                    })}
-                >
-                    {iconLeft && <span className="jkl-button__icon">{iconLeft}</span>}
-                    <span className="jkl-button__children">{children}</span>
-                    {iconRight && <span className="jkl-button__icon">{iconRight}</span>}
-
-                    {loader && (
-                        <div className="jkl-button__loader">
-                            <Loader textDescription={loader.textDescription} aria-hidden={!loader.showLoader} />
-                        </div>
-                    )}
-                </div>
+            <div className="jkl-button__label">
+                {iconLeft && iconLeft}
+                {icon && iconPosition === "left" && icon}
+                {children && <span className="jkl-button__text">{children}</span>}
+                {iconRight && iconRight}
+                {icon && iconPosition === "right" && icon}
             </div>
+
+            {children && (
+                <Loader
+                    className="jkl-button__loader"
+                    variant="medium"
+                    textDescription={loader?.textDescription || "Vennligst vent"}
+                    aria-hidden={!loader?.showLoader}
+                />
+            )}
         </Component>
     );
 }) as ButtonComponent;

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -2,156 +2,144 @@
 @use "sass:string";
 @use "../../../core/jkl";
 
-$_animation-timing: jkl.timing("snappy") jkl.easing("focus");
-$_flash-animation-name: jkl-flash-#{string.unique-id()};
-$_tertiary-flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
-$_hover-elevation-distance: -0.25rem;
+$_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
 
-$_button-border-width: jkl.rem(1px);
-$_focus-ring-distance: jkl.rem(4px);
-$_focus-ring-width: jkl.rem(2px);
-
-@include jkl.comfortable-density-variables {
-    --jkl-button-font-size: var(--jkl-body-font-size);
-    --jkl-button-line-height: #{jkl.rem(48px)};
-    --jkl-button-font-weight: #{jkl.$typography-weight-bold};
-    --jkl-button-min-width: #{jkl.rem(104px)};
-    --jkl-button-padding: 0 #{jkl.$spacing-24};
-    --jkl-button-tertiary-padding: 0 #{jkl.$spacing-2};
-    --jkl-button-children-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-tertiary-padding-with-icon: 0;
-    --jkl-button-focus-ring-placement: -#{($_button-border-width + $_focus-ring-distance)};
-
-    @include jkl.small-device {
-        --jkl-button-line-height: #{jkl.rem(44px)};
-    }
+@include jkl.comfortable-density(".jkl-button") {
+    --padding-block: #{jkl.$spacing-8};
+    --padding-text: #{jkl.$spacing-24};
+    --padding-icon: #{jkl.$spacing-16};
+    --padding-icon-button: #{jkl.$spacing-8};
+    --padding-tertiary-inline: #{jkl.$spacing-4};
+    --padding-ghost-inline: #{jkl.$spacing-8};
 }
 
-@include jkl.compact-density-variables {
-    --jkl-button-font-size: var(--jkl-small-font-size);
-    --jkl-button-line-height: #{jkl.rem(32px)};
-    --jkl-button-font-weight: #{jkl.$typography-weight-bold};
-    --jkl-button-min-width: #{jkl.rem(76px)};
-    --jkl-button-padding: 0 #{jkl.$spacing-12};
-    --jkl-button-tertiary-padding: 0 #{jkl.$spacing-2};
-    --jkl-button-children-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-tertiary-padding-with-icon: #{jkl.$spacing-2};
-    --jkl-button-focus-ring-placement: -#{($_button-border-width + calc($_focus-ring-distance / 2))};
-}
-
-a.jkl-button {
-    text-decoration: none;
+@include jkl.compact-density(".jkl-button") {
+    --padding-block: #{jkl.$spacing-4};
+    --padding-text: #{jkl.$spacing-12};
+    --padding-icon: #{jkl.$spacing-8};
+    --padding-icon-button: #{jkl.$spacing-4};
+    --padding-tertiary-inline: #{jkl.$spacing-2};
+    --padding-ghost-inline: #{jkl.$spacing-4};
 }
 
 .jkl-button {
-    --border-color: var(--jkl-color-background-action);
-    --text-color: var(--jkl-color-background-action);
-    --focus-color: var(--jkl-color-background-action);
+    --text-color: var(--jkl-color-text-default);
     --background-color: transparent;
+    --border-radius: 0;
+    --border-width: #{jkl.rem(1px)}; // For secondary og tertiary button
 
-    display: inline-flex;
-    box-sizing: border-box;
-    justify-content: center;
-
-    background-color: var(--background-color);
-    color: var(--text-color);
-
-    @include jkl.use-font-variables("jkl-button");
-
-    height: var(--jkl-button-line-height);
-    min-width: var(--jkl-button-min-width);
+    // button and link resets
     cursor: pointer;
     user-select: none;
-    overflow: visible;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    border: unset;
+    text-decoration: none;
+    -webkit-tap-highlight-color: transparent;
+
+    border-radius: var(--border-radius);
+    padding-inline: var(--padding-text);
+    padding-block: var(--padding-block);
     position: relative;
+    overflow: hidden;
+    max-width: 100%;
 
-    @include jkl.motion;
-    transform-origin: 50% 90%;
-    transition-property: transform, background-color;
+    @include jkl.motion("standard", "productive", scale);
 
-    @include jkl.reset-outline;
-
-    &:focus-visible,
-    html:not([data-touchnavigation]) &:hover {
-        transform: scale(1.05);
+    @include jkl.text-style("body") {
+        --jkl-icon-weight: #{jkl.$icon-weight-bold};
+        font-weight: jkl.$typography-weight-bold;
     }
 
-    html:not([data-mousenavigation]) &:active,
-    html:not([data-touchnavigation]) &:active,
-    &:active {
-        transform: scale(1);
+    &:has(.jkl-icon:first-child) {
+        padding-inline-start: var(--padding-icon);
+    }
+
+    &:has(.jkl-icon:last-child) {
+        padding-inline-end: var(--padding-icon);
+    }
+
+    &:has(.jkl-icon:first-child):has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-icon-button);
+    }
+
+    &__label {
+        @include jkl.motion("standard", "expressive", translate);
+
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: jkl.$spacing-2;
+        pointer-events: none;
+    }
+
+    &__loader {
+        @include jkl.motion("standard", "expressive", opacity, translate);
+
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        translate: -50% 350%;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    &__text {
+        // Håndter tekster som er lenger enn knappen
+        // Knappen vokser til teksten, men kan f.eks. begrenses
+        // av sidebredde på mobil
+        max-width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &[data-loading="true"] &__label {
+        translate: 0 -120%;
+    }
+
+    &[data-loading="true"] &__loader {
+        translate: -50% -50%;
+        opacity: 1;
     }
 
     &:focus-visible {
         @include jkl.focus-outline;
     }
 
-    html[data-touchnavigation] &--pressed {
-        transform: scale(0.95);
-        -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+    // Dette er elementet som viser touch-animasjon
+    &::before {
+        content: "";
+        pointer-events: none;
+        display: block;
+        position: absolute;
+        left: var(--jkl-touch-xcoord, 50%);
+        top: var(--jkl-touch-ycoord, 50%);
+        translate: -100%, -100%;
+        transform-origin: center;
+        border-radius: 9999px;
+        background-color: var(--text-color);
+        opacity: 0;
+        width: jkl.rem(16px);
+        height: jkl.rem(16px);
     }
 
-    &__content {
-        height: var(--jkl-button-line-height);
-        overflow: hidden;
+    html[data-touchnavigation] &.jkl-button--pressed::before {
+        animation: jkl.easing("focus") jkl.timing("expressive") $_flash-animation-name;
     }
-
-    &__slider {
-        @include jkl.motion;
-        transition-property: transform;
-
-        &--show-loader {
-            transform: translateY(-51%);
-        }
-    }
-
-    &__loader {
-        display: flex;
-        padding: 0;
-        align-items: center;
-        justify-content: center;
-        height: var(--jkl-button-line-height);
-    }
-
-    // ********* VARIANTS *********
 
     &--primary,
     &--secondary,
-    &--ghost {
-        border: solid $_button-border-width var(--border-color);
-        border-radius: 999px;
-        padding: var(--jkl-button-padding);
-
-        &::before {
-            content: "";
-            position: absolute;
-            border-radius: 999px;
-            inset: 0;
-        }
-
-        html[data-touchnavigation] &.jkl-button--pressed::before {
-            animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_flash-animation-name;
+    &--tertiary {
+        :not([data-touchnavigation]) &:hover {
+            scale: 1.05;
+            transform-origin: center;
         }
     }
 
-    &--ghost {
-        --border-color: transparent;
-        border-radius: jkl.rem(4px);
-        padding: 0 jkl.$spacing-4;
-
-        &:focus-visible,
-        html:not([data-touchnavigation]) &:hover {
-            --background-color: var(--jkl-color-background-interactive-hover);
-            transform: scale(1);
-        }
-
-        &.jkl-button--icon-left .jkl-button__children {
-            padding-left: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--icon-right .jkl-button__children {
-            padding-right: var(--jkl-button-children-padding-with-icon);
-        }
+    &--primary,
+    &--secondary {
+        --border-radius: 999px;
     }
 
     &--primary {
@@ -160,135 +148,56 @@ a.jkl-button {
     }
 
     &--secondary {
-        transition-property: box-shadow, transform, background-color;
-
-        &:hover,
-        &:focus-visible,
-        html[data-touchnavigation] &.jkl-button--pressed {
-            box-shadow: inset 0 0 0 1px var(--border-color), inset 0 0 0 1px var(--border-color);
-        }
-    }
-
-    &--tertiary {
-        border-bottom: solid $_button-border-width var(--border-color);
-        border-top: solid $_button-border-width transparent;
-        padding: var(--jkl-button-tertiary-padding);
-        transition: transform $_animation-timing, border $_animation-timing;
-        min-width: unset;
-
-        // Base for touch-effekt
-        &::before {
+        &::after {
             content: "";
-            pointer-events: none;
-            display: block;
             position: absolute;
-            left: var(--jkl-touch-xcoord, 50%);
-            top: var(--jkl-touch-ycoord, 50%);
-            transform: translate3d(-50%, -50%, 0);
-            border-radius: 100%;
-            width: jkl.rem(16px);
-            height: jkl.rem(16px);
-            background-color: transparent;
+            inset: 0;
+            border-radius: var(--border-radius);
+            border: var(--border-width) solid var(--text-color);
         }
+    }
 
-        html[data-touchnavigation] &.jkl-button--pressed::before {
-            animation: jkl.easing("easeInBounceOut") jkl.timing("lazy") $_tertiary-flash-animation-name;
-        }
+    &--tertiary,
+    &--tertiary:has(.jkl-icon:first-child),
+    &--tertiary:has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-tertiary-inline);
 
-        &:focus-visible {
-            border: none;
-
-            @include jkl.forced-colors-mode {
-                border: revert;
-            }
+        &::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: var(--border-radius);
+            border-bottom: var(--border-width) solid var(--text-color);
         }
 
         &:hover,
-        &:focus-visible,
-        html[data-touchnavigation] &.jkl-button--pressed {
-            border-bottom-color: var(--focus-color);
-            border-bottom-width: $_focus-ring-width;
-            color: var(--focus-color);
+        &:focus-visible {
+            --border-width: #{jkl.rem(2px)};
         }
     }
 
-    &--icon-left,
-    &--icon-right {
-        .jkl-button__icon {
-            display: inline-block;
-            vertical-align: sub;
-        }
-    }
+    &--ghost,
+    &--ghost:has(.jkl-icon:first-child),
+    &--ghost:has(.jkl-icon:last-child) {
+        padding-inline: var(--padding-ghost-inline);
+        border-radius: jkl.rem(4px);
 
-    &--icon-left {
-        padding-left: jkl.$spacing-8;
+        @include jkl.motion("standard", "productive", background-color);
 
-        .jkl-button__children {
-            padding-left: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--tertiary {
-            padding-left: var(--jkl-button-tertiary-padding-with-icon);
-        }
-    }
-
-    &--icon-right {
-        padding-right: jkl.$spacing-8;
-
-        .jkl-button__children {
-            padding-right: var(--jkl-button-children-padding-with-icon);
-        }
-
-        &.jkl-button--tertiary {
-            padding-right: var(--jkl-button-tertiary-padding-with-icon);
-        }
-    }
-
-    @include jkl.forced-colors-mode {
-        &.jkl-button--primary:not(a),
-        &.jkl-button--secondary:not(a),
-        &.jkl-button--primary:hover:not(a),
-        &.jkl-button--secondary:hover:not(a),
-        &.jkl-button--primary:focus:not(a),
-        &.jkl-button--secondary:focus:not(a) {
-            border-color: ButtonText;
-        }
-
-        & .jkl-loader__dot {
-            background-color: ButtonText;
-        }
-
-        &.jkl-button--tertiary {
-            outline-offset: jkl.$spacing-3xs;
-            border-top-style: none;
-            border-right-style: none;
-            border-left-style: none;
+        &:hover {
+            --background-color: var(--jkl-color-background-interactive-hover);
         }
     }
 }
 
 @keyframes #{$_flash-animation-name} {
     0% {
-        box-shadow: 0 0 0 0 var(--focus-color);
         opacity: 0.5;
+        scale: 1;
     }
 
     100% {
-        box-shadow: 0 0 0 #{jkl.rem(16px)} var(--focus-color);
         opacity: 0;
-    }
-}
-
-@keyframes #{$_tertiary-flash-animation-name} {
-    0% {
-        box-shadow: 0 0 0 0 var(--focus-color);
-        background-color: var(--focus-color);
-        opacity: 0.5;
-    }
-
-    100% {
-        box-shadow: 0 0 0 #{jkl.rem(40px)} var(--focus-color);
-        background-color: var(--focus-color);
-        opacity: 0;
+        scale: 8;
     }
 }

--- a/packages/jokul/src/components/button/types.ts
+++ b/packages/jokul/src/components/button/types.ts
@@ -1,7 +1,28 @@
-import { Density, PolymorphicPropsWithRef } from "../..";
+import { Density } from "../../core";
+import { PolymorphicPropsWithRef } from "../../utilities";
 
 export const buttonVariants = ["primary", "secondary", "tertiary", "ghost"] as const;
 export type ButtonVariant = (typeof buttonVariants)[number];
+export type IconPosition = "left" | "right";
+
+type IconOptions<T extends React.ElementType> =
+    // Hvis ikke knappen har ikon, MÅ den ha children:
+    | {
+          iconPosition?: never;
+          icon?: never;
+          children: React.ComponentPropsWithoutRef<T>["children"];
+      }
+    | {
+          /**
+           * Plasseringen av ikonet
+           * @default "left"
+           */
+          iconPosition?: IconPosition;
+          /**
+           * Hvilket ikon som skal vises i knappen
+           */
+          icon: React.ReactElement;
+      };
 
 export type ButtonProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
     ElementType,
@@ -17,9 +38,15 @@ export type ButtonProps<ElementType extends React.ElementType> = PolymorphicProp
             showLoader: boolean;
             textDescription: string;
         };
+        /**
+         * @deprecated Bruk `icon` i kombinasjon med `iconPosition="left"`
+         */
         iconLeft?: React.ReactNode;
+        /**
+         * @deprecated Bruk `icon` i kombinasjon med `iconPosition="right"`
+         */
         iconRight?: React.ReactNode;
-    }
+    } & IconOptions<ElementType>
 >;
 
 export type ButtonComponent = <ElementType extends React.ElementType = "button">(

--- a/packages/jokul/src/core/jkl/_theme.scss
+++ b/packages/jokul/src/core/jkl/_theme.scss
@@ -59,24 +59,43 @@
 
 /// Brukes til å sette CSS-variabler inne i en komponent, og som skal gjelde i vanlig (ukompakt) modus.
 /// @content Settes på .jkl &, [data-density="comfortable"] &, og [data-layout-density="comfortable"] &
-@mixin comfortable-density {
-    .jkl &,
-    &[data-layout-density="comfortable"],
-    &[data-density="comfortable"],
-    [data-layout-density="comfortable"] &,
-    [data-density="comfortable"] & {
-        @content;
+@mixin comfortable-density($selector: null) {
+    @if $selector {
+        .jkl #{$selector},
+        #{$selector}[data-layout-density="comfortable"],
+        #{$selector}[data-density="comfortable"],
+        [data-layout-density="comfortable"] #{$selector},
+        [data-density="comfortable"] #{$selector} {
+            @content;
+        }
+    } @else {
+        .jkl &,
+        &[data-layout-density="comfortable"],
+        &[data-density="comfortable"],
+        [data-layout-density="comfortable"] &,
+        [data-density="comfortable"] & {
+            @content;
+        }
     }
 }
 
 /// Brukes til å sette CSS-variabler inne i en komponent, og som skal gjelde i kompakt modus.
 /// @content Settes på [data-density="compact"] &, og på [data-layout-density="compact"] &
-@mixin compact-density {
-    &[data-layout-density="compact"],
-    &[data-density="compact"],
-    [data-layout-density="compact"] &,
-    [data-density="compact"] & {
-        @content;
+@mixin compact-density($selector: null) {
+    @if $selector {
+        #{$selector}[data-layout-density="compact"],
+        #{$selector}[data-density="compact"],
+        [data-layout-density="compact"] #{$selector},
+        [data-density="compact"] #{$selector} {
+            @content;
+        }
+    } @else {
+        &[data-layout-density="compact"],
+        &[data-density="compact"],
+        [data-layout-density="compact"] &,
+        [data-density="compact"] & {
+            @content;
+        }
     }
 }
 

--- a/portal/src/layout/header/MainMenu.tsx
+++ b/portal/src/layout/header/MainMenu.tsx
@@ -66,7 +66,7 @@ export const MainMenu: React.FC<MainMenuProps> = ({ className, items }) => {
             {isSmallScreen && (
                 <Button
                     variant="ghost"
-                    iconLeft={isOpen ? <CloseIcon /> : <HamburgerIcon />}
+                    icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
                     aria-label={`${isOpen ? "Lukk" : "Åpne"} meny`}
                     id="jkl-portal-main-menu-hamburger"
                     aria-controls="jkl-portal-main-menu-overlay"


### PR DESCRIPTION
APIet til knappene er nå likere mellom kode og skisser, som forberedelse til Figma Code Connect. Gammel måte å legge til ikoner på er deprecated, men fungerer fortsatt.

`button.min.css`: ~~6,82 kB~~ -> **4,66 kB** 🎉

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
