### PR TITLE
chore: helper for launching dev-servers

### DIFF
--- a/packages/jokul/.gitignore
+++ b/packages/jokul/.gitignore
@@ -1,1 +1,3 @@
 dev-server.js
+**/documentation/index.html
+**/documentation/main.tsx

--- a/utils/vite/index.html
+++ b/utils/vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Demooo</title>
+    </head>
+    <body class="jkl">
+        <div id="root"></div>
+        <script type="module" src="main.tsx"></script>
+    </body>
+</html>

--- a/utils/vite/index.ts
+++ b/utils/vite/index.ts
@@ -1,1 +1,2 @@
 export * from "./copy-jkl-fonts";
+export * from "./setup-dev";

--- a/utils/vite/main.tsx
+++ b/utils/vite/main.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { initTabListener } from "../../..";
+import Example from "./Example";
+
+initTabListener();
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<Example />);

--- a/utils/vite/setup-dev.ts
+++ b/utils/vite/setup-dev.ts
@@ -1,0 +1,20 @@
+import { cpSync, rmSync } from "fs";
+import { resolve } from "path";
+
+function setupDev(destination: string) {
+    return {
+        name: "setup-dev",
+        buildStart() {
+            cpSync(resolve(__dirname, "index.html"), resolve(destination, "index.html"));
+            cpSync(resolve(__dirname, "main.tsx"), resolve(destination, "main.tsx"));
+            console.log(`Copied index.html and main.tsx into "${destination}"`);
+        },
+        buildEnd() {
+            rmSync(resolve(destination, "index.html"));
+            rmSync(resolve(destination, "main.tsx"));
+            console.log(`Deleted index.html and main.tsx from "${destination}"`);
+        },
+    };
+}
+
+export { setupDev };


### PR DESCRIPTION
Legger til vite-plugin i config så man slipper å lage nye kopier av index-fila og main-fila hver gang.

Trenger da følgende `vite.dev.config.ts`

```typescript
import react from "@vitejs/plugin-react-swc";
import { resolve } from "path";
import { defineConfig } from "vite";
import { copyJklFonts, setupDev } from "../../../../../../utils/vite";

export default defineConfig({
    plugins: [react(), copyJklFonts(resolve(__dirname, "public", "fonts")), setupDev(__dirname)],
});
```

På sikt tenker jeg at det skal gå å fjerne behovet for denne også, men vil prioritere å bare pløy gjennom resten av pakkene og få på plass dev-servere.