### PR TITLE
Riktig tekst- og ikonstørrelse på kompakte knapper

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -20,6 +20,11 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     --padding-icon-button: #{jkl.$spacing-4};
     --padding-tertiary-inline: #{jkl.$spacing-2};
     --padding-ghost-inline: #{jkl.$spacing-4};
+
+    @include jkl.text-style("small") {
+        --jkl-icon-weight: #{jkl.$icon-weight-bold};
+        font-weight: jkl.$typography-weight-bold;
+    }
 }
 
 .jkl-button {

--- a/packages/core/jkl/_typography.scss
+++ b/packages/core/jkl/_typography.scss
@@ -3,6 +3,7 @@
 @use "sass:list";
 @use "screens";
 @use "tokens" as *;
+@use "responsive-units";
 
 /// Tilsvarer 16px
 /// @deprecated Bruk heller $typography-font-size-16
@@ -92,12 +93,14 @@ $text-styles: (
             "line-height": $typography-title-small-line-height,
             "font-weight": $typography-title-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-title-base-font-size,
             "line-height": $typography-title-base-line-height,
             "font-weight": $typography-title-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "title-small": (
@@ -106,12 +109,14 @@ $text-styles: (
             "line-height": $typography-title-small-small-line-height,
             "font-weight": $typography-title-small-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-title-small-base-font-size,
             "line-height": $typography-title-small-base-line-height,
             "font-weight": $typography-title-small-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-1": (
@@ -120,12 +125,14 @@ $text-styles: (
             "line-height": $typography-heading-1-small-line-height,
             "font-weight": $typography-heading-1-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-1-base-font-size,
             "line-height": $typography-heading-1-base-line-height,
             "font-weight": $typography-heading-1-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-2": (
@@ -134,12 +141,14 @@ $text-styles: (
             "line-height": $typography-heading-2-small-line-height,
             "font-weight": $typography-heading-2-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-2-base-font-size,
             "line-height": $typography-heading-2-base-line-height,
             "font-weight": $typography-heading-2-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-3": (
@@ -148,12 +157,14 @@ $text-styles: (
             "line-height": $typography-heading-3-small-line-height,
             "font-weight": $typography-heading-3-small-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-3-base-font-size,
             "line-height": $typography-heading-3-base-line-height,
             "font-weight": $typography-heading-3-base-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-4": (
@@ -176,12 +187,16 @@ $text-styles: (
             "line-height": $typography-heading-5-small-line-height,
             "font-weight": $typography-heading-5-small-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
         "large-screen": (
             "font-size": $typography-heading-5-base-font-size,
             "line-height": $typography-heading-5-base-line-height,
             "font-weight": $typography-heading-5-base-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
     ),
     "body": (
@@ -204,12 +219,16 @@ $text-styles: (
             "line-height": $typography-small-small-line-height,
             "font-weight": $typography-small-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
         "large-screen": (
             "font-size": $typography-small-base-font-size,
             "line-height": $typography-small-base-line-height,
             "font-weight": $typography-small-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
     ),
 );

--- a/packages/icons/icons.scss
+++ b/packages/icons/icons.scss
@@ -14,10 +14,10 @@
 
     font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
     font-variation-settings: "FILL" var(--jkl-icon-fill, 0), "GRAD" var(--jkl-icon-grade, 0),
-        "opsz" var(--jkl-icon-opsz, 20);
+        "opsz" var(--jkl-icon-opsz, 24);
     font-feature-settings: "liga";
     -webkit-font-feature-settings: "liga";
-    font-size: jkl.rem(24px);
+    font-size: var(--jkl-icon-size, #{jkl.rem(24px)});
     font-weight: var(--jkl-icon-weight, 300);
     line-height: 1;
     display: inline-block;
@@ -36,17 +36,17 @@
 
     &--medium {
         --jkl-icon-opsz: 24;
-        font-size: jkl.rem(24px);
+        --jkl-icon-size: #{jkl.rem(24px)};
     }
 
     &--small {
         --jkl-icon-opsz: 20;
-        font-size: jkl.rem(20px);
+        --jkl-icon-size: #{jkl.rem(20px)};
     }
 
     &--inherit {
         --jkl-icon-opsz: 20;
-        font-size: 1em;
+        --jkl-icon-size: 1.2em;
     }
 
     &--animated {

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -20,6 +20,11 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     --padding-icon-button: #{jkl.$spacing-4};
     --padding-tertiary-inline: #{jkl.$spacing-2};
     --padding-ghost-inline: #{jkl.$spacing-4};
+
+    @include jkl.text-style("small") {
+        --jkl-icon-weight: #{jkl.$icon-weight-bold};
+        font-weight: jkl.$typography-weight-bold;
+    }
 }
 
 .jkl-button {

--- a/packages/jokul/src/components/icon/styles/icon.scss
+++ b/packages/jokul/src/components/icon/styles/icon.scss
@@ -14,10 +14,10 @@
 
     font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
     font-variation-settings: "FILL" var(--jkl-icon-fill, 0), "GRAD" var(--jkl-icon-grade, 0),
-        "opsz" var(--jkl-icon-opsz, 20);
+        "opsz" var(--jkl-icon-opsz, 24);
     font-feature-settings: "liga";
     -webkit-font-feature-settings: "liga";
-    font-size: jkl.rem(24px);
+    font-size: var(--jkl-icon-size, #{jkl.rem(24px)});
     font-weight: var(--jkl-icon-weight, 300);
     line-height: 1;
     display: inline-block;
@@ -36,17 +36,17 @@
 
     &--medium {
         --jkl-icon-opsz: 24;
-        font-size: jkl.rem(24px);
+        --jkl-icon-size: #{jkl.rem(24px)};
     }
 
     &--small {
         --jkl-icon-opsz: 20;
-        font-size: jkl.rem(20px);
+        --jkl-icon-size: #{jkl.rem(20px)};
     }
 
     &--inherit {
         --jkl-icon-opsz: 20;
-        font-size: 1em;
+        --jkl-icon-size: 1.2em;
     }
 
     &--animated {

--- a/packages/jokul/src/core/jkl/_typography.scss
+++ b/packages/jokul/src/core/jkl/_typography.scss
@@ -3,6 +3,7 @@
 @use "sass:list";
 @use "screens";
 @use "tokens" as *;
+@use "responsive-units";
 
 /// Tilsvarer 16px
 /// @deprecated Bruk heller $typography-font-size-16
@@ -92,12 +93,14 @@ $text-styles: (
             "line-height": $typography-title-small-line-height,
             "font-weight": $typography-title-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-title-base-font-size,
             "line-height": $typography-title-base-line-height,
             "font-weight": $typography-title-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "title-small": (
@@ -106,12 +109,14 @@ $text-styles: (
             "line-height": $typography-title-small-small-line-height,
             "font-weight": $typography-title-small-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-title-small-base-font-size,
             "line-height": $typography-title-small-base-line-height,
             "font-weight": $typography-title-small-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-1": (
@@ -120,12 +125,14 @@ $text-styles: (
             "line-height": $typography-heading-1-small-line-height,
             "font-weight": $typography-heading-1-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-1-base-font-size,
             "line-height": $typography-heading-1-base-line-height,
             "font-weight": $typography-heading-1-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-2": (
@@ -134,12 +141,14 @@ $text-styles: (
             "line-height": $typography-heading-2-small-line-height,
             "font-weight": $typography-heading-2-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-2-base-font-size,
             "line-height": $typography-heading-2-base-line-height,
             "font-weight": $typography-heading-2-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-3": (
@@ -148,12 +157,14 @@ $text-styles: (
             "line-height": $typography-heading-3-small-line-height,
             "font-weight": $typography-heading-3-small-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": 1.2em,
         ),
         "large-screen": (
             "font-size": $typography-heading-3-base-font-size,
             "line-height": $typography-heading-3-base-line-height,
             "font-weight": $typography-heading-3-base-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": 1.2em,
         ),
     ),
     "heading-4": (
@@ -176,12 +187,16 @@ $text-styles: (
             "line-height": $typography-heading-5-small-line-height,
             "font-weight": $typography-heading-5-small-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
         "large-screen": (
             "font-size": $typography-heading-5-base-font-size,
             "line-height": $typography-heading-5-base-line-height,
             "font-weight": $typography-heading-5-base-font-weight,
             "--jkl-icon-weight": $icon-weight-bold,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
     ),
     "body": (
@@ -204,12 +219,16 @@ $text-styles: (
             "line-height": $typography-small-small-line-height,
             "font-weight": $typography-small-small-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
         "large-screen": (
             "font-size": $typography-small-base-font-size,
             "line-height": $typography-small-base-line-height,
             "font-weight": $typography-small-base-font-weight,
             "--jkl-icon-weight": $icon-weight-normal,
+            "--jkl-icon-size": responsive-units.rem(20px),
+            "--jkl-icon-opsz": 20,
         ),
     ),
 );


### PR DESCRIPTION
Fikser en bug der knappene hadde for stor tekst- og ikonstørrelse i kompakt modus.

Legger også til en generell tilknytning mellom tekststilene våre og ikonstørrelse (dersom størrelse ikke er satt på ikonet med props).

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
