### PR TITLE
Fancy slug-felt i ny portal

### DIFF
--- a/ny-portal/package.json
+++ b/ny-portal/package.json
@@ -24,7 +24,7 @@
         "@payloadcms/db-postgres": "latest",
         "@payloadcms/next": "latest",
         "@payloadcms/richtext-lexical": "latest",
-        "@payloadcms/ui": "^3.20.0",
+        "@payloadcms/ui": "latest",
         "@types/mdx": "^2.0.13",
         "clsx": "^2.1.1",
         "cross-env": "^7.0.3",

--- a/ny-portal/src/app/(payload)/admin/importMap.js
+++ b/ny-portal/src/app/(payload)/admin/importMap.js
@@ -1,3 +1,4 @@
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -23,6 +24,7 @@ import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0
 import { default as default_6b73bc0444f03fe7497cdc21a73ec1c0 } from '@/fields/code-example/CodeExampleInput'
 
 export const importMap = {
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/ny-portal/src/collections/ComponentPages/index.ts
+++ b/ny-portal/src/collections/ComponentPages/index.ts
@@ -1,5 +1,6 @@
-import { CollectionBeforeReadHook, CollectionConfig } from "payload";
+import { CollectionConfig } from "payload";
 import { CodeExampleField } from "@/fields/code-example";
+import { slugField } from "@/fields/slug";
 
 export const ComponentPages: CollectionConfig = {
     slug: "component-page",
@@ -7,12 +8,7 @@ export const ComponentPages: CollectionConfig = {
         useAsTitle: "title",
     },
     fields: [
-        {
-            name: "slug",
-            type: "text",
-            label: "URL-segment",
-            required: true,
-        },
+        ...slugField(),
         {
             name: "title",
             type: "text",

--- a/ny-portal/src/fields/slug/SlugComponent.tsx
+++ b/ny-portal/src/fields/slug/SlugComponent.tsx
@@ -1,0 +1,97 @@
+"use client";
+import {
+    useField,
+    Button,
+    TextInput,
+    FieldLabel,
+    useFormFields,
+    useForm,
+} from "@payloadcms/ui";
+import { TextFieldClientProps } from "payload";
+import React, { useCallback, useEffect } from "react";
+import { formatSlug } from "./formatSlug";
+import "./index.scss";
+
+type SlugComponentProps = {
+    fieldToUse: string;
+    checkboxFieldPath: string;
+} & TextFieldClientProps;
+
+export const SlugComponent: React.FC<SlugComponentProps> = ({
+    field,
+    fieldToUse,
+    checkboxFieldPath: checkboxFieldPathFromProps,
+    path,
+    readOnly: readOnlyFromProps,
+}) => {
+    const { label } = field;
+
+    const checkboxFieldPath = path?.includes(".")
+        ? `${path}.${checkboxFieldPathFromProps}`
+        : checkboxFieldPathFromProps;
+
+    const { value, setValue } = useField<string>({ path: path || field.name });
+
+    const { dispatchFields } = useForm();
+
+    // The value of the checkbox
+    // We're using separate useFormFields to minimise re-renders
+    const checkboxValue = useFormFields(([fields]) => {
+        return fields[checkboxFieldPath]?.value as string;
+    });
+
+    // The value of the field we're listening to for the slug
+    const targetFieldValue = useFormFields(([fields]) => {
+        return fields[fieldToUse]?.value as string;
+    });
+
+    useEffect(() => {
+        if (checkboxValue) {
+            if (targetFieldValue) {
+                const formattedSlug = formatSlug(targetFieldValue);
+
+                if (value !== formattedSlug) setValue(formattedSlug);
+            } else {
+                if (value !== "") setValue("");
+            }
+        }
+    }, [targetFieldValue, checkboxValue, setValue, value]);
+
+    const handleLock = useCallback(
+        (e: React.MouseEvent<Element>) => {
+            e.preventDefault();
+
+            dispatchFields({
+                type: "UPDATE",
+                path: checkboxFieldPath,
+                value: !checkboxValue,
+            });
+        },
+        [checkboxValue, checkboxFieldPath, dispatchFields],
+    );
+
+    const readOnly = readOnlyFromProps || checkboxValue;
+
+    return (
+        <div className="field-type slug-field-component">
+            <div className="label-wrapper">
+                <FieldLabel htmlFor={`field-${path}`} label={label} />
+
+                <Button
+                    className="lock-button"
+                    buttonStyle="none"
+                    onClick={handleLock}
+                >
+                    {checkboxValue ? "Unlock" : "Lock"}
+                </Button>
+            </div>
+
+            <TextInput
+                value={value}
+                onChange={setValue}
+                path={path || field.name}
+                readOnly={Boolean(readOnly)}
+            />
+        </div>
+    );
+};

--- a/ny-portal/src/fields/slug/formatSlug.ts
+++ b/ny-portal/src/fields/slug/formatSlug.ts
@@ -1,0 +1,25 @@
+import type { FieldHook } from "payload";
+
+export const formatSlug = (val: string): string =>
+    val
+        .replace(/ /g, "-")
+        .replace(/[^\w-]+/g, "")
+        .toLowerCase();
+
+export const formatSlugHook =
+    (fallback: string): FieldHook =>
+    ({ data, operation, value }) => {
+        if (typeof value === "string") {
+            return formatSlug(value);
+        }
+
+        if (operation === "create" || !data?.slug) {
+            const fallbackData = data?.[fallback];
+
+            if (fallbackData && typeof fallbackData === "string") {
+                return formatSlug(fallbackData);
+            }
+        }
+
+        return value;
+    };

--- a/ny-portal/src/fields/slug/index.scss
+++ b/ny-portal/src/fields/slug/index.scss
@@ -1,0 +1,12 @@
+.slug-field-component {
+    .label-wrapper {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .lock-button {
+        margin: 0;
+        padding-bottom: 0.3125rem;
+    }
+}

--- a/ny-portal/src/fields/slug/index.ts
+++ b/ny-portal/src/fields/slug/index.ts
@@ -1,0 +1,56 @@
+import type { CheckboxField, TextField } from "payload";
+import { formatSlugHook } from "./formatSlug";
+
+type Overrides = {
+    slugOverrides?: Partial<TextField>;
+    checkboxOverrides?: Partial<CheckboxField>;
+};
+
+type Slug = (
+    fieldToUse?: string,
+    overrides?: Overrides,
+) => [TextField, CheckboxField];
+
+export const slugField: Slug = (fieldToUse = "title", overrides = {}) => {
+    const { slugOverrides, checkboxOverrides } = overrides;
+
+    const checkBoxField: CheckboxField = {
+        name: "slugLock",
+        type: "checkbox",
+        defaultValue: true,
+        admin: {
+            hidden: true,
+            position: "sidebar",
+        },
+        ...checkboxOverrides,
+    };
+
+    // @ts-expect-error - ts mismatch Partial<TextField> with TextField
+    const slugField: TextField = {
+        name: "slug",
+        type: "text",
+        index: true,
+        unique: true,
+        label: "Slug",
+        ...(slugOverrides || {}),
+        hooks: {
+            // Kept this in for hook or API based updates
+            beforeValidate: [formatSlugHook(fieldToUse)],
+        },
+        admin: {
+            position: "sidebar",
+            ...(slugOverrides?.admin || {}),
+            components: {
+                Field: {
+                    path: "@/fields/slug/SlugComponent#SlugComponent",
+                    clientProps: {
+                        fieldToUse,
+                        checkboxFieldPath: checkBoxField.name,
+                    },
+                },
+            },
+        },
+    };
+
+    return [slugField, checkBoxField];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
       '@payloadcms/db-postgres': latest
       '@payloadcms/next': latest
       '@payloadcms/richtext-lexical': latest
-      '@payloadcms/ui': ^3.20.0
+      '@payloadcms/ui': latest
       '@types/mdx': ^2.0.13
       '@types/node': ^22.5.4
       '@types/react': ^18.3.1
@@ -6384,7 +6384,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.71
+      '@types/node': 22.10.2
       jest-mock: 29.7.0
     dev: true
 
@@ -6542,7 +6542,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.71
+      '@types/node': 22.10.2
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -20932,7 +20932,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.71
+      '@types/node': 22.10.2
       jest-util: 29.7.0
     dev: true
 


### PR DESCRIPTION
Legger til et litt mer fancy `slug`-felt hentet fra Payload sin website template, og tar det i bruk på komponentsidene.

- Genererer automatisk slug fra `title`-feltet
- Kan låses opp for å endre slug manuelt
- Sørger for unike slugs innad i en collection