### PR TITLE
fix: close Select's listbox when tooltip trigger receives focus

### DIFF
--- a/packages/jokul/src/components/select/Select.test.tsx
+++ b/packages/jokul/src/components/select/Select.test.tsx
@@ -1051,6 +1051,36 @@ describe("Searchable select", () => {
         expect(screen.queryByRole("option", { name: "foo" })).toBeFalsy();
         expect(screen.queryByRole("option", { name: "bar" })).toBeFalsy();
     });
+
+    it("should close the listbox if a tooltip trigger receives focus", async () => {
+        const items = [
+            { label: "foo", value: "1" },
+            { label: "bar", value: "2" },
+            { label: "baz", value: "3" },
+        ];
+
+        const screen = setup(
+            <Select
+                name="items"
+                items={items}
+                label="Ting"
+                tooltipProps={{ content: "Jeg er en tooltip", placement: "left" }}
+            />,
+        );
+
+        const openDropdownButtonElement = screen.getByTestId("jkl-select__button");
+        await userEvent.click(openDropdownButtonElement);
+
+        const listbox = screen.getByRole("listbox");
+        expect(listbox).toBeVisible();
+
+        const tooltipTrigger = screen.getByTestId("jkl-tooltip-question-button");
+        await act(async () => {
+            tooltipTrigger.focus();
+        });
+
+        expect(listbox).not.toBeVisible();
+    });
 });
 
 describe("a11y", () => {

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -100,6 +100,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
         width,
         maxShownOptions = 5,
         style,
+        tooltipProps,
         ...rest
     } = props;
 
@@ -251,6 +252,18 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
 
     useListNavigation({ ref: dropdownRef });
 
+    const close = useCallback(() => {
+        if (isSearchable) {
+            setSearchValue("");
+        }
+        if (onBlur) {
+            onBlur({ type: "blur", target: { name, value: selectedValue } });
+            selectRef.current?.dispatchEvent(new Event("focusout", { bubbles: true }));
+        }
+        focusInsideRef.current = false;
+        setShown(false);
+    }, [onBlur, setSearchValue, setShown, isSearchable, name, selectedValue]);
+
     const handleBlur = useCallback(
         (e: FocusEvent<HTMLButtonElement | HTMLInputElement>) => {
             const componentRootElement = componentRootElementRef.current;
@@ -260,18 +273,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
             const nextFocusIsInsideComponent =
                 componentRootElement && componentRootElement.contains(e.relatedTarget as Node);
             if (!nextFocusIsInsideComponent) {
-                if (isSearchable) {
-                    setSearchValue("");
-                }
-                if (onBlur) {
-                    onBlur({ type: "blur", target: { name, value: selectedValue } });
-                    selectRef.current?.dispatchEvent(new Event("focusout", { bubbles: true }));
-                }
-                focusInsideRef.current = false;
-                setShown(false);
+                close();
             }
         },
-        [onBlur, isSearchable, name, selectedValue],
+        [close],
     );
 
     const handleFocus = useCallback(() => {
@@ -443,6 +448,18 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>((props, forward
                     "jkl-select--no-value": !hasSelectedValue,
                     "jkl-select--invalid": !!errorLabel || invalid,
                 })}
+                tooltipProps={
+                    tooltipProps && {
+                        ...tooltipProps,
+                        triggerProps: {
+                            ...tooltipProps.triggerProps,
+                            onFocus: (e) => {
+                                tooltipProps.triggerProps?.onFocus?.(e);
+                                close();
+                            },
+                        },
+                    }
+                }
                 {...rest}
                 id={isSearchable ? searchInputId : buttonId}
                 style={{ ["--jkl-select-max-shown-options"]: maxShownOptions, ...style } as CSSProperties}

--- a/packages/jokul/src/components/tooltip/PopupTip.tsx
+++ b/packages/jokul/src/components/tooltip/PopupTip.tsx
@@ -37,6 +37,7 @@ export const PopupTip: FC<PopupTipProps> = ({ content, triggerProps, ...tooltipP
                     onBlur={handleBlur}
                     type="button"
                     className={clsx("jkl-tooltip-question-button", triggerProps?.className)}
+                    data-testid="jkl-tooltip-question-button"
                 >
                     <QuestionIcon variant="inherit" bold={isBold} />
                     <span className="jkl-sr-only">Vis hjelpetekst</span>

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1051,6 +1051,36 @@ describe("Searchable select", () => {
         expect(screen.queryByRole("option", { name: "foo" })).toBeFalsy();
         expect(screen.queryByRole("option", { name: "bar" })).toBeFalsy();
     });
+
+    it("should close the listbox if a tooltip trigger receives focus", async () => {
+        const items = [
+            { label: "foo", value: "1" },
+            { label: "bar", value: "2" },
+            { label: "baz", value: "3" },
+        ];
+
+        const screen = setup(
+            <Select
+                name="items"
+                items={items}
+                label="Ting"
+                tooltipProps={{ content: "Jeg er en tooltip", placement: "left" }}
+            />,
+        );
+
+        const openDropdownButtonElement = screen.getByTestId("jkl-select__button");
+        await userEvent.click(openDropdownButtonElement);
+
+        const listbox = screen.getByRole("listbox");
+        expect(listbox).toBeVisible();
+
+        const tooltipTrigger = screen.getByTestId("jkl-tooltip-question-button");
+        await act(async () => {
+            tooltipTrigger.focus();
+        });
+
+        expect(listbox).not.toBeVisible();
+    });
 });
 
 describe("a11y", () => {

--- a/packages/tooltip-react/src/PopupTip.tsx
+++ b/packages/tooltip-react/src/PopupTip.tsx
@@ -37,6 +37,7 @@ export const PopupTip: FC<PopupTipProps> = ({ content, triggerProps, ...tooltipP
                     onBlur={handleBlur}
                     type="button"
                     className={cn("jkl-tooltip-question-button", triggerProps?.className)}
+                    data-testid="jkl-tooltip-question-button"
                 >
                     <QuestionIcon variant="inherit" bold={isBold} />
                     <span className="jkl-sr-only">Vis hjelpetekst</span>


### PR DESCRIPTION
Fixes a bug where tabbing backwards out of a Select with an open listbox and a tooltip did not close the listbox

ISSUES CLOSED: #4134

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
