### PR TITLE
Legg tilbake mulighet for eksterne lenker i Sanity

### DIFF
--- a/portal/src/components/portable-text/link/Link.tsx
+++ b/portal/src/components/portable-text/link/Link.tsx
@@ -5,11 +5,21 @@ import NextLink from "next/link";
 type LinkProps = PortableTextMarkComponentProps<{
     _type: "link";
     href: string;
+    blank?: boolean;
 }>;
 
 export const Link = ({ value, children }: LinkProps) => {
-    return value?.href ? (
-        <JokulLink as={NextLink} href={value.href}>
+    if (!value) return null;
+
+    const { blank, href } = value;
+
+    return href ? (
+        <JokulLink
+            as={NextLink}
+            href={href}
+            target={blank ? "_blank" : undefined}
+            rel={blank ? "noopener" : undefined}
+        >
             {children}
         </JokulLink>
     ) : (

--- a/portal/src/sanity/schemas/component.ts
+++ b/portal/src/sanity/schemas/component.ts
@@ -1,4 +1,8 @@
-import { CheckmarkCircleIcon, CloseCircleIcon } from "@sanity/icons";
+import {
+    CheckmarkCircleIcon,
+    CloseCircleIcon,
+    EarthGlobeIcon,
+} from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 import { componentPageLink } from "./links/componentPageLink";
 
@@ -147,7 +151,28 @@ export const component = defineType({
                         },
                     ],
                     marks: {
-                        annotations: [componentPageLink],
+                        annotations: [
+                            {
+                                name: "link",
+                                type: "object",
+                                title: "Ekstern lenke",
+                                icon: EarthGlobeIcon,
+                                fields: [
+                                    {
+                                        name: "href",
+                                        type: "url",
+                                        title: "URL",
+                                    },
+                                    {
+                                        title: "Åpne i ny fane",
+                                        name: "blank",
+                                        type: "boolean",
+                                        initialValue: false,
+                                    },
+                                ],
+                            },
+                            componentPageLink,
+                        ],
                     },
                 },
                 { type: "image" },


### PR DESCRIPTION
## 💬 Endringer

Komponentside-lenkene fjernet visst de vanlige lenkene fra Sanity-oppsettet. Her legges den tilbake, med mulighet for å åpnes i en ny fane.
