### PR TITLE
fix: sørg for at lenker i portable tekst rendres riktig

### DIFF
--- a/portal/src/components/portable-text/link/Link.tsx
+++ b/portal/src/components/portable-text/link/Link.tsx
@@ -2,8 +2,17 @@ import { Link as JokulLink } from "@fremtind/jokul/components/link";
 import type { PortableTextMarkComponentProps } from "next-sanity";
 import NextLink from "next/link";
 
-type LinkProps = PortableTextMarkComponentProps<any>;
+type LinkProps = PortableTextMarkComponentProps<{
+    _type: "link";
+    href: string;
+}>;
 
-export const Link = ({ value }: LinkProps) => {
-    return <JokulLink as={NextLink} href={value.href} />;
+export const Link = ({ value, children }: LinkProps) => {
+    return value?.href ? (
+        <JokulLink as={NextLink} href={value.href}>
+            {children}
+        </JokulLink>
+    ) : (
+        children
+    );
 };


### PR DESCRIPTION
## 💬 Endringer

1. Gjør at lenker i rik tekst i portalen rendres riktig.

NB! Dette gjelder _ikke_ #4800, som blir fikset i en egen PR
