### PR TITLE
docs: Toast in context story

### DIFF
--- a/packages/jokul/src/components/toast/Toast.tsx
+++ b/packages/jokul/src/components/toast/Toast.tsx
@@ -1,18 +1,18 @@
-import { type AriaToastProps, useToast } from "@react-aria/toast";
-import type { QueuedToast, ToastState } from "@react-stately/toast";
+import {type AriaToastProps, useToast} from "@react-aria/toast";
+import type {QueuedToast, ToastState} from "@react-stately/toast";
 import clsx from "clsx";
-import React, { useEffect, useRef } from "react";
-import { useBrowserPreferences } from "../../hooks/useBrowserPreferences/useBrowserPreferences.js";
-import { Countdown } from "../countdown/Countdown.js";
-import { IconButton } from "../icon-button/IconButton.js";
-import { CloseIcon } from "../icon/icons/CloseIcon.js";
-import { ErrorIcon } from "../icon/icons/ErrorIcon.js";
-import { InfoIcon } from "../icon/icons/InfoIcon.js";
-import { SuccessIcon } from "../icon/icons/SuccessIcon.js";
-import { WarningIcon } from "../icon/icons/WarningIcon.js";
-import type { ToastContent, ToastOptions } from "./types.js";
+import React, {useEffect, useRef} from "react";
+import {useBrowserPreferences} from "../../hooks/useBrowserPreferences/useBrowserPreferences.js";
+import {Countdown} from "../countdown/Countdown.js";
+import {IconButton} from "../icon-button/IconButton.js";
+import {CloseIcon} from "../icon/icons/CloseIcon.js";
+import {ErrorIcon} from "../icon/icons/ErrorIcon.js";
+import {InfoIcon} from "../icon/icons/InfoIcon.js";
+import {SuccessIcon} from "../icon/icons/SuccessIcon.js";
+import {WarningIcon} from "../icon/icons/WarningIcon.js";
+import type {ToastContent, ToastOptions} from "./types.js";
 
-interface ToastProps<T extends ToastContent> extends AriaToastProps<T> {
+export interface ToastProps<T extends ToastContent> extends AriaToastProps<T> {
     className?: string;
     state: ToastState<T>;
     toast: QueuedToast<T> & ToastOptions;

--- a/packages/jokul/src/components/toast/stories/ToastInCotext.stories.tsx
+++ b/packages/jokul/src/components/toast/stories/ToastInCotext.stories.tsx
@@ -1,67 +1,127 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import type {Meta, StoryObj} from "@storybook/react";
+import React, {useState} from "react";
+import {Button} from "../../button/index.js";
+import {Toast as ToastComponent, type ToastProps} from "../Toast.js";
+import {ToastProvider, useToast} from "../toastContext.js";
+
 import "../styles/_index.scss";
-import { Toast as ToastComponent } from "../Toast.js";
+import "../../button/styles/_index.scss";
 
 const meta = {
     title: "Komponenter/Toast",
     component: ToastComponent,
     tags: ["autodocs"],
     argTypes: {
+        state: {table: {disable: true}},
         toast: {
+            name: "eksempel",
             description:
                 "Obs: Dette er en forenklet versjon av 'toast'-propen for å vise variantene.",
-            options: ["Info", "Error", "Success", "Warning", "Ingen"],
+            options: [
+                "Med timeout",
+                "Info",
+                "Error",
+                "Success",
+                "Warning",
+                "Uten variant",
+            ],
             mapping: {
-                Info: {
-                    content: "Hei verden",
-                    key: "",
-                    variant: "info",
-                },
-                Error: {
-                    content: "Hei verden",
-                    key: "",
-                    variant: "error",
-                },
-                Success: {
-                    content: "Hei verden",
+                "Med timeout": {
+                    content: "Søknad sendt",
                     key: "",
                     variant: "success",
+                    timeout: 5000,
+                },
+                Info: {
+                    content: {
+                        title: "En infomelding",
+                        content: "Lenger tekst om infomeldinga",
+                    },
+                    key: "",
+                    variant: "info",
+                    timeout: 0,
+                },
+                Error: {
+                    content: {
+                        title: "Kunne ikke sende søknaden",
+                        content:
+                            "Sjekk internettforbindelsen din og prøv igjen senere.",
+                    },
+                    key: "",
+                    variant: "error",
+                    timeout: 0,
+                },
+                Success: {
+                    content: "Søknad sendt",
+                    key: "",
+                    variant: "success",
+                    timeout: 0,
                 },
                 Warning: {
-                    content: "Hei verden",
+                    content: "Du blir snart logget ut",
                     key: "",
                     variant: "warning",
+                    timeout: 0,
                 },
-                Ingen: {
+                "Uten variant": {
                     content: "Hei verden",
                     key: "",
+                    timeout: 0,
                 },
             },
         },
     },
     args: {
         state: {
-            add: () => "e",
+            add: () => "",
             close: () => "",
             pauseAll: () => "",
             remove: () => "",
             resumeAll: () => "",
             visibleToasts: [
-                { content: "Hei verden", key: Date.now().toString() },
+                {content: "Hei verden", key: Date.now().toString()},
             ],
         },
         toast: {
-            content: "Hei verden",
+            content: {
+                title: "Her kommer en tittel",
+                content: "Her kommer en lenger tekst.",
+            },
             key: "",
-            variant: "info",
         },
     },
 } satisfies Meta<typeof ToastComponent>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type ToastStory = StoryObj<typeof meta>;
 
-export const Toast: Story = {
-    render: (args) => <ToastComponent {...args} />,
+export const ToastInContext: ToastStory = {
+    render: (args) => {
+        const example: ToastProps<any> = {...args};
+
+        function ToastUsageExample() {
+            const {add} = useToast();
+            const [keys, setKeys] = useState<string[]>([]);
+
+            return (
+                <Button
+                    variant="primary"
+                    onClick={() => {
+                        setKeys([
+                            ...keys,
+                            add(example.toast.content, example.toast),
+                        ]);
+                    }}
+                >
+                    Vis toast
+                </Button>
+            );
+        }
+
+        return (
+            <ToastProvider>
+                <ToastUsageExample/>
+            </ToastProvider>
+        );
+    },
 };

--- a/packages/jokul/src/components/toast/stories/ToastInCotext.stories.tsx
+++ b/packages/jokul/src/components/toast/stories/ToastInCotext.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import "../styles/_index.scss";
+import { Toast as ToastComponent } from "../Toast.js";
+
+const meta = {
+    title: "Komponenter/Toast",
+    component: ToastComponent,
+    tags: ["autodocs"],
+    argTypes: {
+        toast: {
+            description:
+                "Obs: Dette er en forenklet versjon av 'toast'-propen for å vise variantene.",
+            options: ["Info", "Error", "Success", "Warning", "Ingen"],
+            mapping: {
+                Info: {
+                    content: "Hei verden",
+                    key: "",
+                    variant: "info",
+                },
+                Error: {
+                    content: "Hei verden",
+                    key: "",
+                    variant: "error",
+                },
+                Success: {
+                    content: "Hei verden",
+                    key: "",
+                    variant: "success",
+                },
+                Warning: {
+                    content: "Hei verden",
+                    key: "",
+                    variant: "warning",
+                },
+                Ingen: {
+                    content: "Hei verden",
+                    key: "",
+                },
+            },
+        },
+    },
+    args: {
+        state: {
+            add: () => "e",
+            close: () => "",
+            pauseAll: () => "",
+            remove: () => "",
+            resumeAll: () => "",
+            visibleToasts: [
+                { content: "Hei verden", key: Date.now().toString() },
+            ],
+        },
+        toast: {
+            content: "Hei verden",
+            key: "",
+            variant: "info",
+        },
+    },
+} satisfies Meta<typeof ToastComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Toast: Story = {
+    render: (args) => <ToastComponent {...args} />,
+};

--- a/packages/jokul/src/components/toast/styles/_index.scss
+++ b/packages/jokul/src/components/toast/styles/_index.scss
@@ -1,3 +1,4 @@
 @forward "toast";
 @use "../../icon/styles" as icon;
 @use "../../icon-button/styles" as icon-button;
+@use "../../countdown/styles" as countdown;


### PR DESCRIPTION
## 💬 Endringer

1. Legg til story for toast i kontekst
2. Eksponerer toastprops fra toast.tsx

### 🎯 Dokumentasjon

-   [x] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil