### PR TITLE
Feat: Legg til temaside i Sanity og strukturendringer

### DIFF
--- a/portal/src/sanity/schemas/blogPost.ts
+++ b/portal/src/sanity/schemas/blogPost.ts
@@ -31,7 +31,19 @@ export const blogPost = defineType({
             type: "text",
             rows: 2,
         }),
-
+        defineField({
+            name: "category",
+            title: "Kategori",
+            type: "string",
+            options: {
+                list: [
+                    "Release notes",
+                    "Blogg",
+                    "Kom i gang",
+                    "Referat",
+                ].sort(),
+            },
+        }),
         defineField({
             name: "article",
             title: "Artikkel",

--- a/portal/src/sanity/schemas/component.ts
+++ b/portal/src/sanity/schemas/component.ts
@@ -7,7 +7,7 @@ export const component = defineType({
     title: "Komponent",
     type: "document",
     groups: [
-        { name: "documentation", title: "Dokumentasjon", default: true },
+        { name: "documentation", title: "Dokumentasjon" },
         { name: "metadata", title: "Metadata" },
         { name: "images", title: "Bilder" },
     ],
@@ -42,12 +42,28 @@ export const component = defineType({
         defineField({
             name: "status",
             title: "Status",
-            type: "array",
+            type: "string",
             group: "metadata",
             options: {
                 list: ["deprecated", "alpha", "beta", "stabil"],
+                layout: "dropdown",
             },
+        }),
+        defineField({
+            name: "categories",
+            title: "Kategorier",
+            type: "array",
+            group: "metadata",
             of: [{ type: "string" }],
+            options: {
+                list: [
+                    "Knapper",
+                    "Skjema",
+                    "Navigasjon",
+                    "Layout",
+                    "Feedback",
+                ].sort(),
+            },
         }),
         defineField({
             name: "keywords",
@@ -55,6 +71,10 @@ export const component = defineType({
             type: "array",
             group: "metadata",
             of: [{ type: "string" }],
+            options: {
+                layout: "tags",
+                sortable: true,
+            },
         }),
         defineField({
             name: "example_card",
@@ -162,37 +182,7 @@ export const component = defineType({
             ],
             options: {
                 collapsible: true,
-                columns: 2,
             },
-        }),
-        defineField({
-            type: "object",
-            name: "figma_image",
-            title: "Illustrasjon fra Figma",
-            group: "images",
-            hidden: true,
-            fields: [
-                defineField({
-                    type: "string",
-                    name: "light_mode",
-                    title: "Lys modus",
-                    description:
-                        "Lenke til frame i Figma for illustrasjon i lys modus",
-                    // Endre tilbake når importen fra Figma fungerer
-                    // validation: (Rule) => Rule.required(),
-                }),
-                defineField({
-                    type: "string",
-                    name: "dark_mode",
-                    title: "Mørk modus",
-                    description:
-                        "Lenke til frame i Figma for illustrasjon i mørk modus",
-                    // Endre tilbake når importen fra Figma fungerer
-                    // validation: (Rule) => Rule.required(),
-                }),
-            ],
-            // Endre tilbake når importen fra Figma fungerer
-            // validation: (Rule) => Rule.required(),
         }),
         defineField({
             name: "image",

--- a/portal/src/sanity/schemas/index.ts
+++ b/portal/src/sanity/schemas/index.ts
@@ -1,3 +1,4 @@
+import { temaside } from "@/sanity/schemas/temaside";
 import { blogPost } from "./blogPost";
 import { codeBlock } from "./codeBlock";
 import { codeExample } from "./codeExample";
@@ -10,6 +11,7 @@ import { storybook, storybookStory } from "./storybook";
 export const schemaTypes = [
     component,
     blogPost,
+    temaside,
     componentProps,
     codeExample,
     codeBlock,

--- a/portal/src/sanity/schemas/temaside.ts
+++ b/portal/src/sanity/schemas/temaside.ts
@@ -1,0 +1,121 @@
+import { defineField, defineType } from "sanity";
+
+const MAX_LENGTH = 70;
+
+export const temaside = defineType({
+    name: "jokul_temaside",
+    title: "Temaside",
+    type: "document",
+    groups: [
+        { name: "basics", title: "Grunnleggende info" },
+        { name: "related", title: "Relatert innhold" },
+        { name: "seo", title: "SEO" },
+    ],
+    fields: [
+        defineField({
+            name: "tema",
+            title: "Tema",
+            group: "basics",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "slug",
+            title: "Slug",
+            group: "seo",
+            type: "slug",
+            options: {
+                source: "tema",
+                maxLength: MAX_LENGTH,
+                slugify: (input) =>
+                    input.toLowerCase().replace(/\s+/g, "-").slice(0, 200),
+            },
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "short_description",
+            title: "Kort beskrivelse av tematikken",
+            group: "basics",
+            type: "text",
+            rows: 2,
+        }),
+        defineField({
+            name: "article",
+            title: "Artikkel",
+            group: "basics",
+            type: "array",
+            of: [
+                { type: "block" },
+                { type: "jokul_linkCard" },
+                { type: "image" },
+                { type: "jokul_codeBlock" },
+                { type: "jokul_storybook" },
+            ],
+        }),
+        defineField({
+            name: "related_components",
+            title: "Relevante komponenter",
+            type: "array",
+            group: "related",
+            of: [
+                defineField({
+                    type: "reference",
+                    name: "component",
+                    to: [{ type: "jokul_component" }],
+                    options: {
+                        disableNew: true,
+                    },
+                }),
+            ],
+        }),
+        defineField({
+            name: "related_tema",
+            title: "Relaterte temaer",
+            type: "array",
+            group: "related",
+            of: [
+                defineField({
+                    type: "reference",
+                    name: "tema",
+                    to: [{ type: "jokul_temaside" }],
+                    options: {
+                        disableNew: true,
+                    },
+                }),
+            ],
+        }),
+        defineField({
+            name: "resources",
+            title: "Eksterne ressurser",
+            type: "array",
+            group: "related",
+            of: [
+                defineField({
+                    name: "title",
+                    type: "object",
+                    fields: [
+                        defineField({
+                            name: "title",
+                            title: "Navn på siden",
+                            type: "string",
+                        }),
+                        defineField({
+                            name: "url",
+                            type: "url",
+                        }),
+                    ],
+                }),
+            ],
+        }),
+        defineField({
+            name: "keywords",
+            title: "Stikkord",
+            group: "seo",
+            type: "array",
+            of: [{ type: "string" }],
+            options: {
+                layout: "tags",
+            },
+        }),
+    ],
+});


### PR DESCRIPTION
## 💬 Endringer

### Komponenter

1. Får kategori, så vi kan filtrere på det istedenfor stikkord (her kan man velge mellom de samme som er i portalen i dag). Endringen er ikke gjort i portalen.
2. Status er endret fra checkbox til dropdown. Vises ikke i portalen.
3. Stikkord er endret til tags. Vises ikke i portalen.
4. Figmabilde er tatt vekk siden vi ikke får til koblingen (før om en stund™️)

### Bloggpost

1. Bloggposter får kategorier også: release notes, blogg, kom i gang, referat. Vises ikke i portalen.

### Temaside

1. Består av tittel (tema), slug, beskrivelse, artikkelen, relaterte komponenter, relaterte temaer, eksterne ressurser (videre lesing/andre sider utenfor Fremtind med info om temaet), stikkord
3.  Infoen består av tre kategorier: Basics (tittel, beskrivelse, artikkel), relatert innhold (komponenter, tema, eksterne ressurser), SEO (slug, stikkord).
4. Vises ikke i portalen enda

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5286 
