### PR TITLE
patch: Annonserer toast-innhold for skjermlesere umiddelbart.

### DIFF
--- a/.changeset/olive-houses-slide.md
+++ b/.changeset/olive-houses-slide.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Annonserer toast-innhold for skjermlesere umiddelbart.


### PR DESCRIPTION
## 💬 Endringer

Fikset en bug der annonsering av toast-innhold ikke fungerer for skjermlesere.

## 🩹 Løser følgende issues

-   Closes #5381 
