### PR TITLE
feat: allows sending props to inner TextInput

### DIFF
--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -56,6 +56,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             hideCalendarLabel = "Lukk kalender",
             supportLabelProps,
             tooltip,
+            textInputProps,
             ...rest
         } = props;
 
@@ -324,6 +325,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                                 </Popover.Content>
                             </Popover>
                         }
+                        {...textInputProps}
                         {...inputProps}
                     />
                 )}

--- a/packages/datepicker-react/src/types.ts
+++ b/packages/datepicker-react/src/types.ts
@@ -8,6 +8,7 @@ import type {
     KeyboardEvent,
     FocusEvent,
     ButtonHTMLAttributes,
+    ComponentProps,
 } from "react";
 
 export type DateValidationError =
@@ -294,6 +295,23 @@ export interface DatePickerProps
     action?: DatePickerAction;
     showCalendarLabel?: string;
     hideCalendarLabel?: string;
+    /**
+     * Props som sendes direkte til komponentens TextInput
+     */
+    textInputProps?: Omit<
+        ComponentProps<"input">,
+        | "type"
+        | "children"
+        | "className"
+        | "name"
+        | "defaultValue"
+        | "value"
+        | "placeholder"
+        | "width"
+        | "onFocus"
+        | "onBlur"
+        | "onChange"
+    >;
 }
 
 export interface DatePickerAction

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -56,6 +56,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             hideCalendarLabel = "Lukk kalender",
             supportLabelProps,
             tooltip,
+            textInputProps,
             ...rest
         } = props;
 
@@ -324,6 +325,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                                 </Popover.Content>
                             </Popover>
                         }
+                        {...textInputProps}
                         {...inputProps}
                     />
                 )}

--- a/packages/jokul/src/components/datepicker/types.ts
+++ b/packages/jokul/src/components/datepicker/types.ts
@@ -1,6 +1,7 @@
 import type {
     ButtonHTMLAttributes,
     ChangeEvent,
+    ComponentProps,
     FocusEvent,
     KeyboardEvent,
 } from "react";
@@ -292,6 +293,23 @@ export interface DatePickerProps
     action?: DatePickerAction;
     showCalendarLabel?: string;
     hideCalendarLabel?: string;
+    /**
+     * Props som sendes direkte til komponentens TextInput
+     */
+    textInputProps?: Omit<
+        ComponentProps<"input">,
+        | "type"
+        | "children"
+        | "className"
+        | "name"
+        | "defaultValue"
+        | "value"
+        | "placeholder"
+        | "width"
+        | "onFocus"
+        | "onBlur"
+        | "onChange"
+    >;
 }
 
 export interface DatePickerAction


### PR DESCRIPTION
It's now possible to use `textInputProps` on `DatePicker` to send props directly to the component's inner `TextInput` component.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
