### PR TITLE
fix: fiks manglende innlasting av fonter i Storybook

### DIFF
--- a/.storybook/global.scss
+++ b/.storybook/global.scss
@@ -1,4 +1,4 @@
 @use "../packages/jokul/src/core/styles/core";
 @use "../packages/jokul/src/fonts/styles/webfonts.scss" with (
-    $webfonts-dir: "/fonts"
+    $webfonts-dir: "../packages/jokul/src/fonts"
 );

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,2 @@
-<link rel="preload" href="/fonts/Fremtind-Material-Symbols.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
-<link rel="preload" href="/fonts/FremtindGrotesk-Regular-Web.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link rel="preload" href="/storybook/fonts/Fremtind-Material-Symbols.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link rel="preload" href="/storybook/fonts/FremtindGrotesk-Regular-Web.woff2" as="font" type="font/woff2" crossorigin="anonymous" />


### PR DESCRIPTION
## 💬 Endringer

Går tilbake til gammel innlasting av ikonfonten i Storybook midlertidig slik at ikonene vises i eksemplene igjen.
