### PR TITLE
Fiks ikon som knekker feil i eksterne lenker

### DIFF
--- a/packages/jokul/src/components/icon/styles/_base-styles.scss
+++ b/packages/jokul/src/components/icon/styles/_base-styles.scss
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+@use "../../../core/jkl";
+
+/// Vi tilbyr dette som en mixin for å kunne være konsekvent i stilsettingen
+/// av ikoner også der man ikke kan bruke jkl-icon-klassen.
+/// @output Basestiler for Jøkul-ikoner
+@mixin base-styles {
+    font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
+    font-variation-settings: "FILL" var(--jkl-icon-fill, 0),
+        "GRAD" var(--jkl-icon-grade, 0), "opsz" var(--jkl-icon-opsz, 24);
+    font-feature-settings: "liga";
+    -webkit-font-feature-settings: "liga";
+    font-size: var(--jkl-icon-size, #{jkl.rem(24px)});
+    font-weight: var(--jkl-icon-weight, 300);
+    line-height: 1;
+    display: inline-block;
+    -webkit-font-smoothing: antialiased;
+
+    @include jkl.motion("standard", "productive");
+    transition-property: font-variation-settings, transform;
+}

--- a/packages/jokul/src/components/icon/styles/icon.scss
+++ b/packages/jokul/src/components/icon/styles/icon.scss
@@ -1,5 +1,6 @@
 @charset "UTF-8";
 @use "../../../core/jkl";
+@use "./base-styles" as *;
 
 @include jkl.light-mode-variables {
     --jkl-icon-grade: 0;
@@ -12,19 +13,7 @@
 .jkl-icon {
     --jkl-icon-fill: 0;
 
-    font-family: "Fremtind Material Symbols", Arial, Helvetica, sans-serif;
-    font-variation-settings: "FILL" var(--jkl-icon-fill, 0),
-        "GRAD" var(--jkl-icon-grade, 0), "opsz" var(--jkl-icon-opsz, 24);
-    font-feature-settings: "liga";
-    -webkit-font-feature-settings: "liga";
-    font-size: var(--jkl-icon-size, #{jkl.rem(24px)});
-    font-weight: var(--jkl-icon-weight, 300);
-    line-height: 1;
-    display: inline-block;
-    -webkit-font-smoothing: antialiased;
-
-    @include jkl.motion("standard", "productive");
-    transition-property: font-variation-settings, transform;
+    @include base-styles;
 
     &--bold {
         --jkl-icon-weight: 500;

--- a/packages/jokul/src/components/link/Link.tsx
+++ b/packages/jokul/src/components/link/Link.tsx
@@ -1,7 +1,6 @@
 import { clsx } from "clsx";
 import React, { useId } from "react";
 import { PolymorphicRef } from "../../utilities/polymorphism/polymorphism.js";
-import { OpenInNewIcon } from "../icon/icons/OpenInNewIcon.js";
 import { LinkProps } from "./types.js";
 
 type LinkComponent = <ElementType extends React.ElementType = "a">(
@@ -25,15 +24,14 @@ export const Link = React.forwardRef(function Link<
     return (
         <Component
             ref={ref}
-            className={clsx("jkl-link", className, {})}
+            className={clsx("jkl-link", className, {
+                "jkl-link--external": external,
+            })}
             aria-describedby={external ? srId : undefined}
             {...rest}
         >
             <span className="jkl-link__content">{children}</span>
             {(external || rest.target === "_blank") && (
-                <OpenInNewIcon variant="small" className="jkl-link__icon" />
-            )}
-            {external && (
                 <span hidden={true} id={srId}>
                     Ekstern lenke
                 </span>

--- a/packages/jokul/src/components/link/styles/link.scss
+++ b/packages/jokul/src/components/link/styles/link.scss
@@ -1,4 +1,5 @@
 @use "../../../core/jkl";
+@use "../../icon/styles/base-styles" as icon;
 
 .jkl-link {
     --link-color: var(--jkl-color-text-default);
@@ -20,6 +21,23 @@
         margin-inline-start: 0.2em;
         margin-block-start: -0.1em;
         vertical-align: middle;
+    }
+
+    &--external::after,
+    &[target="_blank"]::after {
+        --jkl-icon-fill: 0;
+        --jkl-icon-size: #{jkl.rem(20px)};
+        --jkl-icon-opsz: 20;
+
+        content: "\feff\e89e";
+        margin-block-start: -0.1em;
+        padding-inline-start: 0.2em;
+        vertical-align: middle;
+
+        @include icon.base-styles;
+
+        // Trengs for at non breaking space skal ha effekt
+        display: inline;
     }
 
     &:hover:not(:focus) {


### PR DESCRIPTION
## 💬 Endringer

1. Trekker ut basestilene til `Icon`-komponenten i en egen mixin for enklere gjenbruk
2. Endrer ikonet for eksterne lenker til en inline-variant som knekker sammen med siste ord i lenken

**NB!** Endringene er _kun_ gjort i `@fremtind/jokul`-pakken. Lenkene fra `@fremtind/jkl-core` oppfører seg fremdeles som før.

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
