### PR TITLE
Oppdater import for å unngå feil i Next.js

### DIFF
--- a/ny-portal/src/components/Navigation/Navigation.tsx
+++ b/ny-portal/src/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
-import { Link } from "@fremtind/jokul";
 import { clsx } from "clsx";
+import Link from "next/link";
 import styles from "./navigation.module.scss";
 import { NavigationMenu } from "./NavigationMenu";
 import { NavigationSearch } from "./NavigationSearch";

--- a/ny-portal/src/components/Navigation/NavigationMenuButton.tsx
+++ b/ny-portal/src/components/Navigation/NavigationMenuButton.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon } from "@fremtind/jokul";
+import { ChevronRightIcon } from "@fremtind/jokul/components/icon";
 import { clsx } from "clsx";
 import type { FC, HTMLAttributes } from "react";
 import styles from "./navigation-menu-item.module.scss";

--- a/ny-portal/src/components/Navigation/NavigationMenuContext.tsx
+++ b/ny-portal/src/components/Navigation/NavigationMenuContext.tsx
@@ -1,4 +1,4 @@
-import type { WithChildren } from "@fremtind/jokul";
+import type { WithChildren } from "@fremtind/jokul/core";
 import type { FC } from "react";
 import { createContext, useContext, useState } from "react";
 


### PR DESCRIPTION
Next.js klager på at en klientkomponent blir brukt på serveren når Jøkul-pakken importeres, noe som fører til feil. Oppdaterer importene for å sikre riktig bruk og forhindre krasj.