### PR TITLE
fix(expandable-panel): sikre kompatibilitet for inert-attributt

### DIFF
--- a/packages/jokul/src/components/expander/ExpandablePanel.tsx
+++ b/packages/jokul/src/components/expander/ExpandablePanel.tsx
@@ -74,9 +74,13 @@ export const ExpandablePanel = Object.assign(
         return (
             <div className="jkl-expandable__wrapper">
                 <div
-                    // React typings don't include inert for some reason,
-                    // but destructuring lets us calm down the TS compiler
-                    {...{ inert: "true" }}
+                    /*
+                        Setter `inert` manuelt for å støtte både React 18 og 19.
+
+                        Dette unngår typefeil i React 18 og advarsler i React 19.
+                        Se: https://github.com/WICG/inert/issues/58
+                    */
+                    ref={(node) => node?.setAttribute("inert", "")}
                     className="jkl-expandable__focus-container"
                     style={{ height: expanderHeight }}
                 />

--- a/packages/jokul/src/components/expander/ExpandablePanelContent.tsx
+++ b/packages/jokul/src/components/expander/ExpandablePanelContent.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { useAnimatedHeightBetween } from "../../hooks/useAnimatedHeight/useAnimatedHeightBetween.js";
 import { ExpanderContext } from "./context.js";
 import type {
@@ -21,13 +21,24 @@ export const ExpandablePanelContent: ExpandablePanelContentComponent = ({
         onTransitionEnd,
     });
 
+    /*
+        Setter `inert` manuelt for å støtte både React 18 og 19.
+
+        Dette unngår typefeil i React 18 og advarsler i React 19.
+        Se: https://github.com/WICG/inert/issues/58
+    */
+    useEffect(() => {
+        const node = animationRef.current;
+
+        node?.setAttribute("inert", "true");
+    }, [animationRef]);
+
     return (
         <div
             ref={animationRef}
             className={clsx("jkl-expandable__content", className)}
             {...rest}
             data-expanded={open}
-            {...(!open ? { inert: "true" } : {})}
         >
             <div className="jkl-expandable__content-wrapper">{children}</div>
         </div>


### PR DESCRIPTION
CLOSES #5051

## 💬 Endringer

1. Måten inert-attributten ble brukt ga feilmeldinger i react 18 og advarsler i react 19. Endringen fikser problemet ved å styre attributten manuelt som sørger for at det fungerer i begge versjoner.

[Les for detaljer](https://github.com/WICG/inert/issues/58)

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))
