### PR TITLE
fix?: deprecation notation

### DIFF
--- a/.changeset/famous-eels-divide.md
+++ b/.changeset/famous-eels-divide.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Merker IconButton og egne komponenter for Primary, Secondary, Tertiary og Ghost button som deprecated. Legger også til en tekst om at Tertiary-varianten er tenkt fjernet i fremtinden fordi den ligner veldig på en lenke

--- a/packages/jokul/src/components/button/Button.tsx
+++ b/packages/jokul/src/components/button/Button.tsx
@@ -75,6 +75,9 @@ export const Button = React.forwardRef(function Button<
     );
 }) as ButtonComponent;
 
+/**
+ * @deprecated bruk heller {@link Button} med ghost-varianten
+ */
 export function PrimaryButton<ElementType extends React.ElementType = "button">(
     props: Omit<ButtonProps<ElementType>, "variant" | "onClick" | "as"> &
         Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">,
@@ -86,6 +89,9 @@ export function PrimaryButton<ElementType extends React.ElementType = "button">(
     return <Button {...buttonProps} />;
 }
 
+/**
+ * @deprecated bruk heller {@link Button} med ghost-varianten
+ */
 export function SecondaryButton<
     ElementType extends React.ElementType = "button",
 >(
@@ -99,6 +105,9 @@ export function SecondaryButton<
     return <Button {...buttonProps} />;
 }
 
+/**
+ * @deprecated bruk heller {@link Button} med ghost-varianten
+ */
 export function TertiaryButton<
     ElementType extends React.ElementType = "button",
 >(
@@ -112,6 +121,9 @@ export function TertiaryButton<
     return <Button {...buttonProps} />;
 }
 
+/**
+ * @deprecated bruk heller {@link Button} med ghost-varianten
+ */
 export function GhostButton<ElementType extends React.ElementType = "button">(
     props: Omit<ButtonProps<ElementType>, "variant" | "loader">,
 ) {

--- a/packages/jokul/src/components/button/stories/Button.stories.tsx
+++ b/packages/jokul/src/components/button/stories/Button.stories.tsx
@@ -11,48 +11,43 @@ const meta = {
             toc: true,
         },
     },
+    args: {
+        type: "button",
+        children: "Knapp",
+        variant: "secondary",
+        loader: {
+            showLoader: false,
+            textDescription: "laster inn",
+        },
+    },
     tags: ["autodocs", "forms"],
 } satisfies Meta<typeof ButtonComponent>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const baseArgs = {
-    type: "submit",
-    children: "Knapp",
-    loader: {
-        showLoader: false,
-        textDescription: "laster inn",
-    },
-};
-export const Button: Story = {
-    args: baseArgs,
-};
+export const Button: Story = {};
 
 export const PrimaryButton: Story = {
     args: {
-        ...baseArgs,
         variant: "primary",
     },
 };
 
 export const SecondaryButton: Story = {
     args: {
-        ...baseArgs,
         variant: "secondary",
     },
 };
 
 export const TertiaryButton: Story = {
     args: {
-        ...baseArgs,
         variant: "tertiary",
     },
 };
 
 export const GhostButton: Story = {
     args: {
-        ...baseArgs,
         variant: "ghost",
     },
 };

--- a/packages/jokul/src/components/button/types.ts
+++ b/packages/jokul/src/components/button/types.ts
@@ -32,7 +32,7 @@ export type IconOptions =
 type Props = {
     density?: Density;
     /**
-     * Hvilken variant av knappen skal vises
+     * Hvilken variant av knappen skal vises. Tertiary er planlagt fjernet fordi den ligner for mye på en lenke.
      * @default "secondary"
      */
     variant?: ButtonVariant;

--- a/packages/jokul/src/components/icon-button/IconButton.tsx
+++ b/packages/jokul/src/components/icon-button/IconButton.tsx
@@ -2,6 +2,9 @@ import clsx from "clsx";
 import React, { forwardRef } from "react";
 import type { IconButtonProps } from "./types.js";
 
+/**
+ * @deprecated bruk heller {@link Button} med ghost-varianten
+ */
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     (props, ref) => {
         const { className, children, density, ...rest } = props;


### PR DESCRIPTION
- Merker IconButton og egne komponenter for Primary, Secondary, Tertiary og Ghost button som deprecated. 
- Legger også til en tekst om at Tertiary-varianten er tenkt fjernet i fremtinden fordi den ligner veldig på en lenke.