### PR TITLE
fix: Sikre gyldig fallback for floatingPortalRef i Popover-komponenten

### DIFF
--- a/packages/jokul/src/components/modal/Modal.tsx
+++ b/packages/jokul/src/components/modal/Modal.tsx
@@ -25,7 +25,7 @@ export const ModalContainer = forwardRef<
     HTMLDivElement,
     ModalConfig["container"] & BaseModalProps
 >(({ className, ...rest }, ref) => {
-    // TODO: 'data-portal' fjernes når modalen tar i bruk Popover komponenten
+    // TODO: 'data-portal' fjernes når modalen tar i bruk Popover komponenten. Issue: https://github.com/fremtind/jokul/issues/4356
     return (
         <div
             className={clsx("jkl-modal-container", className)}

--- a/packages/jokul/src/components/popover/Popover.tsx
+++ b/packages/jokul/src/components/popover/Popover.tsx
@@ -329,7 +329,7 @@ const PopoverContent = React.forwardRef<
 
     const floatingPortalRef = React.useRef<HTMLElement | null>(null);
 
-    // TODO: Løser et problem hvor nestede portaler ikke "fester" seg til det nærmeste portal-elementet. Fjernes når alle komponenter som rendres i en portal tar i bruk popover komponenten da den håndterer dette internt.
+    // TODO: Løser et problem hvor nestede portaler ikke "fester" seg til det nærmeste portal-elementet. Fjernes når alle komponenter som rendres i en portal tar i bruk popover komponenten da den håndterer dette internt. Issue: https://github.com/fremtind/jokul/issues/4356
     React.useEffect(() => {
         floatingPortalRef.current =
             context.elements.domReference?.closest<HTMLElement>(

--- a/packages/modal-react/src/Modal.tsx
+++ b/packages/modal-react/src/Modal.tsx
@@ -28,7 +28,7 @@ export const ModalContainer = forwardRef<
     HTMLDivElement,
     ModalConfig["container"] & BaseModalProps
 >(({ className, ...rest }, ref) => {
-    // TODO: 'data-portal' fjernes når modalen tar i bruk Popover komponenten
+    // TODO: 'data-portal' fjernes når modalen tar i bruk Popover komponenten. Issue: https://github.com/fremtind/jokul/issues/4356
     return (
         <div
             className={cn("jkl-modal-container", className)}

--- a/packages/popover-react/src/Popover.tsx
+++ b/packages/popover-react/src/Popover.tsx
@@ -329,7 +329,7 @@ const PopoverContent = React.forwardRef<
 
     const floatingPortalRef = React.useRef<HTMLElement | null>(null);
 
-    // TODO: Løser et problem hvor nestede portaler ikke "fester" seg til det nærmeste portal-elementet. Fjernes når alle komponenter som rendres i en portal tar i bruk popover komponenten da den håndterer dette internt.
+    // TODO: Løser et problem hvor nestede portaler ikke "fester" seg til det nærmeste portal-elementet. Fjernes når alle komponenter som rendres i en portal tar i bruk popover komponenten da den håndterer dette internt. Issue: https://github.com/fremtind/jokul/issues/4356
     React.useEffect(() => {
         floatingPortalRef.current =
             context.elements.domReference?.closest<HTMLElement>(


### PR DESCRIPTION
Problem: Det oppstod en feil i Popover-komponenten når context.elements.domReference?.closest ikke fant et element med attributtet [data-portal]. Dette resulterte i at floatingPortalRef.current ble satt til null, noe som forhindret at portalen ble rendret.

Løsning: La til document.body som fallback-verdi dersom closest ikke finner et gyldig element. Dette sikrer at portalen alltid har et referansepunkt.

- Closes: #4353 