### PR TITLE
feat: Legg til description i input-felter

### DIFF
--- a/.changeset/hip-weeks-cough.md
+++ b/.changeset/hip-weeks-cough.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+Gjør det mulig å bruke helplabel over input-feltet i input-groups

--- a/packages/jokul/src/components/input-group/FieldGroup.tsx
+++ b/packages/jokul/src/components/input-group/FieldGroup.tsx
@@ -57,16 +57,27 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
                     )}
                 </Label>
             </legend>
+            {supportLabelProps?.position === "above-field" &&
+                (helpLabel || errorLabel) && (
+                    <SupportLabel
+                        {...supportLabelProps}
+                        label={supportText}
+                        labelType={supportTextType}
+                        id={supportId}
+                        density={density}
+                    />
+                )}
             {children}
-            {(helpLabel || errorLabel) && (
-                <SupportLabel
-                    {...supportLabelProps}
-                    label={supportText}
-                    labelType={supportTextType}
-                    id={supportId}
-                    density={density}
-                />
-            )}
+            {supportLabelProps?.position !== "above-field" &&
+                (helpLabel || errorLabel) && (
+                    <SupportLabel
+                        {...supportLabelProps}
+                        label={supportText}
+                        labelType={supportTextType}
+                        id={supportId}
+                        density={density}
+                    />
+                )}
         </fieldset>
     );
 };

--- a/packages/jokul/src/components/input-group/InputGroup.tsx
+++ b/packages/jokul/src/components/input-group/InputGroup.tsx
@@ -17,7 +17,7 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
             label,
             labelProps,
             render,
-            supportLabelProps,
+            supportLabelProps = { position: "below-field" },
             tooltip,
             id,
             ...rest
@@ -88,15 +88,27 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
                         label
                     )}
                 </Label>
+                {supportLabelProps?.position === "above-field" && (
+                    <SupportLabel
+                        srOnly={false}
+                        {...supportLabelProps}
+                        label={helpLabel}
+                        labelType={"help"}
+                        id={supportId}
+                        density={density}
+                    />
+                )}
                 {renderInput()}
-                <SupportLabel
-                    srOnly={inline}
-                    {...supportLabelProps}
-                    label={supportText}
-                    labelType={supportTextType}
-                    id={supportId}
-                    density={density}
-                />
+                {supportLabelProps?.position !== "above-field" && (
+                    <SupportLabel
+                        srOnly={inline}
+                        {...supportLabelProps}
+                        label={supportText}
+                        labelType={supportTextType}
+                        id={supportId}
+                        density={density}
+                    />
+                )}
             </div>
         );
     },

--- a/packages/jokul/src/components/input-group/stories/FieldGroup.stories.tsx
+++ b/packages/jokul/src/components/input-group/stories/FieldGroup.stories.tsx
@@ -12,12 +12,19 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
     },
-    tags: ["autodocs", "forms"],
-    argTypes: {
-        tooltip: {
-            type: "boolean",
+    args: {
+        legend: "Hvordan kan vi kontakte deg?",
+        labelProps: {
+            variant: "large",
         },
+        helpLabel: "Hjelpetekst",
+        supportLabelProps: {
+            position: "below-field",
+            labelType: "help",
+        },
+        tooltip: false,
     },
+    tags: ["autodocs", "forms"],
 } satisfies Meta<typeof FieldGroup>;
 
 export default meta;
@@ -30,16 +37,6 @@ const tooltipComponent = (
 
 export const FieldGroupStory: Story = {
     name: "Kontaktpreferanser",
-    args: {
-        legend: "Hvordan kan vi kontakte deg?",
-        labelProps: {
-            variant: "large",
-        },
-        supportLabelProps: {
-            labelType: "help",
-        },
-        tooltip: false,
-    },
     render: ({ tooltip, ...props }) => (
         <FieldGroup {...props} tooltip={tooltip ? tooltipComponent : undefined}>
             <Checkbox name="checklist" value="phone" invalid={false}>

--- a/packages/jokul/src/components/input-group/stories/InputGroup.stories.tsx
+++ b/packages/jokul/src/components/input-group/stories/InputGroup.stories.tsx
@@ -12,6 +12,14 @@ const meta: Meta = {
         layout: "centered",
     },
     tags: ["autodocs", "forms"],
+    args: {
+        label: "Fødeselsnummer",
+        labelProps: {
+            srOnly: false,
+            standAlone: false,
+        },
+        helpLabel: "Hjelpetekst",
+    },
     argTypes: {
         label: {
             control: "text",
@@ -25,9 +33,6 @@ type Story = StoryObj<typeof InputGroup>;
 
 export const InputGroupStory: Story = {
     name: "InputGroup",
-    args: {
-        label: "Fødeselsnummer",
-    },
     render: (props) => (
         <InputGroup {...props}>
             <BaseTextInput />

--- a/packages/jokul/src/components/input-group/types.ts
+++ b/packages/jokul/src/components/input-group/types.ts
@@ -119,4 +119,10 @@ export interface SupportLabelProps {
     density?: Density;
     className?: string;
     srOnly?: boolean;
+    /**
+     * Bestemmer om support label rendres over eller under input-feltet
+     * hvis den brukes i InputGroup eller FieldGroup-komponentene.
+     * @default "below-field"
+     */
+    position?: "above-field" | "below-field";
 }


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->
- Legger til en ny prop, `description`, som kan brukes for å få hjelpetekst over input-feltet, checkboxer og annet.

> [!IMPORTANT]
>  Legg merke til at Autosuggest ikke får description, siden den er bestemt deprecated.

### Eksempler

https://jokul.fremtind.no/preview/5198-beskrivelse-over-inputfelt/

Utdrag:
<img width="513" height="314" alt="Screenshot 2025-10-14 at 16 00 04" src="https://github.com/user-attachments/assets/7ff98ffa-7cff-4b86-8392-e1f23c23469c" />
<img width="476" height="246" alt="Screenshot 2025-10-14 at 15 59 52" src="https://github.com/user-attachments/assets/79c608e9-549c-4f2f-b728-020dfe289a8f" />
<img width="612" height="436" alt="Screenshot 2025-10-14 at 15 59 47" src="https://github.com/user-attachments/assets/d7790d90-d07f-434f-a6b0-6bdd049c0fea" />


## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5198
