### PR TITLE
docs: legg til typografi, lister, lenker og kode i PortableText

### DIFF
--- a/ny-portal/src/components/portable-text/PortableText.tsx
+++ b/ny-portal/src/components/portable-text/PortableText.tsx
@@ -6,6 +6,9 @@ import { PortableText as PortableTextReact } from "@portabletext/react";
 import type { TypedObject } from "@portabletext/types";
 import type { FC } from "react";
 import { Storybook } from "./storybook-story/Storybook";
+import { ListItem, OrderedList, UnorderedList } from "./list";
+import { Link } from "./link/Link";
+import { CodeBlock, InlineCode } from "./typography/Typography";
 
 interface Props {
     blocks: TypedObject[] | null;
@@ -16,10 +19,23 @@ const portableTextComponents: Record<
     FC<PortableTextComponentProps<any>>
 > = {
     jokul_storybook: Storybook,
+    jokul_codeBlock: CodeBlock,
 };
 
 export const baseComponentDefinition: Partial<PortableTextReactComponents> = {
     types: portableTextComponents,
+    list: {
+        bullet: UnorderedList,
+        number: OrderedList,
+    },
+    listItem: {
+        bullet: ListItem,
+        number: ListItem,
+    },
+    marks: {
+        link: Link,
+        code: InlineCode,
+    },
 };
 
 export const PortableText: FC<Props> = (props) => {

--- a/ny-portal/src/components/portable-text/code-block/CodeBlock.tsx
+++ b/ny-portal/src/components/portable-text/code-block/CodeBlock.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import scss from "react-syntax-highlighter/dist/esm/languages/prism/scss";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import fremtindTheme from "./fremtindTheme";
+import fremtindThemeDark from "./fremtindThemeDark";
+import { useBrowserPreferences, type WithChildren } from "@fremtind/jokul";
+
+import styles from "./code-block.module.scss";
+
+SyntaxHighlighter.registerLanguage("scss", scss);
+SyntaxHighlighter.registerLanguage("tsx", tsx);
+
+export type CodeBlockProps = WithChildren & {
+    children: string | string[];
+    language?: string;
+};
+
+export const CodeBlock: React.FC<CodeBlockProps> = ({ language, children }) => {
+    const { prefersColorScheme } = useBrowserPreferences();
+    const [style, setStyle] = useState(fremtindTheme);
+
+    useEffect(
+        () =>
+            setStyle(
+                prefersColorScheme === "dark"
+                    ? fremtindThemeDark
+                    : fremtindTheme,
+            ),
+        [prefersColorScheme],
+    );
+
+    return (
+        <SyntaxHighlighter
+            className={styles.codeBlock}
+            style={style}
+            codeTagProps={{
+                style: {},
+                className: styles.codeBlockCode,
+                tabIndex: 0,
+            }}
+            language={language}
+            data-language={language || undefined}
+        >
+            {children}
+        </SyntaxHighlighter>
+    );
+};

--- a/ny-portal/src/components/portable-text/code-block/code-block.module.scss
+++ b/ny-portal/src/components/portable-text/code-block/code-block.module.scss
@@ -1,0 +1,43 @@
+@use '@fremtind/jokul/styles/core/jkl';
+
+.codeBlock {
+    position: relative;
+    background-color: var(--jkl-color-background-page);
+    box-sizing: border-box;
+    border: 1px solid var(--jkl-color-border-separator);
+    border-radius: jkl.rem(2px);
+    width: 100%;
+    padding: var(--jkl-spacing-12);
+    max-width: min(#{jkl.rem(750px)}, 50vw);
+    @include jkl.text-style("small");
+
+    @include jkl.small-device {
+        width: calc(100% - var(--jkl-spacing-40));
+        max-width: 100%;
+        min-width: initial;
+    }
+
+    &[data-language]::before {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: var(--jkl-spacing-4);
+        background-color: var(--jkl-color-background-alert-neutral);
+        color: var(--jkl-color-brand-granitt);
+        text-transform: uppercase;
+        content: attr(data-language);
+        @include jkl.use-font-family("Fremtind Grotesk");
+        @include jkl.text-style("small");
+    }
+
+    html:not([data-mousenavigation]) &:focus-within {
+        box-shadow: 0 0 0 jkl.rem(2px) var(--jkl-color-background-action);
+    }
+}
+
+.codeBlockCode {
+    @include jkl.use-font-family("Fremtind Grotesk Mono");
+    display: block;
+    padding: var(jkl-spacing-24) var(--jkl-spacing-16);
+    overflow-x: auto;
+}

--- a/ny-portal/src/components/portable-text/code-block/fremtindTheme.ts
+++ b/ny-portal/src/components/portable-text/code-block/fremtindTheme.ts
@@ -1,0 +1,175 @@
+import { CSSProperties } from "react";
+
+const theme: { [key: string]: CSSProperties } = {
+    'code[class*="language-"]': {
+        color: "black",
+        background: "none",
+        textShadow: "0 1px white",
+        fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+        textAlign: "left",
+        whiteSpace: "pre",
+        wordSpacing: "normal",
+        wordBreak: "normal",
+        wordWrap: "normal",
+        lineHeight: "1.5",
+        MozTabSize: "4",
+        OTabSize: "4",
+        tabSize: "4",
+        WebkitHyphens: "none",
+        MozHyphens: "none",
+        msHyphens: "none",
+        hyphens: "none",
+    },
+    'pre[class*="language-"]': {
+        lineHeight: "1.4",
+    },
+    'pre[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    ':not(pre) > code[class*="language-"]': {
+        background: "#f5f2f0",
+        padding: ".1em",
+        borderRadius: ".3em",
+        whiteSpace: "normal",
+    },
+    comment: {
+        color: "#68563E",
+    },
+    prolog: {
+        color: "#68563E",
+    },
+    doctype: {
+        color: "#68563E",
+    },
+    cdata: {
+        color: "#68563E",
+    },
+    punctuation: {
+        color: "#525252",
+    },
+    ".namespace": {
+        opacity: ".7",
+    },
+    property: {
+        color: "#AA1F23",
+    },
+    tag: {
+        color: "#AA1F23",
+    },
+    boolean: {
+        color: "#AA1F23",
+    },
+    number: {
+        color: "#AA1F23",
+    },
+    constant: {
+        color: "#AA1F23",
+    },
+    symbol: {
+        color: "#AA1F23",
+    },
+    deleted: {
+        color: "#AA1F23",
+    },
+    selector: {
+        color: "#287E68",
+    },
+    "attr-name": {
+        color: "#287E68",
+    },
+    string: {
+        color: "#287E68",
+    },
+    char: {
+        color: "#287E68",
+    },
+    builtin: {
+        color: "#287E68",
+    },
+    inserted: {
+        color: "#287E68",
+    },
+    operator: {
+        color: "#9a6e3a",
+        background: "transparent",
+    },
+    entity: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+        cursor: "help",
+    },
+    url: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".language-css .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".style .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    atrule: {
+        color: "#000AFA",
+    },
+    "attr-value": {
+        color: "#000AFA",
+    },
+    keyword: {
+        color: "#000AFA",
+    },
+    function: {
+        color: "#cb252b",
+    },
+    "class-name": {
+        color: "#cb252b",
+    },
+    regex: {
+        color: "#9f5704",
+    },
+    important: {
+        color: "#9f5704",
+        fontWeight: "bold",
+    },
+    variable: {
+        color: "#9f5704",
+    },
+    bold: {
+        fontWeight: "bold",
+    },
+    italic: {
+        fontStyle: "italic",
+    },
+};
+
+export default theme;

--- a/ny-portal/src/components/portable-text/code-block/fremtindThemeDark.ts
+++ b/ny-portal/src/components/portable-text/code-block/fremtindThemeDark.ts
@@ -1,0 +1,175 @@
+import { CSSProperties } from "react";
+
+const theme: { [key: string]: CSSProperties } = {
+    'code[class*="language-"]': {
+        color: "black",
+        background: "none",
+        textShadow: "0 1px white",
+        fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+        textAlign: "left",
+        whiteSpace: "pre",
+        wordSpacing: "normal",
+        wordBreak: "normal",
+        wordWrap: "normal",
+        lineHeight: "1.5",
+        MozTabSize: "4",
+        OTabSize: "4",
+        tabSize: "4",
+        WebkitHyphens: "none",
+        MozHyphens: "none",
+        msHyphens: "none",
+        hyphens: "none",
+    },
+    'pre[class*="language-"]': {
+        lineHeight: "1.4",
+    },
+    'pre[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::-moz-selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'pre[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"]::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    'code[class*="language-"] ::selection': {
+        textShadow: "none",
+        background: "#b3d4fc",
+    },
+    ':not(pre) > code[class*="language-"]': {
+        background: "#f5f2f0",
+        padding: ".1em",
+        borderRadius: ".3em",
+        whiteSpace: "normal",
+    },
+    comment: {
+        color: "#999999",
+    },
+    prolog: {
+        color: "#999999",
+    },
+    doctype: {
+        color: "#999999",
+    },
+    cdata: {
+        color: "#999999",
+    },
+    punctuation: {
+        color: "#D6D6D6",
+    },
+    ".namespace": {
+        opacity: ".7",
+    },
+    property: {
+        color: "#FF8B79",
+    },
+    tag: {
+        color: "#FF8B79",
+    },
+    boolean: {
+        color: "#FF8B79",
+    },
+    number: {
+        color: "#FF8B79",
+    },
+    constant: {
+        color: "#FF8B79",
+    },
+    symbol: {
+        color: "#FF8B79",
+    },
+    deleted: {
+        color: "#FF8B79",
+    },
+    selector: {
+        color: "#5EFFA0",
+    },
+    "attr-name": {
+        color: "#5EFFA0",
+    },
+    string: {
+        color: "#5EFFA0",
+    },
+    char: {
+        color: "#5EFFA0",
+    },
+    builtin: {
+        color: "#5EFFA0",
+    },
+    inserted: {
+        color: "#5EFFA0",
+    },
+    operator: {
+        color: "#9a6e3a",
+        background: "transparent",
+    },
+    entity: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+        cursor: "help",
+    },
+    url: {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".language-css .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    ".style .token.string": {
+        color: "#9a6e3a",
+        background: "hsla(0, 0%, 100%, .5)",
+    },
+    atrule: {
+        color: "#00FAFF",
+    },
+    "attr-value": {
+        color: "#00FAFF",
+    },
+    keyword: {
+        color: "#00FAFF",
+    },
+    function: {
+        color: "#ff644d",
+    },
+    "class-name": {
+        color: "#ff644d",
+    },
+    regex: {
+        color: "#FEC97B",
+    },
+    important: {
+        color: "#FEC97B",
+        fontWeight: "bold",
+    },
+    variable: {
+        color: "#FEC97B",
+    },
+    bold: {
+        fontWeight: "bold",
+    },
+    italic: {
+        fontStyle: "italic",
+    },
+};
+
+export default theme;

--- a/ny-portal/src/components/portable-text/code-block/index.ts
+++ b/ny-portal/src/components/portable-text/code-block/index.ts
@@ -1,0 +1,1 @@
+export { CodeBlock } from "./CodeBlock";

--- a/ny-portal/src/components/portable-text/link/Link.tsx
+++ b/ny-portal/src/components/portable-text/link/Link.tsx
@@ -1,0 +1,9 @@
+import { Link as JokulLink } from "@fremtind/jokul/components";
+import NextLink from "next/link";
+import { PortableTextMarkComponentProps } from "next-sanity";
+
+type LinkProps = PortableTextMarkComponentProps<any>;
+
+export const Link = ({ value }: LinkProps) => {
+    return <JokulLink as={NextLink} href={value.href} />;
+};

--- a/ny-portal/src/components/portable-text/list/ListItem.tsx
+++ b/ny-portal/src/components/portable-text/list/ListItem.tsx
@@ -1,0 +1,7 @@
+import { ListItem as JokulListItem } from "@fremtind/jokul/components";
+import type { PortableTextComponentProps } from "@portabletext/react";
+import type { FC } from "react";
+
+export const ListItem: FC<PortableTextComponentProps<any>> = ({ children }) => {
+    return <JokulListItem>{children}</JokulListItem>;
+};

--- a/ny-portal/src/components/portable-text/list/OrderedList.tsx
+++ b/ny-portal/src/components/portable-text/list/OrderedList.tsx
@@ -1,0 +1,9 @@
+import { OrderedList as JokulOrderedList } from "@fremtind/jokul/components";
+import type { PortableTextComponentProps } from "@portabletext/react";
+import type { FC } from "react";
+
+export const OrderedList: FC<PortableTextComponentProps<any>> = ({
+    children,
+}) => {
+    return <JokulOrderedList className="jkl-body">{children}</JokulOrderedList>;
+};

--- a/ny-portal/src/components/portable-text/list/UnorderedList.tsx
+++ b/ny-portal/src/components/portable-text/list/UnorderedList.tsx
@@ -1,0 +1,11 @@
+import { UnorderedList as JokulUnorderedList } from "@fremtind/jokul/components";
+import type { PortableTextComponentProps } from "@portabletext/react";
+import type { FC } from "react";
+
+export const UnorderedList: FC<PortableTextComponentProps<any>> = ({
+    children,
+}) => {
+    return (
+        <JokulUnorderedList className="jkl-body">{children}</JokulUnorderedList>
+    );
+};

--- a/ny-portal/src/components/portable-text/list/index.ts
+++ b/ny-portal/src/components/portable-text/list/index.ts
@@ -1,0 +1,5 @@
+import { UnorderedList } from "./UnorderedList";
+import { OrderedList } from "./OrderedList";
+import { ListItem } from "./ListItem";
+
+export { UnorderedList, OrderedList, ListItem };

--- a/ny-portal/src/components/portable-text/typography/Typography.tsx
+++ b/ny-portal/src/components/portable-text/typography/Typography.tsx
@@ -1,0 +1,25 @@
+import type { FC } from "react";
+import {
+    PortableTextComponentProps,
+    PortableTextMarkComponentProps,
+} from "next-sanity";
+import { CodeBlock as FTCodeBlock } from "../code-block";
+import { Jokul_codeBlock } from "@/sanity/types";
+
+import styles from "./typography.module.scss";
+
+type InlineCode = PortableTextMarkComponentProps<any>;
+
+export const InlineCode: FC<InlineCode> = ({ children }) => (
+    <code className={styles.inlineCode}>{children}</code>
+);
+
+type CodeBlockProps = PortableTextComponentProps<Jokul_codeBlock>;
+
+export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
+    const { value } = props;
+
+    return (
+        <FTCodeBlock language={value.language}>{value.code || ""}</FTCodeBlock>
+    );
+};

--- a/ny-portal/src/components/portable-text/typography/typography.module.scss
+++ b/ny-portal/src/components/portable-text/typography/typography.module.scss
@@ -1,0 +1,10 @@
+@use '@fremtind/jokul/styles/core/jkl';
+
+.inlineCode {
+  display: inline-block;
+  background-color: var(--jkl-color-background-container-inverted);
+  font-size: 0.8em;
+  padding: 0 var(--jkl-spacing-8);
+  border-radius: jkl.rem(2px);
+  color: var(--jkl-color-text-inverted);
+}

--- a/ny-portal/src/sanity/extract.json
+++ b/ny-portal/src/sanity/extract.json
@@ -394,6 +394,46 @@
     }
   },
   {
+    "name": "jokul_codeBlock",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "jokul_codeBlock"
+          }
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "language": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "union",
+            "of": [
+              {
+                "type": "string",
+                "value": "scss"
+              },
+              {
+                "type": "string",
+                "value": "typescript"
+              }
+            ]
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "jokul_codeExample",
     "type": "type",
     "value": {
@@ -909,6 +949,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_storybook"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_codeBlock"
                 }
               }
             ]

--- a/ny-portal/src/sanity/schemas/codeBlock.ts
+++ b/ny-portal/src/sanity/schemas/codeBlock.ts
@@ -1,0 +1,23 @@
+import { defineType, defineField } from "sanity";
+
+export const codeBlock = defineType({
+    name: "jokul_codeBlock",
+    title: "Kodeblokk",
+    type: "object",
+    fields: [
+        defineField({
+            name: "code",
+            title: "Kode",
+            type: "text",
+        }),
+        defineField({
+            name: "language",
+            title: "Språk",
+            type: "string",
+            options: {
+                list: ["scss", "typescript"],
+            },
+            initialValue: "typescript",
+        }),
+    ],
+});

--- a/ny-portal/src/sanity/schemas/component.ts
+++ b/ny-portal/src/sanity/schemas/component.ts
@@ -101,6 +101,7 @@ export const component = defineType({
                 { type: "jokul_componentProps" },
                 { type: "jokul_codeExample" },
                 { type: "jokul_storybook" },
+                { type: "jokul_codeBlock" },
             ],
         }),
     ],

--- a/ny-portal/src/sanity/schemas/index.ts
+++ b/ny-portal/src/sanity/schemas/index.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from "./codeBlock";
 import { codeExample } from "./codeExample";
 import { component } from "./component";
 import { componentProps } from "./componentProps";
@@ -7,6 +8,7 @@ export const schemaTypes = [
     component,
     componentProps,
     codeExample,
+    codeBlock,
     storybook,
     storybookStory,
 ];

--- a/ny-portal/src/sanity/types.ts
+++ b/ny-portal/src/sanity/types.ts
@@ -83,6 +83,12 @@ export type Jokul_storybook = {
     >;
 };
 
+export type Jokul_codeBlock = {
+    _type: "jokul_codeBlock";
+    code?: string;
+    language?: "scss" | "typescript";
+};
+
 export type Jokul_codeExample = {
     _type: "jokul_codeExample";
     showEditor?: boolean;
@@ -171,6 +177,9 @@ export type Jokul_component = {
         | ({
               _key: string;
           } & Jokul_storybook)
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
     >;
 };
 
@@ -245,6 +254,7 @@ export type AllSanitySchemaTypes =
     | Geopoint
     | Jokul_storybookStory
     | Jokul_storybook
+    | Jokul_codeBlock
     | Jokul_codeExample
     | Jokul_componentProps
     | Jokul_component
@@ -295,6 +305,9 @@ export type ComponentBySlugQueryResult = {
         _type: "image";
     };
     documentation_article?: Array<
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
         | ({
               _key: string;
           } & Jokul_codeExample)


### PR DESCRIPTION
Utvider PortableText-komponenten med støtte for følgende innholdstyper:

- Typografi: legger til støtte for InlineCode og CodeBlock
- Lister: håndterer både uordnede og nummererte lister med egendefinerte komponenter
- Lenker: rendrer link-merker som egne komponenter