### PR TITLE
Legg til Search-komponenten

### DIFF
--- a/.changeset/crazy-bees-prove.md
+++ b/.changeset/crazy-bees-prove.md
@@ -1,0 +1,15 @@
+---
+"@fremtind/jokul": minor
+"portal": patch
+---
+
+Legg til en `Search`-komponent. Før har man måttet bruke en kombinasjon av props på `TextInput` for å få den til å se ut som et søkefelt. Med denne komponenten slipper du det, og den blir semantisk riktigere.
+
+I tillegg følger det med:
+
+- en `Search.Button`, som er en egen knapp tiltenkt kun søkefeltet.
+- en knapp som enkelt tømmer søkefeltet.
+
+Du kan bruke komponenten enten med eller uten et `form`-element, avhengig av behov. Husk at dersom du wrapper søkefeltet i et skjema kan du også sette `type="submit"` på `Search.Button` for å håndtere søking (uten et tredjepartsbibliotek).
+
+**OBS**: `Search` bruker `InputGroup`, og støtter derfor alle props som også finnes i den. Vær oppmerksom på at `label` er skjult by default. Dette kan du endre med `labelProps`-propen.

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -455,6 +455,17 @@
                 "default": "./build/cjs/components/select/index.cjs"
             }
         },
+        "./styles/components/search": "./styles/components-beta/search/_index.scss",
+        "./search": {
+            "import": {
+                "types": "./build/es/components-beta/search/index.d.ts",
+                "default": "./build/es/components-beta/search/index.js"
+            },
+            "require": {
+                "types": "./build/cjs/components-beta/search/index.d.cts",
+                "default": "./build/cjs/components-beta/search/index.cjs"
+            }
+        },
         "./styles/components/segmented-control": "./styles/components/segmented-control/_index.scss",
         "./segmented-control": {
             "import": {

--- a/packages/jokul/src/components-beta/search/Search.tsx
+++ b/packages/jokul/src/components-beta/search/Search.tsx
@@ -1,0 +1,102 @@
+import clsx from "clsx";
+import React, { forwardRef, useRef } from "react";
+import { InputGroup } from "../../components/input-group/index.js";
+import { SearchButton } from "./SearchButton.js";
+import type { SearchInputProps } from "./types.js";
+
+export const Search = forwardRef<HTMLInputElement, SearchInputProps>(
+    function Search(props, forwardedRef): React.JSX.Element {
+        const {
+            label = "Søk",
+            className,
+            density,
+            errorLabel,
+            helpLabel,
+            labelProps = { srOnly: true },
+            supportLabelProps,
+            tooltip,
+            description,
+            name = "q",
+            placeholder = "Søk",
+            spellCheck = false,
+            icon = "search",
+            children,
+            value,
+            ...rest
+        } = props;
+
+        const inputGroupProps = {
+            label,
+            density,
+            errorLabel,
+            helpLabel,
+            labelProps,
+            supportLabelProps,
+            tooltip,
+            description,
+        };
+
+        const internalRef = useRef<HTMLInputElement | null>(null);
+
+        const ref = (instance: HTMLInputElement | null) => {
+            internalRef.current = instance;
+            if (forwardedRef) {
+                if (typeof forwardedRef === "function") {
+                    forwardedRef(instance);
+                } else {
+                    forwardedRef.current = instance;
+                }
+            }
+        };
+
+        const handleClick = () => {
+            if (internalRef.current) {
+                const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                    window.HTMLInputElement.prototype,
+                    "value",
+                )?.set;
+                nativeInputValueSetter?.call(internalRef.current, "");
+                const event = new Event("change", { bubbles: true });
+                internalRef.current.dispatchEvent(event);
+                internalRef.current.focus();
+            }
+        };
+
+        return (
+            <div className={clsx("jkl-search--beta", className)}>
+                <InputGroup
+                    {...inputGroupProps}
+                    label={label}
+                    data-testid="jkl-select--beta"
+                    render={(inputProps) => (
+                        <div className="input-wrapper" data-icon={icon}>
+                            <input
+                                ref={ref}
+                                type="search"
+                                name={name}
+                                placeholder={placeholder}
+                                spellCheck={spellCheck}
+                                {...inputProps}
+                                {...rest}
+                            />
+                            <button
+                                className="clear-button"
+                                type="button"
+                                onClick={handleClick}
+                            >
+                                <span className="jkl-sr-only">
+                                    Tilbakestill søkefeltet
+                                </span>
+                            </button>
+                        </div>
+                    )}
+                />
+                {children}
+            </div>
+        );
+    },
+) as ReturnType<typeof forwardRef<HTMLInputElement, SearchInputProps>> & {
+    Button: typeof SearchButton;
+};
+
+Search.Button = SearchButton;

--- a/packages/jokul/src/components-beta/search/SearchButton.tsx
+++ b/packages/jokul/src/components-beta/search/SearchButton.tsx
@@ -1,0 +1,15 @@
+import type { SearchButtonProps } from "./types.js";
+
+export const SearchButton = (props: SearchButtonProps) => {
+    const { className, type = "button", label = "Søk", ...rest } = props;
+
+    return (
+        <button
+            className="jkl-button jkl-button--ghost jkl-search-submit"
+            type={type}
+            {...rest}
+        >
+            {label}
+        </button>
+    );
+};

--- a/packages/jokul/src/components-beta/search/index.ts
+++ b/packages/jokul/src/components-beta/search/index.ts
@@ -1,0 +1,3 @@
+export { Search as BETA_Search } from "./Search.js";
+
+export type { SearchInputProps as BETA_SearchInputProps } from "./types.js";

--- a/packages/jokul/src/components-beta/search/stories/search-button.stories.tsx
+++ b/packages/jokul/src/components-beta/search/stories/search-button.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SearchButton } from "../SearchButton.jsx";
+import { Search } from "../Search.jsx";
+
+import "../styles/_index.scss";
+
+const meta: Meta = {
+    title: "Beta/Search/SearchButton",
+    component: SearchButton,
+    parameters: {
+        layout: "centered",
+    },
+    args: {
+        label: "Søk",
+        type: "button",
+    },
+    argTypes: {
+        type: {
+            control: "inline-radio",
+            options: ["button", "submit"],
+        },
+    },
+    tags: ["autodocs", "forms"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SearchButton>;
+
+import { SearchWithButton } from "./search.stories.jsx";
+export const SearchButtonStory: Story = {
+    name: "Search Button",
+    args: {
+        label: "Søk",
+        type: "button",
+    },
+    render: (args) => (
+        <>
+            <Search
+                {...SearchWithButton.args}
+                label={SearchWithButton.args?.label}
+            >
+                <Search.Button {...args} />
+            </Search>
+        </>
+    ),
+};

--- a/packages/jokul/src/components-beta/search/stories/search.stories.tsx
+++ b/packages/jokul/src/components-beta/search/stories/search.stories.tsx
@@ -1,0 +1,411 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { Button } from "../../../components/button/index.js";
+import { Card } from "../../../components/card/Card.jsx";
+import { Flex } from "../../../components/flex/index.js";
+import { Icon, SearchIcon } from "../../../components/icon/index.js";
+import { List, ListItem } from "../../../components/list/index.js";
+import { MenuItem } from "../../../components/menu/index.js";
+import {
+    Modal,
+    ModalBody,
+    ModalContainer,
+    ModalOverlay,
+    useModal,
+} from "../../../components/modal/index.js";
+import { Popover } from "../../../components/popover/index.js";
+import { BETA_Select } from "../../select/index.js";
+import { Search } from "../Search.js";
+import { SearchButton } from "../SearchButton.js";
+import { BETA_Search } from "../index.js";
+import { SearchButtonStory } from "./search-button.stories.jsx";
+
+import "../styles/_index.scss";
+
+const meta: Meta = {
+    title: "Beta/Search",
+    component: Search,
+    subcomponents: {
+        SearchButton,
+    },
+    parameters: {
+        layout: "centered",
+    },
+    args: {
+        spellCheck: false,
+        label: "Søk",
+        placeholder: "Søk",
+        icon: "search",
+        description: "",
+        required: true,
+        disabled: false,
+        labelProps: {
+            srOnly: true,
+        },
+    },
+    argTypes: {
+        icon: {
+            control: "select",
+            options: ["search", "filter_list", "filter_alt"],
+            table: {
+                defaultValue: { summary: "search" },
+            },
+        },
+    },
+    tags: ["autodocs", "forms"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Search>;
+
+export const _Search: Story = {
+    name: "Søk",
+};
+
+const categories = ["Layout", "Tekst", "Gruppering", "Alle"].sort();
+const components = [
+    "Button",
+    "Autosuggest",
+    "Card",
+    "Breadcrumbs",
+    "Help",
+    "Image",
+    "List",
+    "Pagination",
+    "Modal",
+    "Icon",
+    "Search",
+    "Flex",
+    "Table",
+    "Expander",
+    "Alle",
+].sort();
+
+export const SearchWithDatalist: Story = {
+    name: "Søk med autosuggest",
+    args: {
+        list: "components",
+    },
+    render: (args) => (
+        <>
+            <Search {...args}>
+                <datalist id={args.list}>
+                    {components.map((keyword) => (
+                        <option key={keyword}>{keyword}</option>
+                    ))}
+                </datalist>
+            </Search>
+        </>
+    ),
+};
+
+export const SearchWithButton: Story = {
+    name: "Søk med knapp",
+    args: {
+        label: "Søk",
+        placeholder: "",
+    },
+    render: (args) => (
+        <Flex gap="xl" wrap="wrap">
+            <Flex direction="column" gap="m">
+                <Search {...args}>
+                    <Search.Button {...SearchButtonStory.args} />
+                </Search>
+            </Flex>
+        </Flex>
+    ),
+};
+
+export const BigSearch: Story = {
+    name: "Søk som hovedhandling på en side",
+    parameters: {
+        layout: "centered",
+    },
+    args: {
+        labelProps: {
+            srOnly: true,
+        },
+        placeholder: "",
+    },
+    render: (args) => (
+        <Flex
+            as="form"
+            direction="column"
+            justifyContent="center"
+            alignItems="center"
+        >
+            <h2 className="jkl-heading-2">Hva leter du etter?</h2>
+            <Search {...args}>
+                <Search.Button type="submit" />
+            </Search>
+        </Flex>
+    ),
+};
+
+export const SearchFilter: Story = {
+    name: "Søk som filter",
+    args: {
+        placeholder: "Filtrer etter navn",
+        label: "Filtrer etter navn",
+        icon: "filter_list",
+    },
+    parameters: {
+        layout: "padded",
+    },
+    render: (args) => {
+        const [results, setResults] = useState(components);
+
+        return (
+            <Flex direction="column" gap="s">
+                <Search
+                    {...args}
+                    onChange={(e) => {
+                        setResults(
+                            components.filter((result) =>
+                                result
+                                    .toLowerCase()
+                                    .includes(e.target.value.toLowerCase()),
+                            ),
+                        );
+                    }}
+                />
+                <section aria-live="polite">
+                    <p className={results.length ? "jkl-sr-only" : ""}>
+                        {`${results.length} komponenter funnet`}
+                    </p>
+                    <Flex
+                        as="ul"
+                        gap="xs"
+                        direction="column"
+                        style={{
+                            padding: 0,
+                            margin: 0,
+                        }}
+                    >
+                        {!!results.length &&
+                            results.map((result) => (
+                                <Card as="li" key={result}>
+                                    <p className="jkl-heading-5">{result}</p>
+                                    <div
+                                        style={{
+                                            color: "var(--jkl-color-text-subdued)",
+                                        }}
+                                    >
+                                        <p className="jkl-small">Komponent</p>
+                                        <p className="jkl-small">
+                                            Mer informasjon
+                                        </p>
+                                    </div>
+                                </Card>
+                            ))}
+                    </Flex>
+                </section>
+            </Flex>
+        );
+    },
+};
+
+export const SearchWithResultsInPopover: Story = {
+    name: "Popover med søk",
+    render: (args) => {
+        const [showResults, setShowResults] = useState(false);
+        const [results, setResults] = useState(components);
+
+        return (
+            <Popover open={showResults}>
+                <Popover.Trigger aria-expanded={showResults} asChild>
+                    <Search
+                        {...args}
+                        onChange={(e) => {
+                            e.target.value.length !== 0 && setShowResults(true);
+                            setResults(
+                                components.filter((result) =>
+                                    result
+                                        .toLowerCase()
+                                        .includes(e.target.value.toLowerCase()),
+                                ),
+                            );
+                        }}
+                    />
+                </Popover.Trigger>
+                <Popover.Content
+                    padding={8}
+                    role="menu"
+                    style={{ maxWidth: "25ch" }}
+                    aria-live="polite"
+                >
+                    <p className="jkl-sr-only">
+                        {`${results.length} komponenter funnet`}
+                    </p>
+                    {results.map((result) => (
+                        <MenuItem key={result} as="a" href="#">
+                            {result}
+                        </MenuItem>
+                    ))}
+                </Popover.Content>
+            </Popover>
+        );
+    },
+};
+
+export const SearchHeaderButton: Story = {
+    name: "Header med søkeknapp",
+    parameters: {
+        layout: "centered",
+    },
+    args: {
+        labelProps: {
+            variant: "large",
+        },
+        placeholder: "Søk i hele Jøkul",
+    },
+    render: (args) => {
+        const [searchString, setSearchString] = useState("");
+        const [instance, { overlay, container, modal }] = useModal({
+            title: "",
+        });
+
+        const filteredComponents = components.filter((word) =>
+            word.includes(searchString),
+        );
+
+        return (
+            <>
+                <Flex
+                    as="header"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    style={{
+                        minInlineSize: "50cqi",
+                        padding: "var(--jkl-spacing-s) var(--jkl-spacing-m)",
+                        background:
+                            "var(--jkl-color-background-container-high)",
+                    }}
+                >
+                    <p className="jkl-heading-4">Jøkul</p>
+                    <Flex gap="xs">
+                        <Button
+                            variant="ghost"
+                            onClick={() => instance.show()}
+                            icon={<SearchIcon />}
+                            aria-label="Åpne søk"
+                        />
+                        <Button
+                            variant="ghost"
+                            icon={<Icon>menu</Icon>}
+                            aria-label="Meny"
+                        />
+                    </Flex>
+                </Flex>
+                <ModalContainer {...container}>
+                    <ModalOverlay {...overlay} />
+                    <Modal {...modal}>
+                        <Flex as={ModalBody} gap="m" direction="column">
+                            <BETA_Search
+                                {...args}
+                                value={searchString}
+                                onChange={(e) =>
+                                    setSearchString(e.target.value)
+                                }
+                            />
+                            <div aria-live="polite">
+                                <p className="jkl-sr-only">
+                                    {`${filteredComponents.length} komponenter funnet`}
+                                </p>
+                                <List>
+                                    {filteredComponents.map((word) => (
+                                        <ListItem key={word}>{word}</ListItem>
+                                    ))}
+                                </List>
+                            </div>
+                        </Flex>
+                    </Modal>
+                </ModalContainer>
+            </>
+        );
+    },
+};
+
+export const SearchToolbar: Story = {
+    name: "Toolbar med søkefilter",
+    parameters: {
+        layout: "fullscreen",
+    },
+    args: {
+        label: "Filtrer etter navn",
+        placeholder: "",
+        labelProps: {
+            srOnly: false,
+        },
+        icon: "filter_list",
+    },
+    render: (args) => {
+        const [results, setResults] = useState(components);
+
+        return (
+            <Flex direction="column" gap="s">
+                <Card asChild>
+                    <Flex
+                        as="menu"
+                        alignItems="end"
+                        justifyContent="space-between"
+                        gap="xl"
+                        style={{
+                            display: "flex",
+                            minInlineSize: "50cqi",
+                            padding:
+                                "var(--jkl-spacing-m) var(--jkl-spacing-m)",
+                            background:
+                                "var(--jkl-color-background-container-high)",
+                        }}
+                    >
+                        <Flex gap="xs">
+                            <Search
+                                {...args}
+                                onChange={(e) =>
+                                    setResults(
+                                        components.filter((component) =>
+                                            component
+                                                .toLowerCase()
+                                                .includes(
+                                                    e.target.value.toLowerCase(),
+                                                ),
+                                        ),
+                                    )
+                                }
+                            />
+                        </Flex>
+
+                        <Flex gap="s">
+                            <BETA_Select label="Komponent" placeholder="">
+                                {components.map((word) => (
+                                    <option key={word}>{word}</option>
+                                ))}
+                            </BETA_Select>
+                            <BETA_Select label="Gruppe" placeholder="">
+                                {categories.map((category) => (
+                                    <option key={category}>{category}</option>
+                                ))}
+                            </BETA_Select>
+                        </Flex>
+                    </Flex>
+                </Card>
+                {!!results.length &&
+                    results.map((result) => (
+                        <Card as="li" key={result}>
+                            <p className="jkl-heading-5">{result}</p>
+                            <div
+                                style={{
+                                    color: "var(--jkl-color-text-subdued)",
+                                }}
+                            >
+                                <p className="jkl-small">Komponent</p>
+                                <p className="jkl-small">Mer informasjon</p>
+                            </div>
+                        </Card>
+                    ))}
+            </Flex>
+        );
+    },
+};

--- a/packages/jokul/src/components-beta/search/styles/_index.scss
+++ b/packages/jokul/src/components-beta/search/styles/_index.scss
@@ -1,0 +1,4 @@
+@forward "search";
+@forward "search-with-submit-button";
+@use "../../../components/icon/styles/index" as icon;
+@use "../../../components/input-group/styles/index" as input-group;

--- a/packages/jokul/src/components-beta/search/styles/search-with-submit-button.scss
+++ b/packages/jokul/src/components-beta/search/styles/search-with-submit-button.scss
@@ -1,0 +1,37 @@
+@use "../../../core/jkl/index" as jkl;
+@use "../../../shared/input/styles/shared-input-styles" as shared;
+
+.jkl-search--beta:has(button.jkl-search-submit){
+    display: grid;
+    grid-template-columns: 1fr max-content;
+    align-items: end;
+
+    .input-wrapper {
+        border-inline-end: 0;
+        border-radius: 3px 0 0 3px;
+    }
+
+    button.jkl-search-submit {
+        height: var(--jkl-text-input-height);
+        border-radius: 0 3px 3px 0;
+        border: var(--border);
+        border-inline-start: 0;
+        min-width: unset;
+
+        &::before {
+            content: "";
+            position: absolute;
+            width: 1px;
+            inset: 0;
+            inset-block: 20%;
+            background-color: var(--jkl-color-border-separator);
+
+            @include jkl.motion;
+            transition-property: inset;
+        }
+
+        &:hover::before {
+            inset-block: 0;
+        }
+    }
+}

--- a/packages/jokul/src/components-beta/search/styles/search.scss
+++ b/packages/jokul/src/components-beta/search/styles/search.scss
@@ -1,0 +1,106 @@
+@use "../../../core/jkl/index" as jkl;
+@use "../../../shared/input/styles/shared-input-styles" as shared;
+
+.jkl-search--beta {
+    --icon-size: var(--jkl-text-input-height);
+    --border-radius: 3px;
+    --border: 1px solid var(--jkl-color-border-input);
+
+    width: 100%;
+
+    @include jkl.text-style("body");
+
+    input[type="search"] {
+        appearance: none;
+        padding: 0;
+        background-color: transparent;
+        height: 100%;
+        color: var(--jkl-color-text-default);
+        grid-column: 2 / 3;
+
+        @include jkl.reset-outline;
+
+        &::-webkit-search-cancel-button, &::-webkit-calendar-picker-indicator, &::-webkit-search-results-button {
+            appearance: none;
+            display: none !important;
+        }
+    }
+
+    .input-wrapper {
+        box-sizing: border-box;
+        display: grid;
+        grid-template-columns: var(--icon-size) 1fr;
+        border-radius: var(--border-radius);
+        padding-inline-end: 0;
+        height: var(--jkl-text-input-height);
+        border: var(--border);
+
+        &::before {
+            font-family: "Fremtind Material Symbols";
+            content: attr(data-icon) / "";
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            grid-column: 1;
+        }
+
+        &:has(.clear-button) {
+            grid-template-columns: var(--icon-size) 1fr var(--icon-size);
+        }
+    }
+
+    // Nettlesere har ulik støtte for begge disse metodene, så begge må være med per 12. november 2025
+    &:has(input:not(:valid), input:placeholder-shown) {
+        .clear-button {
+            display: none;
+        }
+    }
+
+    .clear-button {
+        display: grid;
+        appearance: none;
+        background-color: transparent;
+        border: 0;
+        height: 100%;
+        padding: 0;
+        cursor: pointer;
+        color: var(--jkl-color-text-default);
+
+        &::before, &::after {
+            display: inline-grid;
+            align-items: center;
+            justify-content: center;
+            place-self: center;
+            align-self: center;
+            grid-row: 1;
+            grid-column: 1;
+        }
+
+        &::before {
+            content: "close" / "";
+            font-family: "Fremtind Material Symbols";
+            z-index: 1;
+            line-height: 1.25lh;
+        }
+
+        &::after {
+            content: "";
+            background-color: transparent;
+            height: 1.25lh;
+            aspect-ratio: 1;
+            border-radius: 100%;
+
+            @include jkl.motion;
+            transition-property: background-color;
+        }
+
+        &:hover::after {
+            background-color: var(--jkl-color-background-interactive-hover);
+        }
+
+        &:focus-visible {
+            @include jkl.focus-outline;
+        }
+    }
+}

--- a/packages/jokul/src/components-beta/search/types.ts
+++ b/packages/jokul/src/components-beta/search/types.ts
@@ -1,0 +1,31 @@
+import type {
+    ButtonHTMLAttributes,
+    InputHTMLAttributes,
+    ReactNode,
+} from "react";
+import type { InputGroupProps } from "../../components/input-group/types.js";
+
+export type SearchInputProps = Omit<
+    InputGroupProps,
+    "children" | "inline" | "label"
+> &
+    InputHTMLAttributes<HTMLInputElement> & {
+        /**
+         * Label til søket. Bruk {@link LabelProps} for å vise den.
+         */
+        label?: string;
+        /**
+         * Lar deg velge hvilket ikon som vises på venstresiden i feltet.
+         * @default "search"
+         */
+        icon?: "search" | "filter_alt" | "filter_list";
+        children?: ReactNode;
+    };
+
+export type SearchButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+    /**
+     * Lar deg endre teksten i knappen.
+     * @default "Søk"
+     */
+    label?: string;
+};

--- a/packages/jokul/src/styles/styles.scss
+++ b/packages/jokul/src/styles/styles.scss
@@ -32,6 +32,7 @@
 @use "../components/radio-panel/styles" as radio-panel;
 @use "../components/select/styles" as select;
 @use "../components-beta/select/styles" as select-beta;
+@use "../components-beta/search/styles" as search;
 @use "../components/segmented-control/styles" as segmented-control;
 @use "../components/summary-table/styles" as summary-table;
 @use "../components/system-message/styles" as system-message;

--- a/portal/src/components/header/Header.tsx
+++ b/portal/src/components/header/Header.tsx
@@ -1,9 +1,10 @@
 import { Flex } from "@fremtind/jokul/flex";
-import styles from "./header.module.scss";
-import { MenuItemList } from "./menu/MenuItemList";
-import { Menu } from "./menu/Menu";
 import { Link } from "@fremtind/jokul/link";
 import BetaTag from "../BetaTag";
+import { Menu } from "./menu/Menu";
+import { MenuItemList } from "./menu/MenuItemList";
+
+import styles from "./header.module.scss";
 
 export const Header = async () => {
     return (

--- a/portal/src/components/header/global-search/GlobalSearch.tsx
+++ b/portal/src/components/header/global-search/GlobalSearch.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Results } from "@/components/header/global-search/Results";
+import { Button } from "@fremtind/jokul/button";
+import { SearchIcon } from "@fremtind/jokul/icon";
+import {
+    Modal,
+    ModalBody,
+    ModalContainer,
+    ModalOverlay,
+    useModal,
+} from "@fremtind/jokul/modal";
+import { BETA_Search } from "@fremtind/jokul/search";
+import React, { useEffect, useState } from "react";
+
+import styles from "../header.module.scss";
+
+export const GlobalSearch = () => {
+    const [searchText, setSearchText] = useState("");
+    const [showModal, setShowModal] = useState(false);
+    const [instance, { title, overlay, container, modal, closeButton }] =
+        useModal({ title: "Søk" });
+
+    useEffect(() => {
+        if (!instance) {
+            return;
+        }
+        instance.show();
+    }, [instance]);
+
+    return (
+        <>
+            <Button
+                variant="ghost"
+                onClick={(e) => setShowModal(!showModal)}
+                icon={<SearchIcon />}
+                aria-label="Søk"
+                className={styles.search}
+            />
+            {showModal && (
+                <ModalContainer {...container}>
+                    <ModalOverlay {...overlay} />
+                    <Modal {...modal}>
+                        <ModalBody>
+                            <BETA_Search
+                                label="Søk i Jøkul"
+                                labelProps={{ variant: "large" }}
+                                placeholder=""
+                                showClearButton
+                                value={searchText}
+                                onChange={(e) => setSearchText(e.target.value)}
+                            />
+                            <Results searchString={searchText} />
+                        </ModalBody>
+                    </Modal>
+                </ModalContainer>
+            )}
+        </>
+    );
+};

--- a/portal/src/components/header/global-search/Results.tsx
+++ b/portal/src/components/header/global-search/Results.tsx
@@ -1,0 +1,30 @@
+import { List, ListItem } from "@fremtind/jokul/list";
+
+export const Results = ({ searchString = "" }) => {
+    const keywords = [
+        "Button",
+        "Autosuggest",
+        "Card",
+        "Breadcrumbs",
+        "Help",
+        "Image",
+        "List",
+        "Pagination",
+        "Modal",
+        "Icon",
+        "Search",
+        "Flex",
+        "Table",
+        "Expander",
+    ]
+        .sort()
+        .filter((word) => word.includes(searchString));
+
+    return (
+        <List>
+            {keywords.map((word) => (
+                <ListItem key={word}>{word}</ListItem>
+            ))}
+        </List>
+    );
+};


### PR DESCRIPTION
Legg til en `Search`-komponent. Før har man måttet bruke en kombinasjon av props på `TextInput` for å få den til å se ut som et søkefelt. Med denne komponenten slipper du det, og den blir semantisk riktigere.

I tillegg følger det med:

- en `Search.Button`, som er en egen knapp tiltenkt kun søkefeltet.
- en knapp som enkelt tømmer søkefeltet. Denne kan du skru av med `showClearButton`-propen.

Du kan bruke komponenten enten med eller uten et `form`-element, avhengig av behov. Husk at dersom du wrapper søkefeltet i et skjema kan du også sette `type="submit"` på `Search.Button` for å håndtere søking (uten et tredjepartsbibliotek).

**OBS**: `Search` bruker `InputGroup`, og støtter derfor alle props som også finnes i den. Vær oppmerksom på at `label` er skjult by default. Dette kan du endre med `labelProps`-propen.