### PR TITLE
fix: checks if element exists before reading height

### DIFF
--- a/packages/expandable-react/src/Expander.tsx
+++ b/packages/expandable-react/src/Expander.tsx
@@ -40,10 +40,17 @@ export const Expander = React.forwardRef(function Expander<
 
     useEffect(() => {
         const observer = new ResizeObserver(function () {
-            setExpanderHeight(internalRef.current!.offsetHeight);
+            // Default to 64 if the height can not be read because that is
+            // the height of the default summary element. In a custom component
+            // this means that the focus ring might be slightly misaligned but
+            // in most cases we will be able to read the ref correctly.
+            setExpanderHeight(internalRef.current?.offsetHeight || 64);
         });
-        observer.observe(internalRef.current!);
-        return () => observer.disconnect();
+        if (internalRef.current) {
+            observer.observe(internalRef.current);
+            return () => observer.disconnect();
+        }
+        return () => {};
     }, [setExpanderHeight]);
 
     return (

--- a/packages/jokul/src/components/expander/Expander.tsx
+++ b/packages/jokul/src/components/expander/Expander.tsx
@@ -45,10 +45,17 @@ export const Expander = React.forwardRef(function Expander<
 
     useEffect(() => {
         const observer = new ResizeObserver(function () {
-            setExpanderHeight(internalRef.current!.offsetHeight);
+            // Default to 64 if the height can not be read because that is
+            // the height of the default summary element. In a custom component
+            // this means that the focus ring might be slightly misaligned but
+            // in most cases we will be able to read the ref correctly.
+            setExpanderHeight(internalRef.current?.offsetHeight || 64);
         });
-        observer.observe(internalRef.current!);
-        return () => observer.disconnect();
+        if (internalRef.current) {
+            observer.observe(internalRef.current);
+            return () => observer.disconnect();
+        }
+        return () => {};
     }, [setExpanderHeight]);
 
     return (


### PR DESCRIPTION
Fixes an error that would sometimes get thrown if the element we tried to read the height from was no longer in the DOM.

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->


-   [ ] `pnpm build` og `pnpm ci:test` gir ingen feil
