### PR TITLE
fix: redcross and greencheck now uses material icons font

### DIFF
--- a/packages/icons-react/src/icons/GreenCheckIcon.tsx
+++ b/packages/icons-react/src/icons/GreenCheckIcon.tsx
@@ -1,53 +1,20 @@
-import cn from "classnames";
+import classnames from "classnames";
 import React, { FC } from "react";
+import { Icon } from "../Icon";
 import { IconProps } from "../types";
-
 /*
  * NOTE: The green-check and red-cross icons also exists as a copy in the jkl-list package.
  *       If you're here to change them, consider changing them there as well, or
  *       finding a technical solution to sharing the SVG markup
  */
-export const GreenCheckIcon: FC<IconProps> = ({
-    as = "div",
-    bold = false,
-    className,
-    variant = "inherit",
-    "data-testid": testId,
-    style,
-    ...rest
-}) => {
-    const El = as;
-
+export const GreenCheckIcon: FC<IconProps> = (props: IconProps) => {
     return (
-        <El
-            className={cn(
-                className,
-                "jkl-icon",
-                "jkl-icon-green-check",
-                `jkl-icon--${variant}`,
-                {
-                    "jkl-icon--bold": bold,
-                },
-            )}
-            aria-hidden="true"
-            style={style}
-            data-testid={testId}
-            {...rest}
+        <Icon
+            {...props}
+            className={classnames("jkl-icon-green-check", props.className)}
         >
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24px"
-                height="24px"
-            >
-                <circle cx="12" cy="12" r="10" />
-                <path
-                    fillRule="evenodd"
-                    d="M17.52 9.54 10.7 16.2l-4.21-4.1 1.04-1.08 3.17 3.09 5.79-5.65 1.04 1.08Z"
-                    clipRule="evenodd"
-                />
-            </svg>
-        </El>
+            {"\ue86c"}
+        </Icon>
     );
 };
 GreenCheckIcon.displayName = "GreenCheckIcon";

--- a/packages/icons-react/src/icons/RedCrossIcon.tsx
+++ b/packages/icons-react/src/icons/RedCrossIcon.tsx
@@ -1,50 +1,20 @@
-import cn from "classnames";
+import classnames from "classnames";
 import React, { FC } from "react";
+import { Icon } from "../Icon";
 import { IconProps } from "../types";
-
 /*
  * NOTE: The green-check and red-cross icons also exists as a copy in the jkl-list package.
  *       If you're here to change them, consider changing them there as well, or
  *       finding a technical solution to sharing the SVG markup
  */
-export const RedCrossIcon: FC<IconProps> = ({
-    as = "div",
-    bold = false,
-    className,
-    variant = "inherit",
-    "data-testid": testId,
-    style,
-    ...rest
-}) => {
-    const El = as;
-
+export const RedCrossIcon: FC<IconProps> = (props: IconProps) => {
     return (
-        <El
-            className={cn(
-                className,
-                "jkl-icon",
-                "jkl-icon-red-cross",
-                `jkl-icon--${variant}`,
-                {
-                    "jkl-icon--bold": bold,
-                },
-            )}
-            aria-hidden="true"
-            style={style}
-            data-testid={testId}
-            {...rest}
+        <Icon
+            {...props}
+            className={classnames("jkl-icon-red-cross", props.className)}
         >
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24px"
-                height="24px"
-            >
-                <circle cx="12" cy="12" r="10" />
-                <path d="m15.71 7.23 1.06 1.06-8.48 8.48-1.06-1.06 8.48-8.48Z" />
-                <path d="m8.29 7.23 8.48 8.48-1.06 1.06L7.23 8.3l1.06-1.06Z" />
-            </svg>
-        </El>
+            {"\ue5c9"}
+        </Icon>
     );
 };
 RedCrossIcon.displayName = "RedCrossIcon";

--- a/packages/icons/icons.scss
+++ b/packages/icons/icons.scss
@@ -11,6 +11,8 @@
 
 .jkl-icon {
     --jkl-icon-fill: 0;
+    --jkl-color-red-cross: var(--jkl-color-functional-error-dark);
+    --jkl-color-green-check: var(--jkl-color-functional-success-dark);
 
     font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
     font-variation-settings: "FILL" var(--jkl-icon-fill, 0),
@@ -25,6 +27,20 @@
 
     @include jkl.motion("standard", "productive");
     transition-property: font-variation-settings, transform;
+
+    &-green-check,
+    &-red-cross {
+        font-variation-settings: "FILL" 1, "GRAD" var(--jkl-icon-grade, 0),
+            "opsz" var(--jkl-icon-opsz, 24);
+    }
+
+    &-green-check {
+        color: var(--jkl-color-green-check);
+    }
+
+    &-red-cross {
+        color: var(--jkl-color-red-cross);
+    }
 
     &--bold {
         --jkl-icon-weight: 500;
@@ -51,38 +67,6 @@
 
     &--animated {
         display: block;
-    }
-}
-
-.jkl-icon-red-cross {
-    --red-cross-circle: var(--jkl-color-background-alert-error);
-    --red-cross-path: #{jkl.$color-brand-granitt};
-
-    width: jkl.rem(24px);
-    height: jkl.rem(24px);
-
-    & path {
-        fill: var(--red-cross-path);
-    }
-
-    & circle {
-        fill: var(--red-cross-circle);
-    }
-}
-
-.jkl-icon-green-check {
-    --green-check-circle: var(--jkl-color-background-alert-success);
-    --green-check-path: #{jkl.$color-brand-granitt};
-
-    width: jkl.rem(24px);
-    height: jkl.rem(24px);
-
-    & path {
-        fill: var(--green-check-path);
-    }
-
-    & circle {
-        fill: var(--green-check-circle);
     }
 }
 

--- a/packages/jokul/src/components/icon/icons/GreenCheckIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/GreenCheckIcon.tsx
@@ -1,53 +1,20 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 import React, { FC } from "react";
+import { Icon } from "../Icon.js";
 import { IconProps } from "../types.js";
-
 /*
  * NOTE: The green-check and red-cross icons also exists as a copy in the jkl-list package.
  *       If you're here to change them, consider changing them there as well, or
  *       finding a technical solution to sharing the SVG markup
  */
-export const GreenCheckIcon: FC<IconProps> = ({
-    as = "div",
-    bold = false,
-    className,
-    variant = "inherit",
-    "data-testid": testId,
-    style,
-    ...rest
-}) => {
-    const El = as;
-
+export const GreenCheckIcon: FC<IconProps> = (props: IconProps) => {
     return (
-        <El
-            className={clsx(
-                className,
-                "jkl-icon",
-                "jkl-icon-green-check",
-                `jkl-icon--${variant}`,
-                {
-                    "jkl-icon--bold": bold,
-                },
-            )}
-            aria-hidden="true"
-            style={style}
-            data-testid={testId}
-            {...rest}
+        <Icon
+            {...props}
+            className={clsx("jkl-icon-green-check", props.className)}
         >
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24px"
-                height="24px"
-            >
-                <circle cx="12" cy="12" r="10" />
-                <path
-                    fillRule="evenodd"
-                    d="M17.52 9.54 10.7 16.2l-4.21-4.1 1.04-1.08 3.17 3.09 5.79-5.65 1.04 1.08Z"
-                    clipRule="evenodd"
-                />
-            </svg>
-        </El>
+            {"\ue86c"}
+        </Icon>
     );
 };
 GreenCheckIcon.displayName = "GreenCheckIcon";

--- a/packages/jokul/src/components/icon/icons/RedCrossIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/RedCrossIcon.tsx
@@ -1,50 +1,20 @@
 import clsx from "clsx";
 import React, { FC } from "react";
+import { Icon } from "../Icon.js";
 import { IconProps } from "../types.js";
-
 /*
  * NOTE: The green-check and red-cross icons also exists as a copy in the jkl-list package.
  *       If you're here to change them, consider changing them there as well, or
  *       finding a technical solution to sharing the SVG markup
  */
-export const RedCrossIcon: FC<IconProps> = ({
-    as = "div",
-    bold = false,
-    className,
-    variant = "inherit",
-    "data-testid": testId,
-    style,
-    ...rest
-}) => {
-    const El = as;
-
+export const RedCrossIcon: FC<IconProps> = (props: IconProps) => {
     return (
-        <El
-            className={clsx(
-                className,
-                "jkl-icon",
-                "jkl-icon-red-cross",
-                `jkl-icon--${variant}`,
-                {
-                    "jkl-icon--bold": bold,
-                },
-            )}
-            aria-hidden="true"
-            style={style}
-            data-testid={testId}
-            {...rest}
+        <Icon
+            {...props}
+            className={clsx("jkl-icon-red-cross", props.className)}
         >
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24px"
-                height="24px"
-            >
-                <circle cx="12" cy="12" r="10" />
-                <path d="m15.71 7.23 1.06 1.06-8.48 8.48-1.06-1.06 8.48-8.48Z" />
-                <path d="m8.29 7.23 8.48 8.48-1.06 1.06L7.23 8.3l1.06-1.06Z" />
-            </svg>
-        </El>
+            {"\ue5c9"}
+        </Icon>
     );
 };
 RedCrossIcon.displayName = "RedCrossIcon";

--- a/packages/jokul/src/components/icon/styles/icon.scss
+++ b/packages/jokul/src/components/icon/styles/icon.scss
@@ -11,6 +11,8 @@
 
 .jkl-icon {
     --jkl-icon-fill: 0;
+    --jkl-color-red-cross: var(--jkl-color-functional-error-dark);
+    --jkl-color-green-check: var(--jkl-color-functional-success-dark);
 
     font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
     font-variation-settings: "FILL" var(--jkl-icon-fill, 0),
@@ -25,6 +27,20 @@
 
     @include jkl.motion("standard", "productive");
     transition-property: font-variation-settings, transform;
+
+    &-green-check,
+    &-red-cross {
+        font-variation-settings: "FILL" 1, "GRAD" var(--jkl-icon-grade, 0),
+            "opsz" var(--jkl-icon-opsz, 24);
+    }
+
+    &-green-check {
+        color: var(--jkl-color-green-check);
+    }
+
+    &-red-cross {
+        color: var(--jkl-color-red-cross);
+    }
 
     &--bold {
         --jkl-icon-weight: 500;
@@ -51,38 +67,6 @@
 
     &--animated {
         display: block;
-    }
-}
-
-.jkl-icon-red-cross {
-    --red-cross-circle: var(--jkl-color-background-alert-error);
-    --red-cross-path: #{jkl.$color-brand-granitt};
-
-    width: jkl.rem(24px);
-    height: jkl.rem(24px);
-
-    & path {
-        fill: var(--red-cross-path);
-    }
-
-    & circle {
-        fill: var(--red-cross-circle);
-    }
-}
-
-.jkl-icon-green-check {
-    --green-check-circle: var(--jkl-color-background-alert-success);
-    --green-check-path: #{jkl.$color-brand-granitt};
-
-    width: jkl.rem(24px);
-    height: jkl.rem(24px);
-
-    & path {
-        fill: var(--green-check-path);
-    }
-
-    & circle {
-        fill: var(--green-check-circle);
     }
 }
 


### PR DESCRIPTION
ISSUES CLOSED: #3793, #3939

Denne er litt tricky, og ikke 1 til 1 med Figma. Det var litt tricky ``success`` og ``error`` bruker den vanlige fonten for å vise ikonene.

I kort betyr det at det er maskering i midten av ikonet som gjør at det er enkelt å sette fargen til samme farge som tekst. I de fargede ikonene er det derimot tenkt at "maskeringen" er erstattet med svart farge i både light og dark mode. Det hadde gjort komponentene veldig komplekse i forhold til hva den er om vi respekterer samme prinsipp i de fargede variantene også.

**Det kan godt hende at den kompleksiteten er verdt det, eller at det finnes en enklere måte å gjøre det på som jeg ikke vet om. Gjerne del det i tråden her eller noe altså** 😸

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil (pnpm ci:test gir noen feil som ikke er knytta til endringer i denne PR-en såvidt jeg kan se, vet ikke om noen har noe info om hva det kommer av?)
