### PR TITLE
Fiks plassering av understrek og ikon for lenker

### DIFF
--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -47,7 +47,7 @@ export const Link = React.forwardRef(function Link<
                         className={cn(
                             "jkl-icon",
                             `jkl-icon--small`,
-                            "jkl-nav-link__icon",
+                            "jkl-link__icon",
                         )}
                     >
                         {"\ue89e"}

--- a/packages/core/styles/_links.scss
+++ b/packages/core/styles/_links.scss
@@ -14,25 +14,19 @@ $_link-underline-thickness--focus: jkl.rem(2px);
     outline: none;
     text-decoration: none;
 
-    display: inline-flex;
-    align-items: center;
-    gap: jkl.rem(1.5px);
+    @include jkl.motion("standard", "energetic");
+    transition-property: color;
 
     &__content {
-        background-position: 0
-            calc(
-                100% -
-                    (
-                        #{$_link-underline-thickness--focus} - #{$_link-underline-thickness}
-                    )
-            );
-        background-size: $_link-underline-thickness $_link-underline-thickness;
-        background-repeat: repeat-x;
+        text-decoration: underline;
+        text-underline-offset: 0.4em;
+        text-decoration-thickness: 1px;
+    }
 
-        @include jkl.motion("standard", "energetic");
-        transition-property: color;
-
-        @include _underline-gradient(var(--link-color));
+    &__icon {
+        margin-inline-start: 0.2em;
+        margin-block-start: -0.1em;
+        vertical-align: middle;
     }
 
     &:hover:not(:focus) {
@@ -79,6 +73,10 @@ $_link-underline-thickness--focus: jkl.rem(2px);
     }
 
     &__icon {
+        margin-inline-start: 0.1em;
+        margin-block-start: -0.1em;
+        vertical-align: middle;
+
         @include jkl.motion;
         transition-property: transform;
     }
@@ -97,6 +95,10 @@ $_link-underline-thickness--focus: jkl.rem(2px);
         margin-right: 0;
         padding-left: $arrow-spacing;
         margin-left: -#{$arrow-spacing};
+
+        .jkl-nav-link__icon {
+            margin-inline: 0 0.1em;
+        }
 
         &:focus-visible,
         &:hover:not(:focus) {

--- a/packages/jokul/src/components/link/Link.tsx
+++ b/packages/jokul/src/components/link/Link.tsx
@@ -31,7 +31,7 @@ export const Link = React.forwardRef(function Link<
         >
             <span className="jkl-link__content">{children}</span>
             {(external || rest.target === "_blank") && (
-                <OpenInNewIcon variant="small" />
+                <OpenInNewIcon variant="small" className="jkl-link__icon" />
             )}
             {external && (
                 <span hidden={true} id={srId}>

--- a/packages/jokul/src/components/link/styles/link.scss
+++ b/packages/jokul/src/components/link/styles/link.scss
@@ -1,12 +1,5 @@
 @use "../../../core/jkl";
 
-@mixin _underline-gradient($color) {
-    background-image: linear-gradient(to bottom, $color 0%, $color 100%);
-}
-
-$_link-underline-thickness: jkl.rem(1px);
-$_link-underline-thickness--focus: jkl.rem(2px);
-
 .jkl-link {
     --link-color: var(--jkl-color-text-default);
 
@@ -14,25 +7,19 @@ $_link-underline-thickness--focus: jkl.rem(2px);
     outline: none;
     text-decoration: none;
 
-    display: inline-flex;
-    align-items: center;
-    gap: jkl.rem(1.5px);
+    @include jkl.motion("standard", "energetic");
+    transition-property: color;
 
     &__content {
-        background-position: 0
-            calc(
-                100% -
-                    (
-                        #{$_link-underline-thickness--focus} - #{$_link-underline-thickness}
-                    )
-            );
-        background-size: $_link-underline-thickness $_link-underline-thickness;
-        background-repeat: repeat-x;
+        text-decoration: underline;
+        text-underline-offset: 0.4em;
+        text-decoration-thickness: 1px;
+    }
 
-        @include jkl.motion("standard", "energetic");
-        transition-property: color;
-
-        @include _underline-gradient(var(--link-color));
+    &__icon {
+        margin-inline-start: 0.2em;
+        margin-block-start: -0.1em;
+        vertical-align: middle;
     }
 
     &:hover:not(:focus) {

--- a/packages/jokul/src/components/nav-link/styles/nav-link.scss
+++ b/packages/jokul/src/components/nav-link/styles/nav-link.scss
@@ -8,10 +8,6 @@
     text-decoration: none;
     position: relative;
 
-    display: inline-flex;
-    align-items: center;
-    gap: jkl.rem(1.5px);
-
     // Unngå at border ved tastaturfokus "kapper" pila
     $arrow-spacing: 0.15rem;
     padding-right: $arrow-spacing;
@@ -35,6 +31,10 @@
     }
 
     &__icon {
+        margin-inline-start: 0.1em;
+        margin-block-start: -0.1em;
+        vertical-align: middle;
+
         @include jkl.motion;
         transition-property: transform;
     }
@@ -48,6 +48,10 @@
         margin-right: 0;
         padding-left: $arrow-spacing;
         margin-left: -#{$arrow-spacing};
+
+        .jkl-nav-link__icon {
+            margin-inline: 0 0.1em;
+        }
 
         &:focus-visible,
         &:hover:not(:focus) {


### PR DESCRIPTION
- Sørger for at understreken oppfører seg som forventet dersom lenketeksten går over flere linjer
- Plasserer ikonet riktig (inline, etter teksten) for både Link og NavLink dersom teksten går over flere linjer

closes #4569 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
