### PR TITLE
fix: rett opp i typer for portable text-blokker

### DIFF
--- a/ny-portal/src/components/portable-text/PortableText.tsx
+++ b/ny-portal/src/components/portable-text/PortableText.tsx
@@ -1,7 +1,4 @@
-import type {
-    PortableTextComponentProps,
-    PortableTextReactComponents,
-} from "@portabletext/react";
+import type { PortableTextReactComponents } from "@portabletext/react";
 import { PortableText as PortableTextReact } from "@portabletext/react";
 import type { TypedObject } from "@portabletext/types";
 import type { FC } from "react";
@@ -15,48 +12,39 @@ interface Props {
     blocks: TypedObject[] | null;
 }
 
-const portableTextComponents: Record<
-    string,
-    FC<PortableTextComponentProps<any>>
-> = {
+const jokulBlockTypes: PortableTextReactComponents["types"] = {
     jokul_storybook: Storybook,
     jokul_componentKortFortalt: KortFortalt,
     jokul_codeBlock: CodeBlock,
 };
 
-export const baseComponentDefinition: Partial<PortableTextReactComponents> = {
-    types: portableTextComponents,
-    list: {
-        bullet: UnorderedList,
-        number: OrderedList,
-    },
-    listItem: {
-        bullet: ListItem,
-        number: ListItem,
-    },
-    marks: {
-        link: Link,
-        internalLink: ({ value, children }) => {
-            const { slug = {} } = value;
-            const href = `/${slug.current}`;
-            console.log(value);
-            return <a href={href}>{children}</a>;
+export const jokulPortableTextComponents: Partial<PortableTextReactComponents> =
+    {
+        types: jokulBlockTypes,
+        list: {
+            bullet: UnorderedList,
+            number: OrderedList,
         },
-        code: InlineCode,
-    },
-};
-
-export const PortableText: FC<Props> = (props) => {
-    const components = {
-        ...baseComponentDefinition,
-        types: {
-            ...baseComponentDefinition.types,
+        listItem: {
+            bullet: ListItem,
+            number: ListItem,
+        },
+        marks: {
+            link: Link,
+            internalLink: ({ value, children }) => {
+                const { slug = {} } = value;
+                const href = `/${slug.current}`;
+                console.log(value);
+                return <a href={href}>{children}</a>;
+            },
+            code: InlineCode,
         },
     };
 
-    if (props.blocks === null) {
-        return null;
-    }
-
-    return <PortableTextReact value={props.blocks} components={components} />;
-};
+export const PortableText: FC<Props> = (props) =>
+    props.blocks === null ? null : (
+        <PortableTextReact
+            value={props.blocks}
+            components={jokulPortableTextComponents}
+        />
+    );

--- a/ny-portal/src/components/portable-text/typography/Typography.tsx
+++ b/ny-portal/src/components/portable-text/typography/Typography.tsx
@@ -1,24 +1,18 @@
 import {
-    PortableTextComponentProps,
     PortableTextMarkComponentProps,
+    PortableTextTypeComponentProps,
 } from "next-sanity";
 import type { FC } from "react";
 import { CodeBlock as FTCodeBlock } from "../code-block";
 import styles from "./typography.module.scss";
 import { Jokul_codeBlock } from "@/sanity/types";
 
-type InlineCode = PortableTextMarkComponentProps<any>;
+export const InlineCode: FC<PortableTextMarkComponentProps<any>> = ({
+    children,
+}) => <code className={styles.inlineCode}>{children}</code>;
 
-export const InlineCode: FC<InlineCode> = ({ children }) => (
-    <code className={styles.inlineCode}>{children}</code>
+export const CodeBlock: React.FC<
+    PortableTextTypeComponentProps<Jokul_codeBlock>
+> = ({ value }) => (
+    <FTCodeBlock language={value.language}>{value.code || ""}</FTCodeBlock>
 );
-
-type CodeBlockProps = PortableTextComponentProps<Jokul_codeBlock>;
-
-export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
-    const { value } = props;
-
-    return (
-        <FTCodeBlock language={value.language}>{value.code || ""}</FTCodeBlock>
-    );
-};


### PR DESCRIPTION
## 💬 Endringer

1. Fikser opp noen typefeil som krasjet byggsteget i GitHub Actions.
2. Rydder litt i kodestruktur

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
