### PR TITLE
Visuell regresjonstesting med Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
         "boot": "pnpm install && pnpm prepare && pnpm build",
         "reboot": "pnpm clean && pnpm boot",
         "integration:new": "playwright test --project=\"Nye integrasjonstester\"",
-        "integration:ci": "playwright test --project=\"Gamle integrasjonstester\"",
-        "integration:interactive": "playwright test --project=\"Gamle integrasjonstester\" --ui",
+        "integration:ci": "playwright test --project=chromium",
+        "integration:interactive": "playwright test --project=chromium --ui",
         "integration:axe": "playwright test -g axe",
         "build-storybook": "storybook build",
         "prepare": "husky || true"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
         "serve": "run-p serve:*",
         "boot": "pnpm install && pnpm prepare && pnpm build",
         "reboot": "pnpm clean && pnpm boot",
-        "integration:ci": "playwright test",
-        "integration:interactive": "playwright test --ui",
+        "integration:new": "playwright test --project=\"Nye integrasjonstester\"",
+        "integration:ci": "playwright test --project=\"Gamle integrasjonstester\"",
+        "integration:interactive": "playwright test --project=\"Gamle integrasjonstester\" --ui",
         "integration:axe": "playwright test -g axe",
         "build-storybook": "storybook build",
         "prepare": "husky || true"

--- a/packages/jokul/dev-server.mjs
+++ b/packages/jokul/dev-server.mjs
@@ -122,6 +122,7 @@ export default function App() {
                     <Text>Choose a component from the list below</Text>
                     <Text>Filter: {filterString}</Text>
                     <SelectInput
+                        limit={10}
                         items={components.filter((component) =>
                             component.label.startsWith(filterString),
                         )}

--- a/packages/jokul/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/jokul/src/components/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -18,6 +18,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Breadcrumb: Story = {
+    tags: ["visual"],
     args: {
         children: [
             <BreadcrumbItem key={0}>

--- a/packages/jokul/src/components/button/stories/Button.visual.stories.tsx
+++ b/packages/jokul/src/components/button/stories/Button.visual.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button.js";
+import type { ButtonVariant } from "../types.js";
+import "../styles/_index.scss";
+import { Flex } from "../../flex/Flex.js";
+import { CopyIcon } from "../../icon/index.js";
+
+const meta = {
+    title: "Visuelle regresjonstester/Button",
+    component: Button,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["visual"],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseArgs = {
+    type: "button",
+    children: "Kopier",
+    loader: {
+        showLoader: false,
+        textDescription: "laster inn",
+    },
+};
+
+export const IconPlacements: Story = {
+    args: baseArgs,
+    render: (args) => (
+        <Flex direction="column" gap={24} style={{ width: "100%" }}>
+            {["primary", "secondary", "tertiary", "ghost"].map((variant) => (
+                <Flex key={variant} gap={8}>
+                    <Button {...args} variant={variant as ButtonVariant} />
+                    <Button
+                        {...args}
+                        variant={variant as ButtonVariant}
+                        icon={<CopyIcon />}
+                    />
+                    <Button
+                        {...args}
+                        variant={variant as ButtonVariant}
+                        icon={<CopyIcon />}
+                        iconPosition="right"
+                    />
+                    <Button
+                        {...args}
+                        variant={variant as ButtonVariant}
+                        icon={<CopyIcon />}
+                        iconPosition="right"
+                        // biome-ignore lint/correctness/noChildrenProp: kun overstyring av args
+                        children={null}
+                    />
+                </Flex>
+            ))}
+        </Flex>
+    ),
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
 
     projects: [
         {
-            name: "Gamle integrasjonstester",
+            // Denne heter chromium for ikke å endre navn på eksisterende tester
+            name: "chromium",
             testMatch: "packages/jokul/**/integration/*.spec.ts",
             use: { ...devices["Desktop Chrome"] },
             fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,6 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-    testMatch: "**/*.spec.ts",
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
@@ -28,22 +27,18 @@ export default defineConfig({
 
     projects: [
         {
-            name: "chromium",
+            name: "Gamle integrasjonstester",
+            testMatch: "packages/jokul/**/integration/*.spec.ts",
+            use: { ...devices["Desktop Chrome"] },
+            fullyParallel: true,
+            snapshotPathTemplate:
+                ".{/testFileDir}/__screenshots__/{testName}-{arg}.png",
+        },
+        {
+            name: "Nye integrasjonstester",
+            testMatch: "visual-regression/visual.spec.ts",
             use: { ...devices["Desktop Chrome"] },
             fullyParallel: true,
         },
-        /*
-        / ** To keep the number of screenshots in git down we only run one browser
-        {
-            name: "firefox",
-            use: { ...devices["Desktop Firefox"] },
-            fullyParallel: true,
-        },
-        {
-            name: "webkit",
-            use: { ...devices["Desktop Safari"] },
-            fullyParallel: true,
-        },
-        */
     ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-    testMatch: "packages/jokul/**/integration/*.spec.ts",
+    testMatch: "**/*.spec.ts",
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
@@ -25,9 +25,6 @@ export default defineConfig({
             maxDiffPixelRatio: 0.01,
         },
     },
-
-    snapshotPathTemplate:
-        ".{/testFileDir}/__screenshots__/{testName}-{arg}.png",
 
     projects: [
         {

--- a/visual-regression/utils.ts
+++ b/visual-regression/utils.ts
@@ -1,0 +1,33 @@
+import type { Page } from "@playwright/test";
+import type { IndexEntry, StoryIndexEntry } from "storybook/internal/types";
+
+export const filterStories = (stories: IndexEntry[]): StoryIndexEntry[] =>
+    stories.filter(
+        (story) => story.type === "story" && story.tags?.includes("visual"),
+    ) as StoryIndexEntry[];
+
+export function getStoryUrl(storybookUrl: string, id: string): string {
+    const params = new URLSearchParams({
+        id,
+        viewMode: "story",
+        nav: "0",
+    });
+
+    return `${storybookUrl}/iframe.html?${params.toString()}`;
+}
+
+export async function navigate(
+    page: Page,
+    storybookUrl: string,
+    id: string,
+): Promise<void> {
+    try {
+        const url = getStoryUrl(storybookUrl, id);
+        await page.goto(url);
+        await page.waitForLoadState("networkidle");
+        await page.waitForSelector("#storybook-root");
+    } catch (error) {
+        console.error(`Error navigating to storybook URL: ${error}`);
+        throw error;
+    }
+}

--- a/visual-regression/visual.spec.ts
+++ b/visual-regression/visual.spec.ts
@@ -1,0 +1,31 @@
+import { type PageScreenshotOptions, expect, test } from "@playwright/test";
+import type { IndexEntry } from "storybook/internal/types";
+import manifest from "../storybook-static/index.json" assert { type: "json" };
+import { filterStories, navigate } from "./utils";
+
+const options: Partial<PageScreenshotOptions> = {
+    fullPage: true,
+    animations: "disabled",
+};
+
+test.beforeEach(async ({ page }, meta) => {
+    /**
+     * Set the viewport size and other global level browser settings here.
+     * For example you may want to block certain resources, etc.
+     */
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await navigate(page, "http://localhost:6007", meta.title);
+});
+
+const visualStories = filterStories(
+    Object.values(manifest.entries) as IndexEntry[],
+);
+
+for (const story of visualStories) {
+    test(story.id, async ({ page }, meta) => {
+        await expect(page).toHaveScreenshot(
+            `${meta.title}-${process.platform}.png`,
+            options,
+        );
+    });
+}


### PR DESCRIPTION
## 💬 Endringer

1. Legger til mulighet for å gjøre visuell regresjonstesting med stories fra Storybook.

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
