### PR TITLE
docs(changeset): Korrigering av useModal typer

### DIFF
--- a/.changeset/rich-colts-brake.md
+++ b/.changeset/rich-colts-brake.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Korrigerte ModalInstance-typedefinisjonen og oppdaterte returtypen til useModal, slik at instance ikke lenger er typet som any.

--- a/packages/jokul/src/components/modal/useModal.ts
+++ b/packages/jokul/src/components/modal/useModal.ts
@@ -2,7 +2,9 @@ import { useA11yDialog } from "react-a11y-dialog";
 import { useId } from "../../hooks/useId/useId.js";
 import type { ModalConfig, UseModalOptions } from "./types.js";
 
-export type ModalInstance = ReturnType<typeof useModal>[0];
+export type ModalInstance = ReturnType<typeof useA11yDialog>[0];
+
+export type UseModalReturn = readonly [ModalInstance, ModalConfig];
 
 /**
  * @example
@@ -47,7 +49,7 @@ export type ModalInstance = ReturnType<typeof useModal>[0];
  *  );
  * ```
  */
-export function useModal(props: UseModalOptions) {
+export function useModal(props: UseModalOptions): UseModalReturn {
     const {
         id: idProp,
         role = "dialog",
@@ -74,5 +76,5 @@ export function useModal(props: UseModalOptions) {
         },
     };
 
-    return [instance, modalConfig] as const;
+    return [instance, modalConfig];
 }


### PR DESCRIPTION
Endret ModalInstance-typedefinisjonen og oppdaterte returtypen til useModal, slik at instance ikke lenger er typet som any.

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5480 
