### PR TITLE
Refaktorer Skeleton-loader med CSS-maske

### DIFF
--- a/.changeset/four-keys-laugh.md
+++ b/.changeset/four-keys-laugh.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Skeleton-loadere er nå utformet med en CSS-maske, slik at fargen på sveipet i animasjonen alltid matcher bakgrunnsfargen loaderen er plassert på.

--- a/packages/jokul/src/components/loader/styles/skeleton-loader.scss
+++ b/packages/jokul/src/components/loader/styles/skeleton-loader.scss
@@ -2,53 +2,35 @@
 @use "sass:string";
 @use "../../../core/jkl";
 
-$_sweep-animation-name: jkl-sweep-#{string.unique-id()};
 $_blink-animation-name: jkl-blink-#{string.unique-id()};
 
 @layer jokul.components {
+    @property --jkl-skeleton-sweeper-position {
+        syntax: "<percentage>";
+        initial-value: 0%;
+        inherits: true;
+    }
+
+    @keyframes --jkl-skeleton-sweep {
+        0%,
+        67% {
+            --jkl-skeleton-sweeper-position: 0%;
+        }
+
+        100% {
+            --jkl-skeleton-sweeper-position: calc(100% + var(--jkl-skeleton-sweeper-width));
+        }
+    }
+
     .jkl-skeleton-animation {
         --jkl-skeleton-element-color: var(--jkl-color-background-container-low);
-        --jkl-skeleton-sweeper-color: var(--jkl-color-background-page-variant);
-        --jkl-skeleton-sweep-duration: 3s;
+        --jkl-skeleton-sweep-duration: 4500ms;
+        --jkl-skeleton-sweeper-width: 40%;
 
-        position: relative;
-        overflow: hidden;
-
-        &::after {
-            content: " ";
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: jkl.rem(200px);
-            background: linear-gradient(89.17deg,
-                    rgb(249 249 249 / 0%) 0.8%,
-                    var(--jkl-skeleton-sweeper-color) 50.09%,
-                    rgb(249 249 249 / 0%) 96.31%);
-            animation: var(--jkl-skeleton-sweep-duration) ease infinite $_sweep-animation-name;
-        }
-
-        @include jkl.small-device {
-            width: jkl.rem(150px);
-        }
-
-        @include jkl.prefers-reduced-motion {
-            &::after {
-                background: none; // Skjul gradienten som nå ikke beveger seg
-            }
-        }
-
-        @include jkl.forced-colors-mode {
-            &::after {
-                // Vi kan ikke bruke "gradient-trikset" for å skape den samme effekten,
-                // så vi må tenke annerledes. Bruk gjennomsiktighet for å indikere at
-                // noe skjer. Animasjonen gjøres på jkl-skeleton-element.
-                animation: none;
-            }
-        }
-
-        &--compact::after {
-            width: jkl.rem(150px);
-        }
+        mask-image: linear-gradient(to right, #000 calc(var(--jkl-skeleton-sweeper-position) - var(--jkl-skeleton-sweeper-width)), transparent calc(var(--jkl-skeleton-sweeper-position) - var(--jkl-skeleton-sweeper-width) / 2), #000 var(--jkl-skeleton-sweeper-position));
+        mask-size: 100dvi 100dvb;
+        mask-position: center;
+        animation: var(--jkl-skeleton-sweep-duration) ease-in-out infinite --jkl-skeleton-sweep;
     }
 
     .jkl-skeleton-element {
@@ -134,17 +116,6 @@ $_blink-animation-name: jkl-blink-#{string.unique-id()};
             // så vi må tenke annerledes. Bruk gjennomsiktighet for å indikere at
             // noe skjer.
             animation: 2s ease-in-out infinite $_blink-animation-name;
-        }
-    }
-
-    @keyframes #{$_sweep-animation-name} {
-        0% {
-            transform: translateX(calc(0vw - 200px));
-        }
-
-        80%,
-        100% {
-            transform: translateX(calc(100vw + calc(200px * 2)));
         }
     }
 


### PR DESCRIPTION
## 💬 Endringer

Skeleton-loadere er nå utformet med en CSS-maske, slik at fargen på sveipet i animasjonen alltid matcher bakgrunnsfargen loaderen er plassert på.
