### PR TITLE
feat(portal): Funksjonalitet for filtrering og brukertilpasning på komponentsiden

### DIFF
--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -45,8 +45,9 @@ h4 {
 }
 
 p {
-    @include jkl.text-style("body");
     max-width: 55ch;
+
+    @include jkl.text-style("body");
 }
 
 code,

--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -81,9 +81,8 @@ export default async function Page({ params }: Props) {
                                             (relatedComponent) => (
                                                 <li key={relatedComponent.slug}>
                                                     <ComponentCard
-                                                        componentSlug={
-                                                            relatedComponent.slug ||
-                                                            ""
+                                                        component={
+                                                            relatedComponent
                                                         }
                                                     />
                                                 </li>

--- a/portal/src/app/(frontend)/komponenter/komponenter.module.scss
+++ b/portal/src/app/(frontend)/komponenter/komponenter.module.scss
@@ -22,98 +22,57 @@
 }
 
 .componentGallery {
+    --grid-item-min-width: 250px;
+
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    column-gap: clamp(var(--jkl-unit-10),
-    0.4038rem + 0.3846vw,
-    var(--jkl-unit-15));
+    grid-template-columns: repeat(auto-fill, minmax(var(--grid-item-min-width), 1fr));
+    gap: var(--jkl-spacing-8);
 
-    row-gap: clamp(var(--jkl-unit-30),
-    1.1154rem + 1.5385vw,
-    var(--jkl-unit-50));
+    > li > * {
+        height: 100%;
+    }
 
-    &.listView {
-        grid-template-columns: auto;
-        border-top: 1px solid var(--jkl-color-border-separator);
-        gap: 0;
+    &[data-grid-size="small"] {
+        --grid-item-min-width: 200px;
+    }
 
-        > * {
-            border-bottom: 1px solid var(--jkl-color-border-separator);
-        }
+    &[data-grid-size="medium"] {
+        --grid-item-min-width: 250px;
+    }
+
+    &[data-grid-size="large"] {
+        --grid-item-min-width: 300px;
     }
 }
 
 .componentCard {
     --aspect-ratio: 1.5;
 
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: clamp(var(--jkl-unit-10), 0.3077rem + 0.7692vw, var(--jkl-unit-20));
-    box-sizing: border-box;
-    width: 100%;
-    text-decoration: none;
+    display: flex;
+    flex-direction: column;
     color: var(--color-text);
 
-    .componentGallery.listView & {
-        grid-template-columns: repeat(12, 1fr);
-        gap: var(--jkl-unit-05) var(--jkl-unit-30);
-        align-items: center;
-        padding-block: var(--jkl-unit-30);
-
-        > * {
-            grid-column: 1/-1;
-        }
-
-        .image {
-            grid-column: 1/3;
-        }
-
-        .name {
-            grid-column: 3/6;
-        }
-
-        .description {
-            display: block;
-            grid-column: 6/-1;
-        }
-
-        @container (max-width: 45em) {
-            .image {
-                display: none;
-            }
-
-            .name,
-            .description {
-                grid-column-start: 1;
-            }
-
-            .name {
-                grid-row: 1 / 2;
-            }
-
-            .description {
-                grid-row: 2 / 3;
-
-                @include jkl.text-style("small");
-            }
-        }
-    }
 
     .name {
-        margin: 0;
+        margin-bottom: var(--jkl-spacing-8);
+
+        &:last-child {
+            margin-bottom: 0;
+        }
 
         @include jkl.text-style("heading-4");
     }
 
     .description {
-        display: none;
+        margin-bottom: auto;
     }
 
     .image {
         aspect-ratio: var(--aspect-ratio);
+        margin-top: var(--jkl-spacing-16);
 
         img {
             object-fit: cover;

--- a/portal/src/app/(frontend)/komponenter/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/page.tsx
@@ -1,9 +1,6 @@
-import { cookies } from "next/headers";
-
 import { sanityFetch } from "@/sanity/lib/live";
 import { componentsQuery } from "@/sanity/queries/component";
 import { logger } from "logger";
-import { ComponentCard } from "./ComponentCard";
 import { ComponentGallery } from "./ComponentGallery";
 import styles from "./komponenter.module.scss";
 
@@ -15,13 +12,11 @@ export default async function Components() {
         requestTag: "component-overview",
     });
 
-    const viewMode = (await cookies()).get("componentGalleryViewMode")?.value;
-
     if (!components) {
         logger.warn("No components found");
         return (
             <>
-                <h1 className={styles.pageTitle}>Komponent&shy;oversikt</h1>
+                <h1 className={styles.pageTitle}>Komponenter</h1>
                 <p>Fant ingen komponenter :(</p>
             </>
         );
@@ -29,16 +24,8 @@ export default async function Components() {
 
     return (
         <>
-            <h1 className={styles.pageTitle}>Komponent&shy;oversikt</h1>
-            <ComponentGallery mode={viewMode}>
-                {components.map((component) => (
-                    <li key={component.slug?.current}>
-                        <ComponentCard
-                            componentSlug={component.slug?.current || ""}
-                        />
-                    </li>
-                ))}
-            </ComponentGallery>
+            <h1 className={styles.pageTitle}>Komponenter</h1>
+            <ComponentGallery components={components} />
         </>
     );
 }

--- a/portal/src/components/component-filter-toolbar/ComponentFilterToolbar.tsx
+++ b/portal/src/components/component-filter-toolbar/ComponentFilterToolbar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Chip } from "@fremtind/jokul/chip";
+import { ChevronDownIcon } from "@fremtind/jokul/icon";
+import styles from "./component-filter-toolbar.module.scss";
+import { Button } from "@fremtind/jokul/button";
+import { Menu, MenuItem, MenuItemCheckbox } from "@fremtind/jokul/menu";
+import { useUserPreferences } from "@/context/UserPreferencesContext/UserPreferencesContext";
+import { COMPONENT_GRID_SIZES } from "@/context/UserPreferencesContext/types";
+
+const componentKeywords = [
+    "Knapper",
+    "Skjema",
+    "Navigasjon",
+    "Layout",
+    "Feedback",
+];
+
+type ComponentFilterToolbarProps = {
+    selectedKeywords: string[] | null;
+    onSelectedKeywordsChangeAction: (keywords: string[]) => void;
+};
+
+export const ComponentFilterToolbar = ({
+    selectedKeywords,
+    onSelectedKeywordsChangeAction,
+}: ComponentFilterToolbarProps) => {
+    const { preferences, setPreference } = useUserPreferences();
+
+    return (
+        <search title="komponenter" className={styles.componentFilterToolbar}>
+            <div className={styles.category}>
+                {componentKeywords.map((keyword) => (
+                    <Chip
+                        key={keyword}
+                        variant="filter"
+                        selected={selectedKeywords?.includes(keyword)}
+                        onClick={() =>
+                            onSelectedKeywordsChangeAction(
+                                selectedKeywords?.includes(keyword)
+                                    ? selectedKeywords.filter(
+                                          (k) => k !== keyword,
+                                      )
+                                    : [...(selectedKeywords || []), keyword],
+                            )
+                        }
+                    >
+                        {keyword}
+                    </Chip>
+                ))}
+            </div>
+            <Menu
+                initialPlacement="bottom-end"
+                triggerElement={
+                    <Button
+                        variant="ghost"
+                        iconPosition="right"
+                        icon={<ChevronDownIcon />}
+                    >
+                        Visning
+                    </Button>
+                }
+            >
+                <MenuItemCheckbox
+                    aria-checked={preferences.showComponentImage}
+                    onChange={() =>
+                        setPreference(
+                            "showComponentImage",
+                            !preferences.showComponentImage,
+                        )
+                    }
+                >
+                    Se bilde
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                    aria-checked={preferences.showComponentDescription}
+                    onChange={() =>
+                        setPreference(
+                            "showComponentDescription",
+                            !preferences.showComponentDescription,
+                        )
+                    }
+                >
+                    Se beskrivelse
+                </MenuItemCheckbox>
+                <Menu
+                    initialPlacement="right-end"
+                    triggerElement={
+                        <MenuItem expandable={true}>Størrelse</MenuItem>
+                    }
+                >
+                    {COMPONENT_GRID_SIZES.map((size) => (
+                        <MenuItem
+                            key={size}
+                            onClick={() =>
+                                setPreference("componentGridSize", size)
+                            }
+                        >
+                            {size.replace(/^./, size[0].toUpperCase())}
+                        </MenuItem>
+                    ))}
+                </Menu>
+            </Menu>
+        </search>
+    );
+};

--- a/portal/src/components/component-filter-toolbar/component-filter-toolbar.module.scss
+++ b/portal/src/components/component-filter-toolbar/component-filter-toolbar.module.scss
@@ -1,0 +1,12 @@
+.componentFilterToolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--jkl-spacing-40);
+
+    .category {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--jkl-spacing-8);
+    }
+}

--- a/portal/src/components/site-header/menu/MenuItemList.tsx
+++ b/portal/src/components/site-header/menu/MenuItemList.tsx
@@ -1,5 +1,5 @@
 import { client } from "@/sanity/lib/client";
-import { blogPostsQuery, komIGangQuery } from "@/sanity/queries/blog";
+import { komIGangQuery } from "@/sanity/queries/blog";
 import { componentsQuery } from "@/sanity/queries/component";
 import clsx from "clsx";
 import styles from "../SiteHeader.module.scss";
@@ -54,9 +54,7 @@ export const MenuItemList = async () => {
 
                         return (
                             <li key={name} className={clsx("jkl-list__item")}>
-                                <MenuItem
-                                    href={`/komponenter/${slug?.current}`}
-                                >
+                                <MenuItem href={`/komponenter/${slug}`}>
                                     {name}
                                 </MenuItem>
                             </li>

--- a/portal/src/context/UserPreferencesContext/UserPreferencesContext.tsx
+++ b/portal/src/context/UserPreferencesContext/UserPreferencesContext.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback } from "react";
+import { setCookie } from "cookies-next";
+import { defaultPreferences } from "./defaultPreferences";
+import type {
+    UserPreferences,
+    UserPreferencesContextType,
+    UserPreferencesProviderProps,
+} from "./types";
+
+const USER_PREFERENCES_COOKIE = "userPreferences";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+const UserPreferencesContext = createContext<UserPreferencesContextType | null>(
+    null,
+);
+
+export const UserPreferencesProvider = ({
+    children,
+    initialPreferences,
+}: UserPreferencesProviderProps) => {
+    const [preferences, setPreferences] = useState<UserPreferences>(
+        initialPreferences || defaultPreferences,
+    );
+
+    const setPreference = useCallback(
+        <K extends keyof UserPreferences>(
+            key: K,
+            value: UserPreferences[K],
+        ) => {
+            const updatedPreferences = { ...preferences, [key]: value };
+            setPreferences(updatedPreferences);
+            setCookie(
+                USER_PREFERENCES_COOKIE,
+                JSON.stringify(updatedPreferences),
+                {
+                    maxAge: COOKIE_MAX_AGE,
+                },
+            );
+        },
+        [preferences],
+    );
+
+    return (
+        <UserPreferencesContext.Provider value={{ preferences, setPreference }}>
+            {children}
+        </UserPreferencesContext.Provider>
+    );
+};
+
+export const useUserPreferences = () => {
+    const context = useContext(UserPreferencesContext);
+    if (!context) {
+        throw new Error(
+            "useUserPreferences must be used within a UserPreferencesProvider",
+        );
+    }
+    return context;
+};

--- a/portal/src/context/UserPreferencesContext/defaultPreferences.ts
+++ b/portal/src/context/UserPreferencesContext/defaultPreferences.ts
@@ -1,0 +1,7 @@
+import type { UserPreferences } from "./types";
+
+export const defaultPreferences: UserPreferences = {
+    showComponentImage: true,
+    showComponentDescription: false,
+    componentGridSize: "medium",
+};

--- a/portal/src/context/UserPreferencesContext/types.ts
+++ b/portal/src/context/UserPreferencesContext/types.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export const COMPONENT_GRID_SIZES = ["small", "medium", "large"] as const;
+export type ComponentGridSize = (typeof COMPONENT_GRID_SIZES)[number];
+
+export type UserPreferencesProviderProps = {
+    children: ReactNode;
+    initialPreferences?: UserPreferences;
+};
+
+export type UserPreferences = {
+    showComponentImage: boolean;
+    showComponentDescription: boolean;
+    componentGridSize: ComponentGridSize;
+};
+
+export type UserPreferencesContextType = {
+    preferences: UserPreferences;
+    setPreference: <K extends keyof UserPreferences>(
+        key: K,
+        value: UserPreferences[K],
+    ) => void;
+};

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -2,9 +2,13 @@ import { defineQuery } from "next-sanity";
 
 export const componentsQuery = defineQuery(`*[_type == "jokul_component"]{
     name,
-    slug,
-    "imageUrl": image.asset->url,
-    
+    short_description,
+    "slug": slug.current,
+    figma_image,
+    image,
+    imageDark,
+    related_components,
+    keywords
 } | order(name)`);
 
 export const componentBySlugQuery =
@@ -47,7 +51,13 @@ export const componentBySlugQuery =
         related_components {
             components[]->{
                 name,
-                "slug": slug.current
+                short_description,
+                "slug": slug.current,
+                figma_image,
+                image,
+                imageDark,
+                related_components,
+                keywords
             }
         }
     }`);
@@ -60,5 +70,6 @@ export const componentCardQuery =
         figma_image,
         image,
         imageDark,
-        related_components
+        related_components,
+        keywords
     }[0]`);

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -485,14 +485,52 @@ export type KomIGangQueryResult = {
 
 // Source: ./src/sanity/queries/component.ts
 // Variable: componentsQuery
-// Query: *[_type == "jokul_component"]{    name,    slug,    "imageUrl": image.asset->url,    } | order(name)
+// Query: *[_type == "jokul_component"]{    name,    short_description,    "slug": slug.current,    figma_image,    image,    imageDark,    related_components,    keywords} | order(name)
 export type ComponentsQueryResult = Array<{
   name: string | null;
-  slug: Slug | null;
-  imageUrl: string | null;
+  short_description: string | null;
+  slug: string | null;
+  figma_image: {
+    light_mode?: string;
+    dark_mode?: string;
+  } | null;
+  image: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  imageDark: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  related_components: {
+    components?: Array<{
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      _key: string;
+      [internalGroqTypeReferenceTo]?: "jokul_component";
+    }>;
+  } | null;
+  keywords: Array<string> | null;
 }>;
 // Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        documentation_article[]{            ...,            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                }            }        },        related_components {            components[]->{                name,                "slug": slug.current            }        }    }
+// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        documentation_article[]{            ...,            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                }            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                keywords            }        }    }
 export type ComponentBySlugQueryResult = {
   _id: string;
   _type: "jokul_component";
@@ -611,7 +649,46 @@ export type ComponentBySlugQueryResult = {
   related_components: {
     components: Array<{
       name: string | null;
+      short_description: string | null;
       slug: string | null;
+      figma_image: {
+        light_mode?: string;
+        dark_mode?: string;
+      } | null;
+      image: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      imageDark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      related_components: {
+        components?: Array<{
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          _key: string;
+          [internalGroqTypeReferenceTo]?: "jokul_component";
+        }>;
+      } | null;
+      keywords: Array<string> | null;
     }> | null;
   } | null;
   external_links?: {
@@ -649,7 +726,7 @@ export type ComponentBySlugQueryResult = {
   };
 } | null;
 // Variable: componentCardQuery
-// Query: *[_type == "jokul_component" && defined(slug.current) && slug.current == $componentSlug] {        name,        short_description,        "slug": slug.current,        figma_image,        image,        imageDark,        related_components    }[0]
+// Query: *[_type == "jokul_component" && defined(slug.current) && slug.current == $componentSlug] {        name,        short_description,        "slug": slug.current,        figma_image,        image,        imageDark,        related_components,        keywords    }[0]
 export type ComponentCardQueryResult = {
   name: string | null;
   short_description: string | null;
@@ -691,6 +768,7 @@ export type ComponentCardQueryResult = {
       [internalGroqTypeReferenceTo]?: "jokul_component";
     }>;
   } | null;
+  keywords: Array<string> | null;
 } | null;
 
 // Query TypeMap
@@ -700,8 +778,8 @@ declare module "@sanity/client" {
     "*[_type == \"jokul_blog_post\"]{\n        name,\n        slug,\n        short_description,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": BlogPostsQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == $slug][0]": BlogPostBySlugQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0]": KomIGangQueryResult;
-    "*[_type == \"jokul_component\"]{\n    name,\n    slug,\n    \"imageUrl\": image.asset->url,\n    \n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        documentation_article[]{\n            ...,\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                \"slug\": slug.current\n            }\n        }\n    }": ComponentBySlugQueryResult;
-    "*[_type == \"jokul_component\" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        \"slug\": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components\n    }[0]": ComponentCardQueryResult;
+    "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    keywords\n} | order(name)": ComponentsQueryResult;
+    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        documentation_article[]{\n            ...,\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                keywords\n            }\n        }\n    }": ComponentBySlugQueryResult;
+    "*[_type == \"jokul_component\" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        \"slug\": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components,\n        keywords\n    }[0]": ComponentCardQueryResult;
   }
 }

--- a/portal/src/utils/url.ts
+++ b/portal/src/utils/url.ts
@@ -1,0 +1,9 @@
+export const createQueryString = (
+    currentParams: URLSearchParams,
+    name: string,
+    value: string,
+): string => {
+    const params = new URLSearchParams(currentParams.toString());
+    params.set(name, value);
+    return params.toString();
+};


### PR DESCRIPTION
Introduserer to nye hovedfunksjoner på komponentsiden:

1. Filtrering på nøkkelord

- Støtte for å kunne filtrere komponenter ved hjelp av nøkkelord. 

2. Personlig tilpasning av visning

- Kortstørrelse: Justere størrelsen på komponentkortene for bedre oversikt.
- Visning av beskrivelse: Velge om en tekstlig beskrivelse skal vises på kortet.
- Visning av bilde: Velge om et visuelt eksempel (bilde) skal vises på kortet.

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5191
