### PR TITLE
fix: bruk tablistener i storybook for fokushåndtering

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,9 +1,14 @@
 import type { Preview } from "@storybook/react";
+import { initTabListener } from "../packages/jokul/src/utilities/tabListener.js";
 import { backgroundOptions } from "./backgrounds.js";
 import { densities, densityDecorator, densityGlobal } from "./density.js";
 import { themeDecorator, themeGlobal, themes } from "./theme.js";
+
+// Styles
 import "../packages/jokul/src/components/card/styles/_index.scss";
 import "./global.scss";
+
+initTabListener();
 
 const preview: Preview = {
     globalTypes: {


### PR DESCRIPTION
## 💬 Endringer

Sørger for å initiere tablistener fra Jøkul, slik at fokusringer kun vises ved tastaturnavigasjon, ikke ved hvert klikk.

## 🩹 Løser følgende issues

-   Closes #4788 
