### PR TITLE
Gjør ComponentCard til en eksplisitt klient komponent

### DIFF
--- a/portal/src/app/(frontend)/komponenter/ComponentCard.tsx
+++ b/portal/src/app/(frontend)/komponenter/ComponentCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { client } from "@/sanity/lib/client";
 import imageUrlBuilder from "@sanity/image-url";
 import NextLink from "next/link";


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Gjør ComponentCard-komponenten om til en klient-komponent.

Nødvendig fordi "Relaterte komponenter"-seksjonen på komponentsidene rendres på server-siden, og der brukes ComponentCard.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5214 
