### PR TITLE
style: Menu bruker nå Material Icons, istedenfor egne ikoner

### DIFF
--- a/packages/jokul/src/components/menu/MenuItem.tsx
+++ b/packages/jokul/src/components/menu/MenuItem.tsx
@@ -1,10 +1,10 @@
+import { ChevronRightIcon, OpenInNewIcon } from "@fremtind/jokul";
 import clsx from "clsx";
 import React, { forwardRef, ReactNode } from "react";
 import {
     PolymorphicPropsWithRef,
     PolymorphicRef,
 } from "../../utilities/polymorphism/polymorphism.js";
-import { Icon } from "../icon/index.js";
 
 export type MenuItemProps<ElementType extends React.ElementType> =
     PolymorphicPropsWithRef<
@@ -66,11 +66,11 @@ export const MenuItem = forwardRef(function MenuItem<
                 {children}
                 {external && (
                     <div className={"jkl-menu-item__arrow"}>
-                        <Icon>{"\ue89e"}</Icon>
+                        <OpenInNewIcon />
                     </div>
                 )}
             </div>
-            {expandable && <Icon>{"\ue5cc"}</Icon>}
+            {expandable && <ChevronRightIcon />}
         </Component>
     );
 }) as MenuItemComponent;

--- a/packages/jokul/src/components/menu/MenuItem.tsx
+++ b/packages/jokul/src/components/menu/MenuItem.tsx
@@ -4,8 +4,7 @@ import {
     PolymorphicPropsWithRef,
     PolymorphicRef,
 } from "../../utilities/polymorphism/polymorphism.js";
-import { ArrowNorthEastIcon } from "../icon/icons/ArrowNorthEastIcon.js";
-import { ChevronRightIcon } from "../icon/icons/ChevronRightIcon.js";
+import { Icon } from "../icon/index.js";
 
 export type MenuItemProps<ElementType extends React.ElementType> =
     PolymorphicPropsWithRef<
@@ -67,13 +66,11 @@ export const MenuItem = forwardRef(function MenuItem<
                 {children}
                 {external && (
                     <div className={"jkl-menu-item__arrow"}>
-                        <ArrowNorthEastIcon />
+                        <Icon>{"\ue89e"}</Icon>
                     </div>
                 )}
             </div>
-            {expandable && (
-                <ChevronRightIcon className="jkl-menu-item__chevron" bold />
-            )}
+            {expandable && <Icon>{"\ue5cc"}</Icon>}
         </Component>
     );
 }) as MenuItemComponent;

--- a/packages/jokul/src/components/menu/MenuItem.tsx
+++ b/packages/jokul/src/components/menu/MenuItem.tsx
@@ -1,10 +1,11 @@
-import { ChevronRightIcon, OpenInNewIcon } from "@fremtind/jokul";
 import clsx from "clsx";
 import React, { forwardRef, ReactNode } from "react";
 import {
     PolymorphicPropsWithRef,
     PolymorphicRef,
 } from "../../utilities/polymorphism/polymorphism.js";
+import { ChevronRightIcon } from "../icon/icons/ChevronRightIcon.js";
+import { OpenInNewIcon } from "../icon/icons/OpenInNewIcon.js";
 
 export type MenuItemProps<ElementType extends React.ElementType> =
     PolymorphicPropsWithRef<

--- a/packages/jokul/src/components/menu/documentation/MenuExample.tsx
+++ b/packages/jokul/src/components/menu/documentation/MenuExample.tsx
@@ -71,17 +71,27 @@ export const MenuExample: FC<ExampleComponentProps> = ({
                 </MenuItem>
                 <MenuItem icon={<ErrorIcon />}>Skadesaker</MenuItem>
                 <MenuDivider />
-                <MenuItem as="a" href="https://jokul.fremtind.no/">
-                    Jøkuls hjemmeside
-                </MenuItem>
-                <MenuItem
-                    as={CustomLink}
-                    href="https://www.fremtind.no/"
-                    external
-                    target="_blank"
+                <Menu
+                    triggerElement={
+                        <MenuItem expandable={true}>Ressurser</MenuItem>
+                    }
                 >
-                    Fremtind Forsikring
-                </MenuItem>
+                    <MenuItem as="a" href="https://jokul.fremtind.no/">
+                        Jøkuls hjemmeside
+                    </MenuItem>
+                    <MenuItem as="a" href="https://fremtind.no/">
+                        Fremtind Forsikring
+                    </MenuItem>
+                    <MenuDivider />
+                    <MenuItem
+                        as={CustomLink}
+                        href="https://www.w3.org/TR/WCAG22/"
+                        external
+                        target="_blank"
+                    >
+                        WCAG 2.2
+                    </MenuItem>
+                </Menu>
             </Menu>
         </div>
     );

--- a/packages/menu-react/documentation/MenuExample.tsx
+++ b/packages/menu-react/documentation/MenuExample.tsx
@@ -123,12 +123,27 @@ export const MenuExampleCode: CodeExample = ({ boolValues, choiceValues }) => {
     <MenuItem onClick={() => console.log("Hei fra Skadesaker")}>Dokumenter</MenuItem>
     <MenuItem icon={<ErrorIcon />}>Skadesaker</MenuItem>
     <MenuDivider />
-    <MenuItem as="a" href="https://jokul.fremtind.no/">
-        Jøkuls hjemmeside
-    </MenuItem>
-    <MenuItem as={CustomLink} href="https://www.fremtind.no/" external target="_blank">
-        Fremtind Forsikring
-    </MenuItem>
+    <Menu
+        triggerElement={
+            <MenuItem expandable={true}>Ressurser</MenuItem>
+        }
+    >
+        <MenuItem as="a" href="https://jokul.fremtind.no/">
+            Jøkuls hjemmeside
+        </MenuItem>
+        <MenuItem as="a" href="https://fremtind.no/">
+            Fremtind Forsikring
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem
+            as={CustomLink}
+            href="https://www.w3.org/TR/WCAG22/"
+            external
+            target="_blank"
+        >
+            WCAG 2.2
+        </MenuItem>
+    </Menu>
 </Menu>
 `;
 };

--- a/packages/menu-react/documentation/MenuExample.tsx
+++ b/packages/menu-react/documentation/MenuExample.tsx
@@ -74,17 +74,27 @@ export const MenuExample: FC<ExampleComponentProps> = ({
                 </MenuItem>
                 <MenuItem icon={<ErrorIcon />}>Skadesaker</MenuItem>
                 <MenuDivider />
-                <MenuItem as="a" href="https://jokul.fremtind.no/">
-                    Jøkuls hjemmeside
-                </MenuItem>
-                <MenuItem
-                    as={CustomLink}
-                    href="https://www.fremtind.no/"
-                    external
-                    target="_blank"
+                <Menu
+                    triggerElement={
+                        <MenuItem expandable={true}>Ressurser</MenuItem>
+                    }
                 >
-                    Fremtind Forsikring
-                </MenuItem>
+                    <MenuItem as="a" href="https://jokul.fremtind.no/">
+                        Jøkuls hjemmeside
+                    </MenuItem>
+                    <MenuItem as="a" href="https://fremtind.no/">
+                        Fremtind Forsikring
+                    </MenuItem>
+                    <MenuDivider />
+                    <MenuItem
+                        as={CustomLink}
+                        href="https://www.w3.org/TR/WCAG22/"
+                        external
+                        target="_blank"
+                    >
+                        WCAG 2.2
+                    </MenuItem>
+                </Menu>
             </Menu>
         </div>
     );

--- a/packages/menu-react/src/MenuItem.tsx
+++ b/packages/menu-react/src/MenuItem.tsx
@@ -1,8 +1,5 @@
 import { PolymorphicPropsWithRef, PolymorphicRef } from "@fremtind/jkl-core";
-import {
-    ArrowNorthEastIcon,
-    ChevronRightIcon,
-} from "@fremtind/jkl-icons-react";
+import { Icon } from "@fremtind/jkl-icons-react";
 import cn from "classnames";
 import React, { forwardRef, ReactNode } from "react";
 
@@ -66,13 +63,11 @@ export const MenuItem = forwardRef(function MenuItem<
                 {children}
                 {external && (
                     <div className={"jkl-menu-item__arrow"}>
-                        <ArrowNorthEastIcon />
+                        <Icon>{"\ue89e"}</Icon>
                     </div>
                 )}
             </div>
-            {expandable && (
-                <ChevronRightIcon className="jkl-menu-item__chevron" bold />
-            )}
+            {expandable && <Icon>{"\ue89e"}</Icon>}
         </Component>
     );
 }) as MenuItemComponent;

--- a/packages/menu-react/src/MenuItem.tsx
+++ b/packages/menu-react/src/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { PolymorphicPropsWithRef, PolymorphicRef } from "@fremtind/jkl-core";
-import { Icon } from "@fremtind/jkl-icons-react";
+import { ChevronRightIcon, OpenInNewIcon } from "@fremtind/jkl-icons-react";
 import cn from "classnames";
 import React, { forwardRef, ReactNode } from "react";
 
@@ -63,11 +63,11 @@ export const MenuItem = forwardRef(function MenuItem<
                 {children}
                 {external && (
                     <div className={"jkl-menu-item__arrow"}>
-                        <Icon>{"\ue89e"}</Icon>
+                        <OpenInNewIcon />
                     </div>
                 )}
             </div>
-            {expandable && <Icon>{"\ue89e"}</Icon>}
+            {expandable && <ChevronRightIcon />}
         </Component>
     );
 }) as MenuItemComponent;


### PR DESCRIPTION
Oppdatert ikoner, med nye eksempler for å vise dem i bruk. Det var tidligere ikke noen eksempler på nested menu.

## 🎯 Sjekkliste

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
