### PR TITLE
fix: type="button" på chip sin interne knapp

### DIFF
--- a/packages/chip-react/src/Chip.tsx
+++ b/packages/chip-react/src/Chip.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, CloseIcon } from "@fremtind/jkl-icons-react";
 import cl from "classnames";
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, ButtonHTMLAttributes } from "react";
 
 type Size = "small" | "large";
 
@@ -16,7 +16,7 @@ export type ChipVariant =
           size?: Size;
       };
 
-export type ChipProps = ChipVariant & HTMLAttributes<HTMLButtonElement>;
+export type ChipProps = ChipVariant & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
     {
@@ -32,6 +32,7 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
 ) {
     return (
         <button
+            type="button"
             ref={ref}
             className={cl(
                 "jkl-chip",

--- a/packages/jokul/src/components/chip/Chip.tsx
+++ b/packages/jokul/src/components/chip/Chip.tsx
@@ -18,6 +18,7 @@ export const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
 ) {
     return (
         <button
+            type="button"
             ref={ref}
             className={clsx(
                 "jkl-chip",

--- a/packages/jokul/src/components/chip/types.ts
+++ b/packages/jokul/src/components/chip/types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import { ButtonHTMLAttributes } from "react";
 
 type Size = "small" | "large";
 
@@ -14,4 +14,4 @@ export type ChipVariant =
           size?: Size;
       };
 
-export type ChipProps = ChipVariant & HTMLAttributes<HTMLButtonElement>;
+export type ChipProps = ChipVariant & ButtonHTMLAttributes<HTMLButtonElement>;


### PR DESCRIPTION
## 💬 Endringer

1. Setter type="button" på Chip sin interne knapp. 
2. Oppdaterer type-definisjonen for komponenten for at TypeScript skal gi riktig autocomplete og validering av props som faktisk er gyldige for en button element.
