### PR TITLE
fix: deaktiver innebygde tailwind-tema i vår preset

### DIFF
--- a/packages/core/src/tailwind/tailwindPreset.ts
+++ b/packages/core/src/tailwind/tailwindPreset.ts
@@ -4,6 +4,7 @@ import { breakpoints } from "../utils/breakpoints";
 import colors from "./colors";
 
 const tailwindPreset: Partial<Config> = {
+    presets: [], // Deaktiverer innebygde themes fra Tailwind
     theme: {
         colors,
         spacing: tokens.spacing,

--- a/packages/jokul/src/tailwind/tailwindPreset.ts
+++ b/packages/jokul/src/tailwind/tailwindPreset.ts
@@ -4,6 +4,7 @@ import colors from "./colors.js";
 import { jokulTypographyPlugin } from "./plugins/jokulTypographyPlugin.js";
 
 export const jokulPreset: Partial<Config> = {
+    presets: [], // Deaktiverer innebygde presets fra Tailwind
     theme: {
         colors,
         spacing: tokens.spacing,


### PR DESCRIPTION
Det viser seg at man aktivt må [deaktivere innebygde stiler/presets](https://v3.tailwindcss.com/docs/presets#disabling-the-default-configuration) fra Tailwind, selv når man bruker et custom preset som vårt. Det kan heldigvis gjøre fra inne i preset-et. Denne endringen sørger for at det gjøres.

Vi har allerede gått ut fra at dette skjedde, så ingen dokumentasjon trenger å oppdateres.
