### PR TITLE
feat: ny nyttekomponent Flex

### DIFF
--- a/packages/jokul/src/components/flex/Flex.tsx
+++ b/packages/jokul/src/components/flex/Flex.tsx
@@ -1,0 +1,62 @@
+import React, { type CSSProperties } from "react";
+import { tokens } from "../../core";
+import { type AsChildProps, type PolymorphicPropsWithRef, type PolymorphicRef, SlotComponent } from "../../utilities";
+
+export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
+export type GapValue = Exclude<keyof (typeof tokens)["spacing"], 0>;
+
+export type FlexProps<ElementType extends React.ElementType> = PolymorphicPropsWithRef<
+    ElementType,
+    {
+        direction?: FlexDirection;
+        wrap?: boolean;
+        gap?: GapValue;
+        colGap?: GapValue;
+        rowGap?: GapValue;
+    } & Pick<CSSProperties, "alignContent" | "alignItems" | "justifyContent" | "justifyItems">
+>;
+
+export type FlexComponent = <ElementType extends React.ElementType = "div">(
+    props: FlexProps<ElementType> & AsChildProps,
+) => React.ReactElement | null;
+
+export const Flex = React.forwardRef(function Flex<ElementType extends React.ElementType = "div">(
+    props: FlexProps<ElementType>,
+    ref?: PolymorphicRef<ElementType>,
+) {
+    const {
+        asChild,
+        as = "div",
+        alignContent,
+        alignItems,
+        children,
+        colGap,
+        direction,
+        gap,
+        justifyContent,
+        justifyItems,
+        rowGap,
+        wrap = false,
+        ...rest
+    } = props;
+    const Component = asChild ? SlotComponent : as;
+
+    const flexStyle: CSSProperties = {
+        display: "flex",
+        flexDirection: direction,
+        alignContent,
+        alignItems,
+        justifyContent,
+        justifyItems,
+        ...(wrap ? { flexWrap: "wrap" } : {}),
+        ...(gap ? { gap: tokens.spacing[gap] } : {}),
+        ...(colGap ? { columnGap: tokens.spacing[colGap] } : {}),
+        ...(rowGap ? { rowGap: tokens.spacing[rowGap] } : {}),
+    };
+
+    return (
+        <Component ref={ref} {...rest} style={{ ...flexStyle, ...rest.style }}>
+            {children}
+        </Component>
+    );
+}) as FlexComponent;

--- a/packages/jokul/src/components/flex/documentation/Example.tsx
+++ b/packages/jokul/src/components/flex/documentation/Example.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { DevExample } from "../../../../../../doc-utils";
+import { FlexExample, flexExampleKnobs } from "./FlexExample";
+
+import "../../../../../../packages/webfonts/webfonts.scss";
+import "../../../core/styles/core.scss";
+import "../../../styles/styles.scss";
+
+export default function Example() {
+    return <DevExample component={FlexExample} knobs={flexExampleKnobs} />;
+}

--- a/packages/jokul/src/components/flex/documentation/FlexExample.tsx
+++ b/packages/jokul/src/components/flex/documentation/FlexExample.tsx
@@ -1,0 +1,76 @@
+import React, { CSSProperties, FC } from "react";
+import { ExampleComponentProps, ExampleKnobsProps } from "../../../../../../doc-utils";
+import { tokens } from "../../../core";
+import { Card } from "../../card";
+import { Flex, FlexDirection, GapValue } from "../Flex";
+
+export const flexExampleKnobs: ExampleKnobsProps = {
+    boolProps: ["wrap"],
+    choiceProps: [
+        {
+            name: "direction",
+            values: ["row", "row-reverse", "column", "column-reverse"],
+            defaultValue: 0,
+        },
+        {
+            name: "gap",
+            values: Object.keys(tokens.spacing).sort((a, b) => parseInt(a) - parseInt(b)),
+            defaultValue: 0,
+        },
+        {
+            name: "rowGap",
+            values: Object.keys(tokens.spacing).sort((a, b) => parseInt(a) - parseInt(b)),
+            defaultValue: 0,
+        },
+        {
+            name: "colGap",
+            values: Object.keys(tokens.spacing).sort((a, b) => parseInt(a) - parseInt(b)),
+            defaultValue: 0,
+        },
+    ],
+};
+
+const boxStyle: CSSProperties = {
+    width: "250px",
+    height: "150px",
+    backgroundColor: "var(--jkl-color-background-container-low)",
+    border: "1px solid var(--jkl-color-border-subdued)",
+    borderRadius: "4px",
+    display: "grid",
+    placeContent: "center",
+    flexGrow: 1,
+};
+
+export const FlexExample: FC<ExampleComponentProps> = ({ boolValues, choiceValues }) => {
+    const gap = choiceValues?.["gap"] === "0" ? undefined : (parseInt(choiceValues?.["gap"] || "0") as GapValue);
+    const colGap =
+        choiceValues?.["colGap"] === "0" ? undefined : (parseInt(choiceValues?.["colGap"] || "0") as GapValue);
+    const rowGap =
+        choiceValues?.["rowGap"] === "0" ? undefined : (parseInt(choiceValues?.["rowGap"] || "0") as GapValue);
+
+    return (
+        <Flex
+            asChild
+            direction={choiceValues?.["direction"] as FlexDirection}
+            wrap={boolValues?.["wrap"]}
+            gap={gap}
+            colGap={colGap}
+            rowGap={rowGap}
+            style={{ maxWidth: "80vw" }}
+        >
+            <Card variant="outlined" padding="l">
+                <div style={boxStyle}>1</div>
+                <div style={boxStyle}>2</div>
+                <div style={boxStyle}>3</div>
+                <div style={boxStyle}>4</div>
+                <div style={boxStyle}>5</div>
+                <div style={boxStyle}>6</div>
+                <div style={boxStyle}>7</div>
+                <div style={boxStyle}>8</div>
+                <div style={boxStyle}>9</div>
+            </Card>
+        </Flex>
+    );
+};
+
+export default FlexExample;

--- a/packages/jokul/src/components/flex/documentation/index.html
+++ b/packages/jokul/src/components/flex/documentation/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Demooo</title>
+    </head>
+    <body class="jkl">
+        <div id="root"></div>
+        <script type="module" src="main.tsx"></script>
+    </body>
+</html>

--- a/packages/jokul/src/components/flex/documentation/main.tsx
+++ b/packages/jokul/src/components/flex/documentation/main.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { initTabListener } from "../../..";
+import Example from "./Example";
+
+initTabListener();
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<Example />);

--- a/packages/jokul/src/components/flex/documentation/vite.dev.config.ts
+++ b/packages/jokul/src/components/flex/documentation/vite.dev.config.ts
@@ -1,0 +1,8 @@
+import { resolve } from "path";
+import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vite";
+import { copyJklFonts } from "../../../../../../utils/vite";
+
+export default defineConfig({
+    plugins: [react(), copyJklFonts(resolve(__dirname, "public", "fonts"))],
+});

--- a/packages/jokul/src/components/flex/index.ts
+++ b/packages/jokul/src/components/flex/index.ts
@@ -1,0 +1,1 @@
+export { Flex } from "./Flex";

--- a/packages/jokul/src/components/index.ts
+++ b/packages/jokul/src/components/index.ts
@@ -7,6 +7,7 @@ export * from "./combobox";
 export * from "./cookie-consent";
 export * from "./datepicker";
 export * from "./feedback";
+export * from "./flex";
 export * from "./description-list";
 export * from "./expander";
 export * from "./icon";


### PR DESCRIPTION
En veldig enkel utgave av en `Flex`-komponent for enklere layout. Komponenten er polymorf.
Følgende `flex`-egenskaper er implementert:

- flex-direction
- flex-wrap
- gap
- column-gap
- row-gap
- align-items
- align-content
- justify-content
- justify-items

Gap-egenskapene godtar verdier fra spacingskalaen vår, bortsett fra `0` (som er det samme som å ikke sette verdi). Her hadde det vært fint med noen semantiske spacing-variabler på toppnivå ✨

Foreløpig ligger denne bare i `@fremtind/jokul`. Følte at det ikke ga helt mening å gå gjennom alt arbeidet med å opprette en ny pakke hvis vi uansett snart håper å være helt over på allpakka?

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
