### PR TITLE
Gi `Tag` mulihget til å styre variant med prop

### DIFF
--- a/.changeset/plain-baboons-jog.md
+++ b/.changeset/plain-baboons-jog.md
@@ -1,0 +1,13 @@
+---
+"@fremtind/jokul": minor
+---
+
+Tag tar nå inn variant, istedenfor å måtte bruke flere typer tags. Markert egendefinerte tags som deprecated.
+
+```typescript jsx
+// Før
+<ErrorTag>...</ErrorTag>
+
+// Etter
+<Tag variant="error">...</Tag>
+```

--- a/packages/jokul/src/components/tag/Tag.figma.tsx
+++ b/packages/jokul/src/components/tag/Tag.figma.tsx
@@ -1,72 +1,22 @@
 import { figma } from "@figma/code-connect";
 import React from "react";
-import { ErrorTag, InfoTag, SuccessTag, Tag, WarningTag } from "./Tag.jsx";
+import { Tag } from "./Tag.jsx";
 
 figma.connect(
     Tag,
     "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv?node-id=2004%3A303",
     {
         imports: ['import { Tag } from "@fremtind/jokul/components/tag";'],
-        variant: { Type: "Neutral" },
         props: {
             children: figma.string("Text"),
+            variant: figma.enum("Variant", {
+                Error: "error",
+                Warning: "warning",
+                Success: "success",
+                Neutral: "neutral",
+                Info: "info",
+            }),
         },
         example: (props) => <Tag {...props} />,
-    },
-);
-
-figma.connect(
-    ErrorTag,
-    "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv?node-id=2004%3A303",
-    {
-        imports: ['import { ErrorTag } from "@fremtind/jokul/components/tag";'],
-        variant: { Type: "Error" },
-        props: {
-            children: figma.string("Text"),
-        },
-        example: (props) => <ErrorTag {...props} />,
-    },
-);
-
-figma.connect(
-    InfoTag,
-    "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv?node-id=2004%3A303",
-    {
-        imports: ['import { InfoTag } from "@fremtind/jokul/components/tag";'],
-        variant: { Type: "Info" },
-        props: {
-            children: figma.string("Text"),
-        },
-        example: (props) => <InfoTag {...props} />,
-    },
-);
-
-figma.connect(
-    SuccessTag,
-    "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv?node-id=2004%3A303",
-    {
-        imports: [
-            'import { SuccessTag } from "@fremtind/jokul/components/tag";',
-        ],
-        variant: { Type: "Success" },
-        props: {
-            children: figma.string("Text"),
-        },
-        example: (props) => <SuccessTag {...props} />,
-    },
-);
-
-figma.connect(
-    WarningTag,
-    "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv?node-id=2004%3A303",
-    {
-        imports: [
-            'import { WarningTag } from "@fremtind/jokul/components/tag";',
-        ],
-        variant: { Type: "Warning" },
-        props: {
-            children: figma.string("Text"),
-        },
-        example: (props) => <WarningTag {...props} />,
     },
 );

--- a/packages/jokul/src/components/tag/Tag.tsx
+++ b/packages/jokul/src/components/tag/Tag.tsx
@@ -2,9 +2,7 @@ import clsx from "clsx";
 import React, { type FC } from "react";
 import type { TagProps } from "./types.js";
 
-type Variant = "info" | "error" | "warning" | "success";
-
-function getDisplayName(variant?: Variant) {
+function getDisplayName(variant?: TagProps["variant"]) {
     switch (variant) {
         case "info":
             return "InfoTag";
@@ -19,7 +17,8 @@ function getDisplayName(variant?: Variant) {
     }
 }
 
-function tagFactory(variant?: Variant) {
+// Vil fjernes etterhvert :-)
+function tagFactory(variant?: TagProps["variant"]) {
     const Tag: FC<TagProps> = ({ className, density, children, ...rest }) => (
         <span
             className={clsx(
@@ -42,8 +41,32 @@ function tagFactory(variant?: Variant) {
     return Tag;
 }
 
-export const Tag = tagFactory();
+export const Tag = ({ className, density, variant = "neutral", children, ...rest } : TagProps) => (
+    <span
+        className={clsx(
+            "jkl-tag", `jkl-tag--${variant}`,
+            className,
+        )}
+        data-density={density}
+        {...rest}
+    >
+            {children}
+        </span>
+);
+
+/**
+ * @deprecated bruk {@link Tag} med variant="info"
+ */
 export const InfoTag = tagFactory("info");
+/**
+ * @deprecated bruk {@link Tag} med variant="error"
+ */
 export const ErrorTag = tagFactory("error");
+/**
+ * @deprecated bruk {@link Tag} med variant="warning"
+ */
 export const WarningTag = tagFactory("warning");
+/**
+ * @deprecated bruk {@link Tag} med variant="success"
+ */
 export const SuccessTag = tagFactory("success");

--- a/packages/jokul/src/components/tag/stories/Tag.stories.tsx
+++ b/packages/jokul/src/components/tag/stories/Tag.stories.tsx
@@ -1,105 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import { Tag } from "../Tag.js";
+
 import "../styles/_index.scss";
-import { ErrorTag, InfoTag, SuccessTag, Tag, WarningTag } from "../Tag.js";
 
 const meta = {
     title: "Komponenter/Tag",
     component: Tag,
     tags: ["autodocs"],
-    parameters: {
-        docs: {
-            description: {
-                component:
-                    "Tag-komponenten brukes for å vise status, informasjon eller kategorisering. Velg riktig variant for å formidle ønsket betydning.",
-            },
-        },
-    },
     args: {
-        children: "Hei",
-    },
-    argTypes: {
-        children: {
-            description: "Teksten som vises inni taggen.",
-            control: "text",
-        },
+        children: "Under behandling",
+        variant: "neutral",
     },
 } satisfies Meta<typeof Tag>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const TagStory: Story = {
-    name: "Standard",
-    parameters: {
-        docs: {
-            description: {
-                story: "Brukes for å vise nøytral informasjon eller kategorisering.",
-            },
-        },
-    },
-    args: {
-        children: "Under behandling",
-    },
-    render: (args) => <Tag {...args} />,
-};
-
-export const SuccessTagStory: Story = {
-    name: "Suksess",
-    parameters: {
-        docs: {
-            description: {
-                story: "Brukes for å vise at noe har gått bra eller er fullført.",
-            },
-        },
-    },
-    args: {
-        children: "Godkjent",
-    },
-    render: (args) => <SuccessTag {...args} />,
-};
-
-export const InfoTagStory: Story = {
-    name: "Informasjon",
-    parameters: {
-        docs: {
-            description: {
-                story: "Brukes for å vise generell informasjon.",
-            },
-        },
-    },
-    args: {
-        children: "Venter på svar",
-    },
-    render: (args) => <InfoTag {...args} />,
-};
-
-export const WarningTagStory: Story = {
-    name: "Advarsel",
-    parameters: {
-        docs: {
-            description: {
-                story: "Brukes for å vise advarsler eller ting som krever oppmerksomhet.",
-            },
-        },
-    },
-    args: {
-        children: "Manglende dokumentasjon",
-    },
-    render: (args) => <WarningTag {...args} />,
-};
-
-export const ErrorTagStory: Story = {
-    name: "Feil",
-    parameters: {
-        docs: {
-            description: {
-                story: "Brukes for å vise feil eller kritiske problemer.",
-            },
-        },
-    },
-    args: {
-        children: "Avvist",
-    },
-    render: (args) => <ErrorTag {...args} />,
-};
+export const _Story: Story = {};

--- a/packages/jokul/src/components/tag/types.ts
+++ b/packages/jokul/src/components/tag/types.ts
@@ -3,4 +3,5 @@ import type { Density } from "../../core/types.js";
 
 export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
     density?: Density;
+    variant?: "neutral" | "info" | "error" | "warning" | "success";
 }


### PR DESCRIPTION
Tag tar nå inn variant, istedenfor å måtte bruke flere typer tags. Markert egendefinerte tags som deprecated.

```typescript jsx
// Før
<ErrorTag>...</ErrorTag>

// Etter
<Tag variant="error">...</Tag>
```