### PR TITLE
fix: unngå å importere klientsidekode i serverkomponenter

### DIFF
--- a/ny-portal/src/app/(frontend)/komponenter/[slug]/component.tsx
+++ b/ny-portal/src/app/(frontend)/komponenter/[slug]/component.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { InfoMessage, InfoSystemMessage, Link } from "@fremtind/jokul";
-import { Button } from "@fremtind/jokul/components/button";
-import { Flex } from "@fremtind/jokul/components/flex";
-import clsx from "clsx";
-import styles from "./component.module.scss";
 import { PortableText } from "@/components/portable-text/PortableText";
 import { ComponentBySlugQueryResult } from "@/sanity/types";
+import { Button } from "@fremtind/jokul/components/button";
+import { Flex } from "@fremtind/jokul/components/flex";
+import { Link } from "@fremtind/jokul/components/link";
+import { InfoMessage } from "@fremtind/jokul/components/message";
+import clsx from "clsx";
+import styles from "./component.module.scss";
 
 type ComponentProps = {
     component: ComponentBySlugQueryResult;

--- a/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentEmptyState.tsx
+++ b/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentEmptyState.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { InfoMessage, Link } from "@fremtind/jokul";
 import { Flex } from "@fremtind/jokul/components/flex";
+import { Link } from "@fremtind/jokul/components/link";
+import { InfoMessage } from "@fremtind/jokul/components/message";
 
 type ComponentEmptyStateProps = {
     name: string;

--- a/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentFooter.tsx
+++ b/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentFooter.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Link } from "@fremtind/jokul";
 import { Flex } from "@fremtind/jokul/components/flex";
+import { Link } from "@fremtind/jokul/components/link";
 import styles from "../component.module.scss";
 
 type ComponentFooterProps = {

--- a/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeaderLink.tsx
+++ b/ny-portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeaderLink.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "@fremtind/jokul";
 import { Button } from "@fremtind/jokul/components/button";
-import { ReactElement, ReactNode } from "react";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@fremtind/jokul/components/tooltip";
+import { ReactElement } from "react";
 
 type ComponentHeaderLinkProps = {
     name: string;

--- a/ny-portal/src/components/portable-text/code-block/CodeBlock.tsx
+++ b/ny-portal/src/components/portable-text/code-block/CodeBlock.tsx
@@ -1,10 +1,13 @@
+"use client";
+
+import type { WithChildren } from "@fremtind/jokul/core";
+import { useBrowserPreferences } from "@fremtind/jokul/hooks";
 import React, { useEffect, useState } from "react";
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import scss from "react-syntax-highlighter/dist/esm/languages/prism/scss";
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import fremtindTheme from "./fremtindTheme";
 import fremtindThemeDark from "./fremtindThemeDark";
-import { useBrowserPreferences, type WithChildren } from "@fremtind/jokul";
 
 import styles from "./code-block.module.scss";
 

--- a/ny-portal/src/components/portable-text/link/Link.tsx
+++ b/ny-portal/src/components/portable-text/link/Link.tsx
@@ -1,4 +1,4 @@
-import { Link as JokulLink } from "@fremtind/jokul/components";
+import { Link as JokulLink } from "@fremtind/jokul/components/link";
 import NextLink from "next/link";
 import { PortableTextMarkComponentProps } from "next-sanity";
 

--- a/ny-portal/src/components/portable-text/list/ListItem.tsx
+++ b/ny-portal/src/components/portable-text/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem as JokulListItem } from "@fremtind/jokul/components";
+import { ListItem as JokulListItem } from "@fremtind/jokul/components/list";
 import type { PortableTextComponentProps } from "@portabletext/react";
 import type { FC } from "react";
 

--- a/ny-portal/src/components/portable-text/list/OrderedList.tsx
+++ b/ny-portal/src/components/portable-text/list/OrderedList.tsx
@@ -1,4 +1,4 @@
-import { OrderedList as JokulOrderedList } from "@fremtind/jokul/components";
+import { OrderedList as JokulOrderedList } from "@fremtind/jokul/components/list";
 import type { PortableTextComponentProps } from "@portabletext/react";
 import type { FC } from "react";
 

--- a/ny-portal/src/components/portable-text/list/UnorderedList.tsx
+++ b/ny-portal/src/components/portable-text/list/UnorderedList.tsx
@@ -1,4 +1,4 @@
-import { UnorderedList as JokulUnorderedList } from "@fremtind/jokul/components";
+import { UnorderedList as JokulUnorderedList } from "@fremtind/jokul/components/list";
 import type { PortableTextComponentProps } from "@portabletext/react";
 import type { FC } from "react";
 

--- a/ny-portal/src/components/site-header/menu/HamburgerButton.tsx
+++ b/ny-portal/src/components/site-header/menu/HamburgerButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Icon } from "@fremtind/jokul";
+import { Button } from "@fremtind/jokul/components/button";
+import { Icon } from "@fremtind/jokul/components/icon";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import styles from "../SiteHeader.module.scss";


### PR DESCRIPTION
## 💬 Endringer

1. Rydder opp i en del tilfeller der vi importerer Jøkul-komponenter fra rot slik at klientsidekode blir med og skaper feil under bygg av portalen
2. Setter `use client`-direktiv på en komponent som ikke kan rendres på server

### 🎯 Dokumentasjon

Ingen dokumentasjonsendring kreves

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
