### PR TITLE
fix: fjernet ekstra parantes

### DIFF
--- a/packages/jokul/src/hooks/useScreen/useScreen.ts
+++ b/packages/jokul/src/hooks/useScreen/useScreen.ts
@@ -15,11 +15,11 @@ const breakpointsAsNumber = (breakpoint: string): number =>
 const MEDIA_RULES: Record<keyof ScreenState, string> = {
     isSmallDevice: `(max-width: ${
         breakpointsAsNumber(breakpoint.medium) - 1
-    }px))`,
+    }px)`,
     isMediumDevice: `(min-width: ${breakpoint.medium}) and (max-width: ${
         breakpointsAsNumber(breakpoint.large) - 1
     }px)`,
-    isLargeDevice: `(min-width: ${breakpoint.large}) and (max-width: ${
+    isLargeDevice: `(min-width: ${breakpoint.large}) and (max-width: $a{
         breakpointsAsNumber(breakpoint.xl) - 1
     }px)`,
     isXlDevice: `(min-width: ${breakpoint.xl})`,


### PR DESCRIPTION
En ekstra parantes gjorde at ikke smallScreen fungerte

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
