### PR TITLE
Message med støtte for flere native HTML-props

### DIFF
--- a/.changeset/eager-trains-rule.md
+++ b/.changeset/eager-trains-rule.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+Message med støtte for flere native HTML-props

--- a/packages/jokul/src/components/message/types.ts
+++ b/packages/jokul/src/components/message/types.ts
@@ -1,6 +1,6 @@
 import type { Density } from "../../core/types.js";
 
-export interface MessageProps extends React.ComponentPropsWithRef<"div"> {
+export interface MessageProps extends React.ComponentPropsWithoutRef<"div"> {
     fullWidth?: boolean;
     density?: Density;
     dismissed?: boolean;

--- a/packages/jokul/src/components/message/types.ts
+++ b/packages/jokul/src/components/message/types.ts
@@ -1,18 +1,13 @@
-import type { AriaRole } from "react";
-import type { Density, WithChildren } from "../../core/types.js";
+import type { Density } from "../../core/types.js";
 
-export interface MessageProps extends WithChildren {
-    id?: string;
-    title?: string;
+export interface MessageProps extends React.ComponentPropsWithRef<"div"> {
     fullWidth?: boolean;
     density?: Density;
-    className?: string;
     dismissed?: boolean;
     dismissAction?: {
         handleDismiss: () => void;
         buttonTitle?: string;
     };
-    role?: AriaRole;
 }
 
 export interface FormErrorMessageProps {


### PR DESCRIPTION
## 💬 Endringer

1. Message-komponenten er forbedret til å ta imot standard HTML-attributter.

ISSUES CLOSED: #4935 

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
