### PR TITLE
docs(changeset): Bruk Pagination-komponenten i TablePagination

### DIFF
--- a/.changeset/free-breads-tap.md
+++ b/.changeset/free-breads-tap.md
@@ -1,0 +1,23 @@
+---
+"@fremtind/jokul": major
+---
+
+TablePagination bruker nå den eksisterende Pagination-komponenten i stedet for egen paginering-logikk.
+
+**Breaking Changes:**
+
+- `activePage` prop endret fra 0-basert til 1-basert indeksering
+
+**Migrering:**
+
+```typescript
+// Før
+<TablePagination
+  activePage={0}
+/>
+
+// Nå
+<TablePagination
+  activePage={1}
+/>
+```

--- a/packages/jokul/src/components/pagination/Pagination.tsx
+++ b/packages/jokul/src/components/pagination/Pagination.tsx
@@ -64,7 +64,7 @@ export const Pagination = React.forwardRef(function Pagination<
                         const page = index + 1;
                         return (
                             <PageButton
-                                key={index}
+                                key={page}
                                 isActive={currentPage === page}
                                 number={page}
                                 total={numberOfPages}

--- a/packages/jokul/src/components/pagination/stories/Pagination.stories.tsx
+++ b/packages/jokul/src/components/pagination/stories/Pagination.stories.tsx
@@ -23,14 +23,14 @@ export const Pagination: Story = {
         onPageChange: () => {},
     },
     decorators: [
-        (Story, context) => {
+        (_, context) => {
             const [currentPage, setCurrentPage] = useState<number>(
                 context.args.currentPage,
             );
 
             const numberOfPages = context.args.numberOfPages;
 
-            const onPageChange = (newPage: number, fromPage: number) => {
+            const onPageChange = (newPage: number) => {
                 if (newPage > 0 && newPage <= numberOfPages) {
                     setCurrentPage(newPage);
                 }

--- a/packages/jokul/src/components/pagination/styles/pagination.scss
+++ b/packages/jokul/src/components/pagination/styles/pagination.scss
@@ -4,6 +4,7 @@ $_button-size: jkl.rem(32px);
 
 .jkl-pagination {
     display: flex;
+    align-items: center;
 
     &__pages {
         list-style: none;

--- a/packages/jokul/src/components/table/TablePagination.tsx
+++ b/packages/jokul/src/components/table/TablePagination.tsx
@@ -2,36 +2,21 @@ import clsx from "clsx";
 import React, {
     forwardRef,
     useCallback,
+    useEffect,
+    useId,
     useState,
     type ChangeEventHandler,
-    type FC,
-    type MouseEventHandler,
 } from "react";
-import { useId } from "../../hooks/useId/useId.js";
-import { IconButton } from "../icon-button/IconButton.js";
-import { ChevronLeftIcon } from "../icon/icons/ChevronLeftIcon.js";
-import { ChevronRightIcon } from "../icon/icons/ChevronRightIcon.js";
+import { Pagination } from "../pagination/Pagination.js";
 import { NativeSelect } from "../select/NativeSelect.js";
 import { TextInput } from "../text-input/TextInput.js";
 import { useTableContext } from "./tableContext.js";
 import type { TablePaginationProps } from "./types.js";
 
-function clamp(min: number, num: number, max: number): number {
-    if (num < min) {
-        return min;
-    }
-
-    if (num > max) {
-        return max;
-    }
-
-    return num;
-}
-
 export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
     (props, ref) => {
         const {
-            activePage = 0,
+            activePage = 1,
             totalNumberOfRows,
             rowsPerPage,
             rowsPerPageItems,
@@ -49,9 +34,8 @@ export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
             ...rest
         } = props;
 
-        const id = useId(idProp || "jkl-table-pagination", {
-            generateSuffix: !idProp,
-        });
+        const id = idProp || `jkl-table-pagination-${useId()}`;
+
         const { density: contextDensity } = useTableContext();
 
         const showAll = rowsPerPage <= 0;
@@ -59,74 +43,51 @@ export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
             ? 1
             : Math.ceil(totalNumberOfRows / rowsPerPage);
 
-        const [currentPage, setCurrentPage] = useState(
-            clamp(0, activePage, numberOfPages - 1),
+        const [pageInputValue, setPageInputValue] = useState(
+            String(activePage),
         );
+        const [isUserTyping, setIsUserTyping] = useState(false);
 
-        const onPageClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-            (e) => {
-                const toPage = Number.parseInt(
-                    e.currentTarget.dataset.number as string,
-                );
-                onChange(e, toPage, currentPage);
-                setCurrentPage(toPage);
-                setPagePickerValue(String(toPage + 1));
-            },
-            [onChange, currentPage],
-        );
+        useEffect(() => {
+            setPageInputValue(String(activePage));
+            setIsUserTyping(false);
+        }, [activePage]);
 
-        const [pagePickerValue, setPagePickerValue] = useState(
-            String(currentPage + 1),
-        );
-        const onPageChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-            (e) => {
-                setPagePickerValue(e.target.value);
-                try {
-                    const toPage = Number.parseInt(e.target.value) - 1;
-                    if (Number.isNaN(toPage)) {
+        const handlePageInputChange: ChangeEventHandler<HTMLInputElement> =
+            useCallback(
+                (e) => {
+                    setPageInputValue(e.target.value);
+                    setIsUserTyping(true);
+
+                    try {
+                        const enteredPageNumber = Number.parseInt(
+                            e.target.value,
+                        );
+
+                        if (Number.isNaN(enteredPageNumber)) {
+                            return;
+                        }
+
+                        if (
+                            enteredPageNumber >= 1 &&
+                            enteredPageNumber <= numberOfPages
+                        ) {
+                            onChange(enteredPageNumber, activePage);
+                        }
+                    } catch {
                         return;
                     }
+                },
+                [onChange, activePage, numberOfPages],
+            );
 
-                    if (toPage >= 0 && toPage < numberOfPages) {
-                        onChange(e, toPage, currentPage);
-                        setCurrentPage(toPage);
-                    }
-                } catch {
-                    return;
-                }
-            },
-            [onChange, currentPage, numberOfPages],
-        );
-
-        const onPrevious: MouseEventHandler<HTMLButtonElement> = useCallback(
-            (e) => {
-                if (currentPage === 0) {
-                    // TODO: skal dette være en no-op i stedet?
-                    onChange(e, currentPage, currentPage);
-                    return;
-                }
-                const toPage = currentPage - 1;
-                onChange(e, toPage, currentPage);
-                setCurrentPage(toPage);
-                setPagePickerValue(String(toPage + 1));
-            },
-            [onChange, currentPage],
-        );
-
-        const onNext: MouseEventHandler<HTMLButtonElement> = useCallback(
-            (e) => {
-                if (currentPage === numberOfPages - 1) {
-                    // TODO: skal dette være en no-op i stedet?
-                    onChange(e, currentPage, currentPage);
-                    return;
-                }
-                const toPage = currentPage + 1;
-                onChange(e, toPage, currentPage);
-                setCurrentPage(toPage);
-                setPagePickerValue(String(toPage + 1));
-            },
-            [onChange, numberOfPages, currentPage],
-        );
+        const parsedPageNumber = Number.parseInt(pageInputValue);
+        const isInputInvalid =
+            isUserTyping &&
+            pageInputValue &&
+            (Number.isNaN(parsedPageNumber) ||
+                parsedPageNumber < 1 ||
+                parsedPageNumber > numberOfPages);
 
         return (
             <div
@@ -136,7 +97,7 @@ export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
                 data-density={density || contextDensity}
                 ref={ref}
             >
-                <div className="jkl-table-pagination__left">
+                <div className="jkl-table-pagination__page-size">
                     <div className="jkl-table-pagination__picker jkl-table-pagination__picker--rows">
                         <span
                             className="jkl-table-pagination__picker-label"
@@ -167,215 +128,62 @@ export const TablePagination = forwardRef<HTMLDivElement, TablePaginationProps>(
                 <span className="jkl-table-pagination__total-rows">
                     Treff: {totalNumberOfRows}
                 </span>
-                <div className="jkl-table-pagination__right">
+                <div className="jkl-table-pagination__navigation">
+                    {withGoToPage && numberOfPages !== 1 && (
+                        <div className="jkl-table-pagination__picker jkl-table-pagination__picker--page">
+                            <span
+                                className="jkl-table-pagination__picker-label"
+                                aria-hidden="true"
+                            >
+                                {typeof withGoToPage === "object"
+                                    ? withGoToPage.gotoLabel
+                                    : "Gå til side"}
+                                :
+                            </span>
+                            {/* onChange først ved enter/submit */}
+                            <TextInput
+                                className="jkl-table-pagination__picker-input"
+                                label={
+                                    typeof withGoToPage === "object"
+                                        ? withGoToPage.gotoLabel
+                                        : "Gå til side"
+                                }
+                                labelProps={{ srOnly: true }}
+                                name={`${id}-go-to-page`}
+                                value={pageInputValue}
+                                width="min(4rem, 100%)"
+                                onChange={handlePageInputChange}
+                                aria-invalid={
+                                    isInputInvalid ? "true" : undefined
+                                }
+                            />
+                        </div>
+                    )}
                     {numberOfPages !== 1 && (
-                        <nav className="jkl-table-pagination__nav">
-                            {withGoToPage && (
-                                <div className="jkl-table-pagination__picker jkl-table-pagination__picker--page">
-                                    <span
-                                        className="jkl-table-pagination__picker-label"
-                                        aria-hidden="true"
-                                    >
-                                        {typeof withGoToPage === "object"
-                                            ? withGoToPage.gotoLabel
-                                            : "Gå til side"}
-                                        :
-                                    </span>
-                                    {/* onChange først ved enter/submit */}
-                                    <TextInput
-                                        className="jkl-table-pagination__picker-input"
-                                        label={
-                                            typeof withGoToPage === "object"
-                                                ? withGoToPage.gotoLabel
-                                                : "Gå til side"
-                                        }
-                                        labelProps={{ srOnly: true }}
-                                        name={`${id}-go-to-page`}
-                                        value={pagePickerValue}
-                                        width="min(4rem, 100%)"
-                                        onChange={onPageChange}
-                                        aria-invalid={
-                                            pagePickerValue &&
-                                            pagePickerValue !==
-                                                String(currentPage + 1)
-                                                ? "true"
-                                                : undefined
-                                        }
-                                    />
-                                </div>
-                            )}
-                            <ul>
-                                <li>
-                                    <IconButton
-                                        className="jkl-table-pagination__previous"
-                                        title={labels.previous}
-                                        onClick={onPrevious}
-                                    >
-                                        <ChevronLeftIcon />
-                                    </IconButton>
-                                </li>
-                                <PaginationPages
-                                    id={id}
-                                    activePage={activePage}
-                                    numberOfPages={numberOfPages}
-                                    onPageClick={onPageClick}
-                                />
-                                <li>
-                                    <IconButton
-                                        className="jkl-table-pagination__next"
-                                        title={labels.next}
-                                        onClick={onNext}
-                                    >
-                                        <ChevronRightIcon />
-                                    </IconButton>
-                                </li>
-                            </ul>
-                        </nav>
+                        <Pagination
+                            currentPage={activePage}
+                            numberOfPages={numberOfPages}
+                            onPageChange={(newPage) => {
+                                const validPage = Math.max(
+                                    1,
+                                    Math.min(newPage, numberOfPages),
+                                );
+
+                                setPageInputValue(String(validPage));
+                                setIsUserTyping(false);
+
+                                onChange(validPage, activePage);
+                            }}
+                            labels={{
+                                previous: labels.previous,
+                                next: labels.next,
+                            }}
+                        />
                     )}
                 </div>
             </div>
         );
     },
-);
-
-const PaginationPages: FC<{
-    id: string;
-    activePage: number;
-    numberOfPages: number;
-    onPageClick: MouseEventHandler;
-}> = ({ id, activePage, numberOfPages, onPageClick }) => {
-    if (numberOfPages <= 7) {
-        return (
-            <>
-                {Array.from({ length: numberOfPages }).map((_, i) => (
-                    <li key={`${id}-page-${i}`}>
-                        <button
-                            className={clsx("jkl-table-pagination__page", {
-                                "jkl-table-pagination__page--active":
-                                    activePage === i,
-                            })}
-                            type="button"
-                            data-number={i}
-                            onClick={onPageClick}
-                        >
-                            {i + 1}
-                        </button>
-                    </li>
-                ))}
-            </>
-        );
-    }
-
-    const showStartEllipsis = activePage > 3 && numberOfPages > 7;
-    const showEndEllipsis = activePage < numberOfPages - 4 && numberOfPages > 7;
-
-    const startEllipsis = Math.min(
-        Math.max(activePage - 2, 1),
-        numberOfPages - 6,
-    );
-    const centerPageNumberStart = Math.min(
-        startEllipsis + 1,
-        numberOfPages - 5,
-    );
-    const centerPageNumber = Math.min(
-        centerPageNumberStart + 1,
-        numberOfPages - 4,
-    );
-    const centerPageNumberEnd = Math.min(
-        centerPageNumberStart + 2,
-        numberOfPages - 3,
-    );
-    const endEllipsis = Math.min(centerPageNumberStart + 3, numberOfPages - 2);
-
-    return (
-        <>
-            <li>
-                <PaginationPageButton
-                    isActive={activePage === 0}
-                    number={0}
-                    onClick={onPageClick}
-                />
-            </li>
-            <li>
-                {showStartEllipsis ? (
-                    <span
-                        className="jkl-table-pagination__ellipsis"
-                        aria-hidden
-                    >
-                        {"..."}
-                    </span>
-                ) : (
-                    <PaginationPageButton
-                        isActive={activePage === startEllipsis}
-                        number={startEllipsis}
-                        onClick={onPageClick}
-                    />
-                )}
-            </li>
-            <li>
-                <PaginationPageButton
-                    isActive={activePage === centerPageNumberStart}
-                    number={centerPageNumberStart}
-                    onClick={onPageClick}
-                />
-            </li>
-            <li>
-                <PaginationPageButton
-                    isActive={activePage === centerPageNumber}
-                    number={centerPageNumber}
-                    onClick={onPageClick}
-                />
-            </li>
-            <li>
-                <PaginationPageButton
-                    isActive={activePage === centerPageNumberEnd}
-                    number={centerPageNumberEnd}
-                    onClick={onPageClick}
-                />
-            </li>
-            <li>
-                {showEndEllipsis ? (
-                    <span
-                        className="jkl-table-pagination__ellipsis"
-                        aria-hidden
-                    >
-                        {"..."}
-                    </span>
-                ) : (
-                    <PaginationPageButton
-                        isActive={activePage === endEllipsis}
-                        number={endEllipsis}
-                        onClick={onPageClick}
-                    />
-                )}
-            </li>
-            <li>
-                <PaginationPageButton
-                    isActive={activePage === numberOfPages - 1}
-                    number={numberOfPages - 1}
-                    onClick={onPageClick}
-                />
-            </li>
-        </>
-    );
-};
-
-const PaginationPageButton: FC<{
-    isActive: boolean;
-    number: number;
-    onClick: MouseEventHandler;
-}> = ({ isActive, number, onClick, ...rest }) => (
-    <button
-        className={clsx("jkl-table-pagination__page", {
-            "jkl-table-pagination__page--active": isActive,
-        })}
-        type="button"
-        data-number={number}
-        onClick={onClick}
-        {...rest}
-    >
-        {number + 1}
-    </button>
 );
 
 TablePagination.displayName = "TablePagination";

--- a/packages/jokul/src/components/table/development/PaginatedTableExample.tsx
+++ b/packages/jokul/src/components/table/development/PaginatedTableExample.tsx
@@ -27,9 +27,9 @@ export const PaginatedTableExample: FC<ExampleComponentProps> = ({
 }) => {
     const ref = useRef<HTMLTableElement>(null);
 
-    const [activePage, setActivePage] = useState(0);
+    const [activePage, setActivePage] = useState(1);
     const [rowsPerPage, setRowsPerPage] = useState(25);
-    const startIndex = activePage * rowsPerPage;
+    const startIndex = (activePage - 1) * rowsPerPage;
 
     const visibleRows = rows.slice(startIndex, startIndex + rowsPerPage);
 
@@ -84,7 +84,7 @@ export const PaginatedTableExample: FC<ExampleComponentProps> = ({
                                     e.target.value,
                                 );
                                 setRowsPerPage(newRowsPerPage);
-                                setActivePage(0); // TODO: beregne oss fram til riktig side?
+                                setActivePage(1); // TODO: beregne oss fram til riktig side?
                                 if (ref.current) {
                                     ref.current.scrollIntoView({
                                         behavior: "smooth",

--- a/packages/jokul/src/components/table/stories/tableComplex.stories.tsx
+++ b/packages/jokul/src/components/table/stories/tableComplex.stories.tsx
@@ -62,7 +62,7 @@ export const TableComplex: Story = {
     },
     render: (args) => {
         const ref = useRef<HTMLTableElement>(null);
-        const [activePage, setActivePage] = useState(0);
+        const [activePage, setActivePage] = useState(1);
         const [rowsPerPage, setRowsPerPage] = useState(6);
         const [sortBy, setSortBy] = useState(faktura.columns[0]);
         const [direction, setDirection] = useState<TableSortDirection>("desc");
@@ -70,7 +70,7 @@ export const TableComplex: Story = {
         const [status, setStatus] = useState("");
         const [filteredRows, setFilteredRows] = useState(faktura.rows);
 
-        const startIndex = activePage * rowsPerPage;
+        const startIndex = (activePage - 1) * rowsPerPage;
 
         const handleSortChange = (
             sortKey: string,
@@ -306,7 +306,7 @@ export const TableComplex: Story = {
                                             const newRowsPerPage =
                                                 Number.parseInt(e.target.value);
                                             setRowsPerPage(newRowsPerPage);
-                                            setActivePage(0);
+                                            setActivePage(1);
                                             if (ref.current) {
                                                 ref.current.scrollIntoView({
                                                     behavior: "smooth",

--- a/packages/jokul/src/components/table/stories/tablePagination.stories.tsx
+++ b/packages/jokul/src/components/table/stories/tablePagination.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { Flex } from "../../flex/Flex.jsx";
 import { Link } from "../../link/index.js";
 import { Table } from "../Table.js";
 import { TableBody } from "../TableBody.js";
 import { TableCaption } from "../TableCaption.js";
 import { TableCell } from "../TableCell.js";
-import { TableFooter } from "../TableFooter.js";
 import { TableHead } from "../TableHead.js";
 import { TableHeader } from "../TableHeader.js";
 import { TablePagination } from "../TablePagination.js";
@@ -37,7 +37,7 @@ export const TablePaginationStory: Story = {
             previous: "Forrige side",
             rowsPerPage: "Fakturaer per side",
         },
-        activePage: 0,
+        activePage: 1,
         totalNumberOfRows: faktura.rows.length,
         rowsPerPage: 12,
         rowsPerPageItems: [
@@ -84,58 +84,73 @@ export const TablePaginationStory: Story = {
         },
     },
     render: (args) => {
-        const startIndex = (args.activePage || 0) * args.rowsPerPage;
+        const [activePage, setActivePage] = React.useState(
+            args.activePage || 1,
+        );
+        const [rowsPerPage, setRowsPerPage] = React.useState(args.rowsPerPage);
+
+        const startIndex = (activePage - 1) * rowsPerPage;
 
         const visibleRows = faktura.rows.slice(
             startIndex,
-            startIndex + args.rowsPerPage,
+            startIndex + rowsPerPage,
         );
 
         return (
-            <Table
-                caption={<TableCaption>Eksempel på paginering</TableCaption>}
-            >
-                <TableHead sticky={true}>
-                    <TableRow>
-                        {faktura.columns.slice(0, 5).map((column, index) => (
-                            <TableHeader key={index} bold>
-                                {column}
-                            </TableHeader>
-                        ))}
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    {visibleRows.map((row, rowIndex) => (
-                        <TableRow key={rowIndex}>
-                            <TableCell>
-                                <Link
-                                    download={`${row[3]} ${new Date(row[0] as Date).toLocaleDateString()}`}
-                                    href={"#"}
-                                >
-                                    {new Date(
-                                        row[0] as Date,
-                                    ).toLocaleDateString()}
-                                </Link>
-                            </TableCell>
-                            {row.slice(1, 5).map((cell, cellIndex) => (
-                                <TableCell
-                                    key={cellIndex}
-                                    data-th={columns[cellIndex]}
-                                >
-                                    {cell.toLocaleString()}
-                                </TableCell>
-                            ))}
+            <Flex direction="column">
+                <Table
+                    caption={
+                        <TableCaption>Eksempel på paginering</TableCaption>
+                    }
+                >
+                    <TableHead sticky={true}>
+                        <TableRow>
+                            {faktura.columns
+                                .slice(0, 5)
+                                .map((column, index) => (
+                                    <TableHeader key={index} bold>
+                                        {column}
+                                    </TableHeader>
+                                ))}
                         </TableRow>
-                    ))}
-                </TableBody>
-                <TableFooter>
-                    <TableRow>
-                        <TableCell colSpan={99}>
-                            <TablePagination {...args} />
-                        </TableCell>
-                    </TableRow>
-                </TableFooter>
-            </Table>
+                    </TableHead>
+                    <TableBody>
+                        {visibleRows.map((row, rowIndex) => (
+                            <TableRow key={rowIndex}>
+                                <TableCell>
+                                    <Link
+                                        download={`${row[3]} ${new Date(row[0] as Date).toLocaleDateString()}`}
+                                        href={"#"}
+                                    >
+                                        {new Date(
+                                            row[0] as Date,
+                                        ).toLocaleDateString()}
+                                    </Link>
+                                </TableCell>
+                                {row.slice(1, 5).map((cell, cellIndex) => (
+                                    <TableCell
+                                        key={cellIndex}
+                                        data-th={columns[cellIndex]}
+                                    >
+                                        {cell.toLocaleString()}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+                <TablePagination
+                    {...args}
+                    activePage={activePage}
+                    rowsPerPage={rowsPerPage}
+                    onChange={setActivePage}
+                    onChangeRowsPerPage={(e) => {
+                        const newRowsPerPage = Number.parseInt(e.target.value);
+                        setRowsPerPage(newRowsPerPage);
+                        setActivePage(1);
+                    }}
+                />
+            </Flex>
         );
     },
 };

--- a/packages/jokul/src/components/table/styles/_table-pagination.scss
+++ b/packages/jokul/src/components/table/styles/_table-pagination.scss
@@ -1,30 +1,44 @@
 @use "../../../core/jkl";
 
 .jkl-table-pagination {
-    display: flex;
-    gap: var(--jkl-unit-15);
-    flex-direction: column;
+    display: grid;
     width: 100%;
+    gap: var(--jkl-unit-15);
+
+    grid-template-columns: 1fr;
+    grid-template-areas:
+        "page-size"
+        "total-rows"
+        "navigation";
 
     @include jkl.from-medium-device {
-        flex-direction: row;
+        grid-template-columns: auto auto 1fr;
+        grid-template-areas: "page-size total-rows navigation";
         gap: var(--jkl-unit-30);
-        justify-content: space-between;
         align-items: center;
     }
 
-    &__left {
-        flex-shrink: 1;
-    }
-
-    &__right {
-        flex-grow: 1;
-        display: flex;
-        flex-wrap: nowrap;
+    &__page-size {
+        grid-area: page-size;
     }
 
     &__total-rows {
+        grid-area: total-rows;
         white-space: nowrap;
+    }
+
+    &__navigation {
+        grid-area: navigation;
+        display: flex;
+        flex-wrap: nowrap;
+        flex-direction: column;
+        gap: var(--jkl-unit-20);
+
+        @include jkl.from-medium-device {
+            flex-direction: row;
+            justify-content: flex-end;
+            align-items: center;
+        }
     }
 
     &__picker {
@@ -34,93 +48,11 @@
         white-space: nowrap;
 
         &--page {
-            padding-inline-end: var(--jkl-unit-30);
-            width: min(12rem, 100%);
-
-            @include jkl.from-medium-device {
-                justify-content: flex-end;
-            }
-        }
-
-        &--page &-input {
-            width: min(4rem, 100%);
+            width: min(9rem, 100%);
         }
     }
 
     &__picker-label {
         margin-inline-end: var(--jkl-unit-10);
-    }
-
-    &__nav {
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: jkl.$unit-20;
-
-        @include jkl.from-medium-device {
-            flex-direction: row;
-            align-items: center;
-            justify-content: flex-end;
-        }
-
-        ul {
-            list-style: none;
-            display: flex;
-            flex-wrap: nowrap;
-            margin: 0;
-            padding: 0;
-        }
-
-        li {
-            margin: 0;
-            padding: 0;
-        }
-    }
-
-    $_button-size: jkl.rem(32px);
-
-    &__previous,
-    &__next,
-    &__page {
-        background: transparent;
-        color: var(--jkl-link-color);
-        border-radius: jkl.rem(3px);
-        cursor: pointer;
-        user-select: none;
-        padding: 0;
-        height: $_button-size;
-        min-width: $_button-size;
-
-        @include jkl.reset-outline;
-
-        &:hover:not(:focus) {
-            color: var(--jkl-link-hover-color);
-        }
-
-        html:not([data-mousenavigation]) &:focus {
-            outline: jkl.rem(2px) solid var(--jkl-link-active-color);
-            // outline-offset: jkl.rem(2px);
-        }
-    }
-
-    &__previous,
-    &__next {
-        padding-top: jkl.rem(2px);
-    }
-
-    &__ellipsis {
-        text-align: center;
-        vertical-align: bottom;
-        display: inline-block;
-        height: $_button-size;
-        width: $_button-size;
-    }
-
-    &__page {
-        &--active {
-            @include jkl.no-grow-bold;
-        }
     }
 }

--- a/packages/jokul/src/components/table/types.ts
+++ b/packages/jokul/src/components/table/types.ts
@@ -97,7 +97,7 @@ export interface TablePaginationProps {
     id?: string;
     density?: Density;
     /**
-     * @default 0
+     * @default 1
      */
     activePage?: number;
     /**
@@ -113,11 +113,7 @@ export interface TablePaginationProps {
      * @default false
      */
     withGoToPage?: boolean | { gotoLabel: string };
-    onChange: (
-        e: React.SyntheticEvent,
-        toPage: number,
-        fromPage: number,
-    ) => void;
+    onChange: (toPage: number, fromPage: number) => void;
     onChangeRowsPerPage: ChangeEventHandler<HTMLSelectElement>;
     /**
      * Dersom du ønsker å ha custom labels kan du sende inn disse. "rowsPerPage"


### PR DESCRIPTION
## Bakgrunn
TablePagination har egen implementering av paginering-logikk som duplikerer funksjonalitet fra Pagination-komponenten. Dette skaper inkonsistent API og økt vedlikeholdsarbeid.

## Endringer

- Erstattet med bruk av eksisterende Pagination-komponent

### API endringer (breaking changes)

**activePage: 0-basert → 1-basert indeksering**
```typescript
// Før
<TablePagination activePage={0} />  // første side

// Nå (matcher Pagination API)
<TablePagination activePage={1} />  // første side
```

## Fordeler
- **Konsistent API** på tvers av paginering-komponenter
- **Redusert kodebase** og vedlikeholdsarbeid
- **En kilde til sannhet** for paginering-logikk

## Migreringsarbeid
Eksisterende bruk av TablePagination må oppdateres:

1. **activePage prop**: Endre fra 0-basert til 1-basert
3. **Stories**: Oppdater for nye forventninger

## Diskusjonspunkter
- Er breaking changes akseptabelt for å oppnå API-konsistens?

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5444 
