### PR TITLE
Legg til støtte for ReactNode i supportText, og className i DescriptionListItem.tsx

### DIFF
--- a/.changeset/mighty-ghosts-own.md
+++ b/.changeset/mighty-ghosts-own.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legg til støtte for ReactNode i supportText, og className i DescriptionListItem.tsx

--- a/packages/jokul/src/components-beta/description-list/DescriptionListItem.tsx
+++ b/packages/jokul/src/components-beta/description-list/DescriptionListItem.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import React, { type FC } from "react";
 import type { DescriptionListItemProps } from "./types.js";
 
@@ -5,10 +6,14 @@ export const DescriptionListItem: FC<DescriptionListItemProps> = ({
     title,
     value,
     supportText,
+    className,
     ...rest
 }) => {
     return (
-        <div {...rest} className="jkl-description-list-item--beta">
+        <div
+            {...rest}
+            className={clsx("jkl-description-list-item--beta", className)}
+        >
             <dt className="title">{title}</dt>
             <dd className="value">{value}</dd>
             {supportText && <dd className="support-text">{supportText}</dd>}

--- a/packages/jokul/src/components-beta/description-list/types.ts
+++ b/packages/jokul/src/components-beta/description-list/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
 
 export type DescriptionListProps = HTMLAttributes<HTMLDListElement> & {
     /**
@@ -13,11 +13,19 @@ export type DescriptionListProps = HTMLAttributes<HTMLDListElement> & {
     showSeparators?: boolean;
 };
 
-export type DescriptionListItemProps = Omit<
-    HTMLAttributes<HTMLDivElement>,
-    "className"
-> & {
+export type DescriptionListItemProps = HTMLAttributes<HTMLDivElement> & {
+    /**
+     * Tittel/Term som beskrives.
+     */
     title: string;
+    /**
+     * Verdi/Beskrivelse til tittelen.
+     */
     value: string;
-    supportText?: string;
+    /**
+     * SupportText rendres som et dd-element, og støtter kun et
+     * utvalg under-elementer. Les mer om elementene som
+     * støttes: https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#flow_content.
+     */
+    supportText?: string | ReactNode;
 };


### PR DESCRIPTION
Støtte for ReactNode kreves av:
1. KFP for å kunne ha et details-element, med "les mer" info
2. Oppgjør for å kunne obfuskere informasjon som tas opp i Session Replay av Mixpanel