### PR TITLE
Legg tilbake fontskalering for iOS

### DIFF
--- a/.changeset/short-drinks-mix.md
+++ b/.changeset/short-drinks-mix.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legger tilbake fontskalering for iOS basert på brukerinnstillinger, på en måte om ikke overskriver fonten vår i designsystemet.

--- a/packages/jokul/src/core/styles/global/_base-class.scss
+++ b/packages/jokul/src/core/styles/global/_base-class.scss
@@ -1,6 +1,14 @@
 @use "../../jkl";
 
 @layer jokul.global {
+    /* Legger til støtte for fontskalering via OS-innstillinger på Apple-enheter */
+    @supports (font: -apple-system-body) {
+        :root {
+            /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+            font: -apple-system-body;
+        }
+    }
+
     .jkl {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## 💬 Endringer

Legger tilbake fontskalering for iOS basert på brukerinnstillinger, på en måte om ikke overskriver fonten vår i designsystemet.

<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 - 2025-11-20 at 11 53 10" src="https://github.com/user-attachments/assets/bf7ad5f1-39c0-48ff-8028-d6cc0b251c74" />
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 - 2025-11-20 at 11 51 30" src="https://github.com/user-attachments/assets/28e8c469-e6ef-4c6a-bc4e-7b757d2b9618" />
