### PR TITLE
docs: fjern referanser til Tag i dokumentasjon for Combobox

### DIFF
--- a/packages/combobox-react/README.md
+++ b/packages/combobox-react/README.md
@@ -16,7 +16,7 @@ import { Combobox } from "@fremtind/jkl-combobox-react";
 import "@fremtind/jkl-combobox/combobox.min.css";
 import "@fremtind/jkl-icons/icons.min.css";
 import "@fremtind/jkl-input-group/input-group.min.css";
-import "@fremtind/jkl-tag/tag.min.css";
+import "@fremtind/jkl-chip/chip.min.css";
 import "@fremtind/jkl-icon-button/icon-button.min.css";
 ```
 
@@ -25,6 +25,6 @@ import "@fremtind/jkl-icon-button/icon-button.min.css";
 @use "@fremtind/jkl-combobox/combobox";
 @use "@fremtind/jkl-icons/icons";
 @use "@fremtind/jkl-input-group/input-group";
-@use "@fremtind/jkl-tag/tag";
+@use "@fremtind/jkl-chip/chip";
 @use "@fremtind/jkl-icon-button/icon-button";
 ```

--- a/packages/combobox-react/documentation/Combobox.mdx
+++ b/packages/combobox-react/documentation/Combobox.mdx
@@ -32,7 +32,7 @@ Hvis det trengs, kan du legge en hjelpetekst under listen for å forklare mer.
 
 Hvis nedtrekkslisten ikke validerer, viser systemet en feilmelding som forklarer hva som er galt. Feilmeldingen erstatter en eventuell hjelpetekst, så den må eventuelt gjenta informasjonen fra hjelpeteksten.
 
-Valgte alternativer vises i inputfeltet som [Tags](/komponenter/tag). Hvis teksten i tagen består av mer enn 10 karakterer, anbefaler vi at du bruker `tagLabel`.
+Valgte alternativer vises i inputfeltet som [Chips](/komponenter/chip). Hvis teksten til alternativet består av mer enn 10 karakterer, bør du vurdere å bruke `tagLabel` for å angi en kortere tekst som brukes i chip-en. Den fulle teksten til alternativet vil vises som et [Tooltip](/komponenter/tooltip) ved hover.
 
 ## Når bruker vi Combobox?
 


### PR DESCRIPTION
closes #4365 