### PR TITLE
docs: marker riktige filer som opplastet i eksemplet for filopplaster

### DIFF
--- a/packages/file-input-react/documentation/FileInputExample.tsx
+++ b/packages/file-input-react/documentation/FileInputExample.tsx
@@ -175,20 +175,21 @@ export const FileInputExample: FC<ExampleComponentProps> = ({
                     );
 
                     const promises = toUpload.map(
-                        (fileState, i) =>
+                        (fileToUpload) =>
                             new Promise<void>((resolve) => {
-                                const timeout = 2_000;
+                                const timeout = 2000;
                                 setTimeout(() => {
-                                    setFiles((currentState) => {
-                                        return [
-                                            ...currentState.slice(0, i),
-                                            {
-                                                ...currentState[i],
-                                                state: "UPLOAD_SUCCESS",
-                                            },
-                                            ...currentState.slice(i + 1),
-                                        ];
-                                    });
+                                    setFiles((currentFiles) =>
+                                        currentFiles.map((file) =>
+                                            file.file.name ===
+                                            fileToUpload.file.name
+                                                ? {
+                                                      ...file,
+                                                      state: "UPLOAD_SUCCESS",
+                                                  }
+                                                : file,
+                                        ),
+                                    );
                                     resolve();
                                 }, timeout);
                             }),

--- a/packages/jokul/src/components/file-input/documentation/FileInputExample.tsx
+++ b/packages/jokul/src/components/file-input/documentation/FileInputExample.tsx
@@ -180,20 +180,21 @@ export const FileInputExample: FC<ExampleComponentProps> = ({
                     );
 
                     const promises = toUpload.map(
-                        (fileState, i) =>
+                        (fileToUpload) =>
                             new Promise<void>((resolve) => {
-                                const timeout = 2_000;
+                                const timeout = 2000;
                                 setTimeout(() => {
-                                    setFiles((currentState) => {
-                                        return [
-                                            ...currentState.slice(0, i),
-                                            {
-                                                ...currentState[i],
-                                                state: "UPLOAD_SUCCESS",
-                                            },
-                                            ...currentState.slice(i + 1),
-                                        ];
-                                    });
+                                    setFiles((currentFiles) =>
+                                        currentFiles.map((file) =>
+                                            file.file.name ===
+                                            fileToUpload.file.name
+                                                ? {
+                                                      ...file,
+                                                      state: "UPLOAD_SUCCESS",
+                                                  }
+                                                : file,
+                                        ),
+                                    );
                                     resolve();
                                 }, timeout);
                             }),


### PR DESCRIPTION
Sørg for å markere riktige filer som ferdig opplastet i eksemplet dersom noen av filene har feil eller er for store
