### PR TITLE
Legg til manglende eksportstier for beta-stilark

### DIFF
--- a/.changeset/tame-numbers-stop.md
+++ b/.changeset/tame-numbers-stop.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der det ikke gikk an å importere stilarkene til beta-komponentene `DescriptionList` og `NavLink` med `@use` i Sass-stilark.

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -181,6 +181,7 @@
             }
         },
         "./styles/components/description-list": "./styles/components/description-list/_index.scss",
+        "./styles/components-beta/description-list": "./styles/components-beta/description-list/_index.scss",
         "./description-list": {
             "import": {
                 "types": "./build/es/components/description-list/index.d.ts",
@@ -379,6 +380,7 @@
             }
         },
         "./styles/components/nav-link": "./styles/components/nav-link/_index.scss",
+        "./styles/components-beta/nav-link": "./styles/components-beta/nav-link/_index.scss",
         "./nav-link": {
             "import": {
                 "types": "./build/es/components/nav-link/index.d.ts",


### PR DESCRIPTION
## 💬 Endringer

Fikser en feil der det ikke gikk an å importere stilarkene til beta-komponentene `DescriptionList` og `NavLink` med `@use` i Sass-stilark.
