### PR TITLE
fix: tables with a sticky header has tabindex

### DIFF
--- a/packages/jokul/src/components/table/Table.tsx
+++ b/packages/jokul/src/components/table/Table.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { forwardRef, TableHTMLAttributes } from "react";
+import React, { forwardRef, TableHTMLAttributes, useState } from "react";
 import { Density } from "../../core/types.js";
 import { TableContextProvider } from "./tableContext.js";
 
@@ -18,18 +18,29 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
             density,
             collapseToList = false,
             fullWidth = false,
+            tabIndex,
             ...rest
         },
         ref,
     ) => {
+        const [hasStickyHead, setHasStickyHead] = useState<boolean | undefined>(
+            false,
+        );
+
         return (
-            <TableContextProvider state={{ density, collapseToList }}>
+            <TableContextProvider
+                state={{ density, collapseToList, setHasStickyHead }}
+            >
                 <table
                     className={clsx("jkl-table", className, {
                         ["jkl-table--full-width"]: fullWidth,
                         ["jkl-table--collapse-to-list"]: collapseToList,
                     })}
                     {...rest}
+                    // For content in a scrollable table to be accessible with keyboard
+                    // navigation we need to set tabIndex
+                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                    tabIndex={hasStickyHead ? 0 : tabIndex}
                     ref={ref}
                 />
             </TableContextProvider>

--- a/packages/jokul/src/components/table/TableHead.tsx
+++ b/packages/jokul/src/components/table/TableHead.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React, { forwardRef, HTMLAttributes } from "react";
+import { useTableContext } from "./tableContext.js";
 import { TableSectionContextProvider } from "./tableSectionContext.js";
 
 export interface TableHeadProps
@@ -10,6 +11,9 @@ export interface TableHeadProps
 
 const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(
     ({ className, srOnly, sticky, ...rest }, ref) => {
+        const { setHasStickyHead } = useTableContext();
+        setHasStickyHead(sticky);
+
         return (
             <TableSectionContextProvider
                 state={{

--- a/packages/jokul/src/components/table/tableContext.tsx
+++ b/packages/jokul/src/components/table/tableContext.tsx
@@ -4,11 +4,13 @@ import { Density, WithChildren } from "../../core/types.js";
 type TableContext = {
     density?: Density;
     collapseToList: boolean;
+    setHasStickyHead: (hasStcikyHead: boolean | undefined) => void;
 };
 
 const tableContext = createContext<TableContext>({
     density: undefined,
     collapseToList: false,
+    setHasStickyHead: () => {},
 });
 
 export const useTableContext = (): TableContext => useContext(tableContext);

--- a/packages/table-react/src/Table.tsx
+++ b/packages/table-react/src/Table.tsx
@@ -1,6 +1,6 @@
 import { Density } from "@fremtind/jkl-core";
 import cx from "classnames";
-import React, { forwardRef, TableHTMLAttributes } from "react";
+import React, { forwardRef, TableHTMLAttributes, useState } from "react";
 import { TableContextProvider } from "./tableContext";
 
 export interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
@@ -18,18 +18,29 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
             density,
             collapseToList = false,
             fullWidth = false,
+            tabIndex,
             ...rest
         },
         ref,
     ) => {
+        const [hasStickyHead, setHasStickyHead] = useState<boolean | undefined>(
+            false,
+        );
+
         return (
-            <TableContextProvider state={{ density, collapseToList }}>
+            <TableContextProvider
+                state={{ density, collapseToList, setHasStickyHead }}
+            >
                 <table
                     className={cx("jkl-table", className, {
                         ["jkl-table--full-width"]: fullWidth,
                         ["jkl-table--collapse-to-list"]: collapseToList,
                     })}
                     {...rest}
+                    // For content in a scrollable table to be accessible with keyboard
+                    // navigation we need to set tabIndex
+                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                    tabIndex={hasStickyHead ? 0 : tabIndex}
                     ref={ref}
                 />
             </TableContextProvider>

--- a/packages/table-react/src/TableHead.tsx
+++ b/packages/table-react/src/TableHead.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import React, { forwardRef, HTMLAttributes } from "react";
+import { useTableContext } from "./tableContext";
 import { TableSectionContextProvider } from "./tableSectionContext";
 
 export interface TableHeadProps
@@ -10,6 +11,9 @@ export interface TableHeadProps
 
 const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(
     ({ className, srOnly, sticky, ...rest }, ref) => {
+        const { setHasStickyHead } = useTableContext();
+        setHasStickyHead(sticky);
+
         return (
             <TableSectionContextProvider
                 state={{

--- a/packages/table-react/src/tableContext.tsx
+++ b/packages/table-react/src/tableContext.tsx
@@ -4,11 +4,13 @@ import React, { createContext, useContext } from "react";
 type TableContext = {
     density?: Density;
     collapseToList: boolean;
+    setHasStickyHead: (hasStcikyHead: boolean | undefined) => void;
 };
 
 const tableContext = createContext<TableContext>({
     density: undefined,
     collapseToList: false,
+    setHasStickyHead: () => {},
 });
 
 export const useTableContext = (): TableContext => useContext(tableContext);


### PR DESCRIPTION
Without tab-index set somewhere meaningful on a table with a sticky header and scrollable content that content is inaccessible to users navigation with a keyboard

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil

CLOSES #4389
