### PR TITLE
fix: la bruker interagere med åpent PopupTip

### DIFF
--- a/packages/jokul/src/components/tooltip/Tooltip.tsx
+++ b/packages/jokul/src/components/tooltip/Tooltip.tsx
@@ -84,9 +84,9 @@ const useTooltip = ({
     });
 
     const role = useRole(data.context, { role: "tooltip" });
-    const dismiss = useDismiss(data.context, { referencePress: false });
+    const dismiss = useDismiss(data.context);
     const click = useClick(data.context, {
-        enabled: triggerOn === "click" && !isOpen,
+        enabled: triggerOn === "click",
     });
     const hover = useHover(data.context, {
         enabled: triggerOn === "hover",

--- a/packages/jokul/src/components/tooltip/TooltipTrigger.tsx
+++ b/packages/jokul/src/components/tooltip/TooltipTrigger.tsx
@@ -5,7 +5,7 @@ import { useTooltipContext } from "./Tooltip.js";
 
 export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
     function TooltipTrigger({ children, className, ...props }, forwardedRef) {
-        const { isOpen, setOpen, getReferenceProps, refs, triggerOn } =
+        const { isOpen, getReferenceProps, refs, triggerOn } =
             useTooltipContext();
         const childrenRef = (children as any).ref;
         const ref = useMergeRefs([
@@ -13,10 +13,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
             refs.setReference,
             forwardedRef,
         ]);
-
-        const handleBlur = () => {
-            triggerOn === "click" && setOpen(false);
-        };
 
         const filterMaterialSymbols = (
             maybeText: string | null | undefined,
@@ -44,10 +40,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
                     "data-tooltip-shown": isOpen,
                     style: { ...children.props.style },
                     tabIndex: triggerOn === "click" ? 0 : undefined,
-                    onBlur: () => {
-                        children.props.onBlur && children.props.onBlur();
-                        handleBlur();
-                    },
                 }),
             );
         }
@@ -60,7 +52,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
                     // Sørg for at vi ikke sender inn skjemaer ved klikk på knappen
                     type: "button",
                     ref,
-                    onBlur: handleBlur,
                     "aria-label": ariaLabel,
                     ...props,
                 })}

--- a/packages/tooltip-react/src/Tooltip.tsx
+++ b/packages/tooltip-react/src/Tooltip.tsx
@@ -71,9 +71,9 @@ export const useTooltip = ({
     });
 
     const role = useRole(data.context, { role: "tooltip" });
-    const dismiss = useDismiss(data.context, { referencePress: false });
+    const dismiss = useDismiss(data.context);
     const click = useClick(data.context, {
-        enabled: triggerOn === "click" && !isOpen,
+        enabled: triggerOn === "click",
     });
     const hover = useHover(data.context, {
         enabled: triggerOn === "hover",

--- a/packages/tooltip-react/src/TooltipTrigger.tsx
+++ b/packages/tooltip-react/src/TooltipTrigger.tsx
@@ -5,7 +5,7 @@ import { useTooltipContext } from "./Tooltip";
 
 export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
     function TooltipTrigger({ children, className, ...props }, forwardedRef) {
-        const { isOpen, setOpen, getReferenceProps, refs, triggerOn } =
+        const { isOpen, getReferenceProps, refs, triggerOn } =
             useTooltipContext();
         const childrenRef = (children as any).ref;
         const ref = useMergeRefs([
@@ -13,10 +13,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
             refs.setReference,
             forwardedRef,
         ]);
-
-        const handleBlur = () => {
-            triggerOn === "click" && setOpen(false);
-        };
 
         const filterMaterialSymbols = (
             maybeText: string | null | undefined,
@@ -44,10 +40,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
                     "data-tooltip-shown": isOpen,
                     style: { ...children.props.style },
                     tabIndex: triggerOn === "click" ? 0 : undefined,
-                    onBlur: () => {
-                        children.props.onBlur && children.props.onBlur();
-                        handleBlur();
-                    },
                 }),
             );
         }
@@ -60,7 +52,6 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement>>(
                     // Sørg for at vi ikke sender inn skjemaer ved klikk på knappen
                     type: "button",
                     ref,
-                    onBlur: handleBlur,
                     "aria-label": ariaLabel,
                     ...props,
                 })}


### PR DESCRIPTION
Gjør det mulig å interagere med innholdet i `PopupTip` når det er åpent. Gjør det også mulig å lukke `PopupTip` ved å klikke på spørsmålstegnet.

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
