### PR TITLE
fix: la File-komponenten ta inn props for div-elementet

### DIFF
--- a/packages/file-input-react/src/File.tsx
+++ b/packages/file-input-react/src/File.tsx
@@ -24,6 +24,7 @@ export interface FileProps {
 export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     const {
         children,
+        className,
         fileName,
         fileType,
         fileSize,
@@ -33,6 +34,7 @@ export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
         supportLabelType,
         state,
         onRemove,
+        ...rest
     } = props;
 
     const id = useId("jkl-file-preview");
@@ -70,7 +72,7 @@ export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     };
 
     const fileComponent = (
-        <div id={id} className="jkl-file">
+        <div id={id} className={cn(className, "jkl-file")} {...rest}>
             <Component
                 className={cn("jkl-file__content", {
                     "jkl-file__content--error": supportLabelType === "error",

--- a/packages/jokul/src/components/file-input/File.tsx
+++ b/packages/jokul/src/components/file-input/File.tsx
@@ -28,6 +28,7 @@ export type FileProps = {
 export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     const {
         children,
+        className,
         fileName,
         fileType,
         fileSize,
@@ -37,6 +38,7 @@ export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
         supportLabelType,
         state,
         onRemove,
+        ...rest
     } = props;
 
     const id = `jkl-file-preview-${useId()}`;
@@ -74,7 +76,7 @@ export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
     };
 
     const fileComponent = (
-        <div id={id} className="jkl-file">
+        <div id={id} className={clsx(className, "jkl-file")} {...rest}>
             <Component
                 className={clsx("jkl-file__content", {
                     "jkl-file__content--error": supportLabelType === "error",


### PR DESCRIPTION
Hadde glemt å spreade props på elementet. Nå tar `File` faktisk inn alle props som `div` kan ta.
