### PR TITLE
feat: inkluder stiler for avhengigheter i sass-index

### DIFF
--- a/packages/jokul/src/components/accordion/styles/_index.scss
+++ b/packages/jokul/src/components/accordion/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "accordion";
+
+@use "../../icon/styles";

--- a/packages/jokul/src/components/button/styles/_index.scss
+++ b/packages/jokul/src/components/button/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "button";
+
+@use "../../loader/styles/loader";

--- a/packages/jokul/src/components/card/styles/_index.scss
+++ b/packages/jokul/src/components/card/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "card";
+
+@use "../../image/styles" as image;
+@use "../../tag/styles" as tag;

--- a/packages/jokul/src/components/combobox/styles/_index.scss
+++ b/packages/jokul/src/components/combobox/styles/_index.scss
@@ -1,1 +1,7 @@
 @forward "combobox";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;
+@use "../../input-group/styles" as input-group;
+@use "../../tag/styles" as tag;
+@use "../../tooltip/styles" as tooltip;

--- a/packages/jokul/src/components/cookie-consent/styles/_index.scss
+++ b/packages/jokul/src/components/cookie-consent/styles/_index.scss
@@ -1,1 +1,5 @@
 @forward "cookie-consent";
+
+@use "../../button/styles" as button;
+@use "../../checkbox/styles" as checkbox;
+@use "../../list/styles" as list;

--- a/packages/jokul/src/components/datepicker/styles/_index.scss
+++ b/packages/jokul/src/components/datepicker/styles/_index.scss
@@ -1,1 +1,5 @@
 @forward "datepicker";
+
+@use "../../icon/styles" as icon;
+@use "../../input-group/styles" as input-group;
+@use "../../text-input/styles" as text-input;

--- a/packages/jokul/src/components/expander/styles/_index.scss
+++ b/packages/jokul/src/components/expander/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "expander";
+
+// Expander-komponenten avhenger av de følgende pakkene
+@use "../../icon/styles";

--- a/packages/jokul/src/components/feedback/styles/_index.scss
+++ b/packages/jokul/src/components/feedback/styles/_index.scss
@@ -1,1 +1,9 @@
 @forward "feedback";
+
+// Feedback-komponenten avhenger av de følgende pakkene
+@use "../../button/styles" as button;
+@use "../../checkbox/styles" as checkbox;
+@use "../../input-group/styles" as input-group;
+@use "../../message/styles" as message;
+@use "../../radio-button/styles" as radio-button;
+@use "../../text-input/styles" as text-input;

--- a/packages/jokul/src/components/icon/styles/_index.scss
+++ b/packages/jokul/src/components/icon/styles/_index.scss
@@ -1,0 +1,1 @@
+@forward "icon";

--- a/packages/jokul/src/components/input-group/styles/_index.scss
+++ b/packages/jokul/src/components/input-group/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "input-group";
+
+@use "../../icon/styles" as icon;
+@use "../../tooltip/styles" as tooltip;

--- a/packages/jokul/src/components/link-list/styles/_index.scss
+++ b/packages/jokul/src/components/link-list/styles/_index.scss
@@ -1,3 +1,3 @@
-@forward "message";
+@forward "link-list";
 
 @use "../../icon/styles";

--- a/packages/jokul/src/components/link/styles/_index.scss
+++ b/packages/jokul/src/components/link/styles/_index.scss
@@ -1,0 +1,1 @@
+@forward "link";

--- a/packages/jokul/src/components/modal/styles/_index.scss
+++ b/packages/jokul/src/components/modal/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "modal";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;

--- a/packages/jokul/src/components/radio-button/styles/_index.scss
+++ b/packages/jokul/src/components/radio-button/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "radio-button";
+
+@use "../../input-group/styles";

--- a/packages/jokul/src/components/select/styles/_index.scss
+++ b/packages/jokul/src/components/select/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "select";
+
+@use "../../icon/styles" as icon;
+@use "../../input-group/styles" as input-group;

--- a/packages/jokul/src/components/system-message/styles/_index.scss
+++ b/packages/jokul/src/components/system-message/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "system-message";
+
+@use "../../icon/styles";

--- a/packages/jokul/src/components/table/styles/_index.scss
+++ b/packages/jokul/src/components/table/styles/_index.scss
@@ -1,1 +1,7 @@
 @forward "table";
+
+@use "../../expander/styles" as expander;
+@use "../../icon/styles" as icon;
+
+// TablePagination avhenger av en del stiler, men komponenten
+// kan heller skilles ut til en egen "pakke"

--- a/packages/jokul/src/components/table/styles/table.scss
+++ b/packages/jokul/src/components/table/styles/table.scss
@@ -1,0 +1,54 @@
+@charset "UTF-8";
+@use "../../../core/jkl";
+
+@use "table-caption";
+@use "table-cell";
+@use "table-head";
+@use "table-header";
+@use "table-pagination";
+@use "table-row";
+
+@mixin _responsive-table {
+    display: block;
+
+    & > caption {
+        @include jkl.screenreader-only;
+    }
+
+    & > thead,
+    & > thead > tr,
+    & > thead > tr > th {
+        display: none;
+    }
+
+    & > tbody,
+    & > tbody > tr,
+    & > tbody > tr > td {
+        display: block;
+    }
+
+    & > tfoot,
+    & > tfoot > tr,
+    & > tfoot > tr > td {
+        display: block;
+    }
+}
+
+.jkl-table {
+    border-collapse: collapse;
+    position: relative;
+
+    &--full-width {
+        width: 100%;
+    }
+
+    &--collapse-to-list {
+        &[data-collapse] {
+            @include _responsive-table;
+        }
+
+        @include jkl.small-device {
+            @include _responsive-table;
+        }
+    }
+}

--- a/packages/jokul/src/components/tag/styles/_index.scss
+++ b/packages/jokul/src/components/tag/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "tag";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;

--- a/packages/jokul/src/components/text-input/styles/_index.scss
+++ b/packages/jokul/src/components/text-input/styles/_index.scss
@@ -1,1 +1,5 @@
 @forward "text-input";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;
+@use "../../input-group/styles" as input-group;

--- a/packages/jokul/src/components/toast/styles/_index.scss
+++ b/packages/jokul/src/components/toast/styles/_index.scss
@@ -1,1 +1,4 @@
 @forward "toast";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;

--- a/packages/jokul/src/components/toggle-switch/styles/_index.scss
+++ b/packages/jokul/src/components/toggle-switch/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "toggle-switch";
+
+@use "../../icon/styles" as icon;

--- a/packages/jokul/src/components/toggle-switch/styles/toggle-switch.scss
+++ b/packages/jokul/src/components/toggle-switch/styles/toggle-switch.scss
@@ -1,0 +1,138 @@
+@charset "UTF-8";
+@use "../../../core/jkl";
+
+@use "./toggle-slider";
+
+@include jkl.comfortable-density-variables {
+    @include jkl.declare-font-variables("jkl-toggle", "body");
+
+    --jkl-toggle-switch-height: #{jkl.rem(28px)};
+    --jkl-toggle-switch-width: #{jkl.rem(48px)};
+    --jkl-toggle-switch-knob-size: #{jkl.rem(20px)};
+    --jkl-toggle-switch-indicator-spacing: 0;
+    --jkl-toggle-switch-help-label-spacing: var(--jkl-spacing-2);
+}
+
+@include jkl.compact-density-variables {
+    @include jkl.declare-font-variables("jkl-toggle", "small");
+
+    --jkl-toggle-switch-height: #{jkl.rem(20px)};
+    --jkl-toggle-switch-width: #{jkl.rem(36px)};
+    --jkl-toggle-switch-knob-size: #{jkl.rem(12px)};
+    --jkl-toggle-switch-indicator-spacing: #{jkl.rem(-2px)};
+    --jkl-toggle-switch-help-label-spacing: 0;
+}
+
+.jkl-toggle-switch {
+    --border-width: #{jkl.rem(1px)};
+    --switch-padding: #{jkl.rem(4px)};
+    --knob-position: 0;
+    --switch-border-color: var(--jkl-color-border-action);
+    --indicator-color: var(--jkl-color-background-container-high);
+    --knob-border-color: var(--jkl-color-border-action);
+    --knob-color: var(--jkl-color-background-container-high);
+    --text-color: var(--jkl-color-text-default);
+    --icon-color: var(--jkl-color-text-inverted);
+
+    background: transparent;
+    color: var(--text-color);
+    padding: 0;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    gap: var(--jkl-spacing-8);
+    touch-action: none; // Forhindrer at siden flytter på seg når man drar i toggle
+
+    @include jkl.use-font-variables("jkl-toggle");
+
+    @include jkl.reset-outline;
+
+    @include jkl.forced-colors-mode {
+        border-color: transparent;
+        border-style: none;
+    }
+
+    &[aria-pressed="true"],
+    [aria-checked="true"] > & {
+        --indicator-color: var(--jkl-color-background-container-inverted);
+        --knob-color: var(--jkl-color-text-inverted);
+        --knob-position: calc(
+            var(--jkl-toggle-switch-width) - var(--jkl-toggle-switch-knob-size) - var(--switch-padding) * 2
+        );
+    }
+
+    &[disabled] {
+        cursor: revert;
+
+        --text-color: var(--jkl-color-text-subdued);
+        --switch-border-color: var(--jkl-color-border-subdued);
+        --knob-border-color: var(--jkl-color-border-subdued);
+
+        &[aria-pressed="true"],
+        [aria-checked="true"] > & {
+            --indicator-color: var(--jkl-color-border-subdued);
+        }
+    }
+}
+
+.jkl-toggle-switch-widget {
+    position: relative;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: var(--jkl-toggle-switch-height);
+    width: var(--jkl-toggle-switch-width);
+    border-radius: 9999px;
+    border: var(--border-width) solid var(--switch-border-color);
+    overflow: hidden;
+    user-select: none;
+    padding: var(--switch-padding);
+    background-color: var(--indicator-color);
+    pointer-events: none;
+
+    @include jkl.forced-colors-mode {
+        border: jkl.rem(1px) solid ButtonText;
+    }
+
+    .jkl-toggle-switch:focus-visible & {
+        @include jkl.focus-outline;
+    }
+
+    &__slider {
+        position: relative;
+        box-sizing: border-box;
+        height: var(--jkl-toggle-switch-knob-size);
+        width: var(--jkl-toggle-switch-knob-size);
+        color: var(--icon-color);
+
+        @include jkl.motion;
+        transition-property: translate;
+        translate: var(--knob-position);
+    }
+
+    &__knob {
+        position: absolute;
+        inset: 0;
+        border-radius: 9999px;
+        border: var(--border-width) solid var(--knob-border-color);
+        background-color: var(--knob-color);
+    }
+
+    &__indicator {
+        position: absolute;
+        top: 50%;
+        right: 100%;
+        margin-right: var(--jkl-toggle-switch-indicator-spacing);
+        transform: translate(0, -50%);
+
+        & > .jkl-icon__icon {
+            // Uten dette får ikonet feil alignment. Mulig bug i ikonpakken?
+            position: absolute;
+            inset: 0;
+        }
+    }
+}

--- a/packages/jokul/src/components/tooltip/styles/_index.scss
+++ b/packages/jokul/src/components/tooltip/styles/_index.scss
@@ -1,1 +1,3 @@
 @forward "tooltip";
+
+@use "../../icon/styles" as icon;


### PR DESCRIPTION
Legger til stiler for avhengigheten til de forskjellige komponentene i `_index.scss`-filene. Da holder det å importere f.eks. `@fremtind/jokul/styles/accordion` hvis man bare skal bruke den ene komponenten, og Sass drar automatisk inn de andre stilene dersom de ikke allerede er lastet inn annet et sted.

Har sjekket, og dette påvirker ikke felles stilark. Sass er smart nok til å inkludere stilene bare én gang når man bruker `@use` 😊

La også til manglende index-filer og stilark.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
