### PR TITLE
chore: bruk mer spesifikke env-variabler i Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN pnpm install --frozen-lockfile
 RUN find . -name 'node_modules' -print0 | tar -cf node_modules.tar --null --files-from -
 
 FROM base AS builder
-ARG SANITY_DATASET
-ARG NEXT_PUBLIC_STORYBOOK_BASE_URL
+ARG SANITY_PROJECT_ID=rppnrdtw
+ARG SANITY_DATASET=test
+ARG NEXT_PUBLIC_STORYBOOK_BASE_URL=/storybook
 
 WORKDIR /app
 COPY --from=dependencies /app/node_modules.tar ./node_modules.tar
@@ -35,9 +36,13 @@ COPY . .
 RUN tar -xf node_modules.tar 
 RUN pnpm --filter "@fremtind/jokul" build
 RUN pnpm build-storybook
+
+ENV SANITY_PROJECT_ID=$SANITY_PROJECT_ID
+ENV SANITY_DATASET=$SANITY_DATASET
+ENV NEXT_PUBLIC_STORYBOOK_BASE_URL=$NEXT_PUBLIC_STORYBOOK_BASE_URL
 RUN \ 
   --mount=type=secret,id=FIGMA_IMAGE_READ_TOKEN,env=FIGMA_IMAGE_READ_TOKEN \
-  pnpm --filter "ny-portal" build 
+  pnpm --filter "ny-portal" build
 
 FROM base AS runner
 


### PR DESCRIPTION
## 💬 Endringer

1. Nok et forsøk på fiks av Docker-fila. Definerer miljøvariabler spesifikt ut fra bygg-argumentene med `ENV`.

~~Lokalt får jeg nå en feil der `.next`-mappa ikke blir kopiert over fra byggsteget, slik at containeren feiler når den kjører opp, men det er verdt et forsøk å se om det funker på CI-serveren.~~ Dette var pga en feil i dockerfila som er fikset nå.

