### PR TITLE
fix: endret publisering til github slik at andre brancher enn main ka…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,14 @@ jobs:
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3
-              
+
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version-file: '.nvmrc'
+                  node-version-file: ".nvmrc"
                   cache: "pnpm"
 
             - name: Installer avhengigheter
@@ -56,20 +56,20 @@ jobs:
               if: steps.changesets.outputs.published == 'true'
               uses: actions/setup-node@v4
               with:
-                registry-url: "https://npm.pkg.github.com"
-                scope: "@fremtind"
+                  registry-url: "https://npm.pkg.github.com"
+                  scope: "@fremtind"
 
             - name: Tilbakestill endringer i .npmrc
               # Unngår å få feil ved publisering pga. unclean git status
               run: git checkout .npmrc
-                
+
             - name: Reinstaller pakker etter actions/setup-node
               if: steps.changesets.outputs.published == 'true'
               run: pnpm install --frozen-lockfile
-            
+
             - name: Publiser pakker til GitHub Packages
               if: steps.changesets.outputs.published == 'true'
-              run: pnpm -r publish
+              run: pnpm -r publish --tag version-1 --publish-branch jokul-1.x
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -88,8 +88,8 @@ jobs:
             - name: Hent informasjon om commit
               id: commit-info
               run: |
-                echo "committer_name=$(git log -1 --pretty=format:'%an')" >> $GITHUB_OUTPUT
-                echo "committer_email=$(git log -1 --pretty=format:'%ae')" >> $GITHUB_OUTPUT
+                  echo "committer_name=$(git log -1 --pretty=format:'%an')" >> $GITHUB_OUTPUT
+                  echo "committer_email=$(git log -1 --pretty=format:'%ae')" >> $GITHUB_OUTPUT
 
             - name: Send notification om release
               env:


### PR DESCRIPTION
…n brukes

## 💬 Endringer

Endret publish-kommando på bakgrunn av at nyere versjoner ikke blir publisert til Github. Noe usikker på om dette er nok, grunnet denne linjen som er innebygd til å være true i changesets (og vi kjører på main):
`if: steps.changesets.outputs.published == 'true'`

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #NNNN
