### PR TITLE
fix: sørg for at datepicker beholder omriss med åpen velger

### DIFF
--- a/packages/datepicker-react/src/DatePicker.tsx
+++ b/packages/datepicker-react/src/DatePicker.tsx
@@ -252,9 +252,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         return (
             <InputGroup
                 id={id}
-                className={cn("jkl-datepicker", className, {
-                    "jkl-datepicker--open": showCalendar,
-                })}
+                className={cn("jkl-datepicker", className)}
                 {...rest}
                 ref={datepickerRef}
                 label={label}
@@ -266,6 +264,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                 tooltip={tooltip}
                 render={(inputProps) => (
                     <BaseTextInput
+                        data-focused={showCalendar ? "true" : undefined}
                         ref={unifiedInputRef}
                         data-testid="jkl-datepicker__input"
                         data-testautoid={testAutoId}

--- a/packages/datepicker/datepicker.scss
+++ b/packages/datepicker/datepicker.scss
@@ -40,15 +40,6 @@
         z-index: jkl.$z-index--dropdown;
     }
 
-    &--open {
-        .jkl-text-input-wrapper {
-            box-shadow: inset 0 0 0 jkl.rem(1px)
-                    var(--jkl-text-input-focus-color),
-                0 0 0 jkl.rem(1px) var(--jkl-text-input-focus-color);
-            border-color: var(--jkl-text-input-focus-color);
-        }
-    }
-
     @include jkl.small-device {
         &__calendar-wrapper {
             left: -1.15rem;

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -252,9 +252,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         return (
             <InputGroup
                 id={id}
-                className={clsx("jkl-datepicker", className, {
-                    "jkl-datepicker--open": showCalendar,
-                })}
+                className={clsx("jkl-datepicker", className)}
                 {...rest}
                 ref={datepickerRef}
                 label={label}
@@ -266,6 +264,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                 tooltip={tooltip}
                 render={(inputProps) => (
                     <BaseTextInput
+                        data-focused={showCalendar ? "true" : undefined}
                         ref={unifiedInputRef}
                         data-testid="jkl-datepicker__input"
                         data-testautoid={testAutoId}

--- a/packages/jokul/src/components/datepicker/styles/datepicker.scss
+++ b/packages/jokul/src/components/datepicker/styles/datepicker.scss
@@ -40,15 +40,6 @@
         z-index: jkl.$z-index--dropdown;
     }
 
-    &--open {
-        .jkl-text-input-wrapper {
-            box-shadow: inset 0 0 0 jkl.rem(1px)
-                    var(--jkl-text-input-focus-color),
-                0 0 0 jkl.rem(1px) var(--jkl-text-input-focus-color);
-            border-color: var(--jkl-text-input-focus-color);
-        }
-    }
-
     @include jkl.small-device {
         &__calendar-wrapper {
             left: -1.15rem;

--- a/packages/jokul/src/shared/input/styles/shared-input-styles.scss
+++ b/packages/jokul/src/shared/input/styles/shared-input-styles.scss
@@ -76,11 +76,12 @@ $_action-button-focus-position--compact: 0;
     box-shadow: inset 0 0 0 jkl.rem(1px) var(--border-color),
         0 0 0 jkl.rem(1px) transparent;
 
-    &:focus-within {
+    &:focus-within,
+    &:has([data-focused="true"]) {
         --background-color: var(--jkl-color-background-input-focus);
     }
 
-    &[data-invalid="true"]:not(:focus-within) {
+    &[data-invalid="true"]:not(:focus-within):not(:has([data-focused="true"])) {
         --background-color: var(--jkl-color-background-alert-error);
         --text-color: var(--jkl-color-text-on-alert);
         // Vi har ingen god måte å få tak i kun light mode-versjon av subdued
@@ -88,7 +89,9 @@ $_action-button-focus-position--compact: 0;
         --placeholder-color: color(from currentColor sRGB r g b / 0.75);
     }
 
-    &:hover {
+    &:hover,
+    &:focus-within,
+    &:has([data-focused="true"]) {
         --border-color: var(--jkl-color-border-input-focus);
 
         box-shadow: inset 0 0 0 jkl.rem(1px) var(--border-color),

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -110,11 +110,12 @@ $_action-button-focus-position--compact: 0;
     box-shadow: inset 0 0 0 jkl.rem(1px) var(--border-color),
         0 0 0 jkl.rem(1px) transparent;
 
-    &:focus-within {
+    &:focus-within,
+    &:has([data-focused="true"]) {
         --background-color: var(--jkl-color-background-input-focus);
     }
 
-    &[data-invalid="true"]:not(:focus-within) {
+    &[data-invalid="true"]:not(:focus-within):not(:has([data-focused="true"])) {
         --background-color: var(--jkl-color-background-alert-error);
         --text-color: var(--jkl-color-text-on-alert);
         // Vi har ingen god måte å få tak i kun light mode-versjon av subdued
@@ -122,7 +123,9 @@ $_action-button-focus-position--compact: 0;
         --placeholder-color: color(from currentColor sRGB r g b / 0.75);
     }
 
-    &:hover {
+    &:hover,
+    &:focus-within,
+    &:has([data-focused="true"]) {
         --border-color: var(--jkl-color-border-input-focus);
 
         box-shadow: inset 0 0 0 jkl.rem(1px) var(--border-color),


### PR DESCRIPTION
## 💬 Endringer

1. Legg til rette for å styre omriss på `text-input` fra utsiden uten å måtte gjette på variabelnavn
2. Gjør så inputfeltet i `datepicker` ikke mister omriss når datovelgeren er åpen

closes: #4750 

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
