### PR TITLE
minor: alwaysOpen markert deprecated i paneler

### DIFF
--- a/.changeset/tricky-yaks-pay.md
+++ b/.changeset/tricky-yaks-pay.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+alwaysOpen i `CheckboxPanel` og `RadioPanel` er markert som deprecated. Vi ønsker ikke lenger å skjule informasjon for brukerne før de tar et valg i en flyt.

--- a/packages/jokul/src/components/checkbox-panel/stories/CheckboxPanel.stories.tsx
+++ b/packages/jokul/src/components/checkbox-panel/stories/CheckboxPanel.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
         label: "Livsforsikring",
         children:
             "Gir dine etterlatte en engangsutbetaling hvis du dør. Pengene kan de for eksempel bruke til å nedbetale lån og tilpasse seg en ny livssituasjon.",
-        alwaysOpen: false,
+        alwaysOpen: true,
         extraLabel: "xxx kr/mnd",
         value: "Livsforsikring",
     },

--- a/packages/jokul/src/components/checkbox-panel/types.ts
+++ b/packages/jokul/src/components/checkbox-panel/types.ts
@@ -6,5 +6,9 @@ export type CheckboxPanelProps = Omit<
 > & {
     label: string;
     extraLabel?: React.ReactNode;
+    /**
+     * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
+     * @default false
+     */
     alwaysOpen?: boolean;
 };

--- a/packages/jokul/src/components/radio-panel/stories/RadioPanel.stories.tsx
+++ b/packages/jokul/src/components/radio-panel/stories/RadioPanel.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
         label: "Livsforsikring",
         children:
             "Gir dine etterlatte en engangsutbetaling hvis du dør. Pengene kan de for eksempel bruke til å nedbetale lån og tilpasse seg en ny livssituasjon.",
-        alwaysOpen: false,
+        alwaysOpen: true,
         extraLabel: "xxx kr/mnd",
         value: "Livsforsikring",
     },

--- a/packages/jokul/src/components/radio-panel/types.ts
+++ b/packages/jokul/src/components/radio-panel/types.ts
@@ -10,6 +10,10 @@ export type RadioPanelProps = Omit<
     value: string;
     label: string;
     extraLabel?: React.ReactNode;
+    /**
+     * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
+     * @default false
+     */
     alwaysOpen?: boolean;
 };
 

--- a/packages/jokul/src/shared/input-panel/BasePanel.tsx
+++ b/packages/jokul/src/shared/input-panel/BasePanel.tsx
@@ -11,6 +11,10 @@ import { useAutoAnimatedHeight } from "../../hooks/useAnimatedHeight/useAutoAnim
 
 type Props = ComponentPropsWithRef<"input"> & {
     isChecked: boolean;
+    /**
+     * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
+     * @default false
+     */
     alwaysOpen: boolean;
     label: string;
     extraLabel?: ReactNode;
@@ -22,7 +26,7 @@ export const BasePanel = forwardRef(function BasePanel(
         className,
         isChecked,
         children,
-        alwaysOpen,
+        alwaysOpen = false,
         label,
         extraLabel,
         type,


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->
alwaysOpen i `CheckboxPanel` og `RadioPanel` er markert som deprecated. Vi ønsker ikke lenger å skjule informasjon for brukerne før de tar et valg i en flyt.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5384 
