### PR TITLE
rett opp styling på liste av relaterte komponenter

### DIFF
--- a/portal/src/app/(frontend)/komponenter/[slug]/component.module.scss
+++ b/portal/src/app/(frontend)/komponenter/[slug]/component.module.scss
@@ -3,6 +3,8 @@
 .relatedComponents {
     display: flex;
     gap: jkl.$spacing-16;
+    list-style-type: none;
+    padding: 0;
 }
 
 .footer {


### PR DESCRIPTION
Fjerner listepunkter i listen med relaterte komponenter på komponentsiden

**før**
<img width="612" height="233" alt="Skjermbilde 2025-08-13 kl  09 29 51" src="https://github.com/user-attachments/assets/eb89ce97-7385-4364-8d57-d4e2a31d2404" />

**etter**
<img width="570" height="242" alt="Skjermbilde 2025-08-13 kl  09 30 00" src="https://github.com/user-attachments/assets/568fef9a-1385-4b01-8697-a333aba9edc9" />

