### PR TITLE
chore: fjern gammel build and deploy workflow

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -26,7 +26,7 @@ jobs:
                       🧑‍💻 Kjør `pnpm update -r` på rotnivå i prosjektet.
                       🧑‍💻 Kjør `pnpm outdated -r` på rotnivå i prosjektet.
 
-                      Output fra `pnpm outdated` vil vise deg hvilke pakker som trenger å oppdateres manuelt, men også noen som ikke _kan_ oppdateres. Noen ganger har vi avhengigheter som trenger en eldre majorversjon av en pakke, for eksempel `gatsby` som trenger en eldre `mdx-js` og `got`.
+                      Output fra `pnpm outdated` vil vise deg hvilke pakker som trenger å oppdateres manuelt, men også noen som ikke _kan_ oppdateres. Noen ganger har vi avhengigheter som trenger en eldre majorversjon av en pakke.
 
                       Du kan sannsynligvis trygt ignorere `overrides` med mindre noe brekker senere.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,16 +121,6 @@ jobs:
               if: steps.lerna_changed.outcome != 'success'
               run: pnpm build
 
-            - name: Build and deploy portal
-              env:
-                  GATSBY_MIXPANEL_PROJECT_ID: ${{ secrets.MIXPANEL_PROJECT_ID_PROD }}
-                  GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
-              run: |
-                  git config user.email "fremtind.designsystem@fremtind.no"
-                  git config user.name "fremtind-bot"
-                  git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/fremtind/jokul.git
-                  pnpm deploy:docs
-
     main-to-external:
         name: Merge main to external-contributions
         runs-on: ubuntu-latest


### PR DESCRIPTION
ISSUES CLOSED: #4810

## 💬 Endringer

1. Fjerner gammel build and deploy workflow

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
