### PR TITLE
Fjerner CSS som overskrev systemfonter -> 2.x

### DIFF
--- a/.changeset/light-keys-doubt.md
+++ b/.changeset/light-keys-doubt.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+**Feilretting: Fjerner CSS som overskrev Fremtind Grotesk font**
+
+Fjernet en `@supports`-regel som førte til at Fremtind Grotesk på Apple-enheter ble overskrevet.

--- a/packages/jokul/src/core/styles/global/_base-class.scss
+++ b/packages/jokul/src/core/styles/global/_base-class.scss
@@ -8,13 +8,7 @@
         background-color: var(--jkl-background-color);
         color: var(--jkl-color);
 
-        @supports (font: -apple-system-body) {
-            font: -apple-system-body;
-        }
-
-        & {
-            @include jkl.use-font-family("Fremtind Grotesk");
-        }
+        @include jkl.use-font-family("Fremtind Grotesk");
 
         strong {
             --jkl-icon-weight: #{jkl.$icon-weight-bold};
@@ -23,7 +17,6 @@
     }
 
     @include jkl.prefers-reduced-motion {
-
         *,
         *::after,
         *::before {


### PR DESCRIPTION
## 💬 Endringer

**Feilretting: Fjerner CSS som overskrev Fremtind Grotesk font**

Fjernet en `@supports`-regel som førte til at Fremtind Grotesk på Apple-enheter ble overskrevet.
