### PR TITLE
feat: description over input

### DIFF
--- a/.changeset/hip-weeks-cough.md
+++ b/.changeset/hip-weeks-cough.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+Legger til `description`-propen i input-felt.

--- a/packages/jokul/src/components/combobox/Combobox.tsx
+++ b/packages/jokul/src/components/combobox/Combobox.tsx
@@ -48,6 +48,7 @@ export const Combobox: FC<ComboboxProps> = ({
     name,
     className,
     invalid,
+                                                description,
     hasTagHover,
 }) => {
     const listId = useId(id || "jkl-combobox", { generateSuffix: !id });
@@ -396,6 +397,7 @@ export const Combobox: FC<ComboboxProps> = ({
             helpLabel={helpLabel}
             errorLabel={errorLabel}
             density={density}
+            description={description}
             render={(inputProps) => (
                 <div
                     className={clsx("jkl-combobox__wrapper", {

--- a/packages/jokul/src/components/combobox/stories/Combobox.stories.tsx
+++ b/packages/jokul/src/components/combobox/stories/Combobox.stories.tsx
@@ -127,7 +127,7 @@ const meta = {
             variant: "small",
         },
         width: "20ch",
-        helpLabel: "Du kan velge flere, dersom flere passer",
+        description: "Du kan velge flere, dersom flere passer",
         onChange: () => "",
     },
     tags: ["autodocs", "forms"],

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -57,6 +57,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             supportLabelProps,
             tooltip,
             textInputProps,
+            description,
             ...rest
         } = props;
 
@@ -259,6 +260,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                 errorLabel={errorLabel}
                 supportLabelProps={supportLabelProps}
                 tooltip={tooltip}
+                description={description}
                 render={(inputProps) => (
                     <BaseTextInput
                         data-focused={showCalendar ? "true" : undefined}

--- a/packages/jokul/src/components/datepicker/stories/Datepicker.stories.tsx
+++ b/packages/jokul/src/components/datepicker/stories/Datepicker.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
         disableAfterDate: new Date(
             new Date().setDate(new Date().getDate() + 14),
         ).toLocaleDateString("en-US"),
-        helpLabel: "Kortet er gyldig i 3 måneder fra denne datoen",
+        description: "Kortet er gyldig i 3 måneder fra denne datoen",
         label: "Når skal du reise?",
         labelProps: {
             srOnly: false,

--- a/packages/jokul/src/components/input-group/FieldGroup.tsx
+++ b/packages/jokul/src/components/input-group/FieldGroup.tsx
@@ -17,6 +17,7 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
         helpLabel,
         errorLabel,
         density,
+        description,
         "data-testautoid": testAutoId,
         ...rest
     } = props;
@@ -57,6 +58,9 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
                     )}
                 </Label>
             </legend>
+            {description && (
+                <p className="jkl-input-group-description">{description}</p>
+            )}
             {children}
             {(helpLabel || errorLabel) && (
                 <SupportLabel

--- a/packages/jokul/src/components/input-group/InputGroup.tsx
+++ b/packages/jokul/src/components/input-group/InputGroup.tsx
@@ -18,6 +18,7 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
             labelProps,
             render,
             supportLabelProps,
+            description,
             tooltip,
             id,
             ...rest
@@ -88,6 +89,9 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
                         label
                     )}
                 </Label>
+                {description && (
+                    <p className="jkl-input-group-description">{description}</p>
+                )}
                 {renderInput()}
                 <SupportLabel
                     srOnly={inline}

--- a/packages/jokul/src/components/input-group/stories/FieldGroup.stories.tsx
+++ b/packages/jokul/src/components/input-group/stories/FieldGroup.stories.tsx
@@ -12,12 +12,11 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
     },
-    tags: ["autodocs", "forms"],
-    argTypes: {
-        tooltip: {
-            type: "boolean",
-        },
+    args: {
+        description:
+            "Velg metoden som gjør det enklest for oss å få kontakt med deg i jobb-tider.",
     },
+    tags: ["autodocs", "forms"],
 } satisfies Meta<typeof FieldGroup>;
 
 export default meta;

--- a/packages/jokul/src/components/input-group/stories/InputGroup.stories.tsx
+++ b/packages/jokul/src/components/input-group/stories/InputGroup.stories.tsx
@@ -11,12 +11,10 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
     },
-    tags: ["autodocs", "forms"],
-    argTypes: {
-        label: {
-            control: "text",
-        },
+    args: {
+        description: "Fødselsnummer består av 11 siffer.",
     },
+    tags: ["autodocs", "forms"],
 } satisfies Meta<typeof InputGroup>;
 
 export default meta;

--- a/packages/jokul/src/components/input-group/styles/_labels.scss
+++ b/packages/jokul/src/components/input-group/styles/_labels.scss
@@ -8,7 +8,7 @@
 }
 
 $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.unique-id(
-    
+
 )};
 
 @include jkl.comfortable-density-variables {
@@ -117,6 +117,14 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
     &--sr-only {
         @include jkl.screenreader-only;
     }
+}
+
+.jkl-input-group-description {
+    @include jkl.text-style("small");
+    color: var(--jkl-color-text-subdued);
+    margin: var(--jkl-label-medium-margin);
+    max-inline-size: 35ch;
+    text-wrap: pretty;
 }
 
 @keyframes #{$_support-icon-entrance-animation-name} {

--- a/packages/jokul/src/components/input-group/types.ts
+++ b/packages/jokul/src/components/input-group/types.ts
@@ -20,6 +20,7 @@ export interface FieldGroupProps
     helpLabel?: string;
     errorLabel?: string;
     density?: Density;
+    description?: string;
 }
 
 export interface InputProps {
@@ -43,6 +44,7 @@ export type InputGroupProps = WithOptionalChildren &
             SupportLabelProps,
             "id" | "errorLabel" | "helpLabel" | "density"
         >;
+    description?: string;
         tooltip?: ReactNode;
         style?: CSSProperties;
         render?: (props: InputProps) => JSX.Element;

--- a/packages/jokul/src/components/select/NativeSelect.tsx
+++ b/packages/jokul/src/components/select/NativeSelect.tsx
@@ -23,6 +23,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
             tooltip,
             value,
             width,
+            description,
             ...rest
         } = props;
 
@@ -35,6 +36,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
             inline,
             supportLabelProps,
             tooltip,
+            description,
         };
 
         return (

--- a/packages/jokul/src/components/select/stories/native-select.stories.tsx
+++ b/packages/jokul/src/components/select/stories/native-select.stories.tsx
@@ -61,7 +61,7 @@ const meta: Meta = {
         placeholder: "Velg merke",
         inline: false,
         invalid: false,
-        helpLabel: "Du kan kun velge ett merke",
+        description: "Du kan kun velge ett merke",
         labelProps: {
             srOnly: false,
             variant: "small",

--- a/packages/jokul/src/components/select/stories/select.stories.tsx
+++ b/packages/jokul/src/components/select/stories/select.stories.tsx
@@ -55,6 +55,7 @@ const meta: Meta = {
     args: {
         name: "Select",
         label: "Hvilket merke er telefonen?",
+        description: "Du kan kun velge ett merke",
         items: [
             { value: "Apple", label: "Apple" },
             { value: "Samsung", label: "Samsung" },
@@ -66,7 +67,6 @@ const meta: Meta = {
         defaultPrompt: "Velg merke",
         inline: false,
         invalid: false,
-        helpLabel: "Du kan kun velge ett merke",
         labelProps: {
             srOnly: false,
             variant: "small",
@@ -75,7 +75,7 @@ const meta: Meta = {
         width: "20ch",
         searchable: false,
     },
-    tags: ["autodocs"],
+    tags: ["autodocs", "forms"],
 };
 
 export default meta;
@@ -98,6 +98,7 @@ export const SelectInline: Story = {
         ],
         inline: true,
         value: "Frontend-utvikler",
+        description: "",
         helpLabel: "",
     },
     render: (args) => {

--- a/packages/jokul/src/components/text-area/TextArea.tsx
+++ b/packages/jokul/src/components/text-area/TextArea.tsx
@@ -19,6 +19,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             startOpen,
             supportLabelProps,
             tooltip,
+            description,
             ...rest
         } = props;
         const inputGroupProps = {
@@ -30,6 +31,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             inline,
             supportLabelProps,
             tooltip,
+            description,
         };
         const textAreaProps = { autoExpand, counter, startOpen };
         return (

--- a/packages/jokul/src/components/text-area/stories/TextArea.stories.tsx
+++ b/packages/jokul/src/components/text-area/stories/TextArea.stories.tsx
@@ -8,6 +8,15 @@ const meta = {
     parameters: {
         layout: "centered",
     },
+    args: {
+        label: "Tilleggsinformasjon",
+        description: "Legg til relevant informasjon som kan påvirke saken.",
+        counter: {
+            maxLength: 200,
+            hideProgress: false,
+        },
+        autoExpand: true,
+    },
     tags: ["autodocs", "forms"],
 } satisfies Meta<typeof TextAreaComponent>;
 
@@ -17,21 +26,11 @@ type Story = StoryObj<typeof meta>;
 export const TextArea: Story = {
     args: {
         label: "Har du noen tilbakemeldinger til oss?",
-        helpLabel: "Din tilbakemelding hjelper oss å bli bedre.",
+        description: "Din tilbakemelding hjelper oss å bli bedre.",
     },
 };
 
-export const TextAreaWithCounterAndAutoExpand: Story = {
-    args: {
-        label: "Tilleggsinformasjon",
-        helpLabel: "Legg til relevant informasjon som kan påvirke saken.",
-        counter: {
-            maxLength: 200,
-            hideProgress: false,
-        },
-        autoExpand: true,
-    },
-};
+export const TextAreaWithCounterAndAutoExpand: Story = {};
 
 export const WithError: Story = {
     args: {
@@ -53,6 +52,6 @@ export const ReadOnly: Story = {
         label: "Tidligere registrert informasjon",
         readOnly: true,
         value: "Kunde rapporterte vannlekkasje i kjeller 15. mars kl. 08:30. Skaden oppstod som følge av frostsprengt rør under kjøkkengulvet. Rørlegger tilkalt samme dag.",
-        helpLabel: "Denne informasjonen kan ikke endres",
+        description: "Denne informasjonen kan ikke endres",
     },
 };

--- a/packages/jokul/src/components/text-input/TextInput.tsx
+++ b/packages/jokul/src/components/text-input/TextInput.tsx
@@ -17,6 +17,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             labelProps,
             supportLabelProps,
             tooltip,
+            description,
             ...rest
         } = props;
         const inputGroupProps = {
@@ -28,6 +29,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             inline,
             supportLabelProps,
             tooltip,
+            description,
         };
         return (
             <InputGroup

--- a/packages/jokul/src/components/text-input/stories/TextInput.stories.tsx
+++ b/packages/jokul/src/components/text-input/stories/TextInput.stories.tsx
@@ -51,6 +51,7 @@ const meta = {
         disabled: false,
         readOnly: false,
         defaultValue: "",
+        description: "",
     },
 } satisfies Meta<typeof TextInputComponent>;
 


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->
- Legger til en ny prop, `description`, som kan brukes for å få hjelpetekst over input-feltet, checkboxer og annet.

> [!IMPORTANT]
>  Legg merke til at Autosuggest ikke får description, siden den er bestemt deprecated.

### Eksempler

https://jokul.fremtind.no/preview/5198-beskrivelse-over-inputfelt/

Utdrag:
<img width="513" height="314" alt="Screenshot 2025-10-14 at 16 00 04" src="https://github.com/user-attachments/assets/7ff98ffa-7cff-4b86-8392-e1f23c23469c" />
<img width="476" height="246" alt="Screenshot 2025-10-14 at 15 59 52" src="https://github.com/user-attachments/assets/79c608e9-549c-4f2f-b728-020dfe289a8f" />
<img width="612" height="436" alt="Screenshot 2025-10-14 at 15 59 47" src="https://github.com/user-attachments/assets/d7790d90-d07f-434f-a6b0-6bdd049c0fea" />


## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5198
