### PR TITLE
feat: supports setting cookie path for cookie-consent

### DIFF
--- a/packages/cookie-consent-react/documentation/CookieConsent.mdx
+++ b/packages/cookie-consent-react/documentation/CookieConsent.mdx
@@ -75,3 +75,13 @@ Default-verdien dersom ingenting angis er `"fremtind-cookie-consent"`.
 Merk at denne verdien vil brukes direkte i `domain=<domain>;` delen av cookien som lagres.
 Det er ditt ansvar at det som sendes inn er gyldig og at du bruker en verdi som gir deg tilgang til å lese cookien senere.
 Dersom det ikke angis noen custom verdi brukes det domenet siden er på og dette er mest sannsynlig det du ønsker.
+
+Du kan også styre hvilken path cookien lagres på via `cookiePath` prop. Dette
+påvirker hvilke URLer cookien kan leses fra. Hvis applikasjonen din for eksempel
+har en side på URLen _/app/forsikringer/11231_ vil du på denne siden ha tilgang til
+cookies som er lagret under _/_, _/app_, _/app/forsikringer_ og _/app/forsikringer/11231_.
+En side som ligger på _/app_ vil derimot bare kunne lese cookies med path satt til
+_/_ eller _/app_. Dersom du ikke angir noen `cookiePath` gjør browseren det den
+mener er riktig. Hvis du har dype stier i applikasjonen din er det ikke sikkert
+det er dette du ønsker, og i så fall bør du sette verdien til det som er roten
+for din applikasjon (feks _/app_ eller _/_).

--- a/packages/cookie-consent-react/documentation/CookieConsentModalExample.tsx
+++ b/packages/cookie-consent-react/documentation/CookieConsentModalExample.tsx
@@ -70,6 +70,7 @@ export const CookieConsentModalExample: FC<ExampleComponentProps> = ({
     return (
         <CookieConsentProvider
             cookieName="demo-consent-cookie"
+            cookiePath="/"
             functional={boolValues?.["Functional"]}
             statistics={boolValues?.["Statistics"]}
             marketing={boolValues?.["Marketing"]}

--- a/packages/cookie-consent-react/src/CookieConsent.tsx
+++ b/packages/cookie-consent-react/src/CookieConsent.tsx
@@ -33,6 +33,7 @@ export const CookieConsent = ({
         currentConsent,
         cookieName,
         cookieDomain,
+        cookiePath,
         requirement,
         isOpen,
         setIsOpen,
@@ -108,6 +109,7 @@ export const CookieConsent = ({
             consent: updatedConsent,
             name: cookieName,
             domain: cookieDomain,
+            path: cookiePath,
         });
 
         updateCurrentConsents();

--- a/packages/cookie-consent-react/src/CookieConsentContext.tsx
+++ b/packages/cookie-consent-react/src/CookieConsentContext.tsx
@@ -18,6 +18,7 @@ export const CookieConsentProvider: React.FC<CookieConsentProviderProps> = ({
     statistics,
     cookieName = DEFAULT_COOKIE_NAME,
     cookieDomain,
+    cookiePath,
 }) => {
     const [timestamp, setTimestamp] = useState(() => Date.now());
 
@@ -52,6 +53,7 @@ export const CookieConsentProvider: React.FC<CookieConsentProviderProps> = ({
                 currentConsent: consentCookie,
                 cookieName,
                 cookieDomain,
+                cookiePath,
             }}
         >
             {children}

--- a/packages/cookie-consent-react/src/cookieConsentUtils.ts
+++ b/packages/cookie-consent-react/src/cookieConsentUtils.ts
@@ -50,17 +50,20 @@ export const setConsentCookie = ({
     maxAge = DEFAULT_MAX_AGE,
     name,
     domain,
+    path,
 }: {
     consent: Consent;
     maxAge?: number;
     name: string;
     domain?: string;
+    path?: string;
 }): void => {
     document.cookie = [
         `${name}=${JSON.stringify(consent)}`,
         `max-age=${maxAge}`,
         `SameSite=Lax`,
         !!domain && `domain=${domain}`,
+        !!path && `path=${path}`,
     ]
         .filter((f) => f)
         .join(";");

--- a/packages/cookie-consent-react/src/types.ts
+++ b/packages/cookie-consent-react/src/types.ts
@@ -25,6 +25,7 @@ export type InternalContext = {
     currentConsent: Consent;
     cookieName: string;
     cookieDomain?: string;
+    cookiePath?: string;
 };
 
 export type CookieConsentProviderProps = Partial<ConsentRequirement> &
@@ -32,4 +33,5 @@ export type CookieConsentProviderProps = Partial<ConsentRequirement> &
         cookieAdapter?: () => Consent | undefined;
         cookieName?: string;
         cookieDomain?: string;
+        cookiePath?: string;
     };

--- a/packages/jokul/src/components/cookie-consent/CookieConsent.tsx
+++ b/packages/jokul/src/components/cookie-consent/CookieConsent.tsx
@@ -33,6 +33,7 @@ export const CookieConsent = ({
         currentConsent,
         cookieName,
         cookieDomain,
+        cookiePath,
         requirement,
         isOpen,
         setIsOpen,
@@ -108,6 +109,7 @@ export const CookieConsent = ({
             consent: updatedConsent,
             name: cookieName,
             domain: cookieDomain,
+            path: cookiePath,
         });
 
         updateCurrentConsents();

--- a/packages/jokul/src/components/cookie-consent/CookieConsentContext.tsx
+++ b/packages/jokul/src/components/cookie-consent/CookieConsentContext.tsx
@@ -22,6 +22,7 @@ export const CookieConsentProvider: React.FC<CookieConsentProviderProps> = ({
     statistics,
     cookieName = DEFAULT_COOKIE_NAME,
     cookieDomain,
+    cookiePath,
 }) => {
     const [timestamp, setTimestamp] = useState(() => Date.now());
 
@@ -56,6 +57,7 @@ export const CookieConsentProvider: React.FC<CookieConsentProviderProps> = ({
                 currentConsent: consentCookie,
                 cookieName,
                 cookieDomain,
+                cookiePath,
             }}
         >
             {children}

--- a/packages/jokul/src/components/cookie-consent/cookieConsentUtils.ts
+++ b/packages/jokul/src/components/cookie-consent/cookieConsentUtils.ts
@@ -50,17 +50,20 @@ export const setConsentCookie = ({
     maxAge = DEFAULT_MAX_AGE,
     name,
     domain,
+    path,
 }: {
     consent: Consent;
     maxAge?: number;
     name: string;
     domain?: string;
+    path?: string;
 }): void => {
     document.cookie = [
         `${name}=${JSON.stringify(consent)}`,
         `max-age=${maxAge}`,
         `SameSite=Lax`,
         !!domain && `domain=${domain}`,
+        !!path && `path=${path}`,
     ]
         .filter((f) => f)
         .join(";");

--- a/packages/jokul/src/components/cookie-consent/development/CookieConsentModalExample.tsx
+++ b/packages/jokul/src/components/cookie-consent/development/CookieConsentModalExample.tsx
@@ -70,6 +70,7 @@ export const CookieConsentModalExample: FC<ExampleComponentProps> = ({
     return (
         <CookieConsentProvider
             cookieName="demo-consent-cookie"
+            cookiePath="/"
             functional={boolValues?.["Functional"]}
             statistics={boolValues?.["Statistics"]}
             marketing={boolValues?.["Marketing"]}

--- a/packages/jokul/src/components/cookie-consent/types.ts
+++ b/packages/jokul/src/components/cookie-consent/types.ts
@@ -25,6 +25,7 @@ export type InternalContext = {
     currentConsent: Consent;
     cookieName: string;
     cookieDomain?: string;
+    cookiePath?: string;
 };
 
 export type CookieConsentProviderProps = Partial<ConsentRequirement> &
@@ -32,4 +33,5 @@ export type CookieConsentProviderProps = Partial<ConsentRequirement> &
         cookieAdapter?: () => Consent | undefined;
         cookieName?: string;
         cookieDomain?: string;
+        cookiePath?: string;
     };


### PR DESCRIPTION
By using the `cookiePath` prop on `CookieConsentProvier` it is now possible to control what path the resulting cookie is saved on.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil


Closes #4544 