### PR TITLE
fix: returns focus to main element after selection

### DIFF
--- a/packages/jokul/src/components/select/Select.test.tsx
+++ b/packages/jokul/src/components/select/Select.test.tsx
@@ -1270,6 +1270,33 @@ describe("Searchable select", () => {
 
         expect(listbox).not.toBeVisible();
     });
+
+    it("should return focus to the input when an option is selected", async () => {
+        const items = [
+            { label: "foo", value: "1" },
+            { label: "bar", value: "2" },
+            { label: "baz", value: "3" },
+        ];
+
+        const screen = setup(
+            <Select
+                name="items"
+                items={items}
+                label="Ting"
+                tooltip={
+                    <PopupTip content="Jeg er en tooltip" placement="left" />
+                }
+            />,
+        );
+
+        const button = screen.getByTestId("jkl-select__button");
+        await userEvent.click(button);
+
+        const option = screen.getAllByTestId("jkl-select__option")[0];
+        await userEvent.click(option);
+
+        expect(button).toHaveFocus();
+    });
 });
 
 describe("a11y", () => {

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -222,6 +222,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                 setSearchValue("");
                 setSelectedValue(nextValue);
                 toggleListVisibility();
+                buttonRef.current?.focus();
             },
             [setSearchValue, setSelectedValue, toggleListVisibility],
         );

--- a/packages/select-react/src/Select.test.tsx
+++ b/packages/select-react/src/Select.test.tsx
@@ -1265,6 +1265,33 @@ describe("Searchable select", () => {
 
         expect(listbox).not.toBeVisible();
     });
+
+    it("should return focus to the input when an option is selected", async () => {
+        const items = [
+            { label: "foo", value: "1" },
+            { label: "bar", value: "2" },
+            { label: "baz", value: "3" },
+        ];
+
+        const screen = setup(
+            <Select
+                name="items"
+                items={items}
+                label="Ting"
+                tooltip={
+                    <PopupTip content="Jeg er en tooltip" placement="left" />
+                }
+            />,
+        );
+
+        const button = screen.getByTestId("jkl-select__button");
+        await userEvent.click(button);
+
+        const option = screen.getAllByTestId("jkl-select__option")[0];
+        await userEvent.click(option);
+
+        expect(button).toHaveFocus();
+    });
 });
 
 describe("a11y", () => {

--- a/packages/select-react/src/Select.tsx
+++ b/packages/select-react/src/Select.tsx
@@ -229,6 +229,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                 setSearchValue("");
                 setSelectedValue(nextValue);
                 toggleListVisibility();
+                buttonRef.current?.focus();
             },
             [setSearchValue, setSelectedValue, toggleListVisibility],
         );


### PR DESCRIPTION
<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil


Closes #4371
