### PR TITLE
BREAKING: Endre navn på prop i Menu

### DIFF
--- a/.changeset/polite-rings-begin.md
+++ b/.changeset/polite-rings-begin.md
@@ -1,0 +1,23 @@
+---
+"@fremtind/jokul": major
+---
+
+**BREAKING CHANGE**:  
+Menu-komponenten har byttet prop-navn fra `isOpen` til `open`.
+
+- **Prop**: `isOpen` → `open`
+- **Callback**: `onToggle` tar nå et argument kalt `open` (tidligere `isOpen`).
+
+Gjør dette når du bruker menu-komponenten:
+
+**Før:**
+
+```tsx
+<Menu isOpen={true} onToggle={(isOpen) => ...} />
+```
+
+**Etter:**
+
+```tsx
+<Menu open={true} onToggle={(open) => ...} />
+```

--- a/packages/jokul/src/components/menu/Menu.test.tsx
+++ b/packages/jokul/src/components/menu/Menu.test.tsx
@@ -42,11 +42,11 @@ describe("Menu", () => {
         expect(queryByRole("menuitem")).not.toBeInTheDocument();
     });
 
-    it("should render as open if isOpen prop is true", async () => {
+    it("should render as open if open prop is true", async () => {
         const { getByRole } = setup(
             <Menu
                 initialPlacement="bottom-start"
-                isOpen={true}
+                open={true}
                 triggerElement={
                     <IconButton title="En kontekstuell meny">
                         <DotsIcon bold />
@@ -60,11 +60,11 @@ describe("Menu", () => {
         expect(getByRole("menuitem", { name: "Menyvalg" })).toBeInTheDocument();
     });
 
-    it("should not open if isOpen prop is set to false", async () => {
+    it("should not open if open prop is set to false", async () => {
         const { getByRole, queryByRole, user } = setup(
             <Menu
                 initialPlacement="bottom-start"
-                isOpen={false}
+                open={false}
                 triggerElement={
                     <IconButton title="En kontekstuell meny">
                         <DotsIcon bold />

--- a/packages/jokul/src/components/menu/Menu.tsx
+++ b/packages/jokul/src/components/menu/Menu.tsx
@@ -26,9 +26,9 @@ import clsx from "clsx";
 import React, { forwardRef, useEffect, useRef, useState, useId } from "react";
 import { useBrowserPreferences } from "../../hooks/index.js";
 import { getThemeAndDensity } from "../../utilities/getThemeAndDensity.js";
+import { SlotComponent } from "../../utilities/index.js";
 import type { MenuProps } from "./types.js";
 import { useMenuWideEvents } from "./useMenuWideEvents.js";
-import { SlotComponent } from "../../utilities/index.js";
 
 function getTranslation(side: Side, value = 0) {
     switch (side) {
@@ -55,7 +55,7 @@ const MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
             openOnHover = false,
             keepOpenOnClickOutside = false,
             triggerElement,
-            isOpen: isOpenOverride,
+            open: openOverride,
             onToggle,
             ...triggerProps
         } = props;
@@ -73,19 +73,18 @@ const MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
         const [activeIndex, setActiveIndex] = useState<number | null>(null);
         const {
             allowHover,
-            isOpen: isOpenDefault,
-            setIsOpen,
+            open: openDefault,
+            setOpen,
         } = useMenuWideEvents(tree, nodeId, parentId);
 
-        const isOpen =
-            isOpenOverride !== undefined ? isOpenOverride : isOpenDefault;
+        const open = openOverride !== undefined ? openOverride : openDefault;
 
-        useEffect(() => onToggle?.(isOpen), [isOpen, onToggle]);
+        useEffect(() => onToggle?.(open), [open, onToggle]);
 
         const { refs, placement, context, floatingStyles } = useFloating({
             nodeId,
-            open: isOpen,
-            onOpenChange: setIsOpen,
+            open: open,
+            onOpenChange: setOpen,
             placement:
                 initialPlacement || (isNested ? "right-start" : "bottom-start"),
             middleware: [
@@ -187,7 +186,7 @@ const MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
                                 role="menu"
                                 data-placement={placement}
                                 aria-live="assertive"
-                                aria-hidden={!isOpen}
+                                aria-hidden={!open}
                                 ref={refs.setFloating}
                                 {...getFloatingProps({
                                     id: MenuId,
@@ -252,15 +251,13 @@ const MenuComponent = forwardRef<HTMLButtonElement, MenuProps>(
                                                                     "Enter"
                                                             ) {
                                                                 // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role#keyboard_interactions
-                                                                setIsOpen(
-                                                                    false,
-                                                                );
+                                                                setOpen(false);
                                                             }
                                                         },
                                                         onMouseEnter() {
                                                             if (
                                                                 allowHover &&
-                                                                isOpen
+                                                                open
                                                             ) {
                                                                 setActiveIndex(
                                                                     index,

--- a/packages/jokul/src/components/menu/development/MenuExample.tsx
+++ b/packages/jokul/src/components/menu/development/MenuExample.tsx
@@ -12,7 +12,7 @@ import { MenuItem } from "../MenuItem.js";
 export const MenuExampleKnobs: ExampleKnobsProps = {
     choiceProps: [
         {
-            name: "isOpen",
+            name: "open",
             values: ["true", "false", "tom"],
             defaultValue: 2,
         },
@@ -24,9 +24,9 @@ export const MenuExample: FC<ExampleComponentProps> = ({
     choiceValues,
     displayValues,
 }) => {
-    const isOpen =
-        choiceValues?.["isOpen"] !== "tom"
-            ? choiceValues?.["isOpen"] === "true"
+    const open =
+        choiceValues?.["open"] !== "tom"
+            ? choiceValues?.["open"] === "true"
             : undefined;
 
     /* Force a re-render whenever theme or density changes */
@@ -54,7 +54,7 @@ export const MenuExample: FC<ExampleComponentProps> = ({
             <Menu
                 id={key}
                 initialPlacement="bottom-end"
-                isOpen={isOpen}
+                open={open}
                 keepOpenOnClickOutside={
                     boolValues?.["Ikke lukk ved klikk utenfor"]
                 }

--- a/packages/jokul/src/components/menu/development/MenuToggleSwitchExample.tsx
+++ b/packages/jokul/src/components/menu/development/MenuToggleSwitchExample.tsx
@@ -16,7 +16,7 @@ import { MenuItemCheckbox } from "../MenuItemCheckbox.js";
 export const MenuToggleSwitchExampleKnobs: ExampleKnobsProps = {
     choiceProps: [
         {
-            name: "isOpen",
+            name: "open",
             values: ["true", "false", "tom"],
             defaultValue: 2,
         },
@@ -26,9 +26,9 @@ export const MenuToggleSwitchExampleKnobs: ExampleKnobsProps = {
 export const MenuToggleSwitchExample: FC<ExampleComponentProps> = ({
     choiceValues,
 }) => {
-    const isOpen =
-        choiceValues?.["isOpen"] !== "tom"
-            ? choiceValues?.["isOpen"] === "true"
+    const open =
+        choiceValues?.["open"] !== "tom"
+            ? choiceValues?.["open"] === "true"
             : undefined;
 
     const pref = useBrowserPreferences();
@@ -71,7 +71,7 @@ export const MenuToggleSwitchExample: FC<ExampleComponentProps> = ({
             <Tooltip>
                 <Menu
                     initialPlacement="bottom-start"
-                    isOpen={isOpen}
+                    open={open}
                     triggerElement={
                         <TooltipTrigger>
                             <IconButton className="jkl-portal-navigation_menu-trigger">

--- a/packages/jokul/src/components/menu/stories/Menu.stories.tsx
+++ b/packages/jokul/src/components/menu/stories/Menu.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Menu: Story = {
     argTypes: {
-        isOpen: {
+        open: {
             control: { disable: true },
         },
     },
@@ -68,5 +68,5 @@ export const Menu: Story = {
             </>
         ),
     },
-    render: ({ isOpen, ...args }) => <MenuComponent {...args} />,
+    render: ({ open, ...args }) => <MenuComponent {...args} />,
 };

--- a/packages/jokul/src/components/menu/types.ts
+++ b/packages/jokul/src/components/menu/types.ts
@@ -36,11 +36,11 @@ export interface MenuProps
      * Kan brukes til å styre utenfra om menyen skal være åpen eller ikke.
      * @default false
      */
-    isOpen?: boolean;
+    open?: boolean;
     /**
      * Callback som kalles når menyen åpnes eller lukkes.
      */
-    onToggle?: (isOpen: boolean) => void;
+    onToggle?: (open: boolean) => void;
 }
 
 export type MenuItemProps<ElementType extends React.ElementType> =

--- a/packages/jokul/src/components/menu/useMenuWideEvents.ts
+++ b/packages/jokul/src/components/menu/useMenuWideEvents.ts
@@ -7,11 +7,11 @@ export const useMenuWideEvents = (
     parentId: string | null,
 ): {
     allowHover: boolean;
-    isOpen: boolean;
-    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 } => {
     const [allowHover, setAllowHover] = useState(false);
-    const [isOpen, setIsOpen] = useState(false);
+    const [open, setOpen] = useState(false);
 
     // Event emitter allows you to communicate across tree components.
     // This effect closes all menus when an item gets clicked anywhere
@@ -20,7 +20,7 @@ export const useMenuWideEvents = (
         if (!tree) return;
 
         function handleTreeClick() {
-            setIsOpen(false);
+            setOpen(false);
         }
 
         function onSubMenuOpen(event: { nodeId: string; parentId: string }) {
@@ -29,7 +29,7 @@ export const useMenuWideEvents = (
                 event.nodeId !== nodeId &&
                 event.parentId === parentId
             ) {
-                setIsOpen(false);
+                setOpen(false);
             }
         }
 
@@ -43,10 +43,10 @@ export const useMenuWideEvents = (
     }, [tree, nodeId, parentId]);
 
     useEffect(() => {
-        if (isOpen && tree && nodeId) {
+        if (open && tree && nodeId) {
             tree.events.emit("menuopen", { parentId, nodeId });
         }
-    }, [tree, isOpen, nodeId, parentId]);
+    }, [tree, open, nodeId, parentId]);
 
     // Determine if "hover" logic can run based on the modality of input. This
     // prevents unwanted focus synchronization as menus open and close with
@@ -76,5 +76,5 @@ export const useMenuWideEvents = (
         };
     }, [allowHover]);
 
-    return { allowHover, isOpen, setIsOpen };
+    return { allowHover, open, setOpen };
 };


### PR DESCRIPTION
## 💬 Endringer

Menu-komponenten har byttet prop-navn fra `isOpen` til `open`.

- **Prop**: `isOpen` → `open`
- **Callback**: `onToggle` tar nå et argument kalt `open` (tidligere `isOpen`).

Gjør dette når du bruker menu-komponenten:

**Før:**
```tsx
<Menu isOpen={true} onToggle={(isOpen) => ...} />
```

**Etter:**
```tsx
<Menu open={true} onToggle={(open) => ...} />
```