### PR TITLE
fix: makes cascading of layout density work again

### DIFF
--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -4,40 +4,40 @@
 @use "../../../core/jkl";
 @use "../../../core/jkl/colors";
 
+@include jkl.compact-density-variables {
+    --jkl-select-input-height: #{jkl.rem(32px)};
+    --jkl-select-arrow-right: #{jkl.rem(4px)};
+    --jkl-select-button-padding: #{jkl.$spacing-4} #{jkl.$spacing-32} #{jkl.$spacing-4}
+        #{jkl.$spacing-8};
+    --jkl-select-search-input-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
+    --jkl-select-native-padding: #{jkl.$spacing-4} #{jkl.$spacing-24} #{jkl.$spacing-4}
+        #{jkl.$spacing-4};
+    --jkl-select-option-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
+
+    @include jkl.declare-font-variables("jkl-select", "small");
+}
+
+@include jkl.comfortable-density-variables {
+    --jkl-select-input-height: #{jkl.rem(48px)};
+    --jkl-select-arrow-right: #{jkl.$spacing-8};
+    --jkl-select-button-padding: #{jkl.$spacing-8} #{jkl.rem(36px)} #{jkl.$spacing-8}
+        #{jkl.$spacing-12};
+    --jkl-select-search-input-padding: var(--jkl-select-button-padding);
+    --jkl-select-native-padding: 0 #{jkl.$spacing-40} 0 #{jkl.$spacing-8};
+    --jkl-select-option-padding: #{jkl.$spacing-8} #{jkl.$spacing-12};
+
+    @include jkl.declare-font-variables("jkl-select", "body");
+
+    @include jkl.small-device {
+        --jkl-select-input-height: #{jkl.rem(44px)};
+    }
+}
+
 .jkl-select {
     display: block;
     position: relative;
 
     @include jkl.reset-outline;
-
-    @include jkl.comfortable-density {
-        --jkl-select-input-height: #{jkl.rem(48px)};
-        --jkl-select-arrow-right: #{jkl.$spacing-8};
-        --jkl-select-button-padding: #{jkl.$spacing-8} #{jkl.rem(36px)} #{jkl.$spacing-8}
-            #{jkl.$spacing-12};
-        --jkl-select-search-input-padding: var(--jkl-select-button-padding);
-        --jkl-select-native-padding: 0 #{jkl.$spacing-40} 0 #{jkl.$spacing-8};
-        --jkl-select-option-padding: #{jkl.$spacing-8} #{jkl.$spacing-12};
-
-        @include jkl.declare-font-variables("jkl-select", "body");
-
-        @include jkl.small-device {
-            --jkl-select-input-height: #{jkl.rem(44px)};
-        }
-    }
-
-    @include jkl.compact-density {
-        --jkl-select-input-height: #{jkl.rem(32px)};
-        --jkl-select-arrow-right: #{jkl.rem(4px)};
-        --jkl-select-button-padding: #{jkl.$spacing-4} #{jkl.$spacing-32} #{jkl.$spacing-4}
-            #{jkl.$spacing-8};
-        --jkl-select-search-input-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
-        --jkl-select-native-padding: #{jkl.$spacing-4} #{jkl.$spacing-24} #{jkl.$spacing-4}
-            #{jkl.$spacing-4};
-        --jkl-select-option-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
-
-        @include jkl.declare-font-variables("jkl-select", "small");
-    }
 
     & *:focus {
         outline: none;

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -4,40 +4,40 @@
 @use "@fremtind/jkl-core/jkl";
 @use "@fremtind/jkl-core/jkl/colors";
 
+@include jkl.comfortable-density-variables {
+    --jkl-select-input-height: #{jkl.rem(48px)};
+    --jkl-select-arrow-right: #{jkl.$spacing-8};
+    --jkl-select-button-padding: #{jkl.$spacing-8} #{jkl.rem(36px)} #{jkl.$spacing-8}
+        #{jkl.$spacing-12};
+    --jkl-select-search-input-padding: var(--jkl-select-button-padding);
+    --jkl-select-native-padding: 0 #{jkl.$spacing-40} 0 #{jkl.$spacing-8};
+    --jkl-select-option-padding: #{jkl.$spacing-8} #{jkl.$spacing-12};
+
+    @include jkl.declare-font-variables("jkl-select", "body");
+
+    @include jkl.small-device {
+        --jkl-select-input-height: #{jkl.rem(44px)};
+    }
+}
+
+@include jkl.compact-density-variables {
+    --jkl-select-input-height: #{jkl.rem(32px)};
+    --jkl-select-arrow-right: #{jkl.rem(4px)};
+    --jkl-select-button-padding: #{jkl.$spacing-4} #{jkl.$spacing-32} #{jkl.$spacing-4}
+        #{jkl.$spacing-8};
+    --jkl-select-search-input-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
+    --jkl-select-native-padding: #{jkl.$spacing-4} #{jkl.$spacing-24} #{jkl.$spacing-4}
+        #{jkl.$spacing-4};
+    --jkl-select-option-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
+
+    @include jkl.declare-font-variables("jkl-select", "small");
+}
+
 .jkl-select {
     display: block;
     position: relative;
 
     @include jkl.reset-outline;
-
-    @include jkl.comfortable-density {
-        --jkl-select-input-height: #{jkl.rem(48px)};
-        --jkl-select-arrow-right: #{jkl.$spacing-8};
-        --jkl-select-button-padding: #{jkl.$spacing-8} #{jkl.rem(36px)} #{jkl.$spacing-8}
-            #{jkl.$spacing-12};
-        --jkl-select-search-input-padding: var(--jkl-select-button-padding);
-        --jkl-select-native-padding: 0 #{jkl.$spacing-40} 0 #{jkl.$spacing-8};
-        --jkl-select-option-padding: #{jkl.$spacing-8} #{jkl.$spacing-12};
-
-        @include jkl.declare-font-variables("jkl-select", "body");
-
-        @include jkl.small-device {
-            --jkl-select-input-height: #{jkl.rem(44px)};
-        }
-    }
-
-    @include jkl.compact-density {
-        --jkl-select-input-height: #{jkl.rem(32px)};
-        --jkl-select-arrow-right: #{jkl.rem(4px)};
-        --jkl-select-button-padding: #{jkl.$spacing-4} #{jkl.$spacing-32} #{jkl.$spacing-4}
-            #{jkl.$spacing-8};
-        --jkl-select-search-input-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
-        --jkl-select-native-padding: #{jkl.$spacing-4} #{jkl.$spacing-24} #{jkl.$spacing-4}
-            #{jkl.$spacing-4};
-        --jkl-select-option-padding: #{jkl.$spacing-4} #{jkl.$spacing-8};
-
-        @include jkl.declare-font-variables("jkl-select", "small");
-    }
 
     & *:focus {
         outline: none;


### PR DESCRIPTION
Temporarily switches back to old deprecated mixins for density as they handle cascading better

Relates to #4340

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
