### PR TITLE
refactor: erstatt aktiv tab indikator i react med css

### DIFF
--- a/packages/jokul/src/components/tabs/TabList.tsx
+++ b/packages/jokul/src/components/tabs/TabList.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useTabsContext } from "./tabsContext.js";
+import React, { useCallback, useRef } from "react";
 import { TabListProps } from "./types.js";
 
 export interface InjectedProps {
@@ -19,22 +18,9 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
     // props injected by Tabs
     const { activeIndex, setActiveIndex, tabIDs, tabPanelIDs, ...rest } =
         injected as TabListProps & InjectedProps;
-    const { density } = useTabsContext();
-
-    const [tabsRect, setTabsRect] = useState<DOMRect>();
-    const [activeRect, setActiveRect] = useState<DOMRect>();
 
     const tabsRef = useRef<HTMLDivElement>(null);
     const activeRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-        if (tabsRef.current) {
-            setTabsRect(tabsRef.current.getBoundingClientRect());
-        }
-        if (activeRef.current) {
-            setActiveRect(activeRef.current.getBoundingClientRect());
-        }
-    }, [activeIndex, density]);
 
     const keyDownHandler = useCallback(
         (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -89,17 +75,6 @@ export const TabList = ({ children, className, ...injected }: TabListProps) => {
                       })
                     : null;
             })}
-
-            <span
-                className="jkl-tablist__indicator"
-                style={{
-                    left: (activeRect?.left || 0) - (tabsRect?.left || 0),
-                    bottom: -1,
-                    width:
-                        (activeRect?.width || 0) -
-                        (density === "compact" ? 24 : 38),
-                }}
-            />
         </div>
     );
 };

--- a/packages/jokul/src/components/tabs/styles/tabs.scss
+++ b/packages/jokul/src/components/tabs/styles/tabs.scss
@@ -4,11 +4,13 @@
 @include jkl.comfortable-density-variables {
     --jkl-tab-padding: var(--jkl-unit-10) var(--jkl-unit-50) var(--jkl-unit-15)
         var(--jkl-unit-02);
+    --jkl-tab-padding-inline-end: var(--jkl-unit-50);
 
     @include jkl.declare-font-variables("jkl-tab", "body");
     @include jkl.small-device {
         --jkl-tab-padding: var(--jkl-unit-10) var(--jkl-unit-30)
             var(--jkl-unit-15) var(--jkl-unit-02);
+        --jkl-tab-padding-inline-end: var(--jkl-unit-30);
     }
 }
 
@@ -17,6 +19,7 @@
 
     --jkl-tab-padding: var(--jkl-unit-02) var(--jkl-unit-40) var(--jkl-unit-05)
         0;
+    --jkl-tab-padding-inline-end: var(--jkl-unit-40);
 }
 
 .jkl-tabs {
@@ -40,25 +43,30 @@
     width: fit-content;
     max-width: 100%;
 
-    &__indicator {
-        position: absolute;
-        height: 2px;
-        background-color: var(--indicator-color);
-        @include jkl.motion("standard", "lazy");
-        transition-property: left, width;
-        will-change: left, width;
-
-        @include jkl.forced-colors-mode {
-            background-color: Highlight;
-        }
-    }
-
     @include jkl.forced-colors-mode {
         border-color: GrayText;
     }
 
     &::-webkit-scrollbar {
         display: none;
+    }
+
+    @supports (position-anchor: --active-tab) {
+        &::after {
+            content: "";
+            position: absolute;
+            /* stylelint-disable */
+            position-anchor: --active-tab;
+            /* stylelint-enable */
+            height: 2px;
+            width: calc(
+                anchor-size(inline) - var(--jkl-tab-padding-inline-end)
+            );
+            inset-block-start: calc(anchor(end) - 2px);
+            inset-inline-start: calc(anchor(--active-tab start));
+            background-color: var(--indicator-color);
+            @include jkl.motion("standard", "lazy");
+        }
     }
 }
 
@@ -86,6 +94,22 @@
     }
 
     &[aria-selected="true"] {
+        anchor-name: --active-tab;
         @include jkl.no-grow-bold;
+
+        @supports not (position-anchor: --active-tab) {
+            position: relative;
+
+            &::after {
+                content: "";
+                position: absolute;
+                height: 2px;
+                width: calc(100% - var(--jkl-tab-padding-inline-end));
+                inset-block-end: 0;
+                inset-inline-start: 0;
+                background-color: var(--indicator-color);
+                @include jkl.motion("standard", "lazy");
+            }
+        }
     }
 }


### PR DESCRIPTION
Tidligere ville den aktive tabben få indikator basert på dom-logikk i react. Denne ville feile ved
overflow etter #4879 fordi left ble kalkulert feil.
Denne logikken er derfor fjernet til fordel
for en ren CSS løsning med bruk av anchor positioning. Denne har relativt god støtte, men det er
lagt inn en @supports sjekk, hvor fallback er at den aktive tabben får en tilsvarende indikator, men
som ikke er animert.

ISSUES CLOSED: #4881

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
