### PR TITLE
Legg til mulighet for CardImage som fyller hele kortet

### DIFF
--- a/.changeset/shaky-regions-check.md
+++ b/.changeset/shaky-regions-check.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+CardImage har fått muligheten til å blø ut i alle kanter av kortet det er plassert i, dersom det ikke er annet innhold i kortet. Sett `placement` til `full` for å bruke komponenten på denne måten.

--- a/packages/jokul/src/components/card/CardImage.tsx
+++ b/packages/jokul/src/components/card/CardImage.tsx
@@ -14,9 +14,10 @@ export type CardImageProps<ElementType extends React.ElementType> =
             /**
              * Legger til riktig negativ margin avhengig av hvor i kortet bildet
              * skal plasseres. Margin justeres automatisk etter padding i kortet.
+             * Velg "full" hvis bildet skal være eneste innhold i kortet.
              * @default "top"
              */
-            placement?: "top" | "middle" | "bottom";
+            placement?: "top" | "middle" | "bottom" | "full";
         }
     >;
 

--- a/packages/jokul/src/components/card/stories/Card.stories.tsx
+++ b/packages/jokul/src/components/card/stories/Card.stories.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import { CardImage } from "../../card/CardImage.js";
 import { Flex } from "../../flex/index.js";
 import { CheckIcon, CopyIcon } from "../../icon/index.js";
+import { Image } from "../../image/Image.jsx";
 import { InfoTag } from "../../tag/index.js";
 import { Card } from "../Card.js";
 import { CARD_PADDINGS, CARD_VARIANTS } from "../types.js";
+
 import "../styles/_index.scss";
 
 const dog1200 = "/images/dog-1200.jpg";
@@ -171,6 +173,23 @@ export const LinkCard: Story = {
             <Flex>
                 <p>311 kr/mnd</p>
             </Flex>
+        </Card>
+    ),
+};
+
+export const FullImageCard: Story = {
+    name: "Card med heldekkende bilde",
+    args: {
+        children: null,
+    },
+    render: (args) => (
+        <Card {...args} style={{ width: "500px" }}>
+            <CardImage
+                as={Image}
+                src={dog1200}
+                alt="En hund"
+                placement="full"
+            />
         </Card>
     ),
 };

--- a/packages/jokul/src/components/card/styles/card.scss
+++ b/packages/jokul/src/components/card/styles/card.scss
@@ -82,9 +82,7 @@
 }
 
 .jkl-card-image {
-    --margin: calc(
-        var(--padding, 0) * -1
-    ); // Sett negativ margin tilsvarende padding (fra Card)
+    --margin: calc(var(--padding, 0) * -1); // Sett negativ margin tilsvarende padding (fra Card)
 
     width: calc(100% + 2 * var(--padding, 0));
     aspect-ratio: var(--image-aspect-ratio, 3/2);
@@ -96,5 +94,9 @@
 
     &--bottom {
         margin-bottom: var(--margin, 0);
+    }
+
+    &--full {
+        margin-block: var(--margin, 0);
     }
 }


### PR DESCRIPTION
## 💬 Endringer

CardImage har fått muligheten til å blø ut i alle kanter av kortet det er plassert i, dersom det ikke er annet innhold i kortet. Sett `placement` til `full` for å bruke komponenten på denne måten.

