### PR TITLE
docs: legg til info om Tailwind preflight i README

### DIFF
--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -175,6 +175,8 @@ export default {
 };
 ```
 
+Hvis du bruker Tailwind sammen med Jøkul anbefaler vi at du [skrur av Tailwind sine egne reset-regler](https://v3.tailwindcss.com/docs/preflight#disabling-preflight) (preflight), ettersom de kan overskrive Jøkul sine egne grunnstiler.
+
 ### Farger
 
 Preset-et kommer med alle semantiske farger fra Jøkul definert. Vi anbefaler å bruke Tailwind sin plugin til VSCode eller IntelliJ for å få autocomplete for farger og andre verdier i preset-et.


### PR DESCRIPTION
## 💬 Endringer

Legger til informasjon om at man bør skru av Tailwind sine `preflight`-stiler når man bruker det sammen med Jøkul.