### PR TITLE
feat: gjør det mulig å endre density i storybook

### DIFF
--- a/.storybook/density.tsx
+++ b/.storybook/density.tsx
@@ -1,0 +1,46 @@
+import { ReactRenderer } from "@storybook/react";
+import React, { useEffect } from "react";
+import { DecoratorFunction } from "storybook/internal/types";
+
+export const densities = [undefined, "compact", "comfortable"] as const;
+
+const applyDensity = (
+    element: HTMLElement,
+    density: (typeof densities)[number],
+) => {
+    element.classList.add("jkl");
+    element.dataset["layoutDensity"] = density;
+};
+
+const clearDensity = (element: HTMLElement) => {
+    delete element.dataset["layoutDensity"];
+};
+
+export const densityGlobal = {
+    description: "Størrelse for eksemplet",
+    toolbar: {
+        title: "Størrelse",
+        icon: "unfold",
+        items: [
+            { title: "Automatisk", value: densities[0], icon: "browser" },
+            { title: "Compact", value: densities[1], icon: "collapse" },
+            { title: "Comfortable", value: densities[2], icon: "expandalt" },
+        ],
+        dynamicTitle: true,
+    },
+};
+
+export const densityDecorator: DecoratorFunction<ReactRenderer, {}> = (
+    Story,
+    context,
+) => {
+    useEffect(() => {
+        const body = window.document.body;
+        clearDensity(body);
+        applyDensity(body, context.globals.density);
+
+        return () => clearDensity(body);
+    }, [context.globals.density]);
+
+    return <Story />;
+};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,18 +1,21 @@
 import type { Preview } from "@storybook/react";
 import { backgroundOptions } from "./backgrounds.js";
 import { themeDecorator, themeGlobal, themes } from "./theme.js";
+import { densityDecorator, densityGlobal, densities } from "./density.js";
 import "../packages/jokul/src/components/card/styles/_index.scss";
 import "./global.scss";
 
 const preview: Preview = {
     globalTypes: {
         theme: themeGlobal,
+        density: densityGlobal,
     },
     initialGlobals: {
         theme: themes[0], // Automatisk dark/light
+        density: densities[0],
         backgrounds: { value: "pageVariant" },
     },
-    decorators: [themeDecorator],
+    decorators: [themeDecorator, densityDecorator],
     parameters: {
         actions: { argTypesRegex: "^on.*" },
         backgrounds: {


### PR DESCRIPTION
ISSUES CLOSED: #4846

## 💬 Endringer

1. Legger til decorator i storybook for kontroller av density.

### 🎯 Dokumentasjon

-   [x] Teksten i portalen er oppdatert med endringene i [Sanity](https://jokul-portal.app.devaws.fremtind.no/studio)
-   [x] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)
-   [x] [Figma-komponentene](https://www.figma.com/files/784861794507029203/project/52944370/Designsystemet?fuid=1253605757836779042) er oppdatert, og eksempler er lagt til dersom det trengd

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
