### PR TITLE
fix: fikset medium og large device i useScreen

### DIFF
--- a/packages/jokul/src/hooks/useScreen/useScreen.ts
+++ b/packages/jokul/src/hooks/useScreen/useScreen.ts
@@ -9,10 +9,19 @@ import { ScreenAction, ActionType, reducer, ScreenState } from "./state.js";
 
 const { breakpoint } = tokens;
 
+const breakpointsAsNumber = (breakpoint: string): number =>
+    parseInt(breakpoint.replace("px", ""));
+
 const MEDIA_RULES: Record<keyof ScreenState, string> = {
-    isSmallDevice: `(max-width: calc(${breakpoint.medium} - 1px))`,
-    isMediumDevice: `(min-width: ${breakpoint.medium}) and (max-width: calc(${breakpoint.large} -1px))`,
-    isLargeDevice: `(min-width: ${breakpoint.large}) and (max-width: calc(${breakpoint.xl} -1px))`,
+    isSmallDevice: `(max-width: ${
+        breakpointsAsNumber(breakpoint.medium) - 1
+    }px))`,
+    isMediumDevice: `(min-width: ${breakpoint.medium}) and (max-width: ${
+        breakpointsAsNumber(breakpoint.large) - 1
+    }px)`,
+    isLargeDevice: `(min-width: ${breakpoint.large}) and (max-width: ${
+        breakpointsAsNumber(breakpoint.xl) - 1
+    }px)`,
     isXlDevice: `(min-width: ${breakpoint.xl})`,
     isPortrait: "(orientation: portrait)",
     isLandscape: "(orientation: landscape)",


### PR DESCRIPTION
Ser ut som om medium og large device ikke fungerer i useScreen. 
Har ikke fått testet denne fordi det er noe som tryner under bygg lokalt, så fint om noen kan teste denne før den merges inn

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
