### PR TITLE
fix: Støtte for skalering av tekst på iOS-enheter

### DIFF
--- a/.changeset/fair-moons-run.md
+++ b/.changeset/fair-moons-run.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Støtte for skalering av tekst på iOS-enheter

--- a/packages/jokul/src/core/styles/global/_base-class.scss
+++ b/packages/jokul/src/core/styles/global/_base-class.scss
@@ -2,6 +2,9 @@
 
 @layer jokul.global {
     .jkl {
+        @supports (font: -apple-system-body) {
+            font: -apple-system-body;
+        }
         @include jkl.use-font-family("Fremtind Grotesk");
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->
Legger til -apple-system-body som fallback-font for å støtte tekstskalering i mobilbankene

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5267
