### PR TITLE
Eksponer onOpenChange-funksjon for Tooltip

### DIFF
--- a/packages/jokul/src/components/tooltip/PopupTip.tsx
+++ b/packages/jokul/src/components/tooltip/PopupTip.tsx
@@ -1,11 +1,5 @@
 import clsx from "clsx";
-import React, {
-    FocusEventHandler,
-    HTMLProps,
-    useState,
-    type FC,
-    type ReactNode,
-} from "react";
+import React, { HTMLProps, useState, type FC, type ReactNode } from "react";
 import { QuestionIcon } from "../icon/icons/QuestionIcon.js";
 import { Tooltip, type TooltipProps } from "./Tooltip.js";
 import { TooltipContent } from "./TooltipContent.js";
@@ -30,22 +24,11 @@ export const PopupTip: FC<PopupTipProps> = ({
 }) => {
     const [isBold, setIsBold] = useState(false);
 
-    const handleFocus: FocusEventHandler<HTMLButtonElement> = (event) => {
-        setIsBold(true);
-        triggerProps?.onFocus?.(event);
-    };
-    const handleBlur: FocusEventHandler<HTMLButtonElement> = (event) => {
-        setIsBold(false);
-        triggerProps?.onBlur?.(event);
-    };
-
     return (
-        <Tooltip triggerOn="click" {...tooltipProps}>
+        <Tooltip onOpenChange={setIsBold} triggerOn="click" {...tooltipProps}>
             <TooltipTrigger>
                 <button
                     {...triggerProps}
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
                     type="button"
                     className={clsx(
                         "jkl-tooltip-question-button",

--- a/packages/jokul/src/components/tooltip/Tooltip.tsx
+++ b/packages/jokul/src/components/tooltip/Tooltip.tsx
@@ -29,6 +29,11 @@ export interface TooltipProps {
      */
     initialOpen?: boolean;
     /**
+     * En funksjon som skal kalles når Tooltip åpnes eller lukkes
+     * @param open Hvorvidt tooltip endres til å være åpen eller ikke
+     */
+    onOpenChange?: (open: boolean) => void;
+    /**
      * Plassering av tooltipen i forhold til triggeren. Tooltipen vil automatisk
      * bytte posisjon dersom det ikke er plass.
      * @default "top"
@@ -63,6 +68,7 @@ const useTooltip = ({
     placement = "top",
     delay = 250,
     triggerOn = "hover",
+    onOpenChange,
 }: TooltipProps): UseTooltipReturn => {
     const [isOpen, setOpen] = useState(initialOpen);
     const arrowElement = useRef<SVGSVGElement>(null);
@@ -72,7 +78,10 @@ const useTooltip = ({
 
     const data = useFloating({
         open: isOpen,
-        onOpenChange: setOpen,
+        onOpenChange: (open) => {
+            onOpenChange?.(open);
+            setOpen(open);
+        },
         placement,
         whileElementsMounted: autoUpdate,
         middleware: [

--- a/packages/jokul/src/components/tooltip/documentation/TooltipExample.tsx
+++ b/packages/jokul/src/components/tooltip/documentation/TooltipExample.tsx
@@ -18,6 +18,10 @@ export const TooltipExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
     const [copied, setCopied] = useState(false);
     const kontonummer = "16024454979";
 
+    function logState(open: boolean) {
+        console.log(`Tooltip er ${open ? "åpen" : "lukket"}`);
+    }
+
     function copyToClipboard() {
         navigator.clipboard.writeText(kontonummer);
         setCopied(true);
@@ -27,7 +31,11 @@ export const TooltipExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
     return (
         <p>
             Kontonummer: {formatKontonummer(kontonummer)}
-            <Tooltip placement={initialPlacement} delay={delay}>
+            <Tooltip
+                onOpenChange={logState}
+                placement={initialPlacement}
+                delay={delay}
+            >
                 <TooltipTrigger onClick={copyToClipboard}>
                     <Button
                         className="jkl-spacing-8--left"

--- a/packages/tooltip-react/documentation/TooltipExample.tsx
+++ b/packages/tooltip-react/documentation/TooltipExample.tsx
@@ -21,6 +21,10 @@ export const TooltipExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
     const [copied, setCopied] = useState(false);
     const kontonummer = "16024454979";
 
+    function logState(open: boolean) {
+        console.log(`Tooltip er ${open ? "åpen" : "lukket"}`);
+    }
+
     function copyToClipboard() {
         navigator.clipboard.writeText(kontonummer);
         setCopied(true);
@@ -30,7 +34,11 @@ export const TooltipExample: FC<ExampleComponentProps> = ({ choiceValues }) => {
     return (
         <p>
             Kontonummer: {formatKontonummer(kontonummer)}
-            <Tooltip placement={initialPlacement} delay={delay}>
+            <Tooltip
+                onOpenChange={logState}
+                placement={initialPlacement}
+                delay={delay}
+            >
                 <TooltipTrigger onClick={copyToClipboard}>
                     <Button
                         className="jkl-spacing-8--left"
@@ -71,6 +79,10 @@ export const tooltipExampleCode = ({
 }: ExampleComponentProps): string => `const [copied, setCopied] = useState(false);
 const kontonummer = "16024454979";
 
+function logState(open: boolean) {
+    console.log(\`Tooltip er \${open ? "åpen" : "lukket"}\`);
+}
+
 function copyToClipboard() {
     navigator.clipboard.writeText(kontonummer);
     setCopied(true);
@@ -80,9 +92,11 @@ function copyToClipboard() {
 return (
     <p>
         Kontonummer:{" "}
-        <Tooltip placement="${getPlacement(
-            choiceValues?.["Plassering"],
-        )}" delay={${choiceValues?.["Forsinkelse (ms)"] || 250}}>
+        <Tooltip
+            onOpenChange={logState}
+            placement="${getPlacement(choiceValues?.["Plassering"])}"
+            delay={${choiceValues?.["Forsinkelse (ms)"] || 250}}
+        >
             <TooltipTrigger onClick={copyToClipboard}>{formatKontonummer(kontonummer)}</TooltipTrigger>
             <TooltipContent>
                 {copied ? <span aria-live="assertive">Kopiert</span> : "Klikk for å kopiere til utklippstavlen"}

--- a/packages/tooltip-react/src/PopupTip.tsx
+++ b/packages/tooltip-react/src/PopupTip.tsx
@@ -1,12 +1,6 @@
 import { QuestionIcon } from "@fremtind/jkl-icons-react";
 import cn from "classnames";
-import React, {
-    useState,
-    type FC,
-    type ReactNode,
-    HTMLProps,
-    FocusEventHandler,
-} from "react";
+import React, { HTMLProps, useState, type FC, type ReactNode } from "react";
 import { Tooltip, type TooltipProps } from "./Tooltip";
 import { TooltipContent } from "./TooltipContent";
 import { TooltipTrigger } from "./TooltipTrigger";
@@ -30,22 +24,11 @@ export const PopupTip: FC<PopupTipProps> = ({
 }) => {
     const [isBold, setIsBold] = useState(false);
 
-    const handleFocus: FocusEventHandler<HTMLButtonElement> = (event) => {
-        setIsBold(true);
-        triggerProps?.onFocus?.(event);
-    };
-    const handleBlur: FocusEventHandler<HTMLButtonElement> = (event) => {
-        setIsBold(false);
-        triggerProps?.onBlur?.(event);
-    };
-
     return (
-        <Tooltip triggerOn="click" {...tooltipProps}>
+        <Tooltip onOpenChange={setIsBold} triggerOn="click" {...tooltipProps}>
             <TooltipTrigger>
                 <button
                     {...triggerProps}
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
                     type="button"
                     className={cn(
                         "jkl-tooltip-question-button",

--- a/packages/tooltip-react/src/Tooltip.tsx
+++ b/packages/tooltip-react/src/Tooltip.tsx
@@ -28,6 +28,11 @@ export interface TooltipProps {
      */
     initialOpen?: boolean;
     /**
+     * En funksjon som skal kalles når Tooltip åpnes eller lukkes
+     * @param open Hvorvidt tooltip endres til å være åpen eller ikke
+     */
+    onOpenChange?: (open: boolean) => void;
+    /**
      * Plassering av tooltipen i forhold til triggeren. Tooltipen vil automatisk
      * bytte posisjon dersom det ikke er plass.
      * @default "top"


### PR DESCRIPTION
- Eksponer `onOpenChange`-funksjonen fra FloatingUI i `Tooltip` som en prop.
- Fiks en bug introdusert i #4280 der `PopupTip` sitt ikon forble bold når man lukket tipset ved klikk på ikonet

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
