### PR TITLE
chore: preview av endringer i PR gjennom storybook

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,6 +41,12 @@ jobs:
                         - "**/*.tsx"
                         - "**/vite.test.config.mjs"
                         - "pnpm-lock.yaml"
+                      preview:
+                        - "packages/jokul/src/**/*.scss"
+                        - "packages/jokul/src/**/!(*.d|*.test).ts"
+                        - "packages/jokul/src/**/!(*.test).tsx"
+                        - "pnpm-lock.yaml"
+
 
             - name: Setup pnpm
               if: steps.changes.outputs.has_matches == 'true' || github.event_name == 'merge_group'
@@ -50,7 +56,7 @@ jobs:
               uses: actions/setup-node@v3
               if: steps.changes.outputs.has_matches == 'true' || github.event_name == 'merge_group'
               with:
-                  node-version: 18
+                  node-version: 22
                   cache: "pnpm"
 
             - name: Restore Monorepo Runner Cache
@@ -97,7 +103,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 22
                   cache: "pnpm"
 
             - name: Restore Monorepo Runner Cache
@@ -117,3 +123,72 @@ jobs:
 
             - name: Lint and test
               run: pnpm ci:test
+
+    preview:
+        name: Publiser forhåndsvisning
+        needs: [build]
+        if: github.event_name != 'merge_group' && needs.build.outputs.preview == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 22
+                  cache: "pnpm"
+
+            - name: Restore Monorepo Runner Cache
+              uses: actions/cache/restore@v3
+              with:
+                  path: .nx
+                  key: nx-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+                  restore-keys: |
+                      nx-${{ hashFiles('pnpm-lock.yaml') }}-
+
+              # Steget må være med, men vil være cachet
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build packages
+              run: pnpm build
+
+            - name: Add a comment with a link to the preview
+              uses: marocchino/sticky-pull-request-comment@da224cb0e3c8b27cae68d40c93649421b5b93e45
+              with:
+                  header: preview
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
+                  message: |
+                      <span aria-hidden="true">🔄</span> **Gjør klar en forhåndsvisning…**
+                      <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}
+
+            - name: Build site
+              run: pnpm build-storybook
+
+            - name: Deploy preview
+              env:
+                  GH_TOKEN: ${{ secrets.BOT_PUBLISH_TOKEN }}
+              run: |
+                  git config user.email "fremtind.designsystem@fremtind.no"
+                  git config user.name "fremtind-bot"
+                  git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/fremtind/jokul.git
+                  pnpm gh-pages --add --dist storybook-static --dest ${{ env.PREVIEW_PATH }} --message "docs: preview #${{ github.event.number }}"
+
+            - name: Add a comment with a link to the preview
+              uses: marocchino/sticky-pull-request-comment@da224cb0e3c8b27cae68d40c93649421b5b93e45
+              with:
+                  header: preview
+                  GITHUB_TOKEN: ${{ secrets.FREMTIND_BOT_ACCESS_TOKEN }}
+                  message: |
+                      <span aria-hidden="true">✅</span> Forhåndsvisning: https://jokul.fremtind.no/${{ env.PREVIEW_PATH }}/
+                      <span aria-hidden="true">🔍</span> Commit: ${{ github.sha }}
+
+                      Forhåndsvisningen blir tilgjengelig innen et par minutter. Den fjernes automatisk når pull requesten lukkes.


### PR DESCRIPTION
## 💬 Endringer

1. Bygger en statisk versjon av Storybook som publiseres under en adresse på jokul.fremtind.no vha GitHub pages. Dette vil slutte å funke når vi peker om jokul.fremtind.no til ny portal, men da kan vi evt. lage en ny adresse vi kan bruke til previews (eller finne en helt annen løsning).