### PR TITLE
feat: legg til støtte for runtime environment variabler

### DIFF
--- a/ny-portal/sanity.config.ts
+++ b/ny-portal/sanity.config.ts
@@ -1,23 +1,18 @@
 import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
+import type { Config } from "sanity";
 import { structureTool } from "sanity/structure";
 import { schemaTypes } from "@/sanity/schemas";
 
-type SanityConfig = {
-    projectId: string;
-    dataset: string;
-};
-
-export function getSanityConfig(config: SanityConfig) {
+export function getSanityConfig(config: Config) {
     return defineConfig({
         name: "default",
         basePath: "/studio",
         title: "Jøkul Portal Studio",
-        projectId: config.projectId,
-        dataset: config.dataset,
         plugins: [structureTool(), visionTool()],
         schema: {
             types: schemaTypes,
         },
+        ...config,
     });
 }

--- a/ny-portal/sanity.config.ts
+++ b/ny-portal/sanity.config.ts
@@ -3,14 +3,21 @@ import { defineConfig } from "sanity";
 import { structureTool } from "sanity/structure";
 import { schemaTypes } from "@/sanity/schemas";
 
-export default defineConfig({
-    name: "default",
-    basePath: "/studio",
-    title: "Jøkul Portal Studio",
-    projectId: process.env.NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID || "",
-    dataset: process.env.NEXT_PUBLIC_SANITY_STUDIO_DATASET || "test",
-    plugins: [structureTool(), visionTool()],
-    schema: {
-        types: schemaTypes,
-    },
-});
+type SanityConfig = {
+    projectId: string;
+    dataset: string;
+};
+
+export function getSanityConfig(config: SanityConfig) {
+    return defineConfig({
+        name: "default",
+        basePath: "/studio",
+        title: "Jøkul Portal Studio",
+        projectId: config.projectId,
+        dataset: config.dataset,
+        plugins: [structureTool(), visionTool()],
+        schema: {
+            types: schemaTypes,
+        },
+    });
+}

--- a/ny-portal/src/app/studio/Studio.tsx
+++ b/ny-portal/src/app/studio/Studio.tsx
@@ -1,18 +1,11 @@
 "use client";
 
 import { NextStudio } from "next-sanity/studio";
+import type { Config } from "sanity";
 import { getSanityConfig } from "sanity.config";
 
-interface StudioProps {
-    projectId: string;
-    dataset: string;
-}
+export default function Studio(config: Config) {
+    const sanityConfig = getSanityConfig(config);
 
-export default function Studio({ projectId, dataset }: StudioProps) {
-    const config = getSanityConfig({
-        projectId,
-        dataset,
-    });
-
-    return <NextStudio config={config} />;
+    return <NextStudio config={sanityConfig} />;
 }

--- a/ny-portal/src/app/studio/Studio.tsx
+++ b/ny-portal/src/app/studio/Studio.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { NextStudio } from "next-sanity/studio";
+import { getSanityConfig } from "sanity.config";
+
+interface StudioProps {
+    projectId: string;
+    dataset: string;
+}
+
+export default function Studio({ projectId, dataset }: StudioProps) {
+    const config = getSanityConfig({
+        projectId,
+        dataset,
+    });
+
+    return <NextStudio config={config} />;
+}

--- a/ny-portal/src/app/studio/[[...index]]/page.tsx
+++ b/ny-portal/src/app/studio/[[...index]]/page.tsx
@@ -1,8 +1,10 @@
-"use client";
+import Studio from "../Studio";
 
-import { NextStudio } from "next-sanity/studio";
-import config from "../../../../sanity.config";
-
-export default function Studio() {
-    return <NextStudio config={config} />;
+export default async function StudioPage() {
+    return (
+        <Studio
+            projectId={process.env.SANITY_PROJECT_ID || ""}
+            dataset={process.env.SANITY_DATASET || "test"}
+        />
+    );
 }

--- a/ny-portal/src/sanity/client.ts
+++ b/ny-portal/src/sanity/client.ts
@@ -1,6 +1,6 @@
 import { createClient } from "next-sanity";
 
 export const client = createClient({
-    projectId: process.env.NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID || "",
-    dataset: process.env.NEXT_PUBLIC_SANITY_STUDIO_DATASET || "test",
+    projectId: process.env.SANITY_PROJECT_ID || "",
+    dataset: process.env.SANITY_DATASET || "test",
 });


### PR DESCRIPTION
- Oppdatert StudioPage (app/studio/page.tsx) til å hente disse variablene på serversiden før NextStudio rendres.
- Sørget for at sanity.config.ts forblir synkron ved å sende variabler som props til Studio.tsx.

ISSUES CLOSED: #4647