### PR TITLE
feat: gjør navtab polymorf

### DIFF
--- a/packages/jokul/src/components/tabs/NavTab.tsx
+++ b/packages/jokul/src/components/tabs/NavTab.tsx
@@ -1,89 +1,89 @@
 import clsx from "clsx";
 import React, { forwardRef, useCallback } from "react";
+import { PolymorphicRef } from "../../utilities/index.js";
 import { NavTabProps } from "./types.js";
 
-export const NavTab = forwardRef<HTMLAnchorElement, NavTabProps>(
-    (props, ref) => {
-        const {
-            component = "a",
-            "aria-selected": selected,
-            className,
-            componentProps = {},
-            onBeforeKeyboardNavigation: onBeforeNavigate,
-            ...rest
-        } = props;
+type NavTabComponent = <ElementType extends React.ElementType = "a">(
+    props: NavTabProps<ElementType>,
+) => React.ReactElement | null;
 
-        const Component = component;
+export const NavTab = forwardRef(function NavTab<
+    ElementType extends React.ElementType = "a",
+>(props: NavTabProps<ElementType>, ref?: PolymorphicRef<ElementType>) {
+    const {
+        as = "a",
+        "aria-selected": selected,
+        className,
+        onBeforeKeyboardNavigation: onBeforeNavigate,
+        ...rest
+    } = props;
 
-        const navigate = useCallback(
-            (from: HTMLAnchorElement, to: HTMLAnchorElement) => {
-                if (onBeforeNavigate) {
-                    // Åpne for å stoppe selve navigeringen hvis det skulle være behov for å gjøre noe custom med fokus og navigasjon
-                    const doNavigate = onBeforeNavigate(from, to);
-                    if (doNavigate === false) {
-                        return;
-                    }
+    const Component = as;
+
+    const navigate = useCallback(
+        (from: HTMLAnchorElement, to: HTMLAnchorElement) => {
+            if (onBeforeNavigate) {
+                // Åpne for å stoppe selve navigeringen hvis det skulle være behov for å gjøre noe custom med fokus og navigasjon
+                const doNavigate = onBeforeNavigate(from, to);
+                if (doNavigate === false) {
+                    return;
                 }
+            }
 
-                to.focus();
-                // Click brukes for å være router-agnostisk
-                to.click();
-            },
-            [onBeforeNavigate],
-        );
+            to.focus();
+            // Click brukes for å være router-agnostisk
+            to.click();
+        },
+        [onBeforeNavigate],
+    );
 
-        const handleOnKeyDown = useCallback(
-            (event: React.KeyboardEvent<HTMLAnchorElement>) => {
-                if (event.key === "ArrowLeft") {
-                    const current = event.currentTarget;
-                    const prev = event.currentTarget.previousSibling;
+    const handleOnKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+            if (event.key === "ArrowLeft") {
+                const current = event.currentTarget;
+                const prev = event.currentTarget.previousSibling;
 
-                    if (prev) {
-                        navigate(current, prev as HTMLAnchorElement);
-                    } else {
-                        navigate(
-                            current,
-                            current.parentElement?.lastChild
-                                ?.previousSibling as HTMLAnchorElement,
-                        );
-                    }
+                if (prev) {
+                    navigate(current, prev as HTMLAnchorElement);
+                } else {
+                    navigate(
+                        current,
+                        current.parentElement?.lastChild
+                            ?.previousSibling as HTMLAnchorElement,
+                    );
                 }
+            }
 
-                if (event.key === "ArrowRight") {
-                    const current = event.currentTarget;
-                    const next = event.currentTarget.nextSibling;
+            if (event.key === "ArrowRight") {
+                const current = event.currentTarget;
+                const next = event.currentTarget.nextSibling;
 
-                    // skip the focus indicator element
-                    if (next && next.nodeName === "A") {
-                        navigate(current, next as HTMLAnchorElement);
-                    } else {
-                        navigate(
-                            current,
-                            current.parentElement
-                                ?.firstChild as HTMLAnchorElement,
-                        );
-                    }
+                // skip the focus indicator element
+                if (next && next.nodeName === "A") {
+                    navigate(current, next as HTMLAnchorElement);
+                } else {
+                    navigate(
+                        current,
+                        current.parentElement?.firstChild as HTMLAnchorElement,
+                    );
                 }
-            },
-            [navigate],
-        );
+            }
+        },
+        [navigate],
+    );
 
-        return (
-            <Component
-                ref={ref}
-                {...rest}
-                {...componentProps}
-                role="tab"
-                aria-selected={selected}
-                className={clsx("jkl-tab", className)}
-                onKeyDown={handleOnKeyDown}
-                // En faneliste skal være én fokuserbar gruppe.
-                // Piltaster brukes for å veksle mellom faner.
-                // Bare den aktive fanen skal være fokuserbar med tastatur.
-                tabIndex={selected ? 0 : -1}
-            />
-        );
-    },
-);
-
-NavTab.displayName = "NavTab";
+    return (
+        <Component
+            ref={ref}
+            {...rest}
+            role="tab"
+            aria-selected={selected}
+            className={clsx("jkl-tab", className)}
+            onKeyDown={handleOnKeyDown}
+            // En faneliste skal være én fokuserbar gruppe.
+            // Piltaster brukes for å veksle mellom faner.
+            // Bare den aktive fanen skal være fokuserbar med tastatur.
+            tabIndex={selected ? 0 : -1}
+        />
+    );
+}) as NavTabComponent;

--- a/packages/jokul/src/components/tabs/types.ts
+++ b/packages/jokul/src/components/tabs/types.ts
@@ -1,33 +1,22 @@
-import { type AnchorHTMLAttributes, type ElementType } from "react";
 import { Density, WithChildren } from "../../core/types.js";
+import { PolymorphicPropsWithRef } from "../../utilities/index.js";
 
-export interface NavTabProps<T extends object = Record<string, unknown>>
-    extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    /** Sett til true for den nåværende fanen. False på resten. */
-    "aria-selected": boolean;
-    className?: string;
-    id?: string;
-    /**
-     * Overstyr hvilken komponent som skal brukes, for eksempel hvis du har en Link-komponent fra en router.
-     * @default "a"
-     */
-    component?: ElementType;
-    /** Send inn custom props til `component`. Nyttig om routeren din har noe fancy custom greier. */
-    componentProps?: T;
-    /** Vanlig alternativ til `href` i routere. */
-    to?: string;
-    href?: string;
-    /**
-     * Hook for å kunne stoppe default oppførsel ved tastaturnavigasjon.
-     *
-     * Om default oppførsel ikke fungerer for deg og du mister tastaturfokus etter
-     * navigasjon kan du returnere `false` her og sørge for korrekt oppførsel selv.
-     */
-    onBeforeKeyboardNavigation?: (
-        from: HTMLAnchorElement,
-        to: HTMLAnchorElement,
-    ) => boolean | void;
-}
+export type NavTabProps<ElementType extends React.ElementType> =
+    PolymorphicPropsWithRef<
+        ElementType,
+        {
+            /**
+             * Hook for å kunne stoppe default oppførsel ved tastaturnavigasjon.
+             *
+             * Om default oppførsel ikke fungerer for deg og du mister tastaturfokus etter
+             * navigasjon kan du returnere `false` her og sørge for korrekt oppførsel selv.
+             */
+            onBeforeKeyboardNavigation?: (
+                from: HTMLAnchorElement,
+                to: HTMLAnchorElement,
+            ) => boolean | void;
+        }
+    >;
 
 export interface NavTabsProps extends WithChildren {
     "aria-label"?: string;

--- a/packages/tabs-react/src/NavTab.tsx
+++ b/packages/tabs-react/src/NavTab.tsx
@@ -1,121 +1,89 @@
+import { PolymorphicRef } from "@fremtind/jkl-core";
 import cn from "classnames";
-import React, {
-    type ElementType,
-    forwardRef,
-    useCallback,
-    type AnchorHTMLAttributes,
-} from "react";
+import React, { forwardRef, useCallback } from "react";
+import { NavTabProps } from "./types";
 
-export interface NavTabProps<T extends object = Record<string, unknown>>
-    extends AnchorHTMLAttributes<HTMLAnchorElement> {
-    /** Sett til true for den nåværende fanen. False på resten. */
-    "aria-selected": boolean;
-    className?: string;
-    id?: string;
-    /**
-     * Overstyr hvilken komponent som skal brukes, for eksempel hvis du har en Link-komponent fra en router.
-     * @default "a"
-     */
-    component?: ElementType;
-    /** Send inn custom props til `component`. Nyttig om routeren din har noe fancy custom greier. */
-    componentProps?: T;
-    /** Vanlig alternativ til `href` i routere. */
-    to?: string;
-    href?: string;
-    /**
-     * Hook for å kunne stoppe default oppførsel ved tastaturnavigasjon.
-     *
-     * Om default oppførsel ikke fungerer for deg og du mister tastaturfokus etter
-     * navigasjon kan du returnere `false` her og sørge for korrekt oppførsel selv.
-     */
-    onBeforeKeyboardNavigation?: (
-        from: HTMLAnchorElement,
-        to: HTMLAnchorElement,
-    ) => boolean | void;
-}
+type NavTabComponent = <ElementType extends React.ElementType = "a">(
+    props: NavTabProps<ElementType>,
+) => React.ReactElement | null;
 
-export const NavTab = forwardRef<HTMLAnchorElement, NavTabProps>(
-    (props, ref) => {
-        const {
-            component = "a",
-            "aria-selected": selected,
-            className,
-            componentProps = {},
-            onBeforeKeyboardNavigation: onBeforeNavigate,
-            ...rest
-        } = props;
+export const NavTab = forwardRef(function NavTab<
+    ElementType extends React.ElementType = "a",
+>(props: NavTabProps<ElementType>, ref?: PolymorphicRef<ElementType>) {
+    const {
+        as = "a",
+        "aria-selected": selected,
+        className,
+        onBeforeKeyboardNavigation: onBeforeNavigate,
+        ...rest
+    } = props;
 
-        const Component = component;
+    const Component = as;
 
-        const navigate = useCallback(
-            (from: HTMLAnchorElement, to: HTMLAnchorElement) => {
-                if (onBeforeNavigate) {
-                    // Åpne for å stoppe selve navigeringen hvis det skulle være behov for å gjøre noe custom med fokus og navigasjon
-                    const doNavigate = onBeforeNavigate(from, to);
-                    if (doNavigate === false) {
-                        return;
-                    }
+    const navigate = useCallback(
+        (from: HTMLAnchorElement, to: HTMLAnchorElement) => {
+            if (onBeforeNavigate) {
+                // Åpne for å stoppe selve navigeringen hvis det skulle være behov for å gjøre noe custom med fokus og navigasjon
+                const doNavigate = onBeforeNavigate(from, to);
+                if (doNavigate === false) {
+                    return;
                 }
+            }
 
-                to.focus();
-                // Click brukes for å være router-agnostisk
-                to.click();
-            },
-            [onBeforeNavigate],
-        );
+            to.focus();
+            // Click brukes for å være router-agnostisk
+            to.click();
+        },
+        [onBeforeNavigate],
+    );
 
-        const handleOnKeyDown = useCallback(
-            (event: React.KeyboardEvent<HTMLAnchorElement>) => {
-                if (event.key === "ArrowLeft") {
-                    const current = event.currentTarget;
-                    const prev = event.currentTarget.previousSibling;
+    const handleOnKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+            if (event.key === "ArrowLeft") {
+                const current = event.currentTarget;
+                const prev = event.currentTarget.previousSibling;
 
-                    if (prev) {
-                        navigate(current, prev as HTMLAnchorElement);
-                    } else {
-                        navigate(
-                            current,
-                            current.parentElement?.lastChild
-                                ?.previousSibling as HTMLAnchorElement,
-                        );
-                    }
+                if (prev) {
+                    navigate(current, prev as HTMLAnchorElement);
+                } else {
+                    navigate(
+                        current,
+                        current.parentElement?.lastChild
+                            ?.previousSibling as HTMLAnchorElement,
+                    );
                 }
+            }
 
-                if (event.key === "ArrowRight") {
-                    const current = event.currentTarget;
-                    const next = event.currentTarget.nextSibling;
+            if (event.key === "ArrowRight") {
+                const current = event.currentTarget;
+                const next = event.currentTarget.nextSibling;
 
-                    // skip the focus indicator element
-                    if (next && next.nodeName === "A") {
-                        navigate(current, next as HTMLAnchorElement);
-                    } else {
-                        navigate(
-                            current,
-                            current.parentElement
-                                ?.firstChild as HTMLAnchorElement,
-                        );
-                    }
+                // skip the focus indicator element
+                if (next && next.nodeName === "A") {
+                    navigate(current, next as HTMLAnchorElement);
+                } else {
+                    navigate(
+                        current,
+                        current.parentElement?.firstChild as HTMLAnchorElement,
+                    );
                 }
-            },
-            [navigate],
-        );
+            }
+        },
+        [navigate],
+    );
 
-        return (
-            <Component
-                ref={ref}
-                {...rest}
-                {...componentProps}
-                role="tab"
-                aria-selected={selected}
-                className={cn("jkl-tab", className)}
-                onKeyDown={handleOnKeyDown}
-                // En faneliste skal være én fokuserbar gruppe.
-                // Piltaster brukes for å veksle mellom faner.
-                // Bare den aktive fanen skal være fokuserbar med tastatur.
-                tabIndex={selected ? 0 : -1}
-            />
-        );
-    },
-);
-
-NavTab.displayName = "NavTab";
+    return (
+        <Component
+            ref={ref}
+            {...rest}
+            role="tab"
+            aria-selected={selected}
+            className={cn("jkl-tab", className)}
+            onKeyDown={handleOnKeyDown}
+            // En faneliste skal være én fokuserbar gruppe.
+            // Piltaster brukes for å veksle mellom faner.
+            // Bare den aktive fanen skal være fokuserbar med tastatur.
+            tabIndex={selected ? 0 : -1}
+        />
+    );
+}) as NavTabComponent;

--- a/packages/tabs-react/src/types.ts
+++ b/packages/tabs-react/src/types.ts
@@ -1,0 +1,18 @@
+import { PolymorphicPropsWithRef } from "@fremtind/jkl-core";
+
+export type NavTabProps<ElementType extends React.ElementType> =
+    PolymorphicPropsWithRef<
+        ElementType,
+        {
+            /**
+             * Hook for å kunne stoppe default oppførsel ved tastaturnavigasjon.
+             *
+             * Om default oppførsel ikke fungerer for deg og du mister tastaturfokus etter
+             * navigasjon kan du returnere `false` her og sørge for korrekt oppførsel selv.
+             */
+            onBeforeKeyboardNavigation?: (
+                from: HTMLAnchorElement,
+                to: HTMLAnchorElement,
+            ) => boolean | void;
+        }
+    >;


### PR DESCRIPTION
## 💬 Endringer

1. NavTab-komponenten er gjort polymorfisk slik at den støtter egendefinerte komponenter som f.eks. Link fra react-router-dom, next/link eller andre lenkekomponenter. Dette gjør det mulig for brukeren å bestemme hvilken komponent som skal rendres, og gir bedre fleksibilitet ved integrasjon i ulike rammeverk og applikasjoner.

BREAKING CHANGE:
- component-propen er fjernet og erstattet med as, som gir bedre typesikkerhet og autocompletion basert på komponenten du sender inn
- componentProps er fjernet. Bruk heller vanlige props direkte på NavTab når du bruker as.

ISSUES CLOSED: #4801

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
