### PR TITLE
docs: oppdater github-lenker i gammel portal

### DIFF
--- a/packages/accordion-react/package.json
+++ b/packages/accordion-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react accordion component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/accordion-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/accordion-react",
     "keywords": [
         "accordion",
         "jøkul",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for accordion menu",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/accordion",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/accordion",
     "keywords": [
         "accordion",
         "jøkul",

--- a/packages/breadcrumb-react/package.json
+++ b/packages/breadcrumb-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react breadcrumb",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/breadcrumb-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/breadcrumb-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for breadcrumb",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/breadcrumb",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/breadcrumb",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/browserslist-config-jkl/package.json
+++ b/packages/browserslist-config-jkl/package.json
@@ -10,7 +10,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/browserslist-config-jkl",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/browserslist-config-jkl",
     "license": "MIT",
     "main": "index.js",
     "files": [

--- a/packages/button-react/package.json
+++ b/packages/button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react button components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/button-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/button-react",
     "keywords": [
         "button",
         "primary button",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for buttons",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/button",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/button",
     "keywords": [
         "button",
         "primary button",

--- a/packages/card-react/package.json
+++ b/packages/card-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react card component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/card-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/card-react",
     "keywords": [
         "card"
     ],

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for card",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/card",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/card",
     "keywords": [
         "card",
         "jøkul",

--- a/packages/checkbox-react/package.json
+++ b/packages/checkbox-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react checkbox component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/checkbox-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/checkbox-react",
     "keywords": [
         "checkbox",
         "form",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for checkbox",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/checkbox",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/checkbox",
     "keywords": [
         "checkbox",
         "form",

--- a/packages/chip-react/package.json
+++ b/packages/chip-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react chip",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/chip-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/chip-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for chip",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/chip",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/chip",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/combobox-react/package.json
+++ b/packages/combobox-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react combobox",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/combobox-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/combobox-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for combobox",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/combobox",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/combobox",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/constants-util/package.json
+++ b/packages/constants-util/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Common constant values shared across all Jøkul projects",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/constants-util",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/constants-util",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/contextual-menu-react/package.json
+++ b/packages/contextual-menu-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react contextual-menu",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/contextual-menu-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/contextual-menu-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/contextual-menu/package.json
+++ b/packages/contextual-menu/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for contextual-menu",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/contextual-menu",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/contextual-menu",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/cookie-consent-react/package.json
+++ b/packages/cookie-consent-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react cookie consent component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/cookie-consent-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/cookie-consent-react",
     "keywords": [
         "cookie consent",
         "jøkul",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for cookie consent solutions",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/cookie-consent",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/cookie-consent",
     "keywords": [
         "cookie consent",
         "jøkul",

--- a/packages/core/documentation/mixins.mdx
+++ b/packages/core/documentation/mixins.mdx
@@ -15,7 +15,7 @@ Vi har for øvrig en guide for [Hvordan skrive Sass i Jøkul](/guider/sass) som 
 
 ## Hvilke mixins finnes?
 
-For en fullstendig oversikt er det best å [se på kildekoden](https://github.com/fremtind/jokul/tree/main/packages/core/jkl).
+For en fullstendig oversikt er det best å [se på kildekoden](https://github.com/fremtind/jokul/tree/pre-1.0/packages/core/jkl).
 
 Et utvalg av de mest brukte internt i Jøkul:
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul core styles",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/core",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/core",
     "keywords": [
         "core",
         "typography",

--- a/packages/datepicker-react/CHANGELOG.md
+++ b/packages/datepicker-react/CHANGELOG.md
@@ -162,14 +162,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### BREAKING CHANGES
 
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   `BaseInputField` er erstattet av `BaseTextInput`.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 
 ## 12.0.32 (2022-12-23)
 

--- a/packages/datepicker-react/package.json
+++ b/packages/datepicker-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react datepicker component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/datepicker-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/datepicker-react",
     "keywords": [
         "datepicker",
         "jøkul",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for datepicker",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/datepicker",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/datepicker",
     "keywords": [
         "datepicker",
         "jøkul",

--- a/packages/description-list-react/package.json
+++ b/packages/description-list-react/package.json
@@ -10,7 +10,7 @@
         "jøkul",
         "fremtind"
     ],
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/description-list-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/description-list-react",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/description-list/package.json
+++ b/packages/description-list/package.json
@@ -10,7 +10,7 @@
         "jøkul",
         "fremtind"
     ],
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/description-list",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/description-list",
     "license": "MIT",
     "files": [
         "!example",

--- a/packages/expand-button-react/package.json
+++ b/packages/expand-button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react expand-button",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/expand-button-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/expand-button-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/expand-button/package.json
+++ b/packages/expand-button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for expand-button",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/expand-button",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/expand-button",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/expandable-react/package.json
+++ b/packages/expandable-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react expandable",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/expandable-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/expandable-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/expandable/package.json
+++ b/packages/expandable/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for expandable",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/expandable",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/expandable",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/feedback-react/CHANGELOG.md
+++ b/packages/feedback-react/CHANGELOG.md
@@ -121,7 +121,7 @@ It is replaced with a new `counter` prop. To migrate your code, replace
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   `BaseInputField` er erstattet av `BaseTextInput`.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 
 ## 14.1.8 (2022-11-22)
 

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react feedback component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/feedback-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/feedback-react",
     "keywords": [
         "feedback",
         "jøkul",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for feedback",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/feedback",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/feedback",
     "keywords": [
         "feedback",
         "jøkul",

--- a/packages/file-input-react/package.json
+++ b/packages/file-input-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react file-input",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/file-input-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/file-input-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/file-input/package.json
+++ b/packages/file-input/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for file-input",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/file-input",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/file-input",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/formatters-util/package.json
+++ b/packages/formatters-util/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Formatters for common data formats in Jøkul",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/formatters-util",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/formatters-util",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/icon-button-react/package.json
+++ b/packages/icon-button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react icon-button components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/icon-button-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/icon-button-react",
     "keywords": [
         "button",
         "icon button",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for buttons",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/icon-button",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/icon-button",
     "keywords": [
         "button",
         "icon button",

--- a/packages/icons-react/documentation/Icons.mdx
+++ b/packages/icons-react/documentation/Icons.mdx
@@ -28,7 +28,7 @@ import {
     codeExample={iconsExampleCode}
 />
 
-Et lite utvalg av ikonene våre er animerbare. For å bruke animasjonene trengs [CSSen fra ikonpakka](https://github.com/fremtind/jokul/tree/main/packages/icons).
+Et lite utvalg av ikonene våre er animerbare. For å bruke animasjonene trengs [CSSen fra ikonpakka](https://github.com/fremtind/jokul/tree/pre-1.0/packages/icons).
 
 <ComponentExample
     title="Animated"

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Icons in Jøkul style",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/icons-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/icons-react",
     "keywords": [
         "icons",
         "react",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for icons",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/icons",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/icons",
     "keywords": [
         "react",
         "icon",

--- a/packages/image-react/package.json
+++ b/packages/image-react/package.json
@@ -19,7 +19,7 @@
     "files": [
         "build"
     ],
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/image-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/image-react",
     "license": "MIT",
     "types": "./build/index.d.ts",
     "main": "./build/cjs/index.js",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -5,7 +5,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/image",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/image",
     "keywords": [
         "image",
         "images",

--- a/packages/input-group-react/package.json
+++ b/packages/input-group-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react input-group",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/input-group-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/input-group/package.json
+++ b/packages/input-group/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for input-group",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/input-group",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -6,7 +6,7 @@
         "access": "public"
     },
     "description": "Jøkul monopakke",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/jokul",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/jokul",
     "keywords": [],
     "license": "MIT",
     "sideEffects": [

--- a/packages/list-react/package.json
+++ b/packages/list-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react list component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/list-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/list-react",
     "keywords": [
         "bullet list",
         "ordered list",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for list",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/list",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/list",
     "keywords": [
         "bullet list",
         "ordered list",

--- a/packages/loader-react/package.json
+++ b/packages/loader-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react loader component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/loader-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/loader-react",
     "keywords": [
         "loader",
         "jøkul",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for loaders",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/loader",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/loader",
     "keywords": [
         "loader",
         "jøkul",

--- a/packages/logo-react/package.json
+++ b/packages/logo-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react logo component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/logo-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/logo-react",
     "keywords": [
         "logo",
         "jøkul",

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -10,7 +10,7 @@
         "*.scss"
     ],
     "description": "Jøkul style for Fremtind logo",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/logo",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/logo",
     "keywords": [
         "logo",
         "jøkul",

--- a/packages/menu-react/package.json
+++ b/packages/menu-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react menu",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/menu-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/menu-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for menu",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/menu",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/menu",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/message-react/package.json
+++ b/packages/message-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react message components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/message-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/message-react",
     "keywords": [
         "messagebox",
         "message",

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul message style",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/message",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/message",
     "keywords": [
         "message",
         "jøkul",

--- a/packages/modal-react/package.json
+++ b/packages/modal-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react modal",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/modal-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/modal-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for modal",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/modal",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/modal",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/popover-react/package.json
+++ b/packages/popover-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react popover",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/popover-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/popover-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for popover",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/popover",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/popover",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/progress-bar-react/package.json
+++ b/packages/progress-bar-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react progress bar component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/progress-bar-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/progress-bar-react",
     "keywords": [
         "progress bar",
         "jøkul",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for progress bar",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/progress-bar",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/progress-bar",
     "keywords": [
         "progress bar",
         "jøkul",

--- a/packages/radio-button-react/package.json
+++ b/packages/radio-button-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react radio button components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/radio-button-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/radio-button-react",
     "keywords": [
         "radio",
         "form",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for radio button",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/radio-button",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/radio-button",
     "keywords": [
         "radio",
         "radio button",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react button components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/react-hooks",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/react-hooks",
     "keywords": [
         "hooks",
         "react hooks",

--- a/packages/select-react/CHANGELOG.md
+++ b/packages/select-react/CHANGELOG.md
@@ -165,7 +165,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 
 ## 11.2.13 (2023-01-04)
 

--- a/packages/select-react/package.json
+++ b/packages/select-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react select component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/select-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/select-react",
     "keywords": [
         "dropdown",
         "select",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for select",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/select",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/select",
     "keywords": [
         "dropdown",
         "select",

--- a/packages/stylelint-config-jkl/package.json
+++ b/packages/stylelint-config-jkl/package.json
@@ -10,7 +10,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/stylelint-config-jkl",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/stylelint-config-jkl",
     "license": "MIT",
     "main": "index.js",
     "files": [

--- a/packages/summary-table-react/package.json
+++ b/packages/summary-table-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "A simple table with two columns.",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/summary-table-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/summary-table-react",
     "keywords": [
         "summary-table",
         "jøkul",

--- a/packages/summary-table/package.json
+++ b/packages/summary-table/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "A simple table with two columns",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/summary-table",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/summary-table",
     "keywords": [
         "summary-table",
         "jøkul",

--- a/packages/system-message-react/package.json
+++ b/packages/system-message-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul system message components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/system-message-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/system-message-react",
     "keywords": [
         "jøkul",
         "fremtind",

--- a/packages/system-message/package.json
+++ b/packages/system-message/package.json
@@ -11,7 +11,7 @@
         "system",
         "message"
     ],
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/system-message",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/system-message",
     "files": [
         "!example",
         "*.css",

--- a/packages/table-react/package.json
+++ b/packages/table-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react table components",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/table-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/table-react",
     "keywords": [
         "table",
         "jøkul",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for tables",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/table",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/table",
     "keywords": [
         "table",
         "jøkul",

--- a/packages/tabs-react/package.json
+++ b/packages/tabs-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react tabs",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tabs-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tabs-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for tabs",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tabs",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tabs",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/tag-react/package.json
+++ b/packages/tag-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul React tag component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tag-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tag-react",
     "keywords": [
         "tag",
         "tags",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for tags",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tag",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tag",
     "keywords": [
         "tag",
         "tags",

--- a/packages/text-input-react/CHANGELOG.md
+++ b/packages/text-input-react/CHANGELOG.md
@@ -144,7 +144,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   `BaseInputField` er erstattet av `BaseTextInput`.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 
 ## [11.3.6](https://github.com/fremtind/jokul/compare/@fremtind/jkl-text-input-react@11.3.5...@fremtind/jkl-text-input-react@11.3.6) (2023-01-13)
 

--- a/packages/text-input-react/package.json
+++ b/packages/text-input-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react text input component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/text-input-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/text-input-react",
     "keywords": [
         "text",
         "field",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for text input fields",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/text-input",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/text-input",
     "keywords": [
         "text",
         "text field",

--- a/packages/toast-react/package.json
+++ b/packages/toast-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react toast",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/toast-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/toast-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for toast",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/toast",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/toast",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/packages/toggle-switch-react/package.json
+++ b/packages/toggle-switch-react/package.json
@@ -5,7 +5,7 @@
     },
     "version": "13.1.53",
     "description": "Jøkul react toggle switch component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/toggle-switch-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/toggle-switch-react",
     "keywords": [
         "switch",
         "toggle switch",

--- a/packages/toggle-switch/package.json
+++ b/packages/toggle-switch/package.json
@@ -5,7 +5,7 @@
     },
     "version": "13.2.20",
     "description": "Jøkul style for toggle switch",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/toggle-switch",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/toggle-switch",
     "keywords": [
         "switch",
         "toggle switch",

--- a/packages/tooltip-react/package.json
+++ b/packages/tooltip-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react tooltip component",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tooltip-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tooltip-react",
     "keywords": [
         "tooltip",
         "jøkul",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for tooltip",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/tooltip",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/tooltip",
     "keywords": [
         "tooltip",
         "jøkul",

--- a/packages/validators-util/package.json
+++ b/packages/validators-util/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Simple validator-functions to use for validating",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/validators-util",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/validators-util",
     "keywords": [
         "validators",
         "utils",

--- a/packages/webfonts/package.json
+++ b/packages/webfonts/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Web fonts for Jøkul design system",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/webfonts",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/webfonts",
     "keywords": [
         "fremtind",
         "jøkul",

--- a/portal/CHANGELOG.md
+++ b/portal/CHANGELOG.md
@@ -263,7 +263,7 @@ Wrap de i en div om du trenger.
 -   -   `variant` er fjernet. Bruk `labelProps={{ variant }}` i stedet.
 -   `BaseInputField` er erstattet av `BaseTextInput`.
 -   Du må importere CSS for
-    [input-group](https://github.com/fremtind/jokul/tree/main/packages/input-group).
+    [input-group](https://github.com/fremtind/jokul/tree/pre-1.0/packages/input-group).
 
 ## [16.4.1](https://github.com/fremtind/jokul/compare/@fremtind/portal@16.4.0...@fremtind/portal@16.4.1) (2022-12-08)
 

--- a/portal/src/layout/header/GitHubLinks.tsx
+++ b/portal/src/layout/header/GitHubLinks.tsx
@@ -30,7 +30,7 @@ export const GitHubLinks: FC<Props> = ({ react, scss, versions }) => {
         return null;
     }
     const pkgLink = (pkgName: string) =>
-        `https://github.com/fremtind/jokul/tree/main/packages/${pkgName}`;
+        `https://github.com/fremtind/jokul/tree/pre-1.0/packages/${pkgName}`;
 
     return (
         <p className="jkl-portal-github-links">

--- a/portal/src/texts/guider/react-stilguide.mdx
+++ b/portal/src/texts/guider/react-stilguide.mdx
@@ -79,7 +79,7 @@ Med andre ord, gjør `{...rest}` **før** props som ikke skal kunne endres av br
 
 ### Context over drilling
 
-I pakker hvor vi har flere komponenter som jobber sammen, for eksempel i [packages/table](https://github.com/fremtind/jokul/tree/main/packages/table), kan det skje at en _parent component_ ønsker å sette props på noen av sine _children_. I disse tilfellene skal det brukes [Context](https://reactjs.org/docs/context.html).
+I pakker hvor vi har flere komponenter som jobber sammen, for eksempel i [packages/table](https://github.com/fremtind/jokul/tree/pre-1.0/packages/table), kan det skje at en _parent component_ ønsker å sette props på noen av sine _children_. I disse tilfellene skal det brukes [Context](https://reactjs.org/docs/context.html).
 
 Det **skal ikke** finnes props i en komponent sin typedefinisjon som settes automatisk av en annen komponent over den i komponenttreet. Dette er for å unngå forvirring hvor en utvikler setter en sånn prop til noe i sin kode, men opplever at den overskrives av Jøkul.
 

--- a/portal/src/texts/guider/sass-stilguide.mdx
+++ b/portal/src/texts/guider/sass-stilguide.mdx
@@ -151,7 +151,7 @@ Vi bruker ikke [prefixes](https://sass-lang.com/documentation/at-rules/forward#a
 
 Vi bruker partials (filer hvor navnet starter med `_`) for alle filer som ikke skal kompileres til sin egen CSS-fil, men brukes som en _part_ i andre CSS-filer.
 
-Eksempler er moduler som består utelukkende av variabler, funksjoner og mixins. Det kan også være en modul med CSS for en komponent, men hvor alt skal samles opp i én enkelt CSS-fil til slutt (se for eksempel [packages/table](https://github.com/fremtind/jokul/tree/main/packages/table)).
+Eksempler er moduler som består utelukkende av variabler, funksjoner og mixins. Det kan også være en modul med CSS for en komponent, men hvor alt skal samles opp i én enkelt CSS-fil til slutt (se for eksempel [packages/table](https://github.com/fremtind/jokul/tree/pre-1.0/packages/table)).
 
 ### Mappe- og filstruktur
 

--- a/portal/src/texts/profil/ikoner.mdx
+++ b/portal/src/texts/profil/ikoner.mdx
@@ -23,7 +23,7 @@ Ikonene vi bruker er gjerne en del av et skjemafelt, for eksempel [Select](/komp
 
 <ComponentExample title="Icons" component={IconsExample} knobs={iconsExampleKnobs} />
 
-Et lite utvalg av ikonene våre er animerbare. For å bruke animasjonene trengs [CSSen fra ikonpakka](https://github.com/fremtind/jokul/tree/main/packages/icons).
+Et lite utvalg av ikonene våre er animerbare. For å bruke animasjonene trengs [CSSen fra ikonpakka](https://github.com/fremtind/jokul/tree/pre-1.0/packages/icons).
 
 <ComponentExample title="Animated" component={AnimatedIconsExample} knobs={animatedIconsExampleKnobs} />
 

--- a/portal/src/texts/profil/typografi.mdx
+++ b/portal/src/texts/profil/typografi.mdx
@@ -19,7 +19,7 @@ import { TypographyTable } from "../../components/TypograhyTable";
 Vi har vår egen skrifttype: Fremtind Grotesk. Den finnes i snittene Regular, Bold, Display og Mono. Vi bruker hovedsakelig Regular og Bold. Som erstatningsfont bruker vi Calibri Light. Ikke bruk andre skrifttyper når du designer løsninger
 for Fremtind.
 
-[Last ned Fremtind Grotesk](https://github.com/fremtind/jokul/tree/main/packages/webfonts/fonts)
+[Last ned Fremtind Grotesk](https://github.com/fremtind/jokul/tree/pre-1.0/packages/webfonts/fonts)
 
 ## Typografisk skala
 

--- a/scripts/scaffold/templates/component-react/package.json
+++ b/scripts/scaffold/templates/component-react/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul react scaffold",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/scaffold-react",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/scaffold-react",
     "keywords": [
         "jøkul",
         "fremtind"

--- a/scripts/scaffold/templates/component/package.json
+++ b/scripts/scaffold/templates/component/package.json
@@ -5,7 +5,7 @@
         "access": "public"
     },
     "description": "Jøkul style for scaffold",
-    "homepage": "https://github.com/fremtind/jokul/tree/main/packages/scaffold",
+    "homepage": "https://github.com/fremtind/jokul/tree/pre-1.0/packages/scaffold",
     "keywords": [
         "jøkul",
         "fremtind"


### PR DESCRIPTION
ISSUES CLOSED #4916

## 💬 Endringer

1. Oppdaterer github-lenker i gammel portal til å peke mot pre-1.0 branch

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
