### PR TITLE
fix: endre title til name i navigationmenu

### DIFF
--- a/.github/workflows/build-and-deploy-portal.yml
+++ b/.github/workflows/build-and-deploy-portal.yml
@@ -29,5 +29,5 @@ jobs:
                     -H "Accept: application/vnd.github+json" \
                     -H "Authorization: Bearer $DEPLOY_TOKEN" \
                     -H "X-GitHub-Api-Version: 2022-11-28" \
-                    https://api.github.com/repos/fremtind/jokul-portal-deploy/actions/workflows/129328031/dispatches
+                    https://api.github.com/repos/fremtind/jokul-portal-deploy/actions/workflows/129328031/dispatches \
                     -d '{"ref":"main"}'

--- a/ny-portal/src/components/Navigation/NavigationMenu.tsx
+++ b/ny-portal/src/components/Navigation/NavigationMenu.tsx
@@ -13,7 +13,7 @@ export const NavigationMenu = async () => {
                 parentPath="komponenter"
                 items={[
                     {
-                        title: "Oversikt",
+                        name: "Oversikt",
                         slug: {
                             current: "",
                             _type: "slug",

--- a/ny-portal/src/components/Navigation/NavigationMenuGroup.tsx
+++ b/ny-portal/src/components/Navigation/NavigationMenuGroup.tsx
@@ -54,12 +54,12 @@ export const NavigationMenuGroup: FC<NavigationMenuGroupProps> = ({
             >
                 <ul>
                     {items.map((item) => {
-                        const { slug, title } = item;
+                        const { slug, name } = item;
                         const isActive = pathname === getItemPath(slug);
 
                         return (
                             <NavigationMenuLink
-                                key={`${slug}-${title}`}
+                                key={`${slug}-${name}`}
                                 title={title ?? "Untitled"}
                                 path={slug}
                                 parentPath={parentPath}


### PR DESCRIPTION
- Endret title til name i NavigationMenu for å samsvare med oppdatert Sanity-query.
- La til `\` i curl-kommandoen i deploy-workflow. Nødvendig for å fortsette kommandoen på flere linjer og sikre at `-d` flagget tolkes riktig.
