### PR TITLE
chore: flytt melding om release til deploy-repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,29 +73,29 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    notify-release:
+    trigger-release-notification:
         name: Gi beskjed om publiserte pakker
         runs-on: ubuntu-latest
         needs: [changesets-release]
         if: needs.changesets-release.outputs.published == 'true'
         steps:
-          - name: Hent informasjon om commit
-            id: commit-info
-            run: |
-              echo "committer_name=$(git log -1 --pretty=format:'%an')" >> $GITHUB_OUTPUT
-              echo "committer_email=$(git log -1 --pretty=format:'%ae')" >> $GITHUB_OUTPUT
+            - name: Hent informasjon om commit
+              id: commit-info
+              run: |
+                echo "committer_name=$(git log -1 --pretty=format:'%an')" >> $GITHUB_OUTPUT
+                echo "committer_email=$(git log -1 --pretty=format:'%ae')" >> $GITHUB_OUTPUT
 
-          - name: Teams notification
-            uses: fremtind/action-teams-notification@v2
-            with:
-              webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
-              mention: |
-                ${{ steps.commit-info.outputs.committer_name }}
-                ${{ steps.commit-info.outputs.committer_email }}
-              message: |
-                %NAME%
-                ${{ needs.changesets-release.outputs.publishedPackages.length }} pakker ble publisert fra ${{ github.repository }}
-
+            - name: Send notification om release
+              env:
+                  DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+              run: |
+                  curl -L \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $DEPLOY_TOKEN" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/fremtind/jokul-portal-deploy/actions/workflows/notify-jokul-release/dispatches \
+                    -d '{"ref":"main","published_packages":"${{ needs.changesets-release.outputs.publishedPackages }}","committer_name":"${{ steps.commit-info.outputs.committer_name }}","committer_email":"${{ steps.commit-info.outputs.committer_email }}"}'
 
     main-to-external:
         name: Merge main to external-contributions


### PR DESCRIPTION
## 💬 Endringer

1. Flytter varsel om ny release av Jøkul-pakker til deploy-repoet, siden vi ikke har tilgang til riktig action i dette repoet
