### PR TITLE
Legg til lenke til komponentsider i komponentdok.

### DIFF
--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import { ComponentCard } from "@/components/component-card/ComponentCard";
 import { ComponentConsiderations } from "@/app/(frontend)/komponenter/[slug]/components/ComponentConsiderations";
 import { ComponentExampleCard } from "@/app/(frontend)/komponenter/[slug]/components/ComponentExampleCard";
 import { PageFooter } from "@/components/PageFooter";
+import { ComponentCard } from "@/components/component-card/ComponentCard";
 import { PortableText } from "@/components/portable-text/PortableText";
 import { client } from "@/sanity/lib/client";
 import { sanityFetch } from "@/sanity/lib/live";
@@ -173,6 +173,7 @@ export default async function Page({ params }: Props) {
                                             (relatedComponent) => (
                                                 <li key={relatedComponent.slug}>
                                                     <ComponentCard
+                                                        // @ts-expect-error Typene her er fortsatt ikke 100% i sync, men alt som trengs stemmer
                                                         component={
                                                             relatedComponent
                                                         }

--- a/portal/src/components/component-card/ComponentCard.tsx
+++ b/portal/src/components/component-card/ComponentCard.tsx
@@ -1,28 +1,24 @@
 "use client";
 
 import { ComponentThumbnail } from "@/components/component-card/ComponentThumbnail";
-import { client } from "@/sanity/lib/client";
-import type { ComponentsQueryResult } from "@/sanity/types";
+import type { ComponentBySlugQueryResult } from "@/sanity/types";
 import {
     type UserPreferences,
     useUserPreferences,
 } from "@/utils/user-preferences";
 import { Card } from "@fremtind/jokul/card";
-import imageUrlBuilder from "@sanity/image-url";
+import type { SanityImageObject } from "@sanity/image-url/lib/types/types";
 import NextLink from "next/link";
 
 import styles from "./component-card.module.scss";
 
 type ComponentCardProps = {
-    component: ComponentsQueryResult[0] | null;
+    component: Pick<
+        NonNullable<ComponentBySlugQueryResult>,
+        "image" | "imageDark" | "name" | "slug" | "short_description"
+    > | null;
     initialPreferences?: UserPreferences;
 };
-
-const builder = imageUrlBuilder(client);
-
-function urlFor(source?: { asset?: { _ref: string }; _type: string }) {
-    return source?.asset?._ref ? builder.image(source).url() : undefined;
-}
 
 export const ComponentCard = ({
     component,
@@ -31,21 +27,6 @@ export const ComponentCard = ({
     const { preferences } = useUserPreferences(initialPreferences);
 
     if (!component) return null;
-
-    // Bruk placeholderbilde midlertidig, mens vi finner ut av problemene
-    // med å hente figma-bilder under bygging av applikasjonen.
-    // Bruk getFigmaImageUrls for å hente figma-bilder når det er fikset.
-    const [fallbackLight, fallbackDark] = [
-        "/component_placeholder_light.svg",
-        "/component_placeholder_dark.svg",
-    ];
-
-    const imageLightUrl = component.image
-        ? urlFor(component.image)
-        : fallbackLight;
-    const imageDarkUrl = component.imageDark
-        ? urlFor(component.imageDark)
-        : fallbackDark;
 
     return (
         <Card
@@ -65,12 +46,12 @@ export const ComponentCard = ({
                     {component.short_description}
                 </p>
             )}
-            {preferences.showComponentImage && imageDarkUrl && imageLightUrl ? (
+            {preferences.showComponentImage && (
                 <ComponentThumbnail
-                    darkImage={imageDarkUrl}
-                    lightImage={imageLightUrl}
+                    darkImage={component.imageDark as SanityImageObject}
+                    lightImage={component.image as SanityImageObject}
                 />
-            ) : null}
+            )}
         </Card>
     );
 };

--- a/portal/src/components/component-card/ComponentThumbnail.tsx
+++ b/portal/src/components/component-card/ComponentThumbnail.tsx
@@ -1,23 +1,41 @@
 "use client";
 
-import { Card, CardImage } from "@fremtind/jokul/card";
+import { client } from "@/sanity/lib/client";
+import imageUrlBuilder from "@sanity/image-url";
+import type { SanityImageObject } from "@sanity/image-url/lib/types/types";
+
 import styles from "./component-card.module.scss";
 
+const builder = imageUrlBuilder(client);
+
+// Bruk placeholderbilde midlertidig, mens vi finner ut av problemene
+// med å hente figma-bilder under bygging av applikasjonen.
+// Bruk getFigmaImageUrls for å hente figma-bilder når det er fikset.
+const [fallbackLight, fallbackDark] = [
+    "/component_placeholder_light.svg",
+    "/component_placeholder_dark.svg",
+];
+
+function urlFor(source?: SanityImageObject | null) {
+    return source?.asset?._ref ? builder.image(source).url() : undefined;
+}
+
 type Props = {
-    lightImage: string;
-    darkImage: string;
+    lightImage?: SanityImageObject | null;
+    darkImage?: SanityImageObject | null;
 };
 
 export function ComponentThumbnail({ darkImage, lightImage }: Props) {
+    const imageLightUrl = urlFor(lightImage) || fallbackLight;
+    const imageDarkUrl = urlFor(darkImage) || fallbackDark;
+
     return (
-        <Card variant="high" className={styles.image}>
-            <picture>
-                <source
-                    media="(prefers-color-scheme: dark)"
-                    srcSet={darkImage}
-                />
-                <CardImage as="img" placement="top" src={lightImage} alt="" />
-            </picture>
-        </Card>
+        <picture className={styles.componentThumbnail}>
+            <source
+                media="(prefers-color-scheme: dark)"
+                srcSet={imageDarkUrl}
+            />
+            <img src={imageLightUrl} alt="" />
+        </picture>
     );
 }

--- a/portal/src/components/component-card/component-card.module.scss
+++ b/portal/src/components/component-card/component-card.module.scss
@@ -5,7 +5,7 @@
 
     display: flex;
     flex-direction: column;
-    color: var(--color-text);
+    color: var(--jkl-color-text-default);
 
 
     .name {
@@ -27,13 +27,20 @@
         }
     }
 
-    .image {
-        aspect-ratio: var(--aspect-ratio);
-        margin-top: var(--jkl-spacing-16);
+}
 
-        img {
-            object-fit: cover;
-            aspect-ratio: var(--aspect-ratio);
-        }
+.componentThumbnail {
+    height: auto;
+    width: 100%;
+    aspect-ratio: var(--aspect-ratio);
+    overflow: hidden;
+
+    img {
+        margin-block-start: var(--jkl-unit-20);
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+        object-position: center;
+        aspect-ratio: inherit;
     }
 }

--- a/portal/src/components/portable-text/link/ComponentPageLink.tsx
+++ b/portal/src/components/portable-text/link/ComponentPageLink.tsx
@@ -1,22 +1,102 @@
-import type { Slug } from "@/sanity/types";
+"use client";
+
+import { ComponentThumbnail } from "@/components/component-card/ComponentThumbnail";
+import type { ComponentBySlugQueryResult } from "@/sanity/types";
+import { Card } from "@fremtind/jokul/card";
 import { Link } from "@fremtind/jokul/link";
+import type { SanityImageObject } from "@sanity/image-url/lib/types/types";
+import clsx from "clsx";
 import type { PortableTextMarkComponentProps } from "next-sanity";
 import NextLink from "next/link";
+import { useId, useRef } from "react";
+import { createPortal } from "react-dom";
+
+import componentCard from "../../component-card/component-card.module.scss";
+import style from "./component-page-link.module.scss";
 
 type LinkProps = PortableTextMarkComponentProps<{
     _type: "componentPageLink";
-    component: {
-        name: string;
-        slug: Slug;
-    };
+    component: NonNullable<ComponentBySlugQueryResult>;
 }>;
 
 export const ComponentPageLink = ({ value, children }: LinkProps) => {
-    if (!value) return null;
+    const id = useId();
+    const popoverRef = useRef<HTMLDivElement>(null);
+    const linkRef = useRef<HTMLAnchorElement>(null);
+
+    let openTimeout: NodeJS.Timeout;
+    let closeTimeout: NodeJS.Timeout;
+
+    const openPopover = () => {
+        openTimeout = setTimeout(
+            // @ts-ignore Joda, source finnes: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover#source
+            () => popoverRef.current?.showPopover({ source: linkRef.current }),
+            150,
+        );
+    };
+
+    const closePopover = () => {
+        clearTimeout(openTimeout);
+        closeTimeout = setTimeout(() => popoverRef.current?.hidePopover(), 250);
+    };
+
+    const cancelClose = () => {
+        clearTimeout(closeTimeout);
+    };
+
+    if (!value?.component) return null;
+
+    const slug = value.component.slug || "#";
+    const { image, imageDark, name, short_description } = value.component;
 
     return (
-        <Link as={NextLink} href={value.component.slug.current || "#"}>
-            {children}
-        </Link>
+        <>
+            <Link
+                ref={linkRef}
+                // @ts-ignore
+                style={{ anchorName: `--${slug}-${id}-trigger` }}
+                id={`${slug}-${id}-trigger`}
+                as={NextLink}
+                href={slug}
+                onFocus={openPopover}
+                onMouseEnter={openPopover}
+                onBlur={closePopover}
+                onMouseLeave={closePopover}
+            >
+                {value.component.name || children}
+            </Link>
+            {createPortal(
+                <Card
+                    as="div"
+                    padding="m"
+                    className={clsx(
+                        componentCard.componentCard,
+                        style.componentPageLinkPopover,
+                    )}
+                    ref={popoverRef}
+                    id={`${slug}-${id}-popover`}
+                    // @ts-ignore
+                    popover="auto"
+                    // @ts-ignore
+                    style={{ positionAnchor: `--${slug}-${id}-trigger` }}
+                    onMouseEnter={cancelClose}
+                    onFocus={cancelClose}
+                    onMouseLeave={closePopover}
+                    onBlur={closePopover}
+                >
+                    <p className={componentCard.name}>{name}</p>
+                    <p className={componentCard.description}>
+                        {short_description}
+                    </p>
+                    <ComponentThumbnail
+                        darkImage={imageDark as SanityImageObject}
+                        lightImage={image as SanityImageObject}
+                    />
+                </Card>,
+                // Vi rendrer popoveren rett i body for å unngå å legge
+                // et div-element inne i et p-element (som ikke er lov)
+                document.body,
+            )}
+        </>
     );
 };

--- a/portal/src/components/portable-text/link/component-page-link.module.scss
+++ b/portal/src/components/portable-text/link/component-page-link.module.scss
@@ -1,0 +1,16 @@
+@use "@fremtind/jokul/styles/core/jkl";
+
+.componentPageLinkPopover {
+    display: none;
+    position: fixed;
+    border: none;
+    max-width: 30rch;
+    position-area: top center;
+    position-try: top, bottom, right, left;
+    margin: var(--jkl-unit-10);
+    box-shadow: jkl.$shadow-navigation--hover;
+
+    &:popover-open {
+        display: block;
+    }
+}

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -1,2444 +1,2467 @@
 [
-  {
-    "name": "sanity.imagePaletteSwatch",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imagePaletteSwatch"
-          }
-        },
-        "background": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "foreground": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "population": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "title": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imagePalette",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imagePalette"
-          }
-        },
-        "darkMuted": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "lightVibrant": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "darkVibrant": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "vibrant": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "dominant": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "lightMuted": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        },
-        "muted": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePaletteSwatch"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageDimensions",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageDimensions"
-          }
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "aspectRatio": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.fileAsset",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
+    {
+        "name": "sanity.imagePaletteSwatch",
+        "type": "type",
         "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "sanity.fileAsset"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "originalFilename": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "label": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "altText": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "sha1hash": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "extension": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "mimeType": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "size": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "assetId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "uploadId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "path": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "url": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "source": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "sanity.assetSourceData"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "geopoint",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "geopoint"
-          }
-        },
-        "lat": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "lng": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "alt": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_linkCard",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_linkCard"
-          }
-        },
-        "external_links": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "title": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  },
-                  "optional": true
-                },
-                "description": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  },
-                  "optional": true
-                },
-                "url": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  },
-                  "optional": true
-                },
-                "_type": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string",
-                    "value": "link"
-                  }
-                }
-              },
-              "rest": {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_componentKortFortalt",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_componentKortFortalt"
-          }
-        },
-        "bruk": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "bruk_punkt": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "array",
-                    "of": {
-                      "type": "object",
-                      "attributes": {
-                        "children": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "array",
-                            "of": {
-                              "type": "object",
-                              "attributes": {
-                                "marks": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "array",
-                                    "of": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "optional": true
-                                },
-                                "text": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string"
-                                  },
-                                  "optional": true
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "span"
-                                  }
-                                }
-                              },
-                              "rest": {
-                                "type": "object",
-                                "attributes": {
-                                  "_key": {
-                                    "type": "objectAttribute",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "optional": true
-                        },
-                        "style": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "union",
-                            "of": [
-                              {
-                                "type": "string",
-                                "value": "normal"
-                              }
-                            ]
-                          },
-                          "optional": true
-                        },
-                        "listItem": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "union",
-                            "of": []
-                          },
-                          "optional": true
-                        },
-                        "markDefs": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "array",
-                            "of": {
-                              "type": "object",
-                              "attributes": {
-                                "component": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "object",
-                                    "attributes": {
-                                      "_ref": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "_type": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string",
-                                          "value": "reference"
-                                        }
-                                      },
-                                      "_weak": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "boolean"
-                                        },
-                                        "optional": true
-                                      }
-                                    },
-                                    "dereferencesTo": "jokul_component"
-                                  },
-                                  "optional": true
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "componentPageLink"
-                                  }
-                                }
-                              },
-                              "rest": {
-                                "type": "object",
-                                "attributes": {
-                                  "_key": {
-                                    "type": "objectAttribute",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "optional": true
-                        },
-                        "level": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "number"
-                          },
-                          "optional": true
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "block"
-                          }
-                        }
-                      },
-                      "rest": {
-                        "type": "object",
-                        "attributes": {
-                          "_key": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "optional": true
-                }
-              },
-              "rest": {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "optional": true
-        },
-        "ikke_bruk": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "ikke_bruk_punkt": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "array",
-                    "of": {
-                      "type": "object",
-                      "attributes": {
-                        "children": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "array",
-                            "of": {
-                              "type": "object",
-                              "attributes": {
-                                "marks": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "array",
-                                    "of": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "optional": true
-                                },
-                                "text": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string"
-                                  },
-                                  "optional": true
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "span"
-                                  }
-                                }
-                              },
-                              "rest": {
-                                "type": "object",
-                                "attributes": {
-                                  "_key": {
-                                    "type": "objectAttribute",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "optional": true
-                        },
-                        "style": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "union",
-                            "of": [
-                              {
-                                "type": "string",
-                                "value": "normal"
-                              }
-                            ]
-                          },
-                          "optional": true
-                        },
-                        "listItem": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "union",
-                            "of": []
-                          },
-                          "optional": true
-                        },
-                        "markDefs": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "array",
-                            "of": {
-                              "type": "object",
-                              "attributes": {
-                                "component": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "object",
-                                    "attributes": {
-                                      "_ref": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "_type": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "string",
-                                          "value": "reference"
-                                        }
-                                      },
-                                      "_weak": {
-                                        "type": "objectAttribute",
-                                        "value": {
-                                          "type": "boolean"
-                                        },
-                                        "optional": true
-                                      }
-                                    },
-                                    "dereferencesTo": "jokul_component"
-                                  },
-                                  "optional": true
-                                },
-                                "_type": {
-                                  "type": "objectAttribute",
-                                  "value": {
-                                    "type": "string",
-                                    "value": "componentPageLink"
-                                  }
-                                }
-                              },
-                              "rest": {
-                                "type": "object",
-                                "attributes": {
-                                  "_key": {
-                                    "type": "objectAttribute",
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "optional": true
-                        },
-                        "level": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "number"
-                          },
-                          "optional": true
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "block"
-                          }
-                        }
-                      },
-                      "rest": {
-                        "type": "object",
-                        "attributes": {
-                          "_key": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "optional": true
-                }
-              },
-              "rest": {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_storybook",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_storybook"
-          }
-        },
-        "story": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "jokul_storybookStory"
-          },
-          "optional": true
-        },
-        "code": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "jokul_codeBlock"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_storybookStory",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_storybookStory"
-          }
-        },
-        "storyId": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "storyName": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_codeBlock",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_codeBlock"
-          }
-        },
-        "code": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "language": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "union",
-            "of": [
-              {
-                "type": "string",
-                "value": "scss"
-              },
-              {
-                "type": "string",
-                "value": "typescript"
-              }
-            ]
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_codeExample",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_codeExample"
-          }
-        },
-        "showEditor": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        },
-        "codeExample": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_componentProps",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "jokul_componentProps"
-          }
-        },
-        "componentFolder": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "jokul_blog_post",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "jokul_blog_post"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "slug": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "slug"
-        },
-        "optional": true
-      },
-      "short_description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "article": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "union",
-            "of": [
-              {
-                "type": "object",
-                "attributes": {
-                  "children": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "marks": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "array",
-                              "of": {
-                                "type": "string"
-                              }
-                            },
-                            "optional": true
-                          },
-                          "text": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "span"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "style": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "normal"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h1"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h2"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h3"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h4"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h5"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h6"
-                        },
-                        {
-                          "type": "string",
-                          "value": "blockquote"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "listItem": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "bullet"
-                        },
-                        {
-                          "type": "string",
-                          "value": "number"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "markDefs": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "href": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "link"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "level": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "number"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "block"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_linkCard"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "asset": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "sanity.imageAsset"
-                    },
-                    "optional": true
-                  },
-                  "media": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "unknown"
-                    },
-                    "optional": true
-                  },
-                  "hotspot": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageHotspot"
-                    },
-                    "optional": true
-                  },
-                  "crop": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageCrop"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "image"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_codeBlock"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_storybook"
-                }
-              }
-            ]
-          }
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "jokul_component",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "jokul_component"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "slug": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "slug"
-        },
-        "optional": true
-      },
-      "short_description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "status": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "string"
-          }
-        },
-        "optional": true
-      },
-      "keywords": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "string"
-          }
-        },
-        "optional": true
-      },
-      "example_card": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
-                },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "considerations": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
             "type": "object",
             "attributes": {
-              "title": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "description": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                },
-                "optional": true
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "consideration"
-                }
-              }
-            },
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "documentation_article": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "union",
-            "of": [
-              {
-                "type": "object",
-                "attributes": {
-                  "children": {
+                "_type": {
                     "type": "objectAttribute",
                     "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "marks": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "array",
-                              "of": {
-                                "type": "string"
-                              }
-                            },
-                            "optional": true
-                          },
-                          "text": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "span"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "style": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "normal"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h1"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h2"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h3"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h4"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h5"
-                        },
-                        {
-                          "type": "string",
-                          "value": "h6"
-                        },
-                        {
-                          "type": "string",
-                          "value": "blockquote"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "listItem": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "union",
-                      "of": [
-                        {
-                          "type": "string",
-                          "value": "bullet"
-                        },
-                        {
-                          "type": "string",
-                          "value": "number"
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  "markDefs": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "array",
-                      "of": {
-                        "type": "object",
-                        "attributes": {
-                          "href": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            },
-                            "optional": true
-                          },
-                          "_type": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string",
-                              "value": "link"
-                            }
-                          }
-                        },
-                        "rest": {
-                          "type": "object",
-                          "attributes": {
-                            "_key": {
-                              "type": "objectAttribute",
-                              "value": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "optional": true
-                  },
-                  "level": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "number"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "block"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "asset": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "sanity.imageAsset"
-                    },
-                    "optional": true
-                  },
-                  "media": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "unknown"
-                    },
-                    "optional": true
-                  },
-                  "hotspot": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageHotspot"
-                    },
-                    "optional": true
-                  },
-                  "crop": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageCrop"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "image"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "object",
-                  "attributes": {
-                    "_key": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_componentProps"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_componentKortFortalt"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_codeExample"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_storybook"
-                }
-              },
-              {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "rest": {
-                  "type": "inline",
-                  "name": "jokul_codeBlock"
-                }
-              }
-            ]
-          }
-        },
-        "optional": true
-      },
-      "related_components": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "components": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "array",
-                "of": {
-                  "type": "object",
-                  "attributes": {
-                    "_ref": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "string"
-                      }
-                    },
-                    "_type": {
-                      "type": "objectAttribute",
-                      "value": {
                         "type": "string",
-                        "value": "reference"
-                      }
-                    },
-                    "_weak": {
-                      "type": "objectAttribute",
-                      "value": {
-                        "type": "boolean"
-                      },
-                      "optional": true
+                        "value": "sanity.imagePaletteSwatch"
                     }
-                  },
-                  "dereferencesTo": "jokul_component",
-                  "rest": {
+                },
+                "background": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "foreground": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "population": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "title": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "sanity.imagePalette",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "sanity.imagePalette"
+                    }
+                },
+                "darkMuted": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "lightVibrant": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "darkVibrant": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "vibrant": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "dominant": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "lightMuted": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                },
+                "muted": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePaletteSwatch"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "sanity.imageDimensions",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "sanity.imageDimensions"
+                    }
+                },
+                "height": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "width": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "aspectRatio": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "sanity.fileAsset",
+        "type": "document",
+        "attributes": {
+            "_id": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_type": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string",
+                    "value": "sanity.fileAsset"
+                }
+            },
+            "_createdAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_updatedAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_rev": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "originalFilename": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "label": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "title": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "description": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "altText": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "sha1hash": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "extension": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "mimeType": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "size": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "number"
+                },
+                "optional": true
+            },
+            "assetId": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "uploadId": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "path": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "url": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "source": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "inline",
+                    "name": "sanity.assetSourceData"
+                },
+                "optional": true
+            }
+        }
+    },
+    {
+        "name": "geopoint",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "geopoint"
+                    }
+                },
+                "lat": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "lng": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "alt": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_linkCard",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_linkCard"
+                    }
+                },
+                "external_links": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "array",
+                        "of": {
+                            "type": "object",
+                            "attributes": {
+                                "title": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "string"
+                                    },
+                                    "optional": true
+                                },
+                                "description": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "string"
+                                    },
+                                    "optional": true
+                                },
+                                "url": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "string"
+                                    },
+                                    "optional": true
+                                },
+                                "_type": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "string",
+                                        "value": "link"
+                                    }
+                                }
+                            },
+                            "rest": {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_componentKortFortalt",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_componentKortFortalt"
+                    }
+                },
+                "bruk": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "array",
+                        "of": {
+                            "type": "object",
+                            "attributes": {
+                                "bruk_punkt": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "array",
+                                        "of": {
+                                            "type": "object",
+                                            "attributes": {
+                                                "children": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "array",
+                                                        "of": {
+                                                            "type": "object",
+                                                            "attributes": {
+                                                                "marks": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "array",
+                                                                        "of": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "text": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "_type": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string",
+                                                                        "value": "span"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "rest": {
+                                                                "type": "object",
+                                                                "attributes": {
+                                                                    "_key": {
+                                                                        "type": "objectAttribute",
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "style": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "union",
+                                                        "of": [
+                                                            {
+                                                                "type": "string",
+                                                                "value": "normal"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "listItem": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "union",
+                                                        "of": []
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "markDefs": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "array",
+                                                        "of": {
+                                                            "type": "object",
+                                                            "attributes": {
+                                                                "component": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "object",
+                                                                        "attributes": {
+                                                                            "_ref": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "_type": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "string",
+                                                                                    "value": "reference"
+                                                                                }
+                                                                            },
+                                                                            "_weak": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "optional": true
+                                                                            }
+                                                                        },
+                                                                        "dereferencesTo": "jokul_component"
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "_type": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string",
+                                                                        "value": "componentPageLink"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "rest": {
+                                                                "type": "object",
+                                                                "attributes": {
+                                                                    "_key": {
+                                                                        "type": "objectAttribute",
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "level": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "number"
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string",
+                                                        "value": "block"
+                                                    }
+                                                }
+                                            },
+                                            "rest": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "_key": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "optional": true
+                                }
+                            },
+                            "rest": {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "optional": true
+                },
+                "ikke_bruk": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "array",
+                        "of": {
+                            "type": "object",
+                            "attributes": {
+                                "ikke_bruk_punkt": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "array",
+                                        "of": {
+                                            "type": "object",
+                                            "attributes": {
+                                                "children": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "array",
+                                                        "of": {
+                                                            "type": "object",
+                                                            "attributes": {
+                                                                "marks": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "array",
+                                                                        "of": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "text": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "_type": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string",
+                                                                        "value": "span"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "rest": {
+                                                                "type": "object",
+                                                                "attributes": {
+                                                                    "_key": {
+                                                                        "type": "objectAttribute",
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "style": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "union",
+                                                        "of": [
+                                                            {
+                                                                "type": "string",
+                                                                "value": "normal"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "listItem": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "union",
+                                                        "of": []
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "markDefs": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "array",
+                                                        "of": {
+                                                            "type": "object",
+                                                            "attributes": {
+                                                                "component": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "object",
+                                                                        "attributes": {
+                                                                            "_ref": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "_type": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "string",
+                                                                                    "value": "reference"
+                                                                                }
+                                                                            },
+                                                                            "_weak": {
+                                                                                "type": "objectAttribute",
+                                                                                "value": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "optional": true
+                                                                            }
+                                                                        },
+                                                                        "dereferencesTo": "jokul_component"
+                                                                    },
+                                                                    "optional": true
+                                                                },
+                                                                "_type": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string",
+                                                                        "value": "componentPageLink"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "rest": {
+                                                                "type": "object",
+                                                                "attributes": {
+                                                                    "_key": {
+                                                                        "type": "objectAttribute",
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "level": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "number"
+                                                    },
+                                                    "optional": true
+                                                },
+                                                "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string",
+                                                        "value": "block"
+                                                    }
+                                                }
+                                            },
+                                            "rest": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "_key": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "optional": true
+                                }
+                            },
+                            "rest": {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_storybook",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_storybook"
+                    }
+                },
+                "story": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "jokul_storybookStory"
+                    },
+                    "optional": true
+                },
+                "code": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "jokul_codeBlock"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_storybookStory",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_storybookStory"
+                    }
+                },
+                "storyId": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "storyName": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_codeBlock",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_codeBlock"
+                    }
+                },
+                "code": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "language": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "union",
+                        "of": [
+                            {
+                                "type": "string",
+                                "value": "scss"
+                            },
+                            {
+                                "type": "string",
+                                "value": "typescript"
+                            }
+                        ]
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_codeExample",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_codeExample"
+                    }
+                },
+                "showEditor": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "boolean"
+                    },
+                    "optional": true
+                },
+                "codeExample": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_componentProps",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "jokul_componentProps"
+                    }
+                },
+                "componentFolder": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "jokul_blog_post",
+        "type": "document",
+        "attributes": {
+            "_id": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_type": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string",
+                    "value": "jokul_blog_post"
+                }
+            },
+            "_createdAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_updatedAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_rev": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "name": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "slug": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "inline",
+                    "name": "slug"
+                },
+                "optional": true
+            },
+            "short_description": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "article": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "array",
+                    "of": {
+                        "type": "union",
+                        "of": [
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "children": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "array",
+                                            "of": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "marks": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "array",
+                                                            "of": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "text": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string"
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "_type": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string",
+                                                            "value": "span"
+                                                        }
+                                                    }
+                                                },
+                                                "rest": {
+                                                    "type": "object",
+                                                    "attributes": {
+                                                        "_key": {
+                                                            "type": "objectAttribute",
+                                                            "value": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "optional": true
+                                    },
+                                    "style": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "union",
+                                            "of": [
+                                                {
+                                                    "type": "string",
+                                                    "value": "normal"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h1"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h2"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h3"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h4"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h5"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h6"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "blockquote"
+                                                }
+                                            ]
+                                        },
+                                        "optional": true
+                                    },
+                                    "listItem": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "union",
+                                            "of": [
+                                                {
+                                                    "type": "string",
+                                                    "value": "bullet"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "number"
+                                                }
+                                            ]
+                                        },
+                                        "optional": true
+                                    },
+                                    "markDefs": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "array",
+                                            "of": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "href": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string"
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "_type": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string",
+                                                            "value": "link"
+                                                        }
+                                                    }
+                                                },
+                                                "rest": {
+                                                    "type": "object",
+                                                    "attributes": {
+                                                        "_key": {
+                                                            "type": "objectAttribute",
+                                                            "value": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "optional": true
+                                    },
+                                    "level": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "optional": true
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "block"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "object",
+                                    "attributes": {
+                                        "_key": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_linkCard"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "asset": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "object",
+                                            "attributes": {
+                                                "_ref": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string",
+                                                        "value": "reference"
+                                                    }
+                                                },
+                                                "_weak": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "optional": true
+                                                }
+                                            },
+                                            "dereferencesTo": "sanity.imageAsset"
+                                        },
+                                        "optional": true
+                                    },
+                                    "media": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "unknown"
+                                        },
+                                        "optional": true
+                                    },
+                                    "hotspot": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "inline",
+                                            "name": "sanity.imageHotspot"
+                                        },
+                                        "optional": true
+                                    },
+                                    "crop": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "inline",
+                                            "name": "sanity.imageCrop"
+                                        },
+                                        "optional": true
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "image"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "object",
+                                    "attributes": {
+                                        "_key": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_codeBlock"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_storybook"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "optional": true
+            }
+        }
+    },
+    {
+        "name": "jokul_component",
+        "type": "document",
+        "attributes": {
+            "_id": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_type": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string",
+                    "value": "jokul_component"
+                }
+            },
+            "_createdAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_updatedAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_rev": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "name": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "slug": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "inline",
+                    "name": "slug"
+                },
+                "optional": true
+            },
+            "short_description": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "status": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "array",
+                    "of": {
+                        "type": "string"
+                    }
+                },
+                "optional": true
+            },
+            "keywords": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "array",
+                    "of": {
+                        "type": "string"
+                    }
+                },
+                "optional": true
+            },
+            "example_card": {
+                "type": "objectAttribute",
+                "value": {
                     "type": "object",
                     "attributes": {
-                      "_key": {
-                        "type": "objectAttribute",
-                        "value": {
-                          "type": "string"
+                        "asset": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "object",
+                                "attributes": {
+                                    "_ref": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                        }
+                                    },
+                                    "_weak": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "boolean"
+                                        },
+                                        "optional": true
+                                    }
+                                },
+                                "dereferencesTo": "sanity.imageAsset"
+                            },
+                            "optional": true
+                        },
+                        "media": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "unknown"
+                            },
+                            "optional": true
+                        },
+                        "hotspot": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageHotspot"
+                            },
+                            "optional": true
+                        },
+                        "crop": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageCrop"
+                            },
+                            "optional": true
+                        },
+                        "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string",
+                                "value": "image"
+                            }
                         }
-                      }
                     }
-                  }
+                },
+                "optional": true
+            },
+            "considerations": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "array",
+                    "of": {
+                        "type": "object",
+                        "attributes": {
+                            "title": {
+                                "type": "objectAttribute",
+                                "value": {
+                                    "type": "string"
+                                },
+                                "optional": true
+                            },
+                            "description": {
+                                "type": "objectAttribute",
+                                "value": {
+                                    "type": "string"
+                                },
+                                "optional": true
+                            },
+                            "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                    "type": "string",
+                                    "value": "consideration"
+                                }
+                            }
+                        },
+                        "rest": {
+                            "type": "object",
+                            "attributes": {
+                                "_key": {
+                                    "type": "objectAttribute",
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "optional": true
+            },
+            "documentation_article": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "array",
+                    "of": {
+                        "type": "union",
+                        "of": [
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "children": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "array",
+                                            "of": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "marks": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "array",
+                                                            "of": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "text": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string"
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "_type": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string",
+                                                            "value": "span"
+                                                        }
+                                                    }
+                                                },
+                                                "rest": {
+                                                    "type": "object",
+                                                    "attributes": {
+                                                        "_key": {
+                                                            "type": "objectAttribute",
+                                                            "value": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "optional": true
+                                    },
+                                    "style": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "union",
+                                            "of": [
+                                                {
+                                                    "type": "string",
+                                                    "value": "normal"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h1"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h2"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h3"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h4"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h5"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "h6"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "blockquote"
+                                                }
+                                            ]
+                                        },
+                                        "optional": true
+                                    },
+                                    "listItem": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "union",
+                                            "of": [
+                                                {
+                                                    "type": "string",
+                                                    "value": "bullet"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "value": "number"
+                                                }
+                                            ]
+                                        },
+                                        "optional": true
+                                    },
+                                    "markDefs": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "array",
+                                            "of": {
+                                                "type": "object",
+                                                "attributes": {
+                                                    "component": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "object",
+                                                            "attributes": {
+                                                                "_ref": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "_type": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "string",
+                                                                        "value": "reference"
+                                                                    }
+                                                                },
+                                                                "_weak": {
+                                                                    "type": "objectAttribute",
+                                                                    "value": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "optional": true
+                                                                }
+                                                            },
+                                                            "dereferencesTo": "jokul_component"
+                                                        },
+                                                        "optional": true
+                                                    },
+                                                    "_type": {
+                                                        "type": "objectAttribute",
+                                                        "value": {
+                                                            "type": "string",
+                                                            "value": "componentPageLink"
+                                                        }
+                                                    }
+                                                },
+                                                "rest": {
+                                                    "type": "object",
+                                                    "attributes": {
+                                                        "_key": {
+                                                            "type": "objectAttribute",
+                                                            "value": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "optional": true
+                                    },
+                                    "level": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "number"
+                                        },
+                                        "optional": true
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "block"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "object",
+                                    "attributes": {
+                                        "_key": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "asset": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "object",
+                                            "attributes": {
+                                                "_ref": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "string",
+                                                        "value": "reference"
+                                                    }
+                                                },
+                                                "_weak": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "optional": true
+                                                }
+                                            },
+                                            "dereferencesTo": "sanity.imageAsset"
+                                        },
+                                        "optional": true
+                                    },
+                                    "media": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "unknown"
+                                        },
+                                        "optional": true
+                                    },
+                                    "hotspot": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "inline",
+                                            "name": "sanity.imageHotspot"
+                                        },
+                                        "optional": true
+                                    },
+                                    "crop": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "inline",
+                                            "name": "sanity.imageCrop"
+                                        },
+                                        "optional": true
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "image"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "object",
+                                    "attributes": {
+                                        "_key": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_componentProps"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_componentKortFortalt"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_codeExample"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_storybook"
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "attributes": {
+                                    "_key": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "rest": {
+                                    "type": "inline",
+                                    "name": "jokul_codeBlock"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "optional": true
+            },
+            "related_components": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "object",
+                    "attributes": {
+                        "components": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "array",
+                                "of": {
+                                    "type": "object",
+                                    "attributes": {
+                                        "_ref": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "_type": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "string",
+                                                "value": "reference"
+                                            }
+                                        },
+                                        "_weak": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                                "type": "boolean"
+                                            },
+                                            "optional": true
+                                        }
+                                    },
+                                    "dereferencesTo": "jokul_component",
+                                    "rest": {
+                                        "type": "object",
+                                        "attributes": {
+                                            "_key": {
+                                                "type": "objectAttribute",
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "optional": true
+                        }
+                    }
+                },
+                "optional": true
+            },
+            "external_links": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "object",
+                    "attributes": {
+                        "github_link": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string"
+                            },
+                            "optional": true
+                        },
+                        "figma_link": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string"
+                            },
+                            "optional": true
+                        },
+                        "storybook_link": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string"
+                            },
+                            "optional": true
+                        }
+                    }
+                },
+                "optional": true
+            },
+            "figma_image": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "object",
+                    "attributes": {
+                        "light_mode": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string"
+                            },
+                            "optional": true
+                        },
+                        "dark_mode": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string"
+                            },
+                            "optional": true
+                        }
+                    }
+                },
+                "optional": true
+            },
+            "image": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "object",
+                    "attributes": {
+                        "asset": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "object",
+                                "attributes": {
+                                    "_ref": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                        }
+                                    },
+                                    "_weak": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "boolean"
+                                        },
+                                        "optional": true
+                                    }
+                                },
+                                "dereferencesTo": "sanity.imageAsset"
+                            },
+                            "optional": true
+                        },
+                        "media": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "unknown"
+                            },
+                            "optional": true
+                        },
+                        "hotspot": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageHotspot"
+                            },
+                            "optional": true
+                        },
+                        "crop": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageCrop"
+                            },
+                            "optional": true
+                        },
+                        "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string",
+                                "value": "image"
+                            }
+                        }
+                    }
+                },
+                "optional": true
+            },
+            "imageDark": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "object",
+                    "attributes": {
+                        "asset": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "object",
+                                "attributes": {
+                                    "_ref": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                        }
+                                    },
+                                    "_weak": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                            "type": "boolean"
+                                        },
+                                        "optional": true
+                                    }
+                                },
+                                "dereferencesTo": "sanity.imageAsset"
+                            },
+                            "optional": true
+                        },
+                        "media": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "unknown"
+                            },
+                            "optional": true
+                        },
+                        "hotspot": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageHotspot"
+                            },
+                            "optional": true
+                        },
+                        "crop": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "inline",
+                                "name": "sanity.imageCrop"
+                            },
+                            "optional": true
+                        },
+                        "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                                "type": "string",
+                                "value": "image"
+                            }
+                        }
+                    }
+                },
+                "optional": true
+            }
+        }
+    },
+    {
+        "name": "sanity.imageCrop",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "sanity.imageCrop"
+                    }
+                },
+                "top": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "bottom": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "left": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "right": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
                 }
-              },
-              "optional": true
             }
-          }
-        },
-        "optional": true
-      },
-      "external_links": {
-        "type": "objectAttribute",
+        }
+    },
+    {
+        "name": "sanity.imageHotspot",
+        "type": "type",
         "value": {
-          "type": "object",
-          "attributes": {
-            "github_link": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "figma_link": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "storybook_link": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      },
-      "figma_image": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "light_mode": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "dark_mode": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      },
-      "image": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
+            "type": "object",
+            "attributes": {
+                "_type": {
                     "type": "objectAttribute",
                     "value": {
-                      "type": "string"
+                        "type": "string",
+                        "value": "sanity.imageHotspot"
                     }
-                  },
-                  "_type": {
+                },
+                "x": {
                     "type": "objectAttribute",
                     "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
+                        "type": "number"
                     },
                     "optional": true
-                  }
                 },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "imageDark": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
+                "y": {
                     "type": "objectAttribute",
                     "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
+                        "type": "number"
                     },
                     "optional": true
-                  }
                 },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
+                "height": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                },
+                "width": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "number"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "sanity.imageAsset",
+        "type": "document",
+        "attributes": {
+            "_id": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
             },
             "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string",
+                    "value": "sanity.imageAsset"
+                }
+            },
+            "_createdAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_updatedAt": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "_rev": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                }
+            },
+            "originalFilename": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "label": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "title": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "description": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "altText": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "sha1hash": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "extension": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "mimeType": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "size": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "number"
+                },
+                "optional": true
+            },
+            "assetId": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "uploadId": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "path": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "url": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "string"
+                },
+                "optional": true
+            },
+            "metadata": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "inline",
+                    "name": "sanity.imageMetadata"
+                },
+                "optional": true
+            },
+            "source": {
+                "type": "objectAttribute",
+                "value": {
+                    "type": "inline",
+                    "name": "sanity.assetSourceData"
+                },
+                "optional": true
             }
-          }
-        },
-        "optional": true
-      }
+        }
+    },
+    {
+        "name": "sanity.assetSourceData",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "sanity.assetSourceData"
+                    }
+                },
+                "name": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "id": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "url": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "sanity.imageMetadata",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "sanity.imageMetadata"
+                    }
+                },
+                "location": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "geopoint"
+                    },
+                    "optional": true
+                },
+                "dimensions": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imageDimensions"
+                    },
+                    "optional": true
+                },
+                "palette": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "inline",
+                        "name": "sanity.imagePalette"
+                    },
+                    "optional": true
+                },
+                "lqip": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "blurHash": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "hasAlpha": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "boolean"
+                    },
+                    "optional": true
+                },
+                "isOpaque": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "boolean"
+                    },
+                    "optional": true
+                }
+            }
+        }
+    },
+    {
+        "name": "slug",
+        "type": "type",
+        "value": {
+            "type": "object",
+            "attributes": {
+                "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string",
+                        "value": "slug"
+                    }
+                },
+                "current": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                },
+                "source": {
+                    "type": "objectAttribute",
+                    "value": {
+                        "type": "string"
+                    },
+                    "optional": true
+                }
+            }
+        }
     }
-  },
-  {
-    "name": "sanity.imageCrop",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageCrop"
-          }
-        },
-        "top": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "bottom": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "left": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "right": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageHotspot",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageHotspot"
-          }
-        },
-        "x": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "y": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageAsset",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "sanity.imageAsset"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "originalFilename": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "label": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "altText": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "sha1hash": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "extension": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "mimeType": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "size": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "assetId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "uploadId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "path": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "url": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "metadata": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "sanity.imageMetadata"
-        },
-        "optional": true
-      },
-      "source": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "sanity.assetSourceData"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "sanity.assetSourceData",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.assetSourceData"
-          }
-        },
-        "name": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "url": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageMetadata",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageMetadata"
-          }
-        },
-        "location": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "geopoint"
-          },
-          "optional": true
-        },
-        "dimensions": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imageDimensions"
-          },
-          "optional": true
-        },
-        "palette": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePalette"
-          },
-          "optional": true
-        },
-        "lqip": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "blurHash": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "hasAlpha": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        },
-        "isOpaque": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "slug",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "slug"
-          }
-        },
-        "current": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  }
 ]

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -14,6 +14,7 @@ export const componentsQuery = defineQuery(`*[_type == "jokul_component"]{
 export const componentBySlugQuery =
     defineQuery(`*[_type == "jokul_component" && slug.current == $slug][0] {
         ...,
+        "slug": slug.current,
         "component_example_card": component_example_card{
         "url": asset->url
         },
@@ -29,7 +30,11 @@ export const componentBySlugQuery =
                                 ...,
                                 component->{
                                     name,
-                                    slug
+                                    short_description,
+                                    "slug": slug.current,
+                                    figma_image,
+                                    image,
+                                    imageDark
                                 }
                             }
                         }
@@ -43,12 +48,28 @@ export const componentBySlugQuery =
                                 ...,
                                 component->{
                                     name,
-                                    slug
+                                    short_description,
+                                    "slug": slug.current,
+                                    figma_image,
+                                    image,
+                                    imageDark
                                 }
                             }
                         }
                     }
                 }
+            },
+            markDefs[] {
+                ...,
+                _type == "componentPageLink" => {
+                    component-> {
+                        "slug": slug.current,
+                        name,
+                        short_description,
+                        image,
+                        imageDark,
+                    }
+                },
             }
         },
         related_components {

--- a/portal/src/sanity/schemas/component.ts
+++ b/portal/src/sanity/schemas/component.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from "sanity";
+import { componentPageLink } from "./links/componentPageLink";
 
 const MAX_LENGTH = 70;
 
@@ -106,7 +107,12 @@ export const component = defineType({
             type: "array",
             group: "documentation",
             of: [
-                { type: "block" },
+                {
+                    type: "block",
+                    marks: {
+                        annotations: [componentPageLink],
+                    },
+                },
                 { type: "image" },
                 { type: "jokul_componentProps" },
                 { type: "jokul_componentKortFortalt" },

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -14,797 +14,930 @@
 
 // Source: schema.json
 export type SanityImagePaletteSwatch = {
-  _type: "sanity.imagePaletteSwatch";
-  background?: string;
-  foreground?: string;
-  population?: number;
-  title?: string;
+    _type: "sanity.imagePaletteSwatch";
+    background?: string;
+    foreground?: string;
+    population?: number;
+    title?: string;
 };
 
 export type SanityImagePalette = {
-  _type: "sanity.imagePalette";
-  darkMuted?: SanityImagePaletteSwatch;
-  lightVibrant?: SanityImagePaletteSwatch;
-  darkVibrant?: SanityImagePaletteSwatch;
-  vibrant?: SanityImagePaletteSwatch;
-  dominant?: SanityImagePaletteSwatch;
-  lightMuted?: SanityImagePaletteSwatch;
-  muted?: SanityImagePaletteSwatch;
+    _type: "sanity.imagePalette";
+    darkMuted?: SanityImagePaletteSwatch;
+    lightVibrant?: SanityImagePaletteSwatch;
+    darkVibrant?: SanityImagePaletteSwatch;
+    vibrant?: SanityImagePaletteSwatch;
+    dominant?: SanityImagePaletteSwatch;
+    lightMuted?: SanityImagePaletteSwatch;
+    muted?: SanityImagePaletteSwatch;
 };
 
 export type SanityImageDimensions = {
-  _type: "sanity.imageDimensions";
-  height?: number;
-  width?: number;
-  aspectRatio?: number;
+    _type: "sanity.imageDimensions";
+    height?: number;
+    width?: number;
+    aspectRatio?: number;
 };
 
 export type SanityFileAsset = {
-  _id: string;
-  _type: "sanity.fileAsset";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  originalFilename?: string;
-  label?: string;
-  title?: string;
-  description?: string;
-  altText?: string;
-  sha1hash?: string;
-  extension?: string;
-  mimeType?: string;
-  size?: number;
-  assetId?: string;
-  uploadId?: string;
-  path?: string;
-  url?: string;
-  source?: SanityAssetSourceData;
+    _id: string;
+    _type: "sanity.fileAsset";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    originalFilename?: string;
+    label?: string;
+    title?: string;
+    description?: string;
+    altText?: string;
+    sha1hash?: string;
+    extension?: string;
+    mimeType?: string;
+    size?: number;
+    assetId?: string;
+    uploadId?: string;
+    path?: string;
+    url?: string;
+    source?: SanityAssetSourceData;
 };
 
 export type Geopoint = {
-  _type: "geopoint";
-  lat?: number;
-  lng?: number;
-  alt?: number;
+    _type: "geopoint";
+    lat?: number;
+    lng?: number;
+    alt?: number;
 };
 
 export type Jokul_linkCard = {
-  _type: "jokul_linkCard";
-  external_links?: Array<{
-    title?: string;
-    description?: string;
-    url?: string;
-    _type: "link";
-    _key: string;
-  }>;
+    _type: "jokul_linkCard";
+    external_links?: Array<{
+        title?: string;
+        description?: string;
+        url?: string;
+        _type: "link";
+        _key: string;
+    }>;
 };
 
 export type Jokul_componentKortFortalt = {
-  _type: "jokul_componentKortFortalt";
-  bruk?: Array<{
-    bruk_punkt?: Array<{
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: "span";
+    _type: "jokul_componentKortFortalt";
+    bruk?: Array<{
+        bruk_punkt?: Array<{
+            children?: Array<{
+                marks?: Array<string>;
+                text?: string;
+                _type: "span";
+                _key: string;
+            }>;
+            style?: "normal";
+            listItem?: never;
+            markDefs?: Array<{
+                component?: {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "jokul_component";
+                };
+                _type: "componentPageLink";
+                _key: string;
+            }>;
+            level?: number;
+            _type: "block";
+            _key: string;
+        }>;
         _key: string;
-      }>;
-      style?: "normal";
-      listItem?: never;
-      markDefs?: Array<{
-        component?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "jokul_component";
-        };
-        _type: "componentPageLink";
-        _key: string;
-      }>;
-      level?: number;
-      _type: "block";
-      _key: string;
     }>;
-    _key: string;
-  }>;
-  ikke_bruk?: Array<{
-    ikke_bruk_punkt?: Array<{
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: "span";
+    ikke_bruk?: Array<{
+        ikke_bruk_punkt?: Array<{
+            children?: Array<{
+                marks?: Array<string>;
+                text?: string;
+                _type: "span";
+                _key: string;
+            }>;
+            style?: "normal";
+            listItem?: never;
+            markDefs?: Array<{
+                component?: {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "jokul_component";
+                };
+                _type: "componentPageLink";
+                _key: string;
+            }>;
+            level?: number;
+            _type: "block";
+            _key: string;
+        }>;
         _key: string;
-      }>;
-      style?: "normal";
-      listItem?: never;
-      markDefs?: Array<{
-        component?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "jokul_component";
-        };
-        _type: "componentPageLink";
-        _key: string;
-      }>;
-      level?: number;
-      _type: "block";
-      _key: string;
     }>;
-    _key: string;
-  }>;
 };
 
 export type Jokul_storybook = {
-  _type: "jokul_storybook";
-  story?: Jokul_storybookStory;
-  code?: Jokul_codeBlock;
+    _type: "jokul_storybook";
+    story?: Jokul_storybookStory;
+    code?: Jokul_codeBlock;
 };
 
 export type Jokul_storybookStory = {
-  _type: "jokul_storybookStory";
-  storyId?: string;
-  storyName?: string;
+    _type: "jokul_storybookStory";
+    storyId?: string;
+    storyName?: string;
 };
 
 export type Jokul_codeBlock = {
-  _type: "jokul_codeBlock";
-  code?: string;
-  language?: "scss" | "typescript";
+    _type: "jokul_codeBlock";
+    code?: string;
+    language?: "scss" | "typescript";
 };
 
 export type Jokul_codeExample = {
-  _type: "jokul_codeExample";
-  showEditor?: boolean;
-  codeExample?: string;
+    _type: "jokul_codeExample";
+    showEditor?: boolean;
+    codeExample?: string;
 };
 
 export type Jokul_componentProps = {
-  _type: "jokul_componentProps";
-  componentFolder?: string;
+    _type: "jokul_componentProps";
+    componentFolder?: string;
 };
 
 export type Jokul_blog_post = {
-  _id: string;
-  _type: "jokul_blog_post";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  name?: string;
-  slug?: Slug;
-  short_description?: string;
-  article?: Array<{
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    _key: string;
-  } & Jokul_linkCard | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  } | {
-    _key: string;
-  } & Jokul_codeBlock | {
-    _key: string;
-  } & Jokul_storybook>;
+    _id: string;
+    _type: "jokul_blog_post";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    name?: string;
+    slug?: Slug;
+    short_description?: string;
+    article?: Array<
+        | {
+              children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+              }>;
+              style?:
+                  | "normal"
+                  | "h1"
+                  | "h2"
+                  | "h3"
+                  | "h4"
+                  | "h5"
+                  | "h6"
+                  | "blockquote";
+              listItem?: "bullet" | "number";
+              markDefs?: Array<{
+                  href?: string;
+                  _type: "link";
+                  _key: string;
+              }>;
+              level?: number;
+              _type: "block";
+              _key: string;
+          }
+        | ({
+              _key: string;
+          } & Jokul_linkCard)
+        | {
+              asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+              _key: string;
+          }
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
+        | ({
+              _key: string;
+          } & Jokul_storybook)
+    >;
 };
 
 export type Jokul_component = {
-  _id: string;
-  _type: "jokul_component";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  name?: string;
-  slug?: Slug;
-  short_description?: string;
-  status?: Array<string>;
-  keywords?: Array<string>;
-  example_card?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    _id: string;
+    _type: "jokul_component";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    name?: string;
+    slug?: Slug;
+    short_description?: string;
+    status?: Array<string>;
+    keywords?: Array<string>;
+    example_card?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  considerations?: Array<{
-    title?: string;
-    description?: string;
-    _type: "consideration";
-    _key: string;
-  }>;
-  documentation_article?: Array<{
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
+    considerations?: Array<{
+        title?: string;
+        description?: string;
+        _type: "consideration";
+        _key: string;
     }>;
-    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    documentation_article?: Array<
+        | {
+              children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+              }>;
+              style?:
+                  | "normal"
+                  | "h1"
+                  | "h2"
+                  | "h3"
+                  | "h4"
+                  | "h5"
+                  | "h6"
+                  | "blockquote";
+              listItem?: "bullet" | "number";
+              markDefs?: Array<{
+                  component?: {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "jokul_component";
+                  };
+                  _type: "componentPageLink";
+                  _key: string;
+              }>;
+              level?: number;
+              _type: "block";
+              _key: string;
+          }
+        | {
+              asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+              _key: string;
+          }
+        | ({
+              _key: string;
+          } & Jokul_componentProps)
+        | ({
+              _key: string;
+          } & Jokul_componentKortFortalt)
+        | ({
+              _key: string;
+          } & Jokul_codeExample)
+        | ({
+              _key: string;
+          } & Jokul_storybook)
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
+    >;
+    related_components?: {
+        components?: Array<{
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            _key: string;
+            [internalGroqTypeReferenceTo]?: "jokul_component";
+        }>;
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  } | {
-    _key: string;
-  } & Jokul_componentProps | {
-    _key: string;
-  } & Jokul_componentKortFortalt | {
-    _key: string;
-  } & Jokul_codeExample | {
-    _key: string;
-  } & Jokul_storybook | {
-    _key: string;
-  } & Jokul_codeBlock>;
-  related_components?: {
-    components?: Array<{
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: "jokul_component";
-    }>;
-  };
-  external_links?: {
-    github_link?: string;
-    figma_link?: string;
-    storybook_link?: string;
-  };
-  figma_image?: {
-    light_mode?: string;
-    dark_mode?: string;
-  };
-  image?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    external_links?: {
+        github_link?: string;
+        figma_link?: string;
+        storybook_link?: string;
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  imageDark?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    figma_image?: {
+        light_mode?: string;
+        dark_mode?: string;
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
+    image?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    };
+    imageDark?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    };
 };
 
 export type SanityImageCrop = {
-  _type: "sanity.imageCrop";
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
+    _type: "sanity.imageCrop";
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
 };
 
 export type SanityImageHotspot = {
-  _type: "sanity.imageHotspot";
-  x?: number;
-  y?: number;
-  height?: number;
-  width?: number;
+    _type: "sanity.imageHotspot";
+    x?: number;
+    y?: number;
+    height?: number;
+    width?: number;
 };
 
 export type SanityImageAsset = {
-  _id: string;
-  _type: "sanity.imageAsset";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  originalFilename?: string;
-  label?: string;
-  title?: string;
-  description?: string;
-  altText?: string;
-  sha1hash?: string;
-  extension?: string;
-  mimeType?: string;
-  size?: number;
-  assetId?: string;
-  uploadId?: string;
-  path?: string;
-  url?: string;
-  metadata?: SanityImageMetadata;
-  source?: SanityAssetSourceData;
+    _id: string;
+    _type: "sanity.imageAsset";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    originalFilename?: string;
+    label?: string;
+    title?: string;
+    description?: string;
+    altText?: string;
+    sha1hash?: string;
+    extension?: string;
+    mimeType?: string;
+    size?: number;
+    assetId?: string;
+    uploadId?: string;
+    path?: string;
+    url?: string;
+    metadata?: SanityImageMetadata;
+    source?: SanityAssetSourceData;
 };
 
 export type SanityAssetSourceData = {
-  _type: "sanity.assetSourceData";
-  name?: string;
-  id?: string;
-  url?: string;
+    _type: "sanity.assetSourceData";
+    name?: string;
+    id?: string;
+    url?: string;
 };
 
 export type SanityImageMetadata = {
-  _type: "sanity.imageMetadata";
-  location?: Geopoint;
-  dimensions?: SanityImageDimensions;
-  palette?: SanityImagePalette;
-  lqip?: string;
-  blurHash?: string;
-  hasAlpha?: boolean;
-  isOpaque?: boolean;
+    _type: "sanity.imageMetadata";
+    location?: Geopoint;
+    dimensions?: SanityImageDimensions;
+    palette?: SanityImagePalette;
+    lqip?: string;
+    blurHash?: string;
+    hasAlpha?: boolean;
+    isOpaque?: boolean;
 };
 
 export type Slug = {
-  _type: "slug";
-  current?: string;
-  source?: string;
+    _type: "slug";
+    current?: string;
+    source?: string;
 };
 
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybook | Jokul_storybookStory | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | Jokul_blog_post | Jokul_component | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | Slug;
+export type AllSanitySchemaTypes =
+    | SanityImagePaletteSwatch
+    | SanityImagePalette
+    | SanityImageDimensions
+    | SanityFileAsset
+    | Geopoint
+    | Jokul_linkCard
+    | Jokul_componentKortFortalt
+    | Jokul_storybook
+    | Jokul_storybookStory
+    | Jokul_codeBlock
+    | Jokul_codeExample
+    | Jokul_componentProps
+    | Jokul_blog_post
+    | Jokul_component
+    | SanityImageCrop
+    | SanityImageHotspot
+    | SanityImageAsset
+    | SanityAssetSourceData
+    | SanityImageMetadata
+    | Slug;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
 // Query: *[_type == "jokul_blog_post"]{        name,        slug,        short_description,        "date": _createdAt,    } | order(_createdAt desc)
 export type BlogPostsQueryResult = Array<{
-  name: string | null;
-  slug: Slug | null;
-  short_description: string | null;
-  date: string;
+    name: string | null;
+    slug: Slug | null;
+    short_description: string | null;
+    date: string;
 }>;
 // Variable: blogPostBySlugQuery
 // Query: *[_type == "jokul_blog_post" && slug.current == $slug][0]
 export type BlogPostBySlugQueryResult = {
-  _id: string;
-  _type: "jokul_blog_post";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  name?: string;
-  slug?: Slug;
-  short_description?: string;
-  article?: Array<{
-    _key: string;
-  } & Jokul_codeBlock | {
-    _key: string;
-  } & Jokul_linkCard | {
-    _key: string;
-  } & Jokul_storybook | {
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  }>;
+    _id: string;
+    _type: "jokul_blog_post";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    name?: string;
+    slug?: Slug;
+    short_description?: string;
+    article?: Array<
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
+        | ({
+              _key: string;
+          } & Jokul_linkCard)
+        | ({
+              _key: string;
+          } & Jokul_storybook)
+        | {
+              children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+              }>;
+              style?:
+                  | "blockquote"
+                  | "h1"
+                  | "h2"
+                  | "h3"
+                  | "h4"
+                  | "h5"
+                  | "h6"
+                  | "normal";
+              listItem?: "bullet" | "number";
+              markDefs?: Array<{
+                  href?: string;
+                  _type: "link";
+                  _key: string;
+              }>;
+              level?: number;
+              _type: "block";
+              _key: string;
+          }
+        | {
+              asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+              _key: string;
+          }
+    >;
 } | null;
 // Variable: komIGangQuery
 // Query: *[_type == "jokul_blog_post" && slug.current == "kom-i-gang"][0]
 export type KomIGangQueryResult = {
-  _id: string;
-  _type: "jokul_blog_post";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  name?: string;
-  slug?: Slug;
-  short_description?: string;
-  article?: Array<{
-    _key: string;
-  } & Jokul_codeBlock | {
-    _key: string;
-  } & Jokul_linkCard | {
-    _key: string;
-  } & Jokul_storybook | {
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  }>;
+    _id: string;
+    _type: "jokul_blog_post";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    name?: string;
+    slug?: Slug;
+    short_description?: string;
+    article?: Array<
+        | ({
+              _key: string;
+          } & Jokul_codeBlock)
+        | ({
+              _key: string;
+          } & Jokul_linkCard)
+        | ({
+              _key: string;
+          } & Jokul_storybook)
+        | {
+              children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+              }>;
+              style?:
+                  | "blockquote"
+                  | "h1"
+                  | "h2"
+                  | "h3"
+                  | "h4"
+                  | "h5"
+                  | "h6"
+                  | "normal";
+              listItem?: "bullet" | "number";
+              markDefs?: Array<{
+                  href?: string;
+                  _type: "link";
+                  _key: string;
+              }>;
+              level?: number;
+              _type: "block";
+              _key: string;
+          }
+        | {
+              asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+              _key: string;
+          }
+    >;
 } | null;
 
 // Source: ./src/sanity/queries/component.ts
 // Variable: componentsQuery
 // Query: *[_type == "jokul_component"]{    name,    short_description,    "slug": slug.current,    figma_image,    image,    imageDark,    related_components,    keywords} | order(name)
 export type ComponentsQueryResult = Array<{
-  name: string | null;
-  short_description: string | null;
-  slug: string | null;
-  figma_image: {
-    light_mode?: string;
-    dark_mode?: string;
-  } | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  related_components: {
-    components?: Array<{
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: "jokul_component";
-    }>;
-  } | null;
-  keywords: Array<string> | null;
-}>;
-// Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "component_example_card": component_example_card{        "url": asset->url        },        documentation_article[]{            ...,            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    slug                                }                            }                        }                    }                }            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                keywords            }        }    }
-export type ComponentBySlugQueryResult = {
-  _id: string;
-  _type: "jokul_component";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  name?: string;
-  slug?: Slug;
-  short_description?: string;
-  status?: Array<string>;
-  keywords?: Array<string>;
-  example_card?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  considerations?: Array<{
-    title?: string;
-    description?: string;
-    _type: "consideration";
-    _key: string;
-  }>;
-  documentation_article: Array<{
-    children?: Array<{
-      marks?: Array<string>;
-      text?: string;
-      _type: "span";
-      _key: string;
-    }>;
-    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
-    listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
-    level?: number;
-    _type: "block";
-    _key: string;
-  } | {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-    _key: string;
-  } | {
-    _key: string;
-    _type: "jokul_codeBlock";
-    code?: string;
-    language?: "scss" | "typescript";
-  } | {
-    _key: string;
-    _type: "jokul_codeExample";
-    showEditor?: boolean;
-    codeExample?: string;
-  } | {
-    _key: string;
-    _type: "jokul_componentKortFortalt";
-    bruk: Array<{
-      bruk_punkt: Array<{
-        children?: Array<{
-          marks?: Array<string>;
-          text?: string;
-          _type: "span";
-          _key: string;
-        }>;
-        style?: "normal";
-        listItem?: never;
-        markDefs: Array<{
-          component: {
-            name: string | null;
-            slug: Slug | null;
-          } | null;
-          _type: "componentPageLink";
-          _key: string;
-        }> | null;
-        level?: number;
-        _type: "block";
-        _key: string;
-      }> | null;
-    }> | null;
-    ikke_bruk: Array<{
-      ikke_bruk_punkt: Array<{
-        children?: Array<{
-          marks?: Array<string>;
-          text?: string;
-          _type: "span";
-          _key: string;
-        }>;
-        style?: "normal";
-        listItem?: never;
-        markDefs: Array<{
-          component: {
-            name: string | null;
-            slug: Slug | null;
-          } | null;
-          _type: "componentPageLink";
-          _key: string;
-        }> | null;
-        level?: number;
-        _type: "block";
-        _key: string;
-      }> | null;
-    }> | null;
-  } | {
-    _key: string;
-    _type: "jokul_componentProps";
-    componentFolder?: string;
-  } | {
-    _key: string;
-    _type: "jokul_storybook";
-    story?: Jokul_storybookStory;
-    code?: Jokul_codeBlock;
-  }> | null;
-  related_components: {
-    components: Array<{
-      name: string | null;
-      short_description: string | null;
-      slug: string | null;
-      figma_image: {
+    name: string | null;
+    short_description: string | null;
+    slug: string | null;
+    figma_image: {
         light_mode?: string;
         dark_mode?: string;
-      } | null;
-      image: {
+    } | null;
+    image: {
         asset?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
         media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         _type: "image";
-      } | null;
-      imageDark: {
+    } | null;
+    imageDark: {
         asset?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
         media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         _type: "image";
-      } | null;
-      related_components: {
+    } | null;
+    related_components: {
         components?: Array<{
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          _key: string;
-          [internalGroqTypeReferenceTo]?: "jokul_component";
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            _key: string;
+            [internalGroqTypeReferenceTo]?: "jokul_component";
         }>;
-      } | null;
-      keywords: Array<string> | null;
-    }> | null;
-  } | null;
-  external_links?: {
-    github_link?: string;
-    figma_link?: string;
-    storybook_link?: string;
-  };
-  figma_image?: {
-    light_mode?: string;
-    dark_mode?: string;
-  };
-  image?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    } | null;
+    keywords: Array<string> | null;
+}>;
+// Variable: componentBySlugQuery
+// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "component_example_card": component_example_card{        "url": asset->url        },        documentation_article[]{            ...,            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    "slug": slug.current                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    "slug": slug.current                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                keywords            }        }    }
+export type ComponentBySlugQueryResult = {
+    _id: string;
+    _type: "jokul_component";
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    name?: string;
+    slug: string | null;
+    short_description?: string;
+    status?: Array<string>;
+    keywords?: Array<string>;
+    example_card?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  imageDark?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    considerations?: Array<{
+        title?: string;
+        description?: string;
+        _type: "consideration";
+        _key: string;
+    }>;
+    documentation_article: Array<
+        | {
+              children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+              }>;
+              style?:
+                  | "blockquote"
+                  | "h1"
+                  | "h2"
+                  | "h3"
+                  | "h4"
+                  | "h5"
+                  | "h6"
+                  | "normal";
+              listItem?: "bullet" | "number";
+              markDefs: Array<{
+                  component: {
+                      slug: string | null;
+                      name: string | null;
+                      short_description: string | null;
+                      image: {
+                          asset?: {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                          };
+                          media?: unknown;
+                          hotspot?: SanityImageHotspot;
+                          crop?: SanityImageCrop;
+                          _type: "image";
+                      } | null;
+                      imageDark: {
+                          asset?: {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                          };
+                          media?: unknown;
+                          hotspot?: SanityImageHotspot;
+                          crop?: SanityImageCrop;
+                          _type: "image";
+                      } | null;
+                  } | null;
+                  _type: "componentPageLink";
+                  _key: string;
+              }> | null;
+              level?: number;
+              _type: "block";
+              _key: string;
+          }
+        | {
+              asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+              _key: string;
+              markDefs: null;
+          }
+        | {
+              _key: string;
+              _type: "jokul_codeBlock";
+              code?: string;
+              language?: "scss" | "typescript";
+              markDefs: null;
+          }
+        | {
+              _key: string;
+              _type: "jokul_codeExample";
+              showEditor?: boolean;
+              codeExample?: string;
+              markDefs: null;
+          }
+        | {
+              _key: string;
+              _type: "jokul_componentKortFortalt";
+              bruk: Array<{
+                  bruk_punkt: Array<{
+                      children?: Array<{
+                          marks?: Array<string>;
+                          text?: string;
+                          _type: "span";
+                          _key: string;
+                      }>;
+                      style?: "normal";
+                      listItem?: never;
+                      markDefs: Array<{
+                          component: {
+                              name: string | null;
+                              slug: string | null;
+                          } | null;
+                          _type: "componentPageLink";
+                          _key: string;
+                      }> | null;
+                      level?: number;
+                      _type: "block";
+                      _key: string;
+                  }> | null;
+              }> | null;
+              ikke_bruk: Array<{
+                  ikke_bruk_punkt: Array<{
+                      children?: Array<{
+                          marks?: Array<string>;
+                          text?: string;
+                          _type: "span";
+                          _key: string;
+                      }>;
+                      style?: "normal";
+                      listItem?: never;
+                      markDefs: Array<{
+                          component: {
+                              name: string | null;
+                              slug: string | null;
+                          } | null;
+                          _type: "componentPageLink";
+                          _key: string;
+                      }> | null;
+                      level?: number;
+                      _type: "block";
+                      _key: string;
+                  }> | null;
+              }> | null;
+              markDefs: null;
+          }
+        | {
+              _key: string;
+              _type: "jokul_componentProps";
+              componentFolder?: string;
+              markDefs: null;
+          }
+        | {
+              _key: string;
+              _type: "jokul_storybook";
+              story?: Jokul_storybookStory;
+              code?: Jokul_codeBlock;
+              markDefs: null;
+          }
+    > | null;
+    related_components: {
+        components: Array<{
+            name: string | null;
+            short_description: string | null;
+            slug: string | null;
+            figma_image: {
+                light_mode?: string;
+                dark_mode?: string;
+            } | null;
+            image: {
+                asset?: {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+            } | null;
+            imageDark: {
+                asset?: {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+            } | null;
+            related_components: {
+                components?: Array<{
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    _key: string;
+                    [internalGroqTypeReferenceTo]?: "jokul_component";
+                }>;
+            } | null;
+            keywords: Array<string> | null;
+        }> | null;
+    } | null;
+    external_links?: {
+        github_link?: string;
+        figma_link?: string;
+        storybook_link?: string;
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  component_example_card: null;
+    figma_image?: {
+        light_mode?: string;
+        dark_mode?: string;
+    };
+    image?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    };
+    imageDark?: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    };
+    component_example_card: null;
 } | null;
 // Variable: componentCardQuery
 // Query: *[_type == "jokul_component" && defined(slug.current) && slug.current == $componentSlug] {        name,        short_description,        "slug": slug.current,        figma_image,        image,        imageDark,        related_components,        keywords    }[0]
 export type ComponentCardQueryResult = {
-  name: string | null;
-  short_description: string | null;
-  slug: string | null;
-  figma_image: {
-    light_mode?: string;
-    dark_mode?: string;
-  } | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  related_components: {
-    components?: Array<{
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      _key: string;
-      [internalGroqTypeReferenceTo]?: "jokul_component";
-    }>;
-  } | null;
-  keywords: Array<string> | null;
+    name: string | null;
+    short_description: string | null;
+    slug: string | null;
+    figma_image: {
+        light_mode?: string;
+        dark_mode?: string;
+    } | null;
+    image: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    } | null;
+    imageDark: {
+        asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+    } | null;
+    related_components: {
+        components?: Array<{
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            _key: string;
+            [internalGroqTypeReferenceTo]?: "jokul_component";
+        }>;
+    } | null;
+    keywords: Array<string> | null;
 } | null;
 
 // Query TypeMap
 import "@sanity/client";
 declare module "@sanity/client" {
-  interface SanityQueries {
-    "*[_type == \"jokul_blog_post\"]{\n        name,\n        slug,\n        short_description,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": BlogPostsQueryResult;
-    "*[_type == \"jokul_blog_post\" && slug.current == $slug][0]": BlogPostBySlugQueryResult;
-    "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0]": KomIGangQueryResult;
-    "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    keywords\n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"component_example_card\": component_example_card{\n        \"url\": asset->url\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    slug\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                keywords\n            }\n        }\n    }": ComponentBySlugQueryResult;
-    "*[_type == \"jokul_component\" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        \"slug\": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components,\n        keywords\n    }[0]": ComponentCardQueryResult;
-  }
+    interface SanityQueries {
+        '*[_type == "jokul_blog_post"]{\n        name,\n        slug,\n        short_description,\n        "date": _createdAt,\n    } | order(_createdAt desc)': BlogPostsQueryResult;
+        '*[_type == "jokul_blog_post" && slug.current == $slug][0]': BlogPostBySlugQueryResult;
+        '*[_type == "jokul_blog_post" && slug.current == "kom-i-gang"][0]': KomIGangQueryResult;
+        '*[_type == "jokul_component"]{\n    name,\n    short_description,\n    "slug": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    keywords\n} | order(name)': ComponentsQueryResult;
+        '*[_type == "jokul_component" && slug.current == $slug][0] {\n        ...,\n        "slug": slug.current,\n        "component_example_card": component_example_card{\n        "url": asset->url\n        },\n        documentation_article[]{\n            ...,\n            _type == "jokul_componentKortFortalt" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == "componentPageLink" => {\n                                ...,\n                                component->{\n                                    name,\n                                    "slug": slug.current\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == "componentPageLink" => {\n                                ...,\n                                component->{\n                                    name,\n                                    "slug": slug.current\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == "componentPageLink" => {\n                    component-> {\n                        "slug": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                "slug": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                keywords\n            }\n        }\n    }': ComponentBySlugQueryResult;
+        '*[_type == "jokul_component" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        "slug": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components,\n        keywords\n    }[0]': ComponentCardQueryResult;
+    }
 }


### PR DESCRIPTION
## 💬 Endringer

Legger til mulighet for å lenke til andre komponenter fra riktekstfeltet i komponentdokumentasjonen. Lenkene rendres alltid ut med navnet til komponenten (uavhengig av hva den opprinnelige teksten var), og man får en forhåndsvisning i form av et `ComponentCard` ved hover/fokus av lenken.

https://github.com/user-attachments/assets/08a17451-a280-4145-b6c7-3f9fd19f402c

### Noen ting å forbedre

- Fullt gjenbruk av `ComponentCard`. Den komponenten er ikke akkurat polymorf, så det var vanskelig å bruke den direkte for å rendre ut popoveren
- Vise at teksten blir endret til komponentnavnet, også i redaktørgrensesnittet
- Markere lenkene til komponentsider med et ikon e.l. på samme måte som eksterne- og nedlastingslenker (?)
- Litt mykere overgang når popover vises (se #5284)
