### PR TITLE
fix: last inn brukerinnstillinger serverside

### DIFF
--- a/.changeset/happy-mice-laugh.md
+++ b/.changeset/happy-mice-laugh.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Det viser seg at `useReactiveGetCookies` ikke var så smart som jeg trodde, så for å unngå et flash av standardinnstillinger når siden lastes inn henter vi nå brukerinnstillingene på server og sender inn til komponentene _i tillegg til_ å hente dem "live" under bruk av siden.

--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -112,6 +112,7 @@ article header {
 
 .date {
     color: var(--jkl-color-text-subdued);
+    
     @include jkl.text-style("small");
     @include jkl.use-font-family("Fremtind Grotesk Mono");
 }

--- a/portal/src/app/(frontend)/komponenter/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/page.tsx
@@ -3,9 +3,14 @@ import { ComponentGrid } from "@/components/component-grid/ComponentGrid";
 import { PreferencesMenu } from "@/components/preferences-menu/PreferencesMenu";
 import { sanityFetch } from "@/sanity/lib/live";
 import { componentsQuery } from "@/sanity/queries/component";
-import { COMPONENT_KEYWORDS } from "@/utils/user-preferences";
+import {
+    COMPONENT_KEYWORDS,
+    parseUserPreferences,
+} from "@/utils/user-preferences";
 import { Flex } from "@fremtind/jokul/flex";
+import { getCookie } from "cookies-next";
 import { logger } from "logger";
+import { cookies } from "next/headers";
 import { FilterChip } from "./FilterChip";
 import styles from "./komponenter.module.scss";
 
@@ -30,6 +35,10 @@ export default async function Components({
             </>
         );
     }
+
+    const userPreferences = parseUserPreferences(
+        await getCookie("userPreferences", { cookies }),
+    );
 
     const { keywords } = await searchParams;
     const selectedKeywords = (keywords || "").split(",");
@@ -65,10 +74,13 @@ export default async function Components({
                 </Flex>
                 <PreferencesMenu />
             </Flex>
-            <ComponentGrid>
+            <ComponentGrid initialPreferences={userPreferences}>
                 {components.map((component) => (
                     <li key={component.slug}>
-                        <ComponentCard component={component} />
+                        <ComponentCard
+                            component={component}
+                            initialPreferences={userPreferences}
+                        />
                     </li>
                 ))}
             </ComponentGrid>

--- a/portal/src/components/component-card/ComponentCard.tsx
+++ b/portal/src/components/component-card/ComponentCard.tsx
@@ -3,7 +3,10 @@
 import { ComponentThumbnail } from "@/components/component-card/ComponentThumbnail";
 import { client } from "@/sanity/lib/client";
 import type { ComponentsQueryResult } from "@/sanity/types";
-import { useUserPreferences } from "@/utils/user-preferences";
+import {
+    type UserPreferences,
+    useUserPreferences,
+} from "@/utils/user-preferences";
 import { Card } from "@fremtind/jokul/card";
 import imageUrlBuilder from "@sanity/image-url";
 import NextLink from "next/link";
@@ -12,6 +15,7 @@ import styles from "./component-card.module.scss";
 
 type ComponentCardProps = {
     component: ComponentsQueryResult[0] | null;
+    initialPreferences?: UserPreferences;
 };
 
 const builder = imageUrlBuilder(client);
@@ -20,8 +24,11 @@ function urlFor(source?: { asset?: { _ref: string }; _type: string }) {
     return source?.asset?._ref ? builder.image(source).url() : undefined;
 }
 
-export const ComponentCard = ({ component }: ComponentCardProps) => {
-    const { preferences } = useUserPreferences();
+export const ComponentCard = ({
+    component,
+    initialPreferences,
+}: ComponentCardProps) => {
+    const { preferences } = useUserPreferences(initialPreferences);
 
     if (!component) return null;
 

--- a/portal/src/components/component-grid/ComponentGrid.tsx
+++ b/portal/src/components/component-grid/ComponentGrid.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { useUserPreferences } from "@/utils/user-preferences";
+import {
+    type UserPreferences,
+    useUserPreferences,
+} from "@/utils/user-preferences";
 import styles from "./component-grid.module.scss";
 
 type ComponentGridProps = {
     children: React.ReactNode;
+    initialPreferences?: UserPreferences;
 };
 
-export function ComponentGrid({ children }: ComponentGridProps) {
-    const { preferences } = useUserPreferences();
+export function ComponentGrid({
+    children,
+    initialPreferences,
+}: ComponentGridProps) {
+    const { preferences } = useUserPreferences(initialPreferences);
 
     return (
         <ul

--- a/portal/src/utils/user-preferences.ts
+++ b/portal/src/utils/user-preferences.ts
@@ -29,24 +29,28 @@ export const defaultPreferences: UserPreferences = {
 
 export function parseUserPreferences(
     cookieValue: CookieValueTypes,
+    fallback = defaultPreferences,
 ): UserPreferences {
     if (!cookieValue) {
-        return defaultPreferences;
+        return fallback;
     }
 
     try {
         return JSON.parse(decodeURIComponent(cookieValue)) as UserPreferences;
     } catch (error) {
         console.error("Error parsing user preferences from cookie:", error);
-        return defaultPreferences;
+        return fallback;
     }
 }
 
-export function useUserPreferences() {
+export function useUserPreferences(initialPreferences?: UserPreferences) {
     const getCookie = useReactiveGetCookie();
     const setCookie = useReactiveSetCookie();
 
-    const preferences = parseUserPreferences(getCookie("userPreferences"));
+    const preferences = parseUserPreferences(
+        getCookie("userPreferences"),
+        initialPreferences,
+    );
 
     const updatePreference = <T extends keyof UserPreferences>(
         key: T,


### PR DESCRIPTION
## 💬 Endringer

Det viser seg at `useReactiveGetCookies` ikke var så smart som jeg trodde, så for å unngå et flash av standardinnstillinger når siden lastes inn henter vi nå brukerinnstillingene på server og sender inn til komponentene _i tillegg til_ å hente dem "live" under bruk av siden.
