### PR TITLE
patch: Fikser typekompatibilitet med React 19 for useIntersectionObserver

### DIFF
--- a/.changeset/common-pugs-think.md
+++ b/.changeset/common-pugs-think.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser typekompatibilitet med React 19 for useIntersectionObserver. Hooken aksepterer nå nullable refs.

--- a/packages/jokul/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
+++ b/packages/jokul/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
@@ -9,8 +9,12 @@ type ValidElement = HTMLElement | SVGElement;
 type Target =
     | MutableRefObject<ValidElement>
     | RefObject<ValidElement>
+    | MutableRefObject<ValidElement | null>
+    | RefObject<ValidElement | null>
     | MutableRefObject<NodeListOf<ValidElement>>
     | RefObject<NodeListOf<ValidElement>>
+    | MutableRefObject<NodeListOf<ValidElement> | null>
+    | RefObject<NodeListOf<ValidElement> | null>
     | NodeListOf<ValidElement>;
 
 function isNodeList(


### PR DESCRIPTION
## 💬 Endringer

Oppdaterer Target-typen til å akseptere nullable refs for kompatibilitet med React 19.

Dette skal løse typefeilen i [issue](https://github.com/fremtind/jokul/issues/5439).


## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5439 
