### PR TITLE
Legg til globale stiler for popovers

### DIFF
--- a/.changeset/lovely-radios-beg.md
+++ b/.changeset/lovely-radios-beg.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legger til globale stiler for elementer som bruker [popover-APIet](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API), som sørger for at popovers animeres inn og ut med en enkel overtoning dersom ikke noe annet er spesifisert i selve komponenten. Siden disse stilene ligger i `jokul.global`-laget er de enkle å overstyre.

--- a/packages/jokul/src/components/help/styles/help.scss
+++ b/packages/jokul/src/components/help/styles/help.scss
@@ -7,13 +7,6 @@
 }
 
 .jkl-help-popover {
-    @include jkl.motion("standard", "productive");
-
-    opacity: 0;
-    transition: opacity,
-        overlay allow-discrete,
-        display allow-discrete;
-
     max-width: 40ch;
     padding: var(--jkl-unit-30);
     margin: var(--jkl-unit-05);
@@ -50,13 +43,5 @@
     &[data-position="right"] {
         position-area: right center;
         position-try: right, left, top, bottom;
-    }
-
-    &:popover-open {
-        opacity: 1;
-
-        @starting-style {
-            opacity: 0;
-        }
     }
 }

--- a/packages/jokul/src/core/styles/global/_index.scss
+++ b/packages/jokul/src/core/styles/global/_index.scss
@@ -1,1 +1,2 @@
 @forward "base-class";
+@forward "top-layer";

--- a/packages/jokul/src/core/styles/global/_top-layer.scss
+++ b/packages/jokul/src/core/styles/global/_top-layer.scss
@@ -1,0 +1,20 @@
+@use "../../jkl";
+
+@layer jokul.global {
+    [popover] {
+        opacity: 0;
+        transition: opacity,
+            overlay allow-discrete,
+            display allow-discrete;
+
+        @include jkl.motion("standard", "productive");
+
+        &:popover-open {
+            opacity: 1;
+
+            @starting-style {
+                opacity: 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 💬 Endringer

Legger til globale stiler for elementer som bruker [popover-APIet](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API), som sørger for at popovers animeres inn og ut med en enkel overtoning dersom ikke noe annet er spesifisert i selve komponenten. Siden disse stilene ligger i `jokul.global`-laget er de enkle å overstyre.
