### PR TITLE
fix: actions in a modal stack on small screens

### DIFF
--- a/packages/jokul/src/components/modal/styles/modal.scss
+++ b/packages/jokul/src/components/modal/styles/modal.scss
@@ -95,6 +95,10 @@
 .jkl-modal-actions {
     margin: var(--jkl-modal-actions-margin);
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: jkl.$unit-20;
+
+    @include jkl.from-medium-device {
+        flex-direction: row;
+    }
 }

--- a/packages/modal/modal.scss
+++ b/packages/modal/modal.scss
@@ -95,6 +95,10 @@
 .jkl-modal-actions {
     margin: var(--jkl-modal-actions-margin);
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: jkl.$spacing-16;
+
+    @include jkl.from-medium-device {
+        flex-direction: row;
+    }
 }


### PR DESCRIPTION
Having several actions (e.g. buttons) shown next to each other inside the ModalActions component is unlikely to work well on small screens, therefore they are now shown as a column on small screens and a row on medium and larger screens

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
