### PR TITLE
fix: tabbing to radio/checkbox now scrolls it into view

### DIFF
--- a/packages/checkbox/checkbox.scss
+++ b/packages/checkbox/checkbox.scss
@@ -73,10 +73,12 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
 
     &__input {
         // Hide native checkbox
-        opacity: 0;
         position: absolute;
-        // Position the hidden input so that Cypress can hit it without it being obscured by the visual checkbox
-        top: -6px;
+        opacity: 0;
+        // Make sure that when the browser scrolls here because of focus, the control
+        // is positioned below the label so that the label becomes visible.
+        top: var(--jkl-checkbox-box-size);
+        left: calc(-0.5 * var(--jkl-checkbox-box-size));
 
         &:checked {
             + .jkl-checkbox__label .jkl-checkbox__check-mark::after {

--- a/packages/jokul/src/components/checkbox/styles/checkbox.scss
+++ b/packages/jokul/src/components/checkbox/styles/checkbox.scss
@@ -73,10 +73,12 @@ $_checkbox-indeterminate-animation-name: jkl-checkbox-indeterminate-#{string.uni
 
     &__input {
         // Hide native checkbox
-        opacity: 0;
         position: absolute;
-        // Position the hidden input so that Cypress can hit it without it being obscured by the visual checkbox
-        top: -6px;
+        opacity: 0;
+        // Make sure that when the browser scrolls here because of focus, the control
+        // is positioned below the label so that the label becomes visible.
+        top: var(--jkl-checkbox-box-size);
+        left: calc(-0.5 * var(--jkl-checkbox-box-size));
 
         &:checked {
             + .jkl-checkbox__label .jkl-checkbox__check-mark::after {

--- a/packages/jokul/src/components/radio-button/styles/radio-button.scss
+++ b/packages/jokul/src/components/radio-button/styles/radio-button.scss
@@ -92,8 +92,10 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         // hide default radio button
         position: absolute;
         opacity: 0;
-        // Position the hidden input so that Cypress can hit it without it being obscured by the visual checkbox
-        top: -6px;
+        // Make sure that when the browser scrolls here because of focus, the control
+        // is positioned below the label so that the label becomes visible.
+        top: var(--jkl-radio-button-size);
+        left: calc(-0.5 * var(--jkl-radio-button-size));
 
         // Checked state
         &:checked {

--- a/packages/radio-button/radio-button.scss
+++ b/packages/radio-button/radio-button.scss
@@ -92,8 +92,10 @@ $_radio-button-dot-animation-name: jkl-dot-in-#{string.unique-id()};
         // hide default radio button
         position: absolute;
         opacity: 0;
-        // Position the hidden input so that Cypress can hit it without it being obscured by the visual checkbox
-        top: -6px;
+        // Make sure that when the browser scrolls here because of focus, the control
+        // is positioned below the label so that the label becomes visible.
+        top: var(--jkl-radio-button-size);
+        left: calc(-0.5 * var(--jkl-radio-button-size));
 
         // Checked state
         &:checked {


### PR DESCRIPTION
When using tab to navigate to a radio/checkbox that is below the viewport most browsers will scroll untill the input-control itself is in view and call it a day. In this case, that means it makes more sense to keep the hidden input control next to the visible label instead of above it.

ISSUES CLOSED: #4649

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [ ] Nye features er dokumentert (sjekk [Contributing](https://github.com/fremtind/jokul/blob/main/CONTRIBUTING.md) om du er usikker på hva som trengs av dokumentasjon)
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
