### PR TITLE
fix: makes sure the aria-label on File's success icon is actually exposed to ATs

### DIFF
--- a/packages/jokul/src/components/file-input/File.tsx
+++ b/packages/jokul/src/components/file-input/File.tsx
@@ -69,6 +69,7 @@ export const File: FC<FileProps & ComponentProps<"div">> = (props) => {
                 <SuccessIcon
                     variant="small"
                     aria-label="Filen ble lastet opp uten feil"
+                    aria-hidden={false}
                 />
             );
 


### PR DESCRIPTION
Relates to #4723

<!-- Oppsummer kort hva som er gjort, og hvorfor. Lenk til issuet som løses av endringen. -->

## 🎯 Sjekkliste

<!-- Sjekk av de som er relevant. Du kan slette irrelevante steg om du vil.  -->

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [UU](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
