### PR TITLE
Forhindre at Autosuggest nullstiller egendefinert verdi i stories

### DIFF
--- a/packages/jokul/src/components/autosuggest/stories/Autosuggest.stories.tsx
+++ b/packages/jokul/src/components/autosuggest/stories/Autosuggest.stories.tsx
@@ -74,6 +74,18 @@ export const Autosuggest: Story = {
                 .map((country) => country.name),
         },
     },
+    render: (args) => {
+        const [value, setValue] = React.useState("");
+
+        return (
+            <AutosuggestComponent
+                {...args}
+                value={value}
+                onInputValueChange={setValue}
+                onChange={setValue}
+            />
+        );
+    },
 };
 
 export const AutosuggestMedTooltip: Story = {
@@ -104,5 +116,17 @@ export const AutosuggestMedTooltip: Story = {
                 }
             />
         ),
+    },
+    render: (args) => {
+        const [value, setValue] = React.useState("");
+
+        return (
+            <AutosuggestComponent
+                {...args}
+                value={value}
+                onInputValueChange={setValue}
+                onChange={setValue}
+            />
+        );
     },
 };


### PR DESCRIPTION
## 💬 Endringer

Endringen sørger for at egendefinerte verdier i `Autosuggest`-storyen blir værende etter at feltet mister fokus. Løste dette med å gjeninnfører logikken fra tidligere fungerende eksempel fra gamle portalen ved å koble `onChange` og `onInputValueChange` til en useState hook.

Ikke helt sikker på rotårsaken, men problemet ser ut til å være knyttet til hvordan Storybook håndterer tilstanden for kontrollerte komponenter. Fiksen løser iallefall symptomet og oppfører seg mer som normalt nå.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5163 
