### PR TITLE
style: fjerne egenvalgt selection-farge i input-felter

### DIFF
--- a/packages/combobox/combobox.scss
+++ b/packages/combobox/combobox.scss
@@ -287,10 +287,6 @@ $_combobox-search-input-selection-color--inverted: color.scale(
         .jkl-combobox__wrapper {
             color: var(--jkl-combobox-error-text-color);
         }
-
-        .jkl-combobox__search-input::selection {
-            background-color: var(--jkl-combobox-search-input-selection-color);
-        }
     }
 
     &--menu-closed {

--- a/packages/jokul/src/components/combobox/styles/combobox.scss
+++ b/packages/jokul/src/components/combobox/styles/combobox.scss
@@ -285,10 +285,6 @@ $_combobox-search-input-selection-color--inverted: color.scale(
         .jkl-combobox__wrapper {
             color: var(--jkl-combobox-error-text-color);
         }
-
-        .jkl-combobox__search-input::selection {
-            background-color: var(--jkl-combobox-search-input-selection-color);
-        }
     }
 
     &--menu-closed {

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -78,14 +78,6 @@
         box-sizing: border-box;
         padding: var(--jkl-select-search-input-padding);
         color: var(--jkl-color-text-subdued);
-
-        &::selection {
-            background-color: color-mix(
-                in oklab,
-                var(--jkl-color-text-subdued) 25%,
-                var(--jkl-color-background-container) 15%
-            );
-        }
     }
 
     &__search-input,

--- a/packages/jokul/src/shared/input/styles/shared-input-styles.scss
+++ b/packages/jokul/src/shared/input/styles/shared-input-styles.scss
@@ -174,9 +174,4 @@ $_action-button-focus-position--compact: 0;
         opacity: 1;
         color: var(--placeholder-color);
     }
-
-    // Color of text selection
-    &::selection {
-        background-color: color(from currentColor sRGB r g b / 0.25);
-    }
 }

--- a/packages/select/select.scss
+++ b/packages/select/select.scss
@@ -78,14 +78,6 @@
         box-sizing: border-box;
         padding: var(--jkl-select-search-input-padding);
         color: var(--jkl-color-text-subdued);
-
-        &::selection {
-            background-color: color-mix(
-                in oklab,
-                var(--jkl-color-text-subdued) 25%,
-                var(--jkl-color-background-container) 15%
-            );
-        }
     }
 
     &__search-input,

--- a/packages/text-input/text-input.scss
+++ b/packages/text-input/text-input.scss
@@ -79,11 +79,6 @@ $_action-button-focus-position--compact: 0;
         opacity: 1;
         color: var(--placeholder-color);
     }
-
-    // Color of text selection
-    &::selection {
-        background-color: color(from currentColor sRGB r g b / 0.25);
-    }
 }
 
 .jkl-text-input-wrapper {


### PR DESCRIPTION
ISSUES CLOSED: #4837

## 💬 Endringer

1. Fjerner egen bakgrunnsfarge `::selection`

### 🎯 Dokumentasjon

-   [x] Teksten i portalen er oppdatert med endringene i [Sanity](https://jokul-portal.app.devaws.fremtind.no/studio)
-   [x] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)
-   [x] [Figma-komponentene](https://www.figma.com/files/784861794507029203/project/52944370/Designsystemet?fuid=1253605757836779042) er oppdatert, og eksempler er lagt til dersom det trengd

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
