### PR TITLE
fix: no longer updates Table while rendering TableHead

### DIFF
--- a/packages/jokul/src/components/table/Table.tsx
+++ b/packages/jokul/src/components/table/Table.tsx
@@ -23,9 +23,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
         },
         ref,
     ) => {
-        const [hasStickyHead, setHasStickyHead] = useState<boolean | undefined>(
-            false,
-        );
+        const [hasStickyHead, setHasStickyHead] = useState<boolean>(false);
 
         return (
             <TableContextProvider

--- a/packages/jokul/src/components/table/TableHead.tsx
+++ b/packages/jokul/src/components/table/TableHead.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, HTMLAttributes, useEffect } from "react";
 import { useTableContext } from "./tableContext.js";
 import { TableSectionContextProvider } from "./tableSectionContext.js";
 
@@ -10,9 +10,11 @@ export interface TableHeadProps
 }
 
 const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(
-    ({ className, srOnly, sticky, ...rest }, ref) => {
+    ({ className, srOnly, sticky = false, ...rest }, ref) => {
         const { setHasStickyHead } = useTableContext();
-        setHasStickyHead(sticky);
+        useEffect(() => {
+            setHasStickyHead(sticky);
+        }, [sticky, setHasStickyHead]);
 
         return (
             <TableSectionContextProvider

--- a/packages/jokul/src/components/table/tableContext.tsx
+++ b/packages/jokul/src/components/table/tableContext.tsx
@@ -4,7 +4,7 @@ import { Density, WithChildren } from "../../core/types.js";
 type TableContext = {
     density?: Density;
     collapseToList: boolean;
-    setHasStickyHead: (hasStcikyHead: boolean | undefined) => void;
+    setHasStickyHead: (hasStcikyHead: boolean) => void;
 };
 
 const tableContext = createContext<TableContext>({

--- a/packages/table-react/src/Table.tsx
+++ b/packages/table-react/src/Table.tsx
@@ -23,9 +23,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
         },
         ref,
     ) => {
-        const [hasStickyHead, setHasStickyHead] = useState<boolean | undefined>(
-            false,
-        );
+        const [hasStickyHead, setHasStickyHead] = useState<boolean>(false);
 
         return (
             <TableContextProvider

--- a/packages/table-react/src/TableHead.tsx
+++ b/packages/table-react/src/TableHead.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, HTMLAttributes, useEffect } from "react";
 import { useTableContext } from "./tableContext";
 import { TableSectionContextProvider } from "./tableSectionContext";
 
@@ -10,9 +10,11 @@ export interface TableHeadProps
 }
 
 const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(
-    ({ className, srOnly, sticky, ...rest }, ref) => {
+    ({ className, srOnly, sticky = false, ...rest }, ref) => {
         const { setHasStickyHead } = useTableContext();
-        setHasStickyHead(sticky);
+        useEffect(() => {
+            setHasStickyHead(sticky);
+        }, [sticky, setHasStickyHead]);
 
         return (
             <TableSectionContextProvider

--- a/packages/table-react/src/tableContext.tsx
+++ b/packages/table-react/src/tableContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext } from "react";
 type TableContext = {
     density?: Density;
     collapseToList: boolean;
-    setHasStickyHead: (hasStcikyHead: boolean | undefined) => void;
+    setHasStickyHead: (hasStcikyHead: boolean) => void;
 };
 
 const tableContext = createContext<TableContext>({


### PR DESCRIPTION
TableHead was calling a context callback during render that caused Table to update and change a state variable. Make sure this does not happend for any value of the "sticky" prop

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil

Closes #4522 