### PR TITLE
Legg til attributter fra div på File-komponenten

### DIFF
--- a/packages/file-input-react/src/File.tsx
+++ b/packages/file-input-react/src/File.tsx
@@ -1,16 +1,15 @@
-import type { WithOptionalChildren } from "@fremtind/jkl-core";
 import { formatBytes } from "@fremtind/jkl-formatters-util";
 import { IconButton } from "@fremtind/jkl-icon-button-react";
-import { TrashCanIcon, SuccessIcon } from "@fremtind/jkl-icons-react";
+import { SuccessIcon, TrashCanIcon } from "@fremtind/jkl-icons-react";
 import { SupportLabel } from "@fremtind/jkl-input-group-react";
 import { useId } from "@fremtind/jkl-react-hooks";
 import cn from "classnames";
-import React, { FC, MouseEvent } from "react";
+import React, { ComponentProps, FC, MouseEvent } from "react";
 import { useFileInputContext } from "./internal/fileInputContext";
 import { Thumbnail } from "./internal/Thumbnail";
 import { FileInputFileState } from "./types";
 
-export interface FileProps extends WithOptionalChildren {
+export interface FileProps {
     fileName: string;
     fileType: string;
     fileSize: number;
@@ -22,7 +21,7 @@ export interface FileProps extends WithOptionalChildren {
     onRemove?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const File: FC<FileProps> = (props) => {
+export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     const {
         children,
         fileName,

--- a/packages/jokul/src/components/file-input/File.tsx
+++ b/packages/jokul/src/components/file-input/File.tsx
@@ -1,16 +1,19 @@
 import clsx from "clsx";
-import React, { FC, MouseEvent } from "react";
+import React, {
+    type ComponentProps,
+    type FC,
+    type MouseEvent,
+    useId,
+} from "react";
 import { TrashCanIcon, SuccessIcon } from "../../components/icon/index.js";
 import { IconButton } from "../../components/icon-button/IconButton.js";
 import { SupportLabel } from "../../components/input-group/SupportLabel.js";
-import { type WithOptionalChildren } from "../../core/types.js";
-import { useId } from "../../hooks/useId/useId.js";
 import { formatBytes } from "../../utilities/formatters/bytes/formatBytes.js";
 import { useFileInputContext } from "./internal/fileInputContext.js";
 import { Thumbnail } from "./internal/Thumbnail.js";
-import { FileInputFileState } from "./types.js";
+import type { FileInputFileState } from "./types.js";
 
-export interface FileProps extends WithOptionalChildren {
+export type FileProps = {
     fileName: string;
     fileType: string;
     fileSize: number;
@@ -20,9 +23,9 @@ export interface FileProps extends WithOptionalChildren {
     supportLabelType?: "help" | "error" | "warning" | "success";
     state?: FileInputFileState;
     onRemove?: (e: MouseEvent<HTMLButtonElement>) => void;
-}
+};
 
-export const File: FC<FileProps> = (props) => {
+export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     const {
         children,
         fileName,
@@ -36,7 +39,7 @@ export const File: FC<FileProps> = (props) => {
         onRemove,
     } = props;
 
-    const id = useId("jkl-file-preview");
+    const id = `jkl-file-preview-${useId()}`;
     const supportId = id + "-support";
 
     const context = useFileInputContext();

--- a/packages/jokul/src/components/file-input/styles/_index.scss
+++ b/packages/jokul/src/components/file-input/styles/_index.scss
@@ -1,1 +1,5 @@
 @forward "file-input";
+
+@use "../../icon/styles" as icon;
+@use "../../icon-button/styles" as icon-button;
+@use "../../input-group/styles" as input-group;


### PR DESCRIPTION
- Lar File-komponenten ta inn attributtene til elementet den rendres som (`div`)
- Legger til manglende stilavhengigheter for `file-input` i `jokul`-pakken

closes: #4685 

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
