### PR TITLE
Fall tilbake til placeholder-bilder for komponentene i portalen

### DIFF
--- a/ny-portal/src/app/(frontend)/komponenter/ComponentCard.tsx
+++ b/ny-portal/src/app/(frontend)/komponenter/ComponentCard.tsx
@@ -63,9 +63,13 @@ export const ComponentCard = async ({ componentSlug }: Props) => {
 
     if (!component) return null;
 
-    const [lightImage, darkImage] = await getFigmaImageUrls(
-        component.figma_image || {},
-    );
+    // Bruk placeholderbilde midlertidig, mens vi finner ut av problemene
+    // med å hente figma-bilder under bygging av applikasjonen.
+    // Bruk getFigmaImageUrls for å hente figma-bilder når det er fikset.
+    const [lightImage, darkImage] = [
+        "/component_placeholder_light.svg",
+        "/component_placeholder_dark.svg",
+    ];
 
     return (
         <Flex


### PR DESCRIPTION
## 💬 Endringer

Faller tiilbake til å bruke placeholder-bilder for komponentene i portalen mens vi finner ut hva vi gjør med Figma-bildene. Disse har feilet under bygg, slik at vi ikke har fått ut nye versjoner av portalen i test.

