### PR TITLE
fix: sikre korrekt innrykk for tekst i checklistitem

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,3 @@
+<body class="jkl-body">
+
+</body>

--- a/packages/jokul/src/components/list/styles/list.scss
+++ b/packages/jokul/src/components/list/styles/list.scss
@@ -81,19 +81,19 @@
         }
 
         &--iconed {
+            display: flex;
             list-style: none;
             position: relative;
             padding-left: 0;
 
             &::before {
-                vertical-align: middle;
-                translate: 0 -0.07em;
                 text-indent: -9999px;
                 background-size: contain;
-                display: inline-block;
                 width: 1em;
                 height: 1em;
+                flex-shrink: 0;
                 margin-right: 0.5em;
+                margin-top: 0.2em; // Vertical offset (using em for font-size scaling) to align icon properly with the first line.
             }
         }
 

--- a/packages/list/list.scss
+++ b/packages/list/list.scss
@@ -82,19 +82,19 @@
         }
 
         &--iconed {
+            display: flex;
             list-style: none;
             position: relative;
             padding-left: 0;
 
             &::before {
-                vertical-align: middle;
-                translate: 0 -0.07em;
                 text-indent: -9999px;
                 background-size: contain;
-                display: inline-block;
                 width: 1em;
                 height: 1em;
+                flex-shrink: 0;
                 margin-right: 0.5em;
+                margin-top: 0.2em; // Vertical offset (using em for font-size scaling) to align icon properly with the first line.
             }
         }
 


### PR DESCRIPTION
Korrigerer en layout-regresjon i \`CheckListItem\`-komponenten.

BREAKING CHANGE:
Fikser opp i layout issue i CheckListItem-komponenten. Når tekst i et listepunkt gikk over flere linjer, startet de påfølgende linjene feilaktig helt til venstre (under ikonet).

ISSUES CLOSED: #4673
