### PR TITLE
fix: button labels have the same width as the button

### DIFF
--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -33,6 +33,8 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     --border-radius: 0;
     --border-width: #{jkl.rem(1px)}; // For secondary og tertiary button
 
+    display: block;
+
     // button and link resets
     cursor: pointer;
     user-select: none;

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -71,6 +71,7 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     &__label {
         @include jkl.motion("standard", "expressive", translate);
 
+        width: 100%;
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -93,6 +94,7 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
         // Håndter tekster som er lenger enn knappen
         // Knappen vokser til teksten, men kan f.eks. begrenses
         // av sidebredde på mobil
+        width: 100%;
         max-width: 100%;
         overflow: hidden;
         white-space: nowrap;

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -33,6 +33,8 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     --border-radius: 0;
     --border-width: #{jkl.rem(1px)}; // For secondary og tertiary button
 
+    display: block;
+
     // button and link resets
     cursor: pointer;
     user-select: none;

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -71,6 +71,7 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     &__label {
         @include jkl.motion("standard", "expressive", translate);
 
+        width: 100%;
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -93,6 +94,7 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
         // Håndter tekster som er lenger enn knappen
         // Knappen vokser til teksten, men kan f.eks. begrenses
         // av sidebredde på mobil
+        width: 100%;
         max-width: 100%;
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
This ensures the text stays centered even if the button is very very wide

ISSUES CLOSED: #4259

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
