### PR TITLE
Bug/5114 menu triggerelement

### DIFF
--- a/.changeset/sixty-toes-repair.md
+++ b/.changeset/sixty-toes-repair.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Endret Menu til å bruke [SlotComponent](https://github.com/fremtind/jokul/blob/main/packages/jokul/src/utilities/polymorphism/SlotComponent.tsx) for en mer robust og pålitelig håndtering av triggerElement.

--- a/packages/jokul/src/components/menu/Menu.tsx
+++ b/packages/jokul/src/components/menu/Menu.tsx
@@ -161,10 +161,9 @@ const MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
                             ref: referenceRef,
                             role: isNested ? "menuitem" : undefined,
                             "aria-controls": MenuId,
-                            // Du trenger ikke lenger en custom onClick for stopPropagation her,
-                            // da mergeProps sannsynligvis kan håndtere sammenslåing av event handlers
-                            // (avhengig av implementasjonen). Men for sikkerhets skyld, behold den
-                            // hvis du ser at events bobler feil.
+                            onClick(event) {
+                                event.stopPropagation();
+                            },
                         })}
                     >
                         {triggerElement}

--- a/portal/src/components/DisableDraftMode.tsx
+++ b/portal/src/components/DisableDraftMode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Link } from "@fremtind/jokul/link";
 import { useDraftModeEnvironment } from "next-sanity/hooks";
+import DraftToolbar from "./DraftToolbar";
 
 export function DisableDraftMode() {
     const environment = useDraftModeEnvironment();
@@ -11,5 +11,5 @@ export function DisableDraftMode() {
         return null;
     }
 
-    return <Link href="/api/draft-mode/disable">Disable Draft Mode</Link>;
+    return <DraftToolbar />;
 }

--- a/portal/src/components/DraftToolbar.tsx
+++ b/portal/src/components/DraftToolbar.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@fremtind/jokul/button";
+import { DotsIcon } from "@fremtind/jokul/icon";
+import { Menu, MenuItem } from "@fremtind/jokul/menu";
+
+const DraftToolbar = () => {
+    return (
+        <div style={{ position: "fixed", bottom: "16px", right: "16px" }}>
+            <Menu
+                initialPlacement="bottom-end"
+                triggerElement={
+                    <Button
+                        variant="ghost"
+                        icon={<DotsIcon bold />}
+                        iconPosition="right"
+                        aria-label="Draft Toolbar"
+                    />
+                }
+            >
+                <MenuItem as="a" href="/api/draft-mode/disable">
+                    Exit Draft Mode
+                </MenuItem>
+            </Menu>
+        </div>
+    );
+};
+
+export default DraftToolbar;


### PR DESCRIPTION
## 💬 Endringer

1. Endret Menu til å bruke Slot-komponent for en mer robust og pålitelig håndtering av triggerElement.
2. Laget DraftToolbar for å gjøre det enklere å avslutte draft-modus, med mulighet for å legge til flere innstillinger dersom behovet skulle oppstå.

### ♿️ Testing

-   [x] `pnpm build` og `pnpm ci:test` gir ingen feil
