### PR TITLE
feat: adds option to programmatically close toasts

### DIFF
--- a/packages/jokul/src/components/toast/development/ToastExample.tsx
+++ b/packages/jokul/src/components/toast/development/ToastExample.tsx
@@ -1,8 +1,9 @@
 import { ExampleComponentProps, ExampleKnobsProps } from "doc-utils/index.js";
-import React, { FC } from "react";
-import { PrimaryButton } from "../../button/Button.js";
+import React, { FC, useState } from "react";
+import { PrimaryButton, SecondaryButton } from "../../button/Button.js";
 import { ToastContent, ToastProvider, useToast } from "../index.js";
 import { ToastOptions } from "../types.js";
+import { Flex } from "../../flex/Flex.js";
 
 export const toastExampleKnobs: ExampleKnobsProps = {
     boolProps: [],
@@ -54,17 +55,24 @@ const examples: Array<[ToastContent, ToastOptions]> = [
 ];
 
 function ToastUsageExample() {
-    const { add } = useToast();
+    const { add, close } = useToast();
+    const [keys, setKeys] = useState<string[]>([]);
+
     return (
-        <PrimaryButton
-            onClick={() => {
-                const [content, options] =
-                    examples[Math.floor(Math.random() * examples.length)];
-                add(content, options);
-            }}
-        >
-            Vis toast i kontekst
-        </PrimaryButton>
+        <Flex direction="column" rowGap={24}>
+            <PrimaryButton
+                onClick={() => {
+                    const [content, options] =
+                        examples[Math.floor(Math.random() * examples.length)];
+                    setKeys([...keys, add(content, options)]);
+                }}
+            >
+                Vis toast i kontekst
+            </PrimaryButton>
+            <SecondaryButton onClick={() => keys.forEach((key) => close(key))}>
+                Lukk alle åpne toasts
+            </SecondaryButton>
+        </Flex>
     );
 }
 

--- a/packages/jokul/src/components/toast/toastContext.tsx
+++ b/packages/jokul/src/components/toast/toastContext.tsx
@@ -12,6 +12,7 @@ const context = createContext<ToastContext>({
     add: () => {
         return "missing-provider";
     },
+    close: () => {},
 });
 
 export const useToast = (): ToastContext => useContext(context);
@@ -31,6 +32,7 @@ export const ToastProvider: FC<ToastContextProviderProps> = ({
     return (
         <context.Provider
             value={{
+                close: queue.close.bind(queue),
                 add: (toast: ToastContent, options?: ToastOptions) => {
                     let timeout: number | undefined = 5000;
 

--- a/packages/jokul/src/components/toast/types.ts
+++ b/packages/jokul/src/components/toast/types.ts
@@ -16,6 +16,7 @@ export type ToastOptions = Omit<StatelyToastOptions, "timeout"> & {
 
 export type ToastContext = {
     add: (toast: ToastContent, options?: ToastOptions) => string;
+    close: (key: string) => void;
 };
 
 export type ToastContextProviderProps = WithChildren & {

--- a/packages/toast-react/src/toastContext.tsx
+++ b/packages/toast-react/src/toastContext.tsx
@@ -14,12 +14,14 @@ interface ToastContextProviderProps extends WithChildren {
 
 type ToastContext = {
     add: (toast: ToastContent, options?: ToastOptions) => string;
+    close: (key: string) => void;
 };
 
 const context = createContext<ToastContext>({
     add: () => {
         return "missing-provider";
     },
+    close: () => {},
 });
 
 export const useToast = (): ToastContext => useContext(context);
@@ -39,6 +41,7 @@ export const ToastProvider: FC<ToastContextProviderProps> = ({
     return (
         <context.Provider
             value={{
+                close: queue.close.bind(queue),
                 add: (toast: ToastContent, options?: ToastOptions) => {
                     let timeout: number | undefined = 5000;
 


### PR DESCRIPTION
Adds option to programmatically close an open toast before its
timer expires or the user closes it manually. To do this, use
the `close` function from the `useToast` hook and provide the key
that was returned by `add` when the toast was created.


ISSUES CLOSED: #4869

### 🎯 Dokumentasjon

-   [ ] Teksten i portalen er oppdatert med endringene i [Sanity](https://jokul-portal.app.devaws.fremtind.no/studio)
-   [ ] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
