### PR TITLE
fix: flytt action prop på topp for å unngå overskriving av props

### DIFF
--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -265,15 +265,16 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>((props, 
                             offset={8}
                         >
                             <Popover.Trigger
+                                {...action}
                                 data-testid="jkl-datepicker__trigger"
-                                title={showCalendar ? hideCalendarLabel : showCalendarLabel}
                                 className="jkl-text-input-action-button"
+                                title={showCalendar ? hideCalendarLabel : showCalendarLabel}
+                                tabIndex={0}
                                 onClick={clickCalendar}
                                 onKeyDown={handleKeyDownAction}
-                                tabIndex={0}
                                 asChild
                             >
-                                <IconButton {...action}>
+                                <IconButton>
                                     <CalendarIcon />
                                 </IconButton>
                             </Popover.Trigger>


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

Flyttet action-proppen til å være den første i komponenten, slik at den ikke overskriver onClick-events og andre props som kommer senere.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
