### PR TITLE
chore: copies .d.ts files to where we expect them to be

### DIFF
--- a/packages/jokul/vite.build.config.mjs
+++ b/packages/jokul/vite.build.config.mjs
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { cpSync } from "node:fs";
 import { extname, relative, resolve } from "path";
 import terser from "@rollup/plugin-terser";
 import react from "@vitejs/plugin-react-swc";
@@ -15,6 +16,13 @@ export default defineConfig({
         dts({
             include: ["src"],
             exclude: ["src/**/*.test.{ts,tsx}", "src/components/**/documentation/*"],
+            afterBuild() {
+                cpSync(
+                    resolve(fileURLToPath(new URL(".", import.meta.url)), "build", "packages", "jokul", "src"),
+                    resolve(fileURLToPath(new URL(".", import.meta.url)), "build"),
+                    { recursive: true },
+                );
+            },
         }),
         visualizer({
             emitFile: true,


### PR DESCRIPTION
The dts plugin has for unknown reasons suddenly decided to dump the generated files in a different subtree. This happens even with the exact same configuration and the exact same resolved version from npm so the only remaining explanation I can think of is that the amount of generated files prompted the plugin to change the output path. I can find no obvious way of telling it to do otherwise and I don't like this structure so for the time being this is a workaround


