### PR TITLE
fix: sørg for at vi tar med undermapper når vi bygger stiler

### DIFF
--- a/packages/jokul/build-styles.mjs
+++ b/packages/jokul/build-styles.mjs
@@ -24,8 +24,9 @@ import * as sass from "sass-embedded";
                         new URL(source, import.meta.url),
                     );
                     const outDirName = sourcePath
-                        .substring(0, sourcePath.lastIndexOf("/styles/"))
-                        .replace("/src", "/styles");
+                        .replace("/styles/", "/") // Fjern styles-mappa inne i komponenten
+                        .replace(/\/[\w-]+.scss/, "") // Fjern filnavn og siste slash
+                        .replace("/src", "/styles"); // Flytt til mappen styles på rot
 
                     const content = sass.compile(sourcePath);
                     mkdirSync(outDirName, { recursive: true });
@@ -77,15 +78,11 @@ import * as sass from "sass-embedded";
                         const sourcePath = fileURLToPath(
                             new URL(source, import.meta.url),
                         );
-                        const cutPoint = sourcePath.lastIndexOf("/styles/");
+
                         const outDirName = sourcePath
-                            .substring(
-                                0,
-                                cutPoint > 0
-                                    ? cutPoint
-                                    : sourcePath.lastIndexOf("/"),
-                            )
-                            .replace("/src", "/styles");
+                            .replace("/styles/", "/") // Fjern styles-mappa inne i komponenten
+                            .replace(/\/[\w-]+.scss/, "") // Fjern filnavn og siste slash
+                            .replace("/src", "/styles"); // Flytt til mappen styles på rot
 
                         mkdirSync(outDirName, { recursive: true });
 

--- a/packages/jokul/src/components/expander/styles/_index.scss
+++ b/packages/jokul/src/components/expander/styles/_index.scss
@@ -1,5 +1,5 @@
 @forward "expandable";
-@forward "./deprecated/expander.scss";
+@forward "./deprecated/expander";
 
 // Expander-komponenten avhenger av de følgende pakkene
 @use "../../icon/styles";


### PR DESCRIPTION
Fikser en bug der mappestrukturen inne i `styles`-mappa i komponentene i `jokul` ble fjernet når man bygget stiler. Dermed blir f.eks. `components/expander/styles/deprecated/expander.scss` flyttet til `styles/components/expander/expander.scss`, noe som vil kunne ødelegge relative importer innad i Sass-filene.

## 🎯 Sjekkliste

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
