### PR TITLE
Midtstille innhold i portalen

### DIFF
--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -17,6 +17,7 @@ body {
     column-gap: var(--jkl-unit-30);
     max-width: var(--max-width);
     padding: var(--jkl-spacing-16);
+    margin-inline: auto;
 
     @media (width >=940px) {
         padding: 0;


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Innholdet i portalen, som tidligere var venstrestilt på grunn av sidemenyen, midtstilles nå som menyen er fjernet.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5212
