### PR TITLE
Overfør initiell searchparams fra server til klient

### DIFF
--- a/portal/src/app/(frontend)/komponenter/ComponentGallery.tsx
+++ b/portal/src/app/(frontend)/komponenter/ComponentGallery.tsx
@@ -9,19 +9,28 @@ import { createQueryString } from "@/utils/url";
 import { useUserPreferences } from "@/context/UserPreferencesContext/UserPreferencesContext";
 import type { ComponentsQueryResult } from "@/sanity/types";
 
-type ComponentGalleryProps = {
-    components: ComponentsQueryResult;
+export type InitialSearchParams = {
+    keywords?: string;
 };
 
-export const ComponentGallery = ({ components }: ComponentGalleryProps) => {
+type ComponentGalleryProps = {
+    components: ComponentsQueryResult;
+    initialSearchParams: InitialSearchParams;
+};
+
+export const ComponentGallery = ({
+    components,
+    initialSearchParams,
+}: ComponentGalleryProps) => {
     const { preferences } = useUserPreferences();
     const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
-    const keywordsParam = searchParams.get("keywords");
 
     const [selectedKeywords, setSelectedKeywords] = useState<string[]>(
-        keywordsParam ? keywordsParam.split(",") : [],
+        initialSearchParams.keywords
+            ? initialSearchParams.keywords.split(",")
+            : [],
     );
 
     const filteredComponents = useMemo(() => {

--- a/portal/src/app/(frontend)/komponenter/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/page.tsx
@@ -1,10 +1,16 @@
 import { sanityFetch } from "@/sanity/lib/live";
 import { componentsQuery } from "@/sanity/queries/component";
 import { logger } from "logger";
-import { ComponentGallery } from "./ComponentGallery";
+import { ComponentGallery, type InitialSearchParams } from "./ComponentGallery";
 import styles from "./komponenter.module.scss";
 
-export default async function Components() {
+export default async function Components({
+    searchParams,
+}: {
+    searchParams: Promise<InitialSearchParams>;
+}) {
+    const initialSearchParams = await searchParams;
+
     logger.info("Rendering component overview page");
 
     const { data: components } = await sanityFetch({
@@ -25,7 +31,10 @@ export default async function Components() {
     return (
         <>
             <h1 className={styles.pageTitle}>Komponenter</h1>
-            <ComponentGallery components={components} />
+            <ComponentGallery
+                components={components}
+                initialSearchParams={initialSearchParams}
+            />
         </>
     );
 }

--- a/portal/src/utils/url.ts
+++ b/portal/src/utils/url.ts
@@ -4,6 +4,12 @@ export const createQueryString = (
     value: string,
 ): string => {
     const params = new URLSearchParams(currentParams.toString());
-    params.set(name, value);
+
+    if (value) {
+        params.set(name, value);
+    } else {
+        params.delete(name);
+    }
+
     return params.toString();
 };


### PR DESCRIPTION


## 💬 Endringer

- Rettet opp i en feil der ComponentGallery tidligere var avhengig av useSearchParams-hooken for å sette sin initielle state. Under den initielle render på serveren så har ikke serveren tilgang til nettleserens URL, og vi kan derfor ikke hente verdier fra useSearchParams. Nå får vi heller initiell searchparams på server fra Parent Komponenten.

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5207 
