### PR TITLE
chore: legg til stylelint regel for @supports

### DIFF
--- a/packages/jokul/src/components/tabs/styles/tabs.scss
+++ b/packages/jokul/src/components/tabs/styles/tabs.scss
@@ -55,9 +55,7 @@
         &::after {
             content: "";
             position: absolute;
-            /* stylelint-disable */
             position-anchor: --active-tab;
-            /* stylelint-enable */
             height: 2px;
             width: calc(
                 anchor-size(inline) - var(--jkl-tab-padding-inline-end)

--- a/packages/stylelint-config-jkl/rules/at-rule.js
+++ b/packages/stylelint-config-jkl/rules/at-rule.js
@@ -1,3 +1,4 @@
 module.exports = {
     "at-rule-no-vendor-prefix": true,
+    "property-no-unknown": [true, { ignoreAtRules: ["supports"] }],
 };


### PR DESCRIPTION
Legger til et unntak i stylelint for å støtte @ supports bedre i css. 

Et perfekt scenario her ville vært at stylelint så hvilken property som ble sjekka og gjorde et unntak for den. 

Siden det ikke var noen funksjonalitet for det (såvidt vi så) er det derfor heller gjort unntak for hele scopet i en @ supports sjekk.