### PR TITLE
feat: ny komponent - segmented control

### DIFF
--- a/.changeset/rotten-groups-lick.md
+++ b/.changeset/rotten-groups-lick.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+ny komponent: segmented control

--- a/packages/jokul/src/components/segmented-control/SegmentedControl.tsx
+++ b/packages/jokul/src/components/segmented-control/SegmentedControl.tsx
@@ -1,11 +1,16 @@
-import React, { forwardRef, useId } from "react";
-import type { SegmentedControlProps } from "./types.js";
+import React, {useId} from "react";
+import {RadioButton} from "../radio-button/index.js";
+import type {SegmentedControlProps} from "./types.js";
 
-export const SegmentedControl = forwardRef<
-    HTMLFieldSetElement,
-    SegmentedControlProps
->((props, forwardedSelectRef) => {
-    const { title, items, showTitle = true, seperateItem = 0, ...rest } = props;
+export const SegmentedControl = (props: SegmentedControlProps) => {
+    const {
+        legend,
+        items,
+        showLegend = true,
+        separateItem = 0,
+        ...rest
+    } = props;
+
     const id = useId();
 
     const defaultItem =
@@ -14,40 +19,32 @@ export const SegmentedControl = forwardRef<
         items.indexOf(props.defaultValue);
 
     return (
-        <form className={"jkl-segmented-control"}>
-            <fieldset>
-                <legend
-                    className={`jkl-segmented-control-legend ${!showTitle && "jkl-sr-only"}`}
+        <fieldset className={"jkl-segmented-control"}>
+            <legend
+                className={`jkl-segmented-control-legend ${!showLegend && "jkl-sr-only"}`}
+            >
+                {legend}
+            </legend>
+            {items.map((item, index) => (
+                <RadioButton
+                    {...rest}
+                    key={item}
+                    className={"jkl-segmented-control-item"}
+                    id={`${legend}-${item}`}
+                    value={item}
+                    name={`${legend}-${id}`}
+                    defaultChecked={
+                        index === props.defaultValue || index === defaultItem
+                    }
+                    data-spacing={
+                        separateItem >= 0 ? separateItem === index + 1 : "true"
+                    }
                 >
-                    {title}
-                </legend>
-                {items.map((item, index) => (
-                    <label
-                        key={item}
-                        className={"jkl-segmented-control-item"}
-                        data-spacing={
-                            seperateItem >= 0
-                                ? seperateItem === index + 1
-                                : "true"
-                        }
-                    >
-                        <input
-                            {...rest}
-                            type={"radio"}
-                            id={item}
-                            value={item}
-                            name={id}
-                            defaultChecked={
-                                index === props.defaultValue ||
-                                index === defaultItem
-                            }
-                        />
-                        {item}
-                    </label>
-                ))}
-            </fieldset>
-        </form>
+                    {item}
+                </RadioButton>
+            ))}
+        </fieldset>
     );
-});
+};
 
 SegmentedControl.displayName = "Segmented Control";

--- a/packages/jokul/src/components/segmented-control/SegmentedControl.tsx
+++ b/packages/jokul/src/components/segmented-control/SegmentedControl.tsx
@@ -1,0 +1,53 @@
+import React, { forwardRef, useId } from "react";
+import type { SegmentedControlProps } from "./types.js";
+
+export const SegmentedControl = forwardRef<
+    HTMLFieldSetElement,
+    SegmentedControlProps
+>((props, forwardedSelectRef) => {
+    const { title, items, showTitle = true, seperateItem = 0, ...rest } = props;
+    const id = useId();
+
+    const defaultItem =
+        props.defaultValue &&
+        typeof props.defaultValue === "string" &&
+        items.indexOf(props.defaultValue);
+
+    return (
+        <form className={"jkl-segmented-control"}>
+            <fieldset>
+                <legend
+                    className={`jkl-segmented-control-legend ${!showTitle && "jkl-sr-only"}`}
+                >
+                    {title}
+                </legend>
+                {items.map((item, index) => (
+                    <label
+                        key={item}
+                        className={"jkl-segmented-control-item"}
+                        data-spacing={
+                            seperateItem >= 0
+                                ? seperateItem === index + 1
+                                : "true"
+                        }
+                    >
+                        <input
+                            {...rest}
+                            type={"radio"}
+                            id={item}
+                            value={item}
+                            name={id}
+                            defaultChecked={
+                                index === props.defaultValue ||
+                                index === defaultItem
+                            }
+                        />
+                        {item}
+                    </label>
+                ))}
+            </fieldset>
+        </form>
+    );
+});
+
+SegmentedControl.displayName = "Segmented Control";

--- a/packages/jokul/src/components/segmented-control/stories/segmentedControl.stories.tsx
+++ b/packages/jokul/src/components/segmented-control/stories/segmentedControl.stories.tsx
@@ -1,13 +1,13 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import React, { useState } from "react";
-import { Link } from "../../link/index.js";
+import type {Meta, StoryObj} from "@storybook/react";
+import React, {useState} from "react";
+import {Link} from "../../link/index.js";
 import {
     CheckListItem,
     CrossListItem,
     List,
     ListItem,
 } from "../../list/index.js";
-import { SegmentedControl } from "../SegmentedControl.js";
+import {SegmentedControl} from "../SegmentedControl.js";
 
 import "../styles/_index.scss";
 import "../../list/styles/_index.scss";
@@ -26,19 +26,20 @@ export default meta;
 
 type Story = StoryObj<typeof SegmentedControl>;
 
+const themeChoices = ["Auto", "Light", "Dark", "High Contrast"];
+const coverageChoices = ["Vis alt", "Dekker", "Dekker ikke", "Dekkes kanskje"];
+
 export const SegmentedControlStory: Story = {
     name: "Segmented Control",
     args: {
-        title: "Tema",
-        items: ["Auto", "Light", "Dark", "High Contrast"],
-        seperateItem: 1,
-        defaultValue: "Auto",
-        showTitle: true,
+        legend: "Tema",
+        items: themeChoices,
+        separateItem: 1,
     },
     argTypes: {
         defaultValue: {
             control: "select",
-            options: ["Auto", "Light", "Dark", 0, 1, 2],
+            options: [...themeChoices, ...themeChoices.keys()],
         },
     },
     render: (args) => <SegmentedControl {...args} />,
@@ -47,16 +48,16 @@ export const SegmentedControlStory: Story = {
 export const DekningsoversiktStory: Story = {
     name: "Segmented Control: Dekningsoversikt",
     args: {
-        title: "Velg hva som vises",
-        items: ["Vis alt", "Dekker", "Dekker ikke", "Dekker kanskje"],
-        defaultValue: "Dekker",
-        showTitle: false,
-        seperateItem: 1,
+        legend: "Velg hva som vises",
+        items: coverageChoices,
+        defaultValue: coverageChoices[1],
+        showLegend: false,
+        separateItem: 1,
     },
     argTypes: {
         defaultValue: {
             control: "select",
-            options: ["Vis alt", "Dekker", "Dekker ikke", "Dekker kanskje"],
+            options: [...coverageChoices, ...coverageChoices.keys()],
         },
     },
     render: (args) => {
@@ -89,21 +90,38 @@ export const DekningsoversiktStory: Story = {
             </List>
         );
 
+        const links = (
+            <div style={{marginBlockStart: "24px"}}>
+                <p>
+                    På denne siden har vi forenklet teksten om hva forsikringen
+                    dekker og ikke dekker. Du må alltid lese vilkårene i
+                    avtaledokumentet for å få full oversikt.
+                </p>
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "12px",
+                    }}
+                >
+                    <Link external={true} href={"#"}>
+                        Fullstendige vilkår (PDF)
+                    </Link>
+                    <Link external={true} href={"#"}>
+                        Standardisert produktinformasjon (PDF)
+                    </Link>
+                </div>
+            </div>
+        );
+
         return (
-            <div
-                style={{
-                    display: "flex",
-                    gap: "40px",
-                    flexDirection: "column",
-                }}
-            >
-                <h2>Dekningsoversikt hund og katt</h2>
+            <>
+                <h2 style={{marginBlockEnd: "24px"}}>
+                    Dekningsoversikt hund og katt
+                </h2>
                 <SegmentedControl
                     {...args}
-                    value={value}
-                    onChange={(e) => {
-                        setValue(e.target.value);
-                    }}
+                    onChange={(e) => setValue(e.target.value)}
                 />
                 <div
                     style={{
@@ -111,112 +129,22 @@ export const DekningsoversiktStory: Story = {
                         display: "flex",
                         gap: "24px",
                         flexDirection: "column",
+                        marginBlockStart: "24px",
                     }}
                 >
-                    {value === "Vis alt" && (
+                    {value === coverageChoices[0] && (
                         <>
                             {dekkesListe}
                             {dekkesIkkeListe}
                             {dekkesKanskjeListe}
-                            <p>
-                                På denne siden har vi forenklet teksten om hva
-                                forsikringen dekker og ikke dekker. Du må alltid
-                                lese vilkårene i avtaledokumentet for å få full
-                                oversikt.
-                            </p>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "12px",
-                                }}
-                            >
-                                <Link external={true} href={"#"}>
-                                    Fullstendige vilkår (PDF)
-                                </Link>
-                                <Link external={true} href={"#"}>
-                                    Standardisert produktinformasjon (PDF)
-                                </Link>
-                            </div>
                         </>
                     )}
-                    {value === "Dekker" && (
-                        <>
-                            {dekkesListe}
-                            <p>
-                                På denne siden har vi forenklet teksten om hva
-                                forsikringen dekker og ikke dekker. Du må alltid
-                                lese vilkårene i avtaledokumentet for å få full
-                                oversikt.
-                            </p>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "12px",
-                                }}
-                            >
-                                <Link external={true} href={"#"}>
-                                    Fullstendige vilkår (PDF)
-                                </Link>
-                                <Link external={true} href={"#"}>
-                                    Standardisert produktinformasjon (PDF)
-                                </Link>
-                            </div>
-                        </>
-                    )}
-                    {value === "Dekker kanskje" && (
-                        <>
-                            {dekkesKanskjeListe}
-                            <p>
-                                På denne siden har vi forenklet teksten om hva
-                                forsikringen dekker og ikke dekker. Du må alltid
-                                lese vilkårene i avtaledokumentet for å få full
-                                oversikt.
-                            </p>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "12px",
-                                }}
-                            >
-                                <Link external={true} href={"#"}>
-                                    Fullstendige vilkår (PDF)
-                                </Link>
-                                <Link external={true} href={"#"}>
-                                    Standardisert produktinformasjon (PDF)
-                                </Link>
-                            </div>
-                        </>
-                    )}
-                    {value === "Dekker ikke" && (
-                        <>
-                            {dekkesIkkeListe}
-                            <p>
-                                På denne siden har vi forenklet teksten om hva
-                                forsikringen dekker og ikke dekker. Du må alltid
-                                lese vilkårene i avtaledokumentet for å få full
-                                oversikt.
-                            </p>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "12px",
-                                }}
-                            >
-                                <Link external={true} href={"#"}>
-                                    Fullstendige vilkår (PDF)
-                                </Link>
-                                <Link external={true} href={"#"}>
-                                    Standardisert produktinformasjon (PDF)
-                                </Link>
-                            </div>
-                        </>
-                    )}
+                    {value === coverageChoices[1] && dekkesListe}
+                    {value === coverageChoices[2] && dekkesKanskjeListe}
+                    {value === coverageChoices[3] && dekkesIkkeListe}
+                    {links}
                 </div>
-            </div>
+            </>
         );
     },
 };

--- a/packages/jokul/src/components/segmented-control/stories/segmentedControl.stories.tsx
+++ b/packages/jokul/src/components/segmented-control/stories/segmentedControl.stories.tsx
@@ -1,0 +1,222 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { Link } from "../../link/index.js";
+import {
+    CheckListItem,
+    CrossListItem,
+    List,
+    ListItem,
+} from "../../list/index.js";
+import { SegmentedControl } from "../SegmentedControl.js";
+
+import "../styles/_index.scss";
+import "../../list/styles/_index.scss";
+import "../../link/styles/_index.scss";
+
+const meta: Meta = {
+    title: "Komponenter/SegmentedControl",
+    component: SegmentedControl,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SegmentedControl>;
+
+export const SegmentedControlStory: Story = {
+    name: "Segmented Control",
+    args: {
+        title: "Tema",
+        items: ["Auto", "Light", "Dark", "High Contrast"],
+        seperateItem: 1,
+        defaultValue: "Auto",
+        showTitle: true,
+    },
+    argTypes: {
+        defaultValue: {
+            control: "select",
+            options: ["Auto", "Light", "Dark", 0, 1, 2],
+        },
+    },
+    render: (args) => <SegmentedControl {...args} />,
+};
+
+export const DekningsoversiktStory: Story = {
+    name: "Segmented Control: Dekningsoversikt",
+    args: {
+        title: "Velg hva som vises",
+        items: ["Vis alt", "Dekker", "Dekker ikke", "Dekker kanskje"],
+        defaultValue: "Dekker",
+        showTitle: false,
+        seperateItem: 1,
+    },
+    argTypes: {
+        defaultValue: {
+            control: "select",
+            options: ["Vis alt", "Dekker", "Dekker ikke", "Dekker kanskje"],
+        },
+    },
+    render: (args) => {
+        const [value, setValue] = useState(args.defaultValue);
+
+        const dekkesListe = (
+            <List>
+                <CheckListItem>
+                    avtalt erstatning hvis hunder dør eller må avlives som følge
+                    av ulykke eller sykdom
+                </CheckListItem>
+                <CheckListItem>forsvinning og tyveri</CheckListItem>
+            </List>
+        );
+
+        const dekkesIkkeListe = (
+            <List>
+                <CrossListItem>
+                    hvis hunden må avlives på grunn av atferdsproblemer, for
+                    eksempel nervøsitet eller aggresjon
+                </CrossListItem>
+            </List>
+        );
+
+        const dekkesKanskjeListe = (
+            <List>
+                <ListItem>
+                    kanskje hunden din stikker av, det dekker vi ikke hehe
+                </ListItem>
+            </List>
+        );
+
+        return (
+            <div
+                style={{
+                    display: "flex",
+                    gap: "40px",
+                    flexDirection: "column",
+                }}
+            >
+                <h2>Dekningsoversikt hund og katt</h2>
+                <SegmentedControl
+                    {...args}
+                    value={value}
+                    onChange={(e) => {
+                        setValue(e.target.value);
+                    }}
+                />
+                <div
+                    style={{
+                        maxWidth: "60ch",
+                        display: "flex",
+                        gap: "24px",
+                        flexDirection: "column",
+                    }}
+                >
+                    {value === "Vis alt" && (
+                        <>
+                            {dekkesListe}
+                            {dekkesIkkeListe}
+                            {dekkesKanskjeListe}
+                            <p>
+                                På denne siden har vi forenklet teksten om hva
+                                forsikringen dekker og ikke dekker. Du må alltid
+                                lese vilkårene i avtaledokumentet for å få full
+                                oversikt.
+                            </p>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "12px",
+                                }}
+                            >
+                                <Link external={true} href={"#"}>
+                                    Fullstendige vilkår (PDF)
+                                </Link>
+                                <Link external={true} href={"#"}>
+                                    Standardisert produktinformasjon (PDF)
+                                </Link>
+                            </div>
+                        </>
+                    )}
+                    {value === "Dekker" && (
+                        <>
+                            {dekkesListe}
+                            <p>
+                                På denne siden har vi forenklet teksten om hva
+                                forsikringen dekker og ikke dekker. Du må alltid
+                                lese vilkårene i avtaledokumentet for å få full
+                                oversikt.
+                            </p>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "12px",
+                                }}
+                            >
+                                <Link external={true} href={"#"}>
+                                    Fullstendige vilkår (PDF)
+                                </Link>
+                                <Link external={true} href={"#"}>
+                                    Standardisert produktinformasjon (PDF)
+                                </Link>
+                            </div>
+                        </>
+                    )}
+                    {value === "Dekker kanskje" && (
+                        <>
+                            {dekkesKanskjeListe}
+                            <p>
+                                På denne siden har vi forenklet teksten om hva
+                                forsikringen dekker og ikke dekker. Du må alltid
+                                lese vilkårene i avtaledokumentet for å få full
+                                oversikt.
+                            </p>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "12px",
+                                }}
+                            >
+                                <Link external={true} href={"#"}>
+                                    Fullstendige vilkår (PDF)
+                                </Link>
+                                <Link external={true} href={"#"}>
+                                    Standardisert produktinformasjon (PDF)
+                                </Link>
+                            </div>
+                        </>
+                    )}
+                    {value === "Dekker ikke" && (
+                        <>
+                            {dekkesIkkeListe}
+                            <p>
+                                På denne siden har vi forenklet teksten om hva
+                                forsikringen dekker og ikke dekker. Du må alltid
+                                lese vilkårene i avtaledokumentet for å få full
+                                oversikt.
+                            </p>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "12px",
+                                }}
+                            >
+                                <Link external={true} href={"#"}>
+                                    Fullstendige vilkår (PDF)
+                                </Link>
+                                <Link external={true} href={"#"}>
+                                    Standardisert produktinformasjon (PDF)
+                                </Link>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        );
+    },
+};

--- a/packages/jokul/src/components/segmented-control/styles/_index.scss
+++ b/packages/jokul/src/components/segmented-control/styles/_index.scss
@@ -1,0 +1,1 @@
+@forward "segmented-control";

--- a/packages/jokul/src/components/segmented-control/styles/segmented-control.scss
+++ b/packages/jokul/src/components/segmented-control/styles/segmented-control.scss
@@ -1,0 +1,96 @@
+@charset "UTF-8";
+@use "../../../core/jkl";
+@use "../../../core/jkl/colors";
+
+@include jkl.comfortable-density-variables {
+  --jkl-segmented-controls-padding: #{jkl.$unit-10};
+  --jkl-segmented-controls-margin: 1.5ch;
+
+  @include jkl.declare-font-variables("jkl-segmented-control", "body");
+}
+
+@include jkl.compact-density-variables {
+  --jkl-segmented-controls-padding: #{jkl.$unit-05};
+  --jkl-segmented-controls-margin: 1ch;
+
+  @include jkl.declare-font-variables("jkl-segmented-control", "small");
+}
+
+.jkl-segmented-control {
+  @include jkl.use-font-variables("jkl-segmented-control");
+
+  .jkl-segmented-control-legend {
+    margin-block-end: 0.5lh;
+  }
+
+  .jkl-segmented-control-item {
+    --jkl-segmented-control-border-width: 1px;
+    --jkl-segmented-controls-border-radius: 1lh;
+
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--jkl-color-background-interactive);
+    padding-block: var(--jkl-segmented-controls-padding);
+    padding-inline: 1ch 1.5ch;
+    border: var(--jkl-segmented-control-border-width) solid var(--jkl-color-border-separator);
+    border-radius: 0; // Gjør det enklere å behandle separering senere
+    cursor: pointer;
+    margin-inline-end: calc(var(--jkl-segmented-control-border-width) * -1);
+    white-space: nowrap;
+
+    @include jkl.motion("easeInBounceOut", "expressive", all);
+
+    input {
+      margin-inline-end: 5px;
+      cursor: pointer;
+    }
+
+    &:hover {
+      background-color: var(--jkl-color-background-interactive-hover);
+      border-color: var(--jkl-color-border-separator-hover);
+      z-index: 1;
+    }
+
+    &:has(input:checked) {
+      background-color: var(--jkl-color-background-interactive-selected);
+      border-color: var(--jkl-color-border-separator-strong);
+      z-index: 1;
+    }
+
+    // Kontrollerer border og margin på separerte items + border-radius til neste sibling
+    &[data-spacing="true"] {
+      border-radius: var(--jkl-segmented-controls-border-radius);
+      margin-inline-start: var(--jkl-segmented-controls-margin);
+
+      &:first-of-type {
+        margin-inline-start: 0;
+      }
+
+      + .jkl-segmented-control-item {
+        border-end-start-radius: var(--jkl-segmented-controls-border-radius);
+        border-start-start-radius: var(--jkl-segmented-controls-border-radius);
+
+        margin-inline-start: var(--jkl-segmented-controls-margin);
+      }
+    }
+
+    // Første element skal alltid ha border-radius på starten
+    &:first-of-type {
+      border-end-start-radius: var(--jkl-segmented-controls-border-radius);
+      border-start-start-radius: var(--jkl-segmented-controls-border-radius);
+    }
+
+    // Siste element skal alltid ha border-radius på slutten
+    &:last-of-type {
+      border-end-end-radius: var(--jkl-segmented-controls-border-radius);
+      border-start-end-radius: var(--jkl-segmented-controls-border-radius);
+    }
+
+    // Dersom nærmeste sibling er separert skal slutten ha border radius
+    &:has(+ .jkl-segmented-control-item[data-spacing="true"]) {
+      border-end-end-radius: var(--jkl-segmented-controls-border-radius);
+      border-start-end-radius: var(--jkl-segmented-controls-border-radius);
+    }
+  }
+}

--- a/packages/jokul/src/components/segmented-control/styles/segmented-control.scss
+++ b/packages/jokul/src/components/segmented-control/styles/segmented-control.scss
@@ -1,16 +1,16 @@
 @charset "UTF-8";
 @use "../../../core/jkl";
-@use "../../../core/jkl/colors";
+@use "../../../components/radio-button/styles";
 
 @include jkl.comfortable-density-variables {
-  --jkl-segmented-controls-padding: #{jkl.$unit-10};
+  --jkl-segmented-controls-padding: #{jkl.$unit-02};
   --jkl-segmented-controls-margin: 1.5ch;
 
   @include jkl.declare-font-variables("jkl-segmented-control", "body");
 }
 
 @include jkl.compact-density-variables {
-  --jkl-segmented-controls-padding: #{jkl.$unit-05};
+  --jkl-segmented-controls-padding: 0;
   --jkl-segmented-controls-margin: 1ch;
 
   @include jkl.declare-font-variables("jkl-segmented-control", "small");
@@ -19,31 +19,34 @@
 .jkl-segmented-control {
   @include jkl.use-font-variables("jkl-segmented-control");
 
+  @include jkl.small-device {
+    @include jkl.declare-font-variables("jkl-segmented-control", "small");
+  }
+
   .jkl-segmented-control-legend {
-    margin-block-end: 0.5lh;
+    margin-block-end: 0.25lh;
   }
 
   .jkl-segmented-control-item {
     --jkl-segmented-control-border-width: 1px;
-    --jkl-segmented-controls-border-radius: 1lh;
+    --jkl-segmented-controls-border-radius: 2lh;
 
+    cursor: pointer;
     position: relative;
     display: inline-flex;
     align-items: center;
     background-color: var(--jkl-color-background-interactive);
-    padding-block: var(--jkl-segmented-controls-padding);
-    padding-inline: 1ch 1.5ch;
     border: var(--jkl-segmented-control-border-width) solid var(--jkl-color-border-separator);
     border-radius: 0; // Gjør det enklere å behandle separering senere
-    cursor: pointer;
     margin-inline-end: calc(var(--jkl-segmented-control-border-width) * -1);
-    white-space: nowrap;
+    margin-block-end: 0.5lh;
 
-    @include jkl.motion("easeInBounceOut", "expressive", all);
+    @include jkl.motion("easeInBounceOut", "expressive", border background);
 
-    input {
-      margin-inline-end: 5px;
+    label {
       cursor: pointer;
+      padding-block: var(--jkl-segmented-controls-padding);
+      padding-inline: 1ch 1.5ch;
     }
 
     &:hover {
@@ -53,13 +56,13 @@
     }
 
     &:has(input:checked) {
-      background-color: var(--jkl-color-background-interactive-selected);
-      border-color: var(--jkl-color-border-separator-strong);
+      background-color: var(--jkl-color-background-container-high);
+      border-color: var(--jkl-color-border-separator);
       z-index: 1;
     }
 
     // Kontrollerer border og margin på separerte items + border-radius til neste sibling
-    &[data-spacing="true"] {
+    &:has(input[data-spacing="true"]) {
       border-radius: var(--jkl-segmented-controls-border-radius);
       margin-inline-start: var(--jkl-segmented-controls-margin);
 
@@ -67,7 +70,7 @@
         margin-inline-start: 0;
       }
 
-      + .jkl-segmented-control-item {
+      + span + .jkl-segmented-control-item {
         border-end-start-radius: var(--jkl-segmented-controls-border-radius);
         border-start-start-radius: var(--jkl-segmented-controls-border-radius);
 
@@ -88,7 +91,7 @@
     }
 
     // Dersom nærmeste sibling er separert skal slutten ha border radius
-    &:has(+ .jkl-segmented-control-item[data-spacing="true"]) {
+    &:has(+ span + .jkl-segmented-control-item > input[data-spacing="true"]) {
       border-end-end-radius: var(--jkl-segmented-controls-border-radius);
       border-start-end-radius: var(--jkl-segmented-controls-border-radius);
     }

--- a/packages/jokul/src/components/segmented-control/types.ts
+++ b/packages/jokul/src/components/segmented-control/types.ts
@@ -1,18 +1,18 @@
-import type { InputHTMLAttributes } from "react";
+import type {InputHTMLAttributes} from "react";
 
 export type SegmentedControlProps = InputHTMLAttributes<HTMLInputElement> & {
     /**
      * OBS: Bruk en god tittel på valgene, ikke på innholdet det kontrollerer.
      */
-    title: string;
+    legend: string;
     /**
      * Vis eller skjul tittel visuelt. Den er alltid tilgjengelig for skjermlesere.
      */
-    showTitle?: boolean;
+    showLegend?: boolean;
     items: string[];
     /**
      * Hvis du ønsker å separere et enkelt valg kan du det.
      * Dersom du setter dette til et negativt tall vil du også kunne separere alle fra hverandre.
      * */
-    seperateItem?: number;
+    separateItem?: number;
 };

--- a/packages/jokul/src/components/segmented-control/types.ts
+++ b/packages/jokul/src/components/segmented-control/types.ts
@@ -1,0 +1,18 @@
+import type { InputHTMLAttributes } from "react";
+
+export type SegmentedControlProps = InputHTMLAttributes<HTMLInputElement> & {
+    /**
+     * OBS: Bruk en god tittel på valgene, ikke på innholdet det kontrollerer.
+     */
+    title: string;
+    /**
+     * Vis eller skjul tittel visuelt. Den er alltid tilgjengelig for skjermlesere.
+     */
+    showTitle?: boolean;
+    items: string[];
+    /**
+     * Hvis du ønsker å separere et enkelt valg kan du det.
+     * Dersom du setter dette til et negativt tall vil du også kunne separere alle fra hverandre.
+     * */
+    seperateItem?: number;
+};


### PR DESCRIPTION
## 💬 Endringer

Segmented Control gjør det ToggleSwitch noen ganger gjorde.

### 🎯 Dokumentasjon

-   [ ] Teksten i portalen er oppdatert med endringene i [Sanity](https://jokul-portal.app.devaws.fremtind.no/studio)
-   [x] [Storybook](https://jokul-portal.app.devaws.fremtind.no/storybook/) er oppdatert med nye [stories](https://storybook.js.org/docs/get-started/whats-a-story)
-   [ ] [Figma-komponentene](https://www.figma.com/files/784861794507029203/project/52944370/Designsystemet?fuid=1253605757836779042) er oppdatert, og eksempler er lagt til dersom det trengd

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
-   [ ] Testet [responsivitet](https://jokul.fremtind.no/universell-utforming/responsivt-design) og [universell utforming](https://jokul.fremtind.no/universell-utforming/testguide) ([tastaturnavigasjon](https://jokul.fremtind.no/universell-utforming/tastatur), [skjermleser](https://jokul.fremtind.no/universell-utforming/skjermleser))

## Eksempler
| Beskrivelse | Eksempel |
|--------|--------|
| Default | <img width="1047" height="868" alt="Skjermbilde 2025-08-01 kl  16 46 37" src="https://github.com/user-attachments/assets/f0c0aeaa-6d58-4db5-b695-17fc1ee4ab8c" /> |
| showTitle="false" | <img width="1031" height="826" alt="Skjermbilde 2025-08-01 kl  16 47 07" src="https://github.com/user-attachments/assets/2a4e5a04-ef04-4ab3-9851-9b5560fc620c" /> |
| separatedItem < 0 | <img width="1037" height="863" alt="Skjermbilde 2025-08-01 kl  16 46 56" src="https://github.com/user-attachments/assets/efbaf8e6-9675-4340-86e6-ac48e4c9df99" /> | 
| separatedItem=0 | <img width="1040" height="878" alt="Skjermbilde 2025-08-01 kl  16 46 50" src="https://github.com/user-attachments/assets/4aa1e1c4-863d-49d7-99b3-d320b219a94f" /> | 
| Dekningsoversikten i PM | <img width="1029" height="596" alt="Skjermbilde 2025-08-01 kl  16 47 27" src="https://github.com/user-attachments/assets/28061184-34b6-40a1-99e4-8642320ec727" /> |









