### PR TITLE
feat: Legg til TooltipButton-komponenten

### DIFF
--- a/.changeset/clear-cases-melt.md
+++ b/.changeset/clear-cases-melt.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legg til TooltipButton-komponenten

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -9,8 +9,15 @@
     "homepage": "https://github.com/fremtind/jokul/tree/main/packages/jokul",
     "keywords": [],
     "license": "MIT",
-    "sideEffects": ["*.css", "*.scss"],
-    "files": ["./build", "./styles", "./src/fonts"],
+    "sideEffects": [
+        "*.css",
+        "*.scss"
+    ],
+    "files": [
+        "./build",
+        "./styles",
+        "./src/fonts"
+    ],
     "main": "./build/cjs/index.cjs",
     "exports": {
         "./core": {
@@ -586,6 +593,17 @@
                 "default": "./build/cjs/components/tooltip/index.cjs"
             }
         },
+        "./styles/components/tooltip-button": "./styles/components/tooltip-button/_index.scss",
+        "./tooltip-button": {
+            "import": {
+                "types": "./build/es/components/tooltip-button/index.d.ts",
+                "default": "./build/es/components/tooltip-button/index.js"
+            },
+            "require": {
+                "types": "./build/cjs/components/tooltip-button/index.d.cts",
+                "default": "./build/cjs/components/tooltip-button/index.cjs"
+            }
+        },
         "./screen-reader-only": {
             "import": {
                 "types": "./build/es/components/screen-reader-only/index.d.ts",
@@ -661,7 +679,9 @@
         "url": "https://github.com/fremtind/jokul/issues"
     },
     "babel": {
-        "presets": ["@babel/preset-react"]
+        "presets": [
+            "@babel/preset-react"
+        ]
     },
     "gitHead": "2728cf20df66dd1c647cdffb49aab5365433abdb"
 }

--- a/packages/jokul/src/components/tooltip-button/TooltipButton.tsx
+++ b/packages/jokul/src/components/tooltip-button/TooltipButton.tsx
@@ -1,0 +1,62 @@
+import React, { type FC } from "react";
+import { Button } from "../button/index.js";
+import { Icon } from "../icon/Icon.jsx";
+import type { TooltipButtonProps } from "./types.js";
+
+export const TooltipButton: FC<TooltipButtonProps> = (props: TooltipButtonProps) => {
+    const {
+        title,
+        content,
+        popover = "auto",
+        position = "bottom",
+        ...rest
+    } = props;
+
+    return (
+        <>
+            <Button
+                {...rest}
+                title={title}
+                aria-label={title}
+                variant="ghost"
+                className="jkl-popuptip--trigger"
+                data-testid="jkl-popuptip-trigger"
+                icon={<Icon aria-hidden="true">help</Icon>}
+                popovertarget={`${title}-popover`}
+                // @ts-ignore
+                style={{ anchorName: `${title}-popover` }}
+            />
+
+            <output aria-live="assertive">
+                <div
+                    data-theme="dark"
+                    popover={popover}
+                    id={`${title}-popover`}
+                    data-position={position}
+                    className="jkl-popuptip--popup"
+                    // @ts-ignore
+                    style={{ positionAnchor: `${title}-popover` }}
+                >
+                    <header>
+                        <p className="title">{title}</p>
+                        <Button
+                            tabIndex={-1}
+                            title="Lukk"
+                            aria-label="Lukk dialogen"
+                            variant="ghost"
+                            icon={<Icon aria-hidden="true">close</Icon>}
+                            // @ts-ignore
+                            popovertarget={`${title}-popover`}
+                            popovertargetaction="hide"
+                        />
+                    </header>
+
+                    {/* biome-ignore lint/a11y/noNoninteractiveTabindex: */}
+                    <div className="jkl-popuptip__content-wrapper" tabIndex={0}>
+                        {content}
+                    </div>
+                </div>
+            </output>
+        </>
+    );
+};

--- a/packages/jokul/src/components/tooltip-button/index.ts
+++ b/packages/jokul/src/components/tooltip-button/index.ts
@@ -1,0 +1,2 @@
+export { TooltipButton } from "./TooltipButton.jsx";
+export type { TooltipButtonProps } from "./types.js";

--- a/packages/jokul/src/components/tooltip-button/stories/TooltipButton.stories.tsx
+++ b/packages/jokul/src/components/tooltip-button/stories/TooltipButton.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TooltipButton } from "../TooltipButton.jsx";
+import React from "react";
+import "../styles/_index.scss";
+import "../../button/styles/_index.scss";
+
+const meta = {
+    title: "Komponenter/Tooltip Button",
+    component: TooltipButton,
+    tags: ["autodocs", "popover"],
+    parameters: {
+        layout: "fullscreen",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ height: "100vh", overflow: "hidden", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof TooltipButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TooltipButtonStory: Story = {
+    name: "Tooltip Button",
+    args: {
+        title: "Hvorfor er prisen 0?",
+        content: (
+            <p>
+                Avtalen er betalt av arbeidsgiveren din. Du betaler ingenting.
+            </p>
+        ),
+        popover: "auto",
+        position: "top",
+    },
+    render: (args) => (
+        <p>
+            Avtalepris: 0 kr/mnd. <TooltipButton {...args} />
+        </p>
+    ),
+};

--- a/packages/jokul/src/components/tooltip-button/styles/_index.scss
+++ b/packages/jokul/src/components/tooltip-button/styles/_index.scss
@@ -1,0 +1,2 @@
+@forward "tooltip-button";
+@use "../../icon/styles" as icon;

--- a/packages/jokul/src/components/tooltip-button/styles/tooltip-button.scss
+++ b/packages/jokul/src/components/tooltip-button/styles/tooltip-button.scss
@@ -1,0 +1,72 @@
+@use "../../../core/jkl";
+
+.jkl-popuptip--trigger {
+    vertical-align: middle;
+    top: -2px;
+}
+
+.jkl-popuptip--popup {
+    max-width: 35ch;
+    padding: var(--jkl-unit-30);
+    margin: var(--jkl-unit-05);
+    inset: auto;
+    border: none;
+    background-color: var(--jkl-color-background-container-high);
+    color: var(--jkl-color-text-default);
+
+    header button {
+        display: none;
+    }
+
+    .title {
+        @include jkl.text-style("body") {
+            font-weight: bold;
+        }
+    }
+
+    &[data-position="top"] {
+        position-area: top center;
+        position-try: top, bottom, right, left;
+    }
+
+    &[data-position="bottom"] {
+        position-area: bottom center;
+        position-try: bottom, top, right, left;
+    }
+
+    &[data-position="left"] {
+        position-area: left center;
+        position-try: left, right, top, bottom;
+    }
+
+    &[data-position="right"] {
+        position-area: right center;
+        position-try: right, left, top, bottom;
+    }
+
+    @supports not (anchor-name: --hei) {
+        position: absolute;
+        max-width: 90dvw;
+        inset-block-start: 25%;
+        inset-inline-start: 50%;
+        transform: translateX(-50%) translateY(-50%);
+
+        &::backdrop {
+            opacity: 0.5;
+            background-color: var(--jkl-color-background-container-high);
+        }
+
+        header {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: var(--jkl-unit-30);
+            align-items: center;
+
+            button {
+                display: revert;
+                grid-column: 2;
+                align-self: start;
+            }
+        }
+    }
+}

--- a/packages/jokul/src/components/tooltip-button/types.ts
+++ b/packages/jokul/src/components/tooltip-button/types.ts
@@ -1,0 +1,23 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type TooltipButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "content"> & {
+    /**
+     * Tittel på knappen som åpner infoen. Prøv å formuler tittelen 
+     * som et spørsmål og content som svaret på spørsmålet.
+     */
+    title: string;
+    /**
+     * Innholdet i tooltipen.
+     */
+    content: ReactNode;
+    /**
+     * Plassering av tooltipen i forhold til triggeren. Tooltipen vil automatisk
+     * bytte posisjon dersom det ikke er plass.
+     * @default "top"
+     */
+    position?: "top" | "bottom" | "left" | "right";
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover#value
+     */
+    popover?: "hint" | "auto" | "manual";
+};

--- a/packages/jokul/src/components/tooltip/PopupTip.tsx
+++ b/packages/jokul/src/components/tooltip/PopupTip.tsx
@@ -6,6 +6,9 @@ import { TooltipContent } from "./TooltipContent.js";
 import { TooltipTrigger } from "./TooltipTrigger.js";
 import type { PopupTipProps } from "./types.js";
 
+/**
+ * @deprecated bruk heller TooltipButton
+ */
 export const PopupTip: FC<PopupTipProps> = ({
     content,
     triggerProps,

--- a/packages/jokul/src/components/tooltip/stories/Popuptip.stories.tsx
+++ b/packages/jokul/src/components/tooltip/stories/Popuptip.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import "../styles/_index.scss";
+import { PopupTip as PopuptipComponent } from "../PopupTip.js";
+
+const meta = {
+    title: "Komponenter/Popuptip",
+    component: PopuptipComponent,
+    tags: ["autodocs"],
+    argTypes: {
+        delay: { control: "number" },
+        initialOpen: { control: "boolean" },
+        placement: {
+            control: "select",
+            options: ["top", "top-start", "top-end", "left", "right"],
+        },
+    },
+} satisfies Meta<typeof PopuptipComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Popuptip: Story = {
+    args: {
+        content: (
+            <p>
+                Avtalen er betalt av arbeidsgiveren din. Du betaler ingenting.
+            </p>
+        ),
+        delay: 0,
+        initialOpen: false,
+        placement: "top",
+    },
+    render: (args) => (
+        <p>
+            Avtalepris: 0 kr/mnd. <PopuptipComponent {...args} />
+        </p>
+    ),
+};

--- a/packages/jokul/src/styles/styles.scss
+++ b/packages/jokul/src/styles/styles.scss
@@ -42,3 +42,4 @@
 @use "../components/toast/styles" as toast;
 @use "../components/toggle-switch/styles" as toggle-switch;
 @use "../components/tooltip/styles" as tooltip;
+@use "../components/tooltip-button/styles" as tooltip-button;


### PR DESCRIPTION
Legger til en ny løsning for popover-knapper. 

Denne bygger ikke lenger på Tooltip, men bruker heller popover-attributten, og nye CSS-funksjoner for plassering.