### PR TITLE
chore: fix list of assignees for monthly github action

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Create issue to upgrade dependencies
               uses: imjohnbo/issue-bot@76645b39cda009302cc49d8624af634795e9eab5
               with:
-                  assignees: "wkillerud, piofinn, fremtindelise"
+                  assignees: "zenabii, kristianulv23, piofinn, fremtindelise, ivarni"
                   rotate-assignees: true
                   labels: "🔁 round robin, 🔗 dependencies"
                   close-previous: true


### PR DESCRIPTION
Denne har feilet siden 1. oktober 2023

https://github.com/fremtind/jokul/actions/workflows/monthly.yml

All den tid ingen har savnet den kan man jo undres på om det er verdt å fikse det men gjør det likevel :)