### PR TITLE
fix: bruk egen logger for express-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "nodemon": "^2.0.22",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-is": "^18.3.1"
+        "react-is": "^18.3.1",
+        "winston": "^3.17.0"
     },
     "devDependencies": {
         "@axe-core/playwright": "^4.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ importers:
       tiny-glob: ^0.2.9
       typescript: ^5.8.3
       vite: ^7.0.2
+      winston: ^3.17.0
     dependencies:
       fs-extra: 11.3.0
       glob: 8.1.0
@@ -81,6 +82,7 @@ importers:
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-is: 18.3.1
+      winston: 3.17.0
     devDependencies:
       '@axe-core/playwright': 4.10.1
       '@biomejs/biome': 1.9.4

--- a/server.js
+++ b/server.js
@@ -1,6 +1,16 @@
 import express from "express";
 import proxy from "express-http-proxy";
-import { logger } from "./portal/logger";
+import winston from "winston";
+
+const { combine, timestamp, json } = winston.format;
+
+export const logger = winston.createLogger({
+    format: combine(timestamp(), json()),
+    level: "info",
+    defaultMeta: { service: "jokul-portal" },
+    transports: [new winston.transports.Console()],
+    exceptionHandlers: [new winston.transports.Console()],
+});
 
 const app = express();
 const PORT = 3000;


### PR DESCRIPTION
Ble krøll med å bruke samme logger for Next-appen og Express-serveren, så legger til en egen for serveren.
