### PR TITLE
fix: import av stiler i text-input og noen andre komponenter

### DIFF
--- a/packages/jokul/build-styles.mjs
+++ b/packages/jokul/build-styles.mjs
@@ -110,8 +110,8 @@ import * as sass from "sass-embedded";
                              * TIL: @use "../accordion";
                              */
                             modifiedContent = modifiedContent.replaceAll(
-                                /@use "(.*)\/styles".*;/g,
-                                '@use "$1";',
+                                /@use "(.*)\/styles(.*)"(.*);/g,
+                                '@use "$1$2"$3;',
                             );
 
                             writeFile(


### PR DESCRIPTION
Sørger for å fjerne /styles-mappe fra importstiene til komponenter som bruker delte stiler som ligger i "shared"-mappa

-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
