### PR TITLE
fix: bruk riktig type for CodeExample-komponenten

### DIFF
--- a/ny-portal/src/components/portable-text/code-example/CodeExample.tsx
+++ b/ny-portal/src/components/portable-text/code-example/CodeExample.tsx
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { PortableTextTypeComponentProps } from "next-sanity";
-import { FC } from "react";
 import { LivePreview } from "./LivePreview";
 
 export const PATH_SEPARATOR = "_";
@@ -14,9 +13,9 @@ type CodeExampleSchema = {
     showEditor: boolean;
 };
 
-export const CodeExample: FC<
-    PortableTextTypeComponentProps<CodeExampleSchema>
-> = async ({ value }) => {
+export const CodeExample = async ({
+    value,
+}: PortableTextTypeComponentProps<CodeExampleSchema>) => {
     const exampleFilePath = resolve(
         process.cwd(),
         "..",

--- a/ny-portal/src/components/portable-text/props-documentation/PropsDocumentation.tsx
+++ b/ny-portal/src/components/portable-text/props-documentation/PropsDocumentation.tsx
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { PortableTextTypeComponentProps } from "next-sanity";
-import { FC } from "react";
 import MissingTypesMessage from "./missing-types.mdx";
 import { Props } from "./Props";
 
@@ -9,9 +8,9 @@ type PropsDocumentationSchema = {
     componentFolder: string;
 };
 
-export const PropsDocumentation: FC<
-    PortableTextTypeComponentProps<PropsDocumentationSchema>
-> = async ({ value }) => {
+export const PropsDocumentation = async ({
+    value,
+}: PortableTextTypeComponentProps<PropsDocumentationSchema>) => {
     const exampleFilePath = resolve(
         process.cwd(),
         "..",


### PR DESCRIPTION
## 💬 Endringer

1. Fjern uriktig `FC`-type fra `CodeExample`- og `PropsDocumentation`-komponentene

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
