### PR TITLE
fix: knapper for valg av måned i kalender fungerer som forventet

### DIFF
--- a/.changeset/quiet-bats-fetch.md
+++ b/.changeset/quiet-bats-fetch.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der knappene i kalenderen ikke fungerte når man klikket seg til første eller siste mulige måned i datovelgeren.

--- a/packages/jokul/src/components/datepicker/internal/Calendar.tsx
+++ b/packages/jokul/src/components/datepicker/internal/Calendar.tsx
@@ -326,10 +326,10 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
             ) {
                 // Fokuser på "neste månded"-knappen
                 document
-                    .querySelectorAll<HTMLButtonElement>(
-                        ".jkl-calendar-navigation__arrow",
-                    )[1]
-                    .focus();
+                    .querySelector<HTMLButtonElement>(
+                        `[data-testid="${id}-forward-button"]`,
+                    )
+                    ?.focus();
             } else if (
                 // Vi er i ferd med å gå til siste måned
                 maxDate &&
@@ -338,12 +338,12 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
             ) {
                 // Fokuser på "forrige månded"-knappen
                 document
-                    .querySelectorAll<HTMLButtonElement>(
-                        ".jkl-calendar-navigation__arrow",
-                    )[0]
-                    .focus();
+                    .querySelector<HTMLButtonElement>(
+                        `[data-testid="${id}-back-button"]`,
+                    )
+                    ?.focus();
             }
-        }, [minDate, maxDate, shownDate]);
+        }, [minDate, maxDate, shownDate, id]);
 
         /// Extended variant events
 
@@ -451,6 +451,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
                                     calendars,
                                     onClick: handleGotoEdgeMonth,
                                 })}
+                                data-testid={`${id}-back-button`}
                                 variant="ghost"
                                 icon={<ArrowLeftIcon variant="medium" bold />}
                             />
@@ -460,6 +461,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
                                     onClick: handleGotoEdgeMonth,
                                 })}
                                 variant="ghost"
+                                data-testid={`${id}-forward-button`}
                                 icon={<ArrowRightIcon variant="medium" bold />}
                             />
                         </div>

--- a/packages/jokul/src/components/datepicker/stories/Datepicker.stories.tsx
+++ b/packages/jokul/src/components/datepicker/stories/Datepicker.stories.tsx
@@ -8,6 +8,18 @@ const meta = {
     parameters: {
         layout: "padded",
     },
+    argTypes: {
+        disableAfterDate: {
+            control: {
+                type: "text",
+            },
+        },
+        disableBeforeDate: {
+            control: {
+                type: "text",
+            },
+        },
+    },
     tags: ["autodocs"],
 } satisfies Meta<typeof DatePickerComponent>;
 
@@ -16,4 +28,12 @@ type Story = StoryObj<typeof meta>;
 
 export const DatePicker: Story = {
     args: {},
+};
+
+export const DatePickerWithEndDates: Story = {
+    name: "Datovelger med maks. og min. dato",
+    args: {
+        disableBeforeDate: "2024-01-01",
+        disableAfterDate: "2026-12-31",
+    },
 };

--- a/packages/jokul/src/components/datepicker/styles/_index.scss
+++ b/packages/jokul/src/components/datepicker/styles/_index.scss
@@ -1,4 +1,5 @@
 @forward "datepicker";
+@use "../../button/styles" as button;
 @use "../../icon/styles" as icon;
 @use "../../input-group/styles" as input-group;
 @use "../../text-input/styles" as text-input;


### PR DESCRIPTION
Retter en feil der man ikke kunne klikke seg til første eller siste tillatte måned i kalenderen i datovelgeren.

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
