### PR TITLE
refactor: bruk moderne CSS for animasjon og hover i knapper

### DIFF
--- a/packages/button-react/src/Button.tsx
+++ b/packages/button-react/src/Button.tsx
@@ -18,6 +18,7 @@ export const Button = React.forwardRef(function Button<
         className,
         density,
         onTouchStart,
+        onAnimationEnd,
         loader,
         icon,
         iconPosition = "left",
@@ -41,37 +42,41 @@ export const Button = React.forwardRef(function Button<
         );
     }
 
-    const handleTouch = useCallback(
-        (event: TouchEvent<HTMLButtonElement>) => {
-            onTouchStart && onTouchStart(event);
+    const removeButtonAnimation = (element: HTMLElement) => {
+        if (element.classList.contains("jkl-button--pressed")) {
+            element.classList.remove("jkl-button--pressed");
+            element.style.removeProperty("--jkl-touch-xcoord");
+            element.style.removeProperty("--jkl-touch-ycoord");
+        }
+    };
 
-            const target = event.target as HTMLButtonElement;
-            if (target && !target.disabled && event.targetTouches.length) {
-                const Xcoord =
-                    event.targetTouches[0].clientX -
-                    target.getBoundingClientRect().x;
-                const Ycoord =
-                    event.targetTouches[0].clientY -
-                    target.getBoundingClientRect().y;
-                target.style.setProperty(
-                    "--jkl-touch-xcoord",
-                    Xcoord.toPrecision(4) + "px",
-                );
-                target.style.setProperty(
-                    "--jkl-touch-ycoord",
-                    Ycoord.toPrecision(4) + "px",
-                );
-                target.classList.add("jkl-button--pressed");
+    const handleTouch = useCallback((event: TouchEvent<HTMLButtonElement>) => {
+        const target = event.target as HTMLButtonElement;
 
-                setTimeout(() => {
-                    target.classList.remove("jkl-button--pressed");
-                    target.style.removeProperty("--jkl-touch-xcoord");
-                    target.style.removeProperty("--jkl-touch-ycoord");
-                }, 400);
-            }
-        },
-        [onTouchStart],
-    );
+        if (target && !target.disabled && event.targetTouches.length) {
+            const Xcoord =
+                event.targetTouches[0].clientX -
+                target.getBoundingClientRect().x;
+            const Ycoord =
+                event.targetTouches[0].clientY -
+                target.getBoundingClientRect().y;
+            target.style.setProperty(
+                "--jkl-touch-xcoord",
+                Xcoord.toFixed(1) + "px",
+            );
+            target.style.setProperty(
+                "--jkl-touch-ycoord",
+                Ycoord.toFixed(1) + "px",
+            );
+            target.classList.add("jkl-button--pressed");
+
+            setTimeout(() => {
+                target.classList.remove("jkl-button--pressed");
+                target.style.removeProperty("--jkl-touch-xcoord");
+                target.style.removeProperty("--jkl-touch-ycoord");
+            }, 400);
+        }
+    }, []);
 
     const ariaLive = useAriaLiveRegion(loader?.showLoader);
     const showLoader = Boolean(children) && Boolean(loader?.showLoader);
@@ -83,7 +88,14 @@ export const Button = React.forwardRef(function Button<
             data-density={density}
             className={cn("jkl-button", "jkl-button--" + variant, className)}
             disabled={as === "button" ? loader?.showLoader : undefined}
-            onTouchStart={handleTouch}
+            onTouchStart={(event) => {
+                onTouchStart?.(event);
+                handleTouch(event);
+            }}
+            onAnimationEnd={(event) => {
+                onAnimationEnd?.(event);
+                removeButtonAnimation(event.target as HTMLElement);
+            }}
             {...rest}
             ref={ref}
         >

--- a/packages/button/button.scss
+++ b/packages/button/button.scss
@@ -2,7 +2,8 @@
 @use "sass:string";
 @use "@fremtind/jkl-core/jkl";
 
-$_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
+$_grow-animation-name: button-grow-#{string.unique-id()};
+$_fade-animation-name: button-fade-#{string.unique-id()};
 
 @include jkl.comfortable-density-variables {
     --jkl-button-padding-block: #{jkl.$spacing-8};
@@ -36,6 +37,40 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     }
 }
 
+// Custom variabler, definert slik at de kan animeres
+
+// Egenskap for hover-effekt
+@property --hover-opacity {
+    syntax: "<number>";
+    initial-value: 0;
+    inherits: false;
+}
+
+// Egenskaper for touch-effekt
+@property --jkl-button-flash-radius {
+    syntax: "<length-percentage>";
+    initial-value: 0%;
+    inherits: false;
+}
+@property --jkl-button-flash-opacity {
+    syntax: "<number>";
+    initial-value: 0;
+    inherits: false;
+}
+
+// Definer animasjoner for touch-effekt
+@keyframes #{$_fade-animation-name} {
+    from {
+        --jkl-button-flash-opacity: 0.5;
+    }
+}
+
+@keyframes #{$_grow-animation-name} {
+    to {
+        --jkl-button-flash-radius: 150%;
+    }
+}
+
 .jkl-button {
     --jkl-icon-weight: var(--jkl-button-icon-weight, initial);
     --text-color: var(--jkl-color-text-default);
@@ -49,10 +84,27 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     font-size: var(--jkl-button-font-size);
     line-height: var(--jkl-button-line-height);
 
-    // button and link resets
     cursor: pointer;
     user-select: none;
-    background-color: var(--background-color);
+    background:
+        // Lag 1: heldekkende "gradient" for hovereffekt
+        linear-gradient(
+            color(from var(--text-color) sRGB r g b / var(--hover-opacity)) 100%,
+            transparent 100%
+        ),
+        // Lag 2: touch-effekt
+        radial-gradient(
+                circle at var(--jkl-touch-xcoord, 50%)
+                    var(--jkl-touch-ycoord, 50%),
+                color(
+                        from var(--text-color) sRGB r g b /
+                            var(--jkl-button-flash-opacity)
+                    )
+                    calc(var(--jkl-button-flash-radius) - 1px),
+                transparent var(--jkl-button-flash-radius, 0%)
+            ),
+        // Lag 3: faktisk bakgrunnsfarge
+        var(--background-color);
     color: var(--text-color);
     border: unset;
     text-decoration: none;
@@ -65,7 +117,7 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     overflow: hidden;
     max-width: 100%;
 
-    @include jkl.motion("standard", "productive", scale);
+    @include jkl.motion("standard", "productive", --hover-opacity);
 
     &:has(.jkl-icon:first-child) {
         padding-inline-start: var(--jkl-button-padding-icon);
@@ -125,42 +177,12 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
         @include jkl.focus-outline;
     }
 
-    // Dette er elementet som viser touch-animasjon
-    &::before {
-        content: "";
-        pointer-events: none;
-        display: block;
-        position: absolute;
-        left: var(--jkl-touch-xcoord, 50%);
-        top: var(--jkl-touch-ycoord, 50%);
-        translate: -100%, -100%;
-        transform-origin: center;
-        border-radius: 9999px;
-        background-color: var(--text-color);
-        opacity: 0;
-        width: jkl.rem(16px);
-        height: jkl.rem(16px);
-    }
-
-    &::after {
-        content: "";
-        opacity: 0;
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        background-color: var(--text-color);
-        @include jkl.motion("standard", "productive", opacity);
-    }
-
     &:hover {
-        &::after {
-            opacity: 0.15;
-        }
+        --hover-opacity: 0.15;
     }
 
-    html[data-touchnavigation] &.jkl-button--pressed::before {
-        animation: jkl.easing("focus") jkl.timing("expressive")
-            $_flash-animation-name;
+    &.jkl-button--pressed {
+        animation-name: #{$_fade-animation-name}, #{$_grow-animation-name};
     }
 
     &--primary,
@@ -212,17 +234,5 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
         &:hover {
             --background-color: var(--jkl-color-background-interactive-hover);
         }
-    }
-}
-
-@keyframes #{$_flash-animation-name} {
-    0% {
-        opacity: 0.5;
-        scale: 1;
-    }
-
-    100% {
-        opacity: 0;
-        scale: 8;
     }
 }

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -2,7 +2,8 @@
 @use "sass:string";
 @use "../../../core/jkl";
 
-$_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
+$_grow-animation-name: button-grow-#{string.unique-id()};
+$_fade-animation-name: button-fade-#{string.unique-id()};
 
 @include jkl.comfortable-density-variables {
     --jkl-button-padding-block: #{jkl.$unit-10};
@@ -36,6 +37,40 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     }
 }
 
+// Custom variabler, definert slik at de kan animeres
+
+// Egenskap for hover-effekt
+@property --hover-opacity {
+    syntax: "<number>";
+    initial-value: 0;
+    inherits: false;
+}
+
+// Egenskaper for touch-effekt
+@property --jkl-button-flash-radius {
+    syntax: "<length-percentage>";
+    initial-value: 0%;
+    inherits: false;
+}
+@property --jkl-button-flash-opacity {
+    syntax: "<number>";
+    initial-value: 0;
+    inherits: false;
+}
+
+// Definer animasjoner for touch-effekt
+@keyframes #{$_fade-animation-name} {
+    from {
+        --jkl-button-flash-opacity: 0.5;
+    }
+}
+
+@keyframes #{$_grow-animation-name} {
+    to {
+        --jkl-button-flash-radius: 150%;
+    }
+}
+
 .jkl-button {
     --jkl-icon-weight: var(--jkl-button-icon-weight, initial);
     --text-color: var(--jkl-color-text-default);
@@ -49,10 +84,27 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     font-size: var(--jkl-button-font-size);
     line-height: var(--jkl-button-line-height);
 
-    // button and link resets
     cursor: pointer;
     user-select: none;
-    background-color: var(--background-color);
+    background:
+        // Lag 1: heldekkende "gradient" for hovereffekt
+        linear-gradient(
+            color(from var(--text-color) sRGB r g b / var(--hover-opacity)) 100%,
+            transparent 100%
+        ),
+        // Lag 2: touch-effekt
+        radial-gradient(
+                circle at var(--jkl-touch-xcoord, 50%)
+                    var(--jkl-touch-ycoord, 50%),
+                color(
+                        from var(--text-color) sRGB r g b /
+                            var(--jkl-button-flash-opacity)
+                    )
+                    calc(var(--jkl-button-flash-radius) - 1px),
+                transparent var(--jkl-button-flash-radius, 0%)
+            ),
+        // Lag 3: faktisk bakgrunnsfarge
+        var(--background-color);
     color: var(--text-color);
     border: unset;
     text-decoration: none;
@@ -64,8 +116,9 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
     position: relative;
     overflow: hidden;
     max-width: 100%;
+    animation: a 0.3s linear;
 
-    @include jkl.motion("standard", "productive", scale);
+    @include jkl.motion("standard", "productive", --hover-opacity);
 
     &:has(.jkl-icon:first-child) {
         padding-inline-start: var(--jkl-button-padding-icon);
@@ -125,42 +178,12 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
         @include jkl.focus-outline;
     }
 
-    // Dette er elementet som viser touch-animasjon
-    &::before {
-        content: "";
-        pointer-events: none;
-        display: block;
-        position: absolute;
-        left: var(--jkl-touch-xcoord, 50%);
-        top: var(--jkl-touch-ycoord, 50%);
-        translate: -100%, -100%;
-        transform-origin: center;
-        border-radius: 9999px;
-        background-color: var(--text-color);
-        opacity: 0;
-        width: jkl.rem(16px);
-        height: jkl.rem(16px);
-    }
-
-    &::after {
-        content: "";
-        opacity: 0;
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        background-color: var(--text-color);
-        @include jkl.motion("standard", "productive", opacity);
-    }
-
     &:hover {
-        &::after {
-            opacity: 0.15;
-        }
+        --hover-opacity: 0.15;
     }
 
-    html[data-touchnavigation] &.jkl-button--pressed::before {
-        animation: jkl.easing("focus") jkl.timing("expressive")
-            $_flash-animation-name;
+    &.jkl-button--pressed {
+        animation-name: #{$_fade-animation-name}, #{$_grow-animation-name};
     }
 
     &--primary,
@@ -176,57 +199,20 @@ $_flash-animation-name: jkl-tertiary-flash-#{string.unique-id()};
 
     &--secondary {
         border: var(--border-width) solid var(--text-color);
-
-        &::after {
-            content: "";
-            position: absolute;
-            inset: 0;
-        }
     }
 
     &--tertiary {
         border-bottom: var(--border-width) solid var(--text-color);
         padding-inline: var(--jkl-button-teritary-padding-icon);
 
-        &::after {
-            content: "";
-            position: absolute;
-            inset: 0;
-            border-radius: var(--border-radius);
-        }
-
         &:has(.jkl-icon:first-child) {
-            padding-inline: var(--jkl-button-teritary-padding-icon) calc(
-                var(--jkl-button-teritary-padding-icon) * 2
-            );
+            padding-inline: var(--jkl-button-teritary-padding-icon)
+                calc(var(--jkl-button-teritary-padding-icon) * 2);
         }
 
         &:has(.jkl-icon:last-child) {
-            padding-inline: calc(
-                var(--jkl-button-teritary-padding-icon) * 2
-            ) var(--jkl-button-teritary-padding-icon);
+            padding-inline: calc(var(--jkl-button-teritary-padding-icon) * 2)
+                var(--jkl-button-teritary-padding-icon);
         }
-    }
-
-    &--ghost,
-    &--ghost:has(.jkl-icon:first-child),
-    &--ghost:has(.jkl-icon:last-child) {
-        @include jkl.motion("standard", "productive", background-color);
-
-        &:hover {
-            --background-color: var(--jkl-color-background-interactive-hover);
-        }
-    }
-}
-
-@keyframes #{$_flash-animation-name} {
-    0% {
-        opacity: 0.5;
-        scale: 1;
-    }
-
-    100% {
-        opacity: 0;
-        scale: 8;
     }
 }


### PR DESCRIPTION
- Flytter touch-animasjon på knappene fra et pseudoelement til en gradient
- Flytter hovereffekt på knappene fra et pseudoelement til en gradient
- Fjern klasse for touch-animasjon ved animationEnd i stedet for hardkodet tid

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
