### PR TITLE
feat: bedre støtte for nedlastingslenker

### DIFF
--- a/.changeset/dry-spies-greet.md
+++ b/.changeset/dry-spies-greet.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+bedre støtte for nedlastingslenker

--- a/packages/jokul/src/components/link/stories/Link.stories.tsx
+++ b/packages/jokul/src/components/link/stories/Link.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { Link } from "../Link.js";
 import "../styles/_index.scss";
+import * as url from "../../file/stories/cow.jpg";
 import { Flex } from "../../flex/index.js";
 
 const meta: Meta = {
@@ -14,7 +15,6 @@ const meta: Meta = {
     argTypes: {
         href: {
             control: "text",
-            defaultValue: "https://www.fremtind.no",
         },
     },
 } satisfies Meta<typeof Link>;
@@ -31,10 +31,11 @@ export const LinkStory: Story = {
         as: "a",
         target: "#",
         href: "https://www.fremtind.no",
+        download: false,
     },
-    render: (props) => (
+    render: (args) => (
         // Setter style.cursor til pointer fordi Storybook overskriver default styles.
-        <Link style={{ cursor: "pointer" }} {...props} as={props.as || "a"} />
+        <Link {...args} as={args.as || "a"} />
     ),
 };
 
@@ -42,21 +43,17 @@ export const LinkInParagraphStory: Story = {
     name: "Mønster: Lenke i avsnitt",
     args: {
         href: "https://www.fremtind.no",
+        download: false,
     },
     render: (args) => (
         // Setter style.cursor til pointer fordi Storybook overskriver default styles.
         <p style={{ maxWidth: "45ch" }}>
             Vi bruker lenker for å lede brukeren til{" "}
-            <Link {...args} external={false} style={{ cursor: "pointer" }}>
+            <Link {...args} external={false}>
                 andre nettsider
             </Link>
             , eller til andre steder på samme nettside.{" "}
-            <Link
-                {...args}
-                external={true}
-                target={"_blank"}
-                style={{ cursor: "pointer" }}
-            >
+            <Link {...args} external={true} target={"_blank"}>
                 Lenker til eksterne nettsider
             </Link>{" "}
             markeres med en pil opp og til høyre etter lenketeksten.
@@ -77,53 +74,60 @@ export const LinkInOtherStory: Story = {
         // Setter style.cursor til pointer fordi Storybook overskriver default styles.
         <Flex direction={"column"} style={{ gap: "1.5lh" }}>
             <h1 className={"jkl-title"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i titler
+                Du står fritt til å bruke <Link {...args} /> i titler
             </h1>
 
             <h2 className={"jkl-title-small"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i små titler
+                Du står fritt til å bruke <Link {...args} /> i små titler
             </h2>
 
             <hr style={{ width: "100%", opacity: "0.1" }} />
 
             <h2 className={"jkl-heading-1"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i overskrifter
+                Du står fritt til å bruke <Link {...args} /> i overskrifter
             </h2>
 
             <h2 className={"jkl-heading-2"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i overskrifter
+                Du står fritt til å bruke <Link {...args} /> i overskrifter
             </h2>
 
             <h3 className={"jkl-heading-3"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i overskrifter
+                Du står fritt til å bruke <Link {...args} /> i overskrifter
             </h3>
 
             <h4 className={"jkl-heading-4"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i overskrifter
+                Du står fritt til å bruke <Link {...args} /> i overskrifter
             </h4>
 
             <h5 className={"jkl-heading-5"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i overskrifter
+                Du står fritt til å bruke <Link {...args} /> i overskrifter
             </h5>
 
             <hr style={{ width: "100%", opacity: "0.1" }} />
 
             <p className={"jkl-body"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i avsnitt
+                Du står fritt til å bruke <Link {...args} /> i avsnitt
             </p>
 
             <small className={"jkl-small"} style={{ maxWidth: "55ch" }}>
-                Du står fritt til å bruke{" "}
-                <Link {...args} style={{ cursor: "pointer" }} /> i små avsnitt
+                Du står fritt til å bruke <Link {...args} /> i små avsnitt
             </small>
         </Flex>
+    ),
+};
+
+export const DownloadStory: Story = {
+    name: "Mønster: Nedlastingslenke",
+    args: {
+        children: "fullstendig dekningsoversikt (PDF)",
+        href: url.default,
+        filename: "IPID",
+        download: true,
+    },
+    render: (args) => (
+        // Setter style.cursor til pointer fordi Storybook overskriver default styles.
+        <p>
+            Dekningsoversikten er forenklet. Last ned en <Link {...args} />.
+        </p>
     ),
 };

--- a/packages/jokul/src/components/link/styles/link.scss
+++ b/packages/jokul/src/components/link/styles/link.scss
@@ -25,12 +25,13 @@
     }
 
     &--external::after,
-    &[target="_blank"]::after {
+    &[target="_blank"]::after,
+    &[download]::after {
         --jkl-icon-fill: 0;
         --jkl-icon-size: 1em;
         --jkl-icon-opsz: 20;
 
-        content: "\feff\e89e";
+        content: "\feff\e89e" / "(Åpnes i ny fane)";
         margin-block-start: -0.1em;
         padding-inline-start: 0.2em;
         vertical-align: middle;
@@ -40,6 +41,11 @@
         // Trengs for at non breaking space skal ha effekt
         display: inline;
     }
+
+    &[download]::after {
+        content: "\feff\f090" / "(Last ned fil)";
+    }
+
 
     &:hover:not(:focus) {
         --link-color: var(--jkl-color-text-subdued);


### PR DESCRIPTION
## 💬 Endringer

1. Legger til bedre støtte for download attributten ved å vise et ikon ved siden av lenken på samme måte som external
2. Bedre alt-text på eksterne lenker ved å skrive (Åpnes i ny fane) ved siden av lenken i accessibility treet


### 🎯 Dokumentasjon

-   [x] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [x] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))