### PR TITLE
chore: endre import for fs og path

### DIFF
--- a/portalen/apps/cms/src/database/postgresAdapter.ts
+++ b/portalen/apps/cms/src/database/postgresAdapter.ts
@@ -1,12 +1,12 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
+import fs from "fs";
+import path from "path";
 import { Signer } from "@aws-sdk/rds-signer";
 import { postgresAdapter } from "@payloadcms/db-postgres";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const ca = readFileSync(path.join(__dirname, "cacert.pem"), "utf-8");
+const ca = fs.readFileSync(path.join(__dirname, "cacert.pem"), "utf-8");
 
 const signer = new Signer({
     hostname: process.env.DB_HOST || "",


### PR DESCRIPTION
Det virker som Docker-miljøet ikke liker node-imports på formen `node:fs`. Forsøker å endre til kun `fs`, etc.