### PR TITLE
docs(changeset): Annonserer toast-innhold for skjermlesere

### DIFF
--- a/.changeset/olive-houses-slide.md
+++ b/.changeset/olive-houses-slide.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Annonserer toast-innhold for skjermlesere umiddelbart.


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Fikset en bug der annonsering av toast-innhold ikke fungerer for skjermlesere.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #4924 
