### PR TITLE
feat: pek på komponentoversikt på "forsiden"

### DIFF
--- a/ny-portal/next.config.mjs
+++ b/ny-portal/next.config.mjs
@@ -4,6 +4,16 @@ import createMDX from "@next/mdx";
 const nextConfig = {
     // Your Next.js config here
     pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+
+    async redirects() {
+        return [
+            {
+                source: "/",
+                destination: "/komponenter",
+                permanent: false,
+            },
+        ];
+    },
 };
 
 const withMdx = createMDX({});

--- a/ny-portal/src/app/(frontend)/page.tsx
+++ b/ny-portal/src/app/(frontend)/page.tsx
@@ -1,3 +1,10 @@
+import PortalLayout from "./komponenter/layout";
+import Components from "./komponenter/page";
+
 export default function FrontPage() {
-    return <h1>Wheee!</h1>;
+    return (
+        <PortalLayout>
+            <Components />
+        </PortalLayout>
+    );
 }

--- a/ny-portal/src/app/(frontend)/page.tsx
+++ b/ny-portal/src/app/(frontend)/page.tsx
@@ -1,10 +1,3 @@
-import PortalLayout from "./komponenter/layout";
-import Components from "./komponenter/page";
-
 export default function FrontPage() {
-    return (
-        <PortalLayout>
-            <Components />
-        </PortalLayout>
-    );
+    return <h1>Wheee!</h1>;
 }


### PR DESCRIPTION
## 💬 Endringer

1. Litt usikker på om jeg har løst oppgaven som tenkt – enten 1) komponentoversikten rendres på "forsiden" (det er dette jeg har gjort) eller 2)url'en skal være /komponentoversikt når siden lastes inn
2. Og så er jeg usikker på om det er en annen måte å få PortalLayout for komponentoversikten inn, uten å importere PortalLayout. Det er jo en annen layout som ligger i layout.tsx for forsiden