### PR TITLE
patch: Markert extraLabel som deprecated, med amount som erstatning

### DIFF
--- a/.changeset/all-beans-call.md
+++ b/.changeset/all-beans-call.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Markert extraLabel som deprecated, med amount som erstatning. Vi ønsker å rendyrke denne komponenten til å vise produkter, dekninger, utbetalinger og lignende.

--- a/packages/jokul/src/components/checkbox-panel/stories/CheckboxPanel.stories.tsx
+++ b/packages/jokul/src/components/checkbox-panel/stories/CheckboxPanel.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
         children:
             "Gir dine etterlatte en engangsutbetaling hvis du dør. Pengene kan de for eksempel bruke til å nedbetale lån og tilpasse seg en ny livssituasjon.",
         alwaysOpen: true,
-        extraLabel: "xxx kr/mnd",
+        amount: "xxx kr/mnd",
         value: "Livsforsikring",
     },
 } satisfies Meta<typeof CheckboxPanelComponent>;

--- a/packages/jokul/src/components/checkbox-panel/types.ts
+++ b/packages/jokul/src/components/checkbox-panel/types.ts
@@ -5,10 +5,18 @@ export type CheckboxPanelProps = Omit<
     "type"
 > & {
     label: string;
+    /**
+     * @deprecated bruk heller {@link amount} for å vise pris.
+     * Dersom du har behov utover dette ta kontakt med oss så finner vi en løsning sammen.
+     */
     extraLabel?: React.ReactNode;
     /**
      * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
      * @default false
      */
     alwaysOpen?: boolean;
+    /**
+     * Viser pris til høyre i panelet
+     */
+    amount?: string;
 };

--- a/packages/jokul/src/components/radio-panel/RadioPanel.tsx
+++ b/packages/jokul/src/components/radio-panel/RadioPanel.tsx
@@ -15,6 +15,7 @@ export const RadioPanel = forwardRef(function RadioPanel(
         alwaysOpen = false,
         label,
         extraLabel,
+        amount,
         checked,
         onChange,
         value,

--- a/packages/jokul/src/components/radio-panel/types.ts
+++ b/packages/jokul/src/components/radio-panel/types.ts
@@ -9,12 +9,20 @@ export type RadioPanelProps = Omit<
 > & {
     value: string;
     label: string;
+    /**
+     * @deprecated bruk heller {@link amount} for å vise pris.
+     * Dersom du har behov utover dette ta kontakt med oss så finner vi en løsning sammen.
+     */
     extraLabel?: React.ReactNode;
     /**
      * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
      * @default false
      */
     alwaysOpen?: boolean;
+    /**
+     * Viser pris til høyre i panelet
+     */
+    amount?: string;
 };
 
 export type RadioPanelGroupProps = FieldGroupProps & {};

--- a/packages/jokul/src/shared/input-panel/BasePanel.tsx
+++ b/packages/jokul/src/shared/input-panel/BasePanel.tsx
@@ -12,12 +12,20 @@ import { useAutoAnimatedHeight } from "../../hooks/useAnimatedHeight/useAutoAnim
 type Props = ComponentPropsWithRef<"input"> & {
     isChecked: boolean;
     /**
-     * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
-     * @default false
+     * @deprecated bruk heller {@link amount} for å vise pris.
+     * Dersom du har behov utover dette ta kontakt med oss så finner vi en løsning sammen.
      */
-    alwaysOpen: boolean;
-    label: string;
     extraLabel?: ReactNode;
+    /**
+     * @deprecated vi ønsker ikke at content skal skjules for brukerne lenger
+     * @default true
+     */
+    alwaysOpen?: boolean;
+    /**
+     * Viser pris til høyre i panelet
+     */
+    amount?: string;
+    label: string;
     type: "radio" | "checkbox";
 };
 
@@ -29,6 +37,7 @@ export const BasePanel = forwardRef(function BasePanel(
         alwaysOpen = false,
         label,
         extraLabel,
+        amount,
         type,
         ...rest
     }: Props,
@@ -58,14 +67,16 @@ export const BasePanel = forwardRef(function BasePanel(
                     className={`jkl-${type}-panel__decorator`}
                 />
                 <span className="jkl-input-panel__main-label">{label}</span>
-                <span
-                    className={clsx("jkl-input-panel__extra-label", {
-                        "jkl-input-panel__extra-label--text":
-                            typeof extraLabel === "string",
-                    })}
-                >
-                    {extraLabel}
-                </span>
+                {(extraLabel || amount) && (
+                    <span
+                        className={clsx("jkl-input-panel__extra-label", {
+                            "jkl-input-panel__extra-label--text":
+                                typeof extraLabel === "string" || amount,
+                        })}
+                    >
+                        {extraLabel || amount}
+                    </span>
+                )}
             </label>
             {hasChildren && (
                 <div ref={animationRef} aria-hidden={!isChecked && !alwaysOpen}>


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Markert extraLabel som deprecated, med amount som erstatning. Vi ønsker å rendyrke denne komponenten til å vise produkter, dekninger, utbetalinger og lignende.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5385
