### PR TITLE
chore: la changeset bruke pnpm under release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
                   node-version: 18
                   cache: pnpm
 
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
             - name: Install Dependencies
               run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## 💬 Endringer

1. Sørg for å kjøre pnpm setup-action før vi forsøker å la changesets lage pr for release av pakker.
