### PR TITLE
fix: fiks scroll i tab-list

### DIFF
--- a/packages/jokul/src/components/tabs/TabList.tsx
+++ b/packages/jokul/src/components/tabs/TabList.tsx
@@ -97,7 +97,7 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
                     bottom: -1,
                     width:
                         (activeRect?.width || 0) -
-                        (density === "compact" ? 32 : 38),
+                        (density === "compact" ? 24 : 38),
                 }}
             />
         </div>

--- a/packages/jokul/src/components/tabs/stories/Tabs.stories.tsx
+++ b/packages/jokul/src/components/tabs/stories/Tabs.stories.tsx
@@ -36,18 +36,23 @@ export const TabsStory: Story = {
         children: <p></p>,
     },
     render: (args) => (
-        <Tabs {...args}>
-            <TabList aria-label="Avtale-filter">
-                <Tab>Alle avtaler</Tab>
-                <Tab>NICE</Tab>
-                <Tab>Prolife</Tab>
-            </TabList>
+        <div style={{ maxWidth: "300px" }}>
+            <Tabs {...args}>
+                <TabList aria-label="Avtale-filter">
+                    <Tab>Alle avtaler</Tab>
+                    <Tab>NICE</Tab>
+                    <Tab>Prolife</Tab>
+                    <Tab>Paris</Tab>
+                </TabList>
 
-            <TabPanel>Alle avtaler</TabPanel>
+                <TabPanel>Alle avtaler</TabPanel>
 
-            <TabPanel>NICE-avtaler</TabPanel>
+                <TabPanel>NICE-avtaler</TabPanel>
 
-            <TabPanel>Prolife-avtaler</TabPanel>
-        </Tabs>
+                <TabPanel>Prolife-avtaler</TabPanel>
+
+                <TabPanel>Paris-avtaler</TabPanel>
+            </Tabs>
+        </div>
     ),
 };

--- a/packages/jokul/src/components/tabs/styles/tabs.scss
+++ b/packages/jokul/src/components/tabs/styles/tabs.scss
@@ -20,14 +20,7 @@
 }
 
 .jkl-tabs {
-    scroll-snap-type: x proximity;
-    overflow: scroll hidden;
-
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-        display: none;
-    }
+    width: 100%;
 }
 
 .jkl-tablist {
@@ -35,14 +28,17 @@
     --line-color: var(--jkl-color-border-separator);
     --indicator-color: var(--jkl-color-border-separator-hover);
 
+    scroll-snap-type: x proximity;
+    overflow: scroll hidden;
+    scrollbar-width: none;
     position: relative;
     display: inline-flex;
     flex-direction: row;
     padding: 0;
     margin: 0;
     border-bottom: 1px solid var(--line-color);
-    min-width: fit-content;
-    width: 100%;
+    width: fit-content;
+    max-width: 100%;
 
     &__indicator {
         position: absolute;
@@ -59,6 +55,10 @@
 
     @include jkl.forced-colors-mode {
         border-color: GrayText;
+    }
+
+    &::-webkit-scrollbar {
+        display: none;
     }
 }
 


### PR DESCRIPTION
Tabs tar ikke lenger bredden på innholdet, men 100% av containeren den står i, og tabs-list scroller
igjen.

ISSUES CLOSED: #4171