### PR TITLE
FIX PRE 1.0: Støtte for tekstskalering ios

### DIFF
--- a/packages/core/core.scss
+++ b/packages/core/core.scss
@@ -52,6 +52,10 @@
 }
 
 .jkl {
+    @supports (font: -apple-system-body) {
+        /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+        font: -apple-system-body;
+    }
     @include jkl.use-font-family("Fremtind Grotesk");
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->
Legger til støtte for tekstskalering på iOS.

Litt usikker på hvordan man releaser og sånn til pre-1.0 branchen, og hvordan vi gjør det så må nesten få litt hjelp der.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5267
