### PR TITLE
fix: fjern knapp i listevisning på komponentoversikt

### DIFF
--- a/ny-portal/src/app/(frontend)/komponenter/komponenter.module.scss
+++ b/ny-portal/src/app/(frontend)/komponenter/komponenter.module.scss
@@ -80,21 +80,8 @@
         }
 
         .description {
-            grid-column: 6/12;
-        }
-
-        &::after {
-            content: "arrow_forward" / "";
-            font-family: "Fremtind Material Symbols", monospace;
-            grid-column: 12/13;
-            aspect-ratio: 1;
-            border: 1px solid var(--jkl-color-border-action);
-            border-radius: 9999px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: var(--jkl-unit-30);
-            padding: var(--jkl-unit-10);
+            display: block;
+            grid-column: 6/-1;
         }
 
         @container (max-width: 45em) {
@@ -113,13 +100,7 @@
 
             .description {
                 grid-row: 2 / 3;
-                display: block;
                 @include jkl.text-style("small");
-            }
-
-            &::after {
-                grid-row: 1 / 3;
-                place-self: center;
             }
         }
     }


### PR DESCRIPTION
ISSUES CLOSED: #4782

## 💬 Endringer

1. Fjernet knapp i listevisningen på komponentoversikten
2. Sikret at kort beskrivelse-teksten ikke forsvinner

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
