### PR TITLE
fix: fjerner alt-tekst fra placeholder-bilde etter innlasting

### DIFF
--- a/.changeset/shy-socks-travel.md
+++ b/.changeset/shy-socks-travel.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+fjerner alt-tekst fra placeholder-bilde etter innlasting

--- a/packages/jokul/src/components/image/Image.tsx
+++ b/packages/jokul/src/components/image/Image.tsx
@@ -24,7 +24,7 @@ export const Image: FC<ImageProps> = ({
             {/* Placeholder er bevisst uten loading og decoding for å vises umiddelbart */}
             <img
                 className="jkl-image__placeholder"
-                alt={alt}
+                alt={imageLoaded ? "" : alt}
                 src={placeholder || imageProperties.src}
             />
             {/* biome-ignore lint/a11y/useAltText: Den har da vitterlig en alt-attributt? */}


### PR DESCRIPTION
Dobbelt opp med bilder med alt-tekst = unødvendig når det er samme bilde