### PR TITLE
chore: oppdater prepare-script til ikke å feile uten husky

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  HUSKY: 0
 
             - name: Switch registry
               if: steps.lerna_changed.outcome == 'success'

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "integration:ci": "playwright test",
         "integration:interactive": "playwright test --ui",
         "integration:axe": "playwright test -g axe",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "prepare": "husky || true"
     },
     "packageManager": "pnpm@7.32.2",
     "pnpm": {


### PR DESCRIPTION
## 💬 Endringer

1. La `prepare`-scriptet returnere `true` hvis husky ikke kjører, som under CI
