### PR TITLE
fix: legg til egen rute for healthcheck

### DIFF
--- a/portal/src/app/healthcheck/route.ts
+++ b/portal/src/app/healthcheck/route.ts
@@ -1,0 +1,6 @@
+import { logger } from "logger";
+
+export async function GET() {
+    logger.info("Healthcheck endpoint hit");
+    return new Response("ok");
+}


### PR DESCRIPTION
Tror dette har ført til litt høy bruk av Sanity-APIet, selv med caching.

**NB!** Vi må også endre innstillingene i configrepo når denne er inne, til å faktisk bruke den nye ruten for healthcheck i Shifter.

## 💬 Endringer

1. Legg til egen rute for healthcheck, så vi slipper å potensielt fyre av requests mot Sanity for komponentene hvert femte sekund. Ruten returnerer en enkel 200-respons med innholdet "ok".
