### PR TITLE
fix: definer riktig returtype for useTooltip

### DIFF
--- a/packages/jokul/src/components/tooltip/Tooltip.tsx
+++ b/packages/jokul/src/components/tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import {
     type Placement,
+    type UseFloatingReturn,
     arrow,
     autoUpdate,
     flip,
@@ -42,12 +43,24 @@ export interface TooltipProps {
     triggerOn?: "click" | "hover";
 }
 
+type UseTooltipReturn = {
+    triggerOn: NonNullable<TooltipProps["triggerOn"]>;
+    isOpen: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    arrowElement: React.RefObject<HTMLElement>;
+    refs: {
+        description: React.MutableRefObject<HTMLElement | null>;
+        setDescription: (element: HTMLElement | null) => void;
+    } & UseFloatingReturn["refs"];
+} & UseFloatingReturn &
+    ReturnType<typeof useInteractions>;
+
 export const useTooltip = ({
     initialOpen = false,
     placement = "top",
     delay = 250,
     triggerOn = "hover",
-}: TooltipProps) => {
+}: TooltipProps): UseTooltipReturn => {
     const [isOpen, setOpen] = useState(initialOpen);
     const arrowElement = useRef<HTMLElement>(null);
     const description = useRef<HTMLElement | null>(null);


### PR DESCRIPTION
Denne fikser feilene/advarslene vi får under bygg om `useTooltip`. TL;DR: Vi burde alltid eksplisitt definere returtyper av funksjoner vi eksporterer ut fra biblioteket.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
