### PR TITLE
Feat/5224 refactor expandable panel api

### DIFF
--- a/.changeset/cyan-loops-buy.md
+++ b/.changeset/cyan-loops-buy.md
@@ -1,0 +1,18 @@
+---
+"@fremtind/jokul": minor
+---
+
+Utvidet ExpandablePanel med Header-prop for et mer konsistent og intuitivt API. Nå kan du bruke <ExpandablePanel.Header> direkte for å definere headeren til panelet. Storybook-eksempler og relevante typer er oppdatert for å støtte endringen.
+
+**Eksempel på bruk:**
+
+```tsx
+<ExpandablePanel>
+	<ExpandablePanel.Header>
+		Klikk for å åpne panelet
+	</ExpandablePanel.Header>
+	<ExpandablePanel.Content>
+		Her er innholdet i panelet.
+	</ExpandablePanel.Content>
+</ExpandablePanel>
+```

--- a/packages/jokul/src/components/expander/ExpandablePanel.tsx
+++ b/packages/jokul/src/components/expander/ExpandablePanel.tsx
@@ -7,6 +7,7 @@ import type {
     ExpandablePanelComponent,
     ExpandablePanelProps,
 } from "./types.js";
+import { Expander } from "./Expander.jsx";
 
 export const ExpandablePanel = Object.assign(
     React.forwardRef(function ExpandablePanel<
@@ -118,5 +119,5 @@ export const ExpandablePanel = Object.assign(
             </div>
         );
     }),
-    { Content: ExpandablePanelContent },
+    { Content: ExpandablePanelContent, Header: Expander },
 ) as ExpandablePanelComponent;

--- a/packages/jokul/src/components/expander/ExpandablePanelContent.tsx
+++ b/packages/jokul/src/components/expander/ExpandablePanelContent.tsx
@@ -48,3 +48,5 @@ export const ExpandablePanelContent: ExpandablePanelContentComponent = ({
         </div>
     );
 };
+
+ExpandablePanelContent.displayName = "ExpandablePanel.Content";

--- a/packages/jokul/src/components/expander/Expander.tsx
+++ b/packages/jokul/src/components/expander/Expander.tsx
@@ -84,3 +84,5 @@ export const Expander = React.forwardRef(function Expander<
         </El>
     );
 }) as ExpanderComponent;
+
+Expander.displayName = "ExpandablePanel.Header";

--- a/packages/jokul/src/components/expander/stories/ExpandablePanel.stories.tsx
+++ b/packages/jokul/src/components/expander/stories/ExpandablePanel.stories.tsx
@@ -46,7 +46,9 @@ export const ExpandablePanelFilled: Story = {
         <Flex style={{ width: "100%" }} direction="column" gap={4}>
             {[...Array(3)].map((_, index) => (
                 <ExpandablePanel key={index} {...args}>
-                    <Expander>Når er det vi faktisk er åpne?</Expander>
+                    <ExpandablePanel.Header>
+                        Klikk på meg for å åpne!
+                    </ExpandablePanel.Header>
                     <ExpandablePanel.Content>
                         Velkommen innom når vi faktisk har kaffe! Vi er åpne
                         mandag til fredag fra kl. 09:00 til 18:00. Lørdag kan du
@@ -70,7 +72,9 @@ export const ExpandablePanelStroke: Story = {
         <>
             {[...Array(3)].map((_, index) => (
                 <ExpandablePanel key={index} {...args}>
-                    <Expander>Når er det vi faktisk er åpne?</Expander>
+                    <ExpandablePanel.Header>
+                        Klikk på meg for å åpne!
+                    </ExpandablePanel.Header>
                     <ExpandablePanel.Content>
                         Velkommen innom når vi faktisk har kaffe! Vi er åpne
                         mandag til fredag fra kl. 09:00 til 18:00. Lørdag kan du

--- a/packages/jokul/src/components/expander/types.ts
+++ b/packages/jokul/src/components/expander/types.ts
@@ -20,6 +20,7 @@ export type ExpandablePanelProps<ElementType extends React.ElementType> =
 
 export type ExpandablePanelComponent = {
     Content: ExpandablePanelContentComponent;
+    Header: ExpanderComponent;
 } & (<ElementType extends React.ElementType = "div">(
     props: ExpandablePanelProps<ElementType>,
 ) => React.ReactElement | null);
@@ -35,11 +36,13 @@ export type ExpanderProps<ElementType extends React.ElementType> =
         }
     >;
 
-export type ExpanderComponent = <
-    ElementType extends React.ElementType = "button",
->(
+type Expander = <ElementType extends React.ElementType = "button">(
     props: ExpanderProps<ElementType>,
 ) => React.ReactElement | null;
+
+export type ExpanderComponent = Expander & {
+    displayName?: string;
+};
 
 /* Shared context */
 export type ExpandableContext = {


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

1. Utvidet API for ExpandablePanel

- ExpandablePanel har nå en Header-egenskap som peker til Expander-komponenten.
- Nå kan man bruke <ExpandablePanel.Header> i stedet for <Expander> direkte.

2. Oppdatert Storybook-eksempler

- Storybook-historiene bruker nå <ExpandablePanel.Header> i stedet for <Expander>.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5224 
