### PR TITLE
chore: oppdater Ubuntu-versjon i runner for en GitHub Action

### DIFF
--- a/.github/workflows/pull_request_close.yml
+++ b/.github/workflows/pull_request_close.yml
@@ -8,7 +8,7 @@ run-name: Fjern preview-branch for "${{ github.event.pull_request.title }}"
 
 jobs:
     remove-preview:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions:
             actions: write
             contents: write


### PR DESCRIPTION
## 💬 Endringer

1. Workflowen for lukking av pull requests bruker et utdatert/avviklet runner-image fra GitHub. Denne PRen oppdaterer det til siste versjon.
