### PR TITLE
4752 fiks hovedlayout

### DIFF
--- a/ny-portal/src/app/(frontend)/global.scss
+++ b/ny-portal/src/app/(frontend)/global.scss
@@ -40,8 +40,11 @@ main {
         )
         var(--jkl-unit-80);
     flex-grow: 1;
-    max-width: 1000px; // Begrenser innholdets maksbredde for å skape luft mot navigasjonen (total layout = 1440px).
-    margin-left: auto;
+    
+    @media (min-width: #{jkl.$breakpoint-large}) {
+        max-width: 1000px; // Begrenser innholdets maksbredde for å skape luft mot navigasjonen (total layout = 1440px).
+        margin-left: auto;
+    }
 }
 
 .prose {

--- a/ny-portal/src/app/(frontend)/global.scss
+++ b/ny-portal/src/app/(frontend)/global.scss
@@ -11,21 +11,22 @@ body {
     // https://clamp.vittoretrivi.dev
     --max-width: 1440px;
     --min-width: 320px;
-
-    padding-inline: clamp(
-        var(--jkl-spacing-16),
-        0.1429rem + 4.2857vw,
-        var(--jkl-spacing-64)
-    );
-    display: flex;
-    gap: clamp(
-        var(--jkl-spacing-24),
-        0.4643rem + 3.9286vw,
-        var(--jkl-spacing-64)
-    );
-    flex-direction: column;
     background-color: var(--jkl-color-background-page);
+}
 
+.jkl-portal-layout {
+    display: flex;
+    flex-direction: column;
+    gap: var(--jkl-unit-30);
+    padding-inline: clamp(
+        var(--jkl-unit-20),
+        0.1429rem + 4.2857vw,
+        var(--jkl-unit-80)
+    );
+
+    max-width: var(--max-width);
+    margin-inline: auto;
+        
     @media (min-width: #{jkl.$breakpoint-large}) {
         flex-direction: row;
     }
@@ -33,11 +34,14 @@ body {
 
 main {
     padding-block: clamp(
-            var(--jkl-spacing-24),
+            var(--jkl-unit-30),
             1.2143rem + 1.4286vw,
-            var(--jkl-spacing-40)
+            var(--jkl-unit-50)
         )
-        var(--jkl-spacing-64);
+        var(--jkl-unit-80);
+    flex-grow: 1;
+    max-width: 1000px; // Begrenser innholdets maksbredde for å skape luft mot navigasjonen (total layout = 1440px).
+    margin-left: auto;
 }
 
 .prose {
@@ -60,7 +64,7 @@ h3,
 h4,
 h5 {
     &:not(:first-child) {
-        margin-block-start: var(--jkl-spacing-104);
+        margin-block-start: var(--jkl-unit-130);
     }
 }
 
@@ -76,7 +80,7 @@ h3 {
     @include jkl.text-style("heading-3");
 
     &:not(:first-child) {
-        margin-block-start: var(--jkl-spacing-104);
+        margin-block-start: var(--jkl-unit-130);
     }
 }
 

--- a/ny-portal/src/app/(frontend)/layout.tsx
+++ b/ny-portal/src/app/(frontend)/layout.tsx
@@ -20,8 +20,10 @@ export default function PortalLayout({ children }: Props) {
                 >
                     Hopp til innhold
                 </Link>
-                <SiteHeader />
-                <main>{children}</main>
+                <div className="jkl-portal-layout">
+                    <SiteHeader />
+                    <main>{children}</main>
+                </div>
             </body>
         </html>
     );

--- a/ny-portal/src/components/site-header/SiteHeader.module.scss
+++ b/ny-portal/src/components/site-header/SiteHeader.module.scss
@@ -6,6 +6,7 @@
         1.2143rem + 1.4286vw,
         var(--jkl-spacing-40)
     );
+    padding-inline: var(--jkl-spacing-4);
 
     div.banner {
         width: 100%;
@@ -36,7 +37,7 @@
             padding-block-end: var(--jkl-spacing-64);
 
             li {
-                padding: 0;
+                padding: var(--jkl-spacing-4);
             }
 
             li.listHeading:first-of-type {


### PR DESCRIPTION
## 💬 Endringer

1. Introdusert padding rundt hovedmenyens container og individuelle
`li`-elementer. Dette gir nødvendig luft slik at fokus-outline
blir fullt synlig og ikke kuttet av når brukeren navigerer
med tastatur.
2. Introdusert en ny `div` med klassen `.jkl-portal-layout` rett
innenfor `<body>` for å håndtere hovedlayouten. Layout-spesifikke
CSS-regler er flyttet fra `body` til denne containeren.

-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
