### PR TITLE
major: multiple-prop og filakkumulering i FileInput

### DIFF
--- a/.changeset/spotty-needles-decide.md
+++ b/.changeset/spotty-needles-decide.md
@@ -1,0 +1,26 @@
+---
+"@fremtind/jokul": major
+---
+
+- Fikset en bug hvor multiple=false fortsatt akkumulerte filer
+- Flyttet filakkumulering-logikk til komponenten når multiple=true
+
+**BREAKING**: Eksisterende konsumenter som manuelt håndterte filakkumulering må oppdatere sine `onChange`-handlere.
+
+```tsx
+<FileInput
+  multiple
+  onChange={(_e, newFiles) => {
+    setFiles((currentFiles) => [...currentFiles, ...newFiles]);
+  }}
+/>
+```
+
+```tsx
+<FileInput
+  multiple
+  onChange={(_e, updatedFiles) => {
+    setFiles(updatedFiles);
+  }}
+/>
+```

--- a/packages/jokul/src/components/file-input/internal/Input.tsx
+++ b/packages/jokul/src/components/file-input/internal/Input.tsx
@@ -24,7 +24,7 @@ export const Input = forwardRef<HTMLInputElement, FileInputProps>(
                 <p>Input must be placed inside a FileInputContextProvider.</p>
             );
         }
-        const { accept, maxSizeBytes, onChange } = context;
+        const { accept, maxSizeBytes, files, onChange } = context;
 
         const elementId = id || defaultId;
 
@@ -50,23 +50,28 @@ export const Input = forwardRef<HTMLInputElement, FileInputProps>(
                     multiple={multiple}
                     value=""
                     onChange={(e) => {
-                        if (e.target.files) {
-                            onChange(
-                                e,
-                                [...e.target.files].map<UploadedFile>(
-                                    (file) => ({
-                                        file,
-                                        state: undefined,
-                                        validation: validateFileInputFiles(
-                                            file,
-                                            accept,
-                                            maxSizeBytes,
-                                        ),
-                                        uploadProgress: 0,
-                                    }),
-                                ),
-                            );
-                        }
+                        const { files: selectedFiles } = e.target;
+
+                        if (!selectedFiles) return;
+
+                        const newUploads = Array.from(
+                            selectedFiles,
+                        ).map<UploadedFile>((file) => ({
+                            file,
+                            state: undefined,
+                            validation: validateFileInputFiles(
+                                file,
+                                accept,
+                                maxSizeBytes,
+                            ),
+                            uploadProgress: 0,
+                        }));
+
+                        const updatedFiles = multiple
+                            ? [...files, ...newUploads]
+                            : newUploads;
+
+                        onChange(e, updatedFiles);
                     }}
                 />
                 <p className="jkl-file-input__dropzone-hint">

--- a/packages/jokul/src/components/file-input/stories/FileInput.stories.tsx
+++ b/packages/jokul/src/components/file-input/stories/FileInput.stories.tsx
@@ -45,11 +45,8 @@ export const FileInputStory: Story = {
                     id="file-input-example"
                     className="jkl-spacing-16-24--bottom"
                     value={files}
-                    onChange={(_e, newFiles) => {
-                        setFiles((currentFiles) => [
-                            ...currentFiles,
-                            ...newFiles,
-                        ]);
+                    onChange={(_e, updatedFiles) => {
+                        setFiles(updatedFiles);
                     }}
                 >
                     {files.map(({ state, file, validation }, index) => {


### PR DESCRIPTION
## 🐛 Problemer
- Filer ble alltid lagt til uavhengig av `multiple`-prop
- Konsumenter måtte selv samle filer i `onChange`

## ✅ Løsning
- FileInput håndterer selv akkumulering av filer
- `multiple=false` erstatter gamle filer (som native input type file )  

> ⚠️ **Breaking:** Fører til at konsumenter som tidligere akkumulerte filer manuelt nå må bruke `updatedFiles` i `onChange`.


### Før:
```tsx
<FileInput
    onChange={(_e, newFiles) => {
      setFiles((currentFiles) => [
        ...currentFiles,
        ...newFiles,
      ]);
    }}
/>
```

### Etter:
```tsx
<FileInput
    onChange={(_e, updatedFiles) => {
         setFiles(updatedFiles);
    }}
/>
```

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5397 
