### PR TITLE
Fiks bug som gjorde at `align`-propen ikke fungerte i `TableHead`

### DIFF
--- a/.changeset/calm-jeans-tap.md
+++ b/.changeset/calm-jeans-tap.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fiks bug som gjorde at `align`-propen ikke fungerte i `TableHead`

--- a/packages/jokul/src/components/table/TableHeader.tsx
+++ b/packages/jokul/src/components/table/TableHeader.tsx
@@ -38,8 +38,6 @@ const TableHeader = forwardRef<HTMLTableCellElement, TableHeaderProps>(
             <th
                 className={clsx("jkl-table-header", className, {
                     "jkl-table-header--bold": bold,
-                    "jkl-table-header--align-right": align === "right",
-                    "jkl-table-header--align-center": align === "center",
                     "jkl-table-header--sr-only": srOnly,
                     "jkl-table-header--sortable":
                         typeof sortable !== "undefined",
@@ -50,7 +48,7 @@ const TableHeader = forwardRef<HTMLTableCellElement, TableHeaderProps>(
                 data-density={density || contextDensity}
                 ref={ref}
             >
-                <div className="jkl-table-header__arrows">
+                <div className="jkl-table-header__arrows" data-align={align}>
                     {children}
                     {sortable && (
                         <SortableArrows direction={sortable.direction} />

--- a/packages/jokul/src/components/table/stories/tableHeader.stories.tsx
+++ b/packages/jokul/src/components/table/stories/tableHeader.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import React from "react";
+import { Table } from "../Table.js";
+import { TableCaption } from "../TableCaption.js";
+import { TableCell } from "../TableCell.js";
+import { TableHead } from "../TableHead.js";
+import { TableHeader } from "../TableHeader.js";
+import { TableRow } from "../TableRow.js";
+import { skadesaker } from "./data.js";
+
+import "../styles/_index.scss";
+
+const meta = {
+    title: "Komponenter/Table/Table Header",
+    component: TableHeader,
+    parameters: {
+        layout: "padded",
+    },
+    args: {
+        align: "left",
+        children: "Handling",
+        bold: true,
+        srOnly: false,
+    },
+} satisfies Meta<typeof TableHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TableHeaderStory: Story = {
+    name: "Table Header",
+    decorators: (Story, args) => {
+        return (
+            <Table caption={<TableCaption>Hei</TableCaption>} fullWidth>
+                <Story />
+                {skadesaker.rows.map((row, rowIndex) => (
+                    <TableRow key={rowIndex}>
+                        {row.map((cell, cellIndex) => (
+                            <TableCell
+                                key={cellIndex}
+                                data-th={skadesaker.columns[cellIndex]}
+                                align={args.align}
+                            >
+                                {cell}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </Table>
+        );
+    },
+    render: (args) => {
+        return (
+            <TableHead>
+                <TableRow>
+                    {skadesaker.columns.map((column, index) => (
+                        <TableHeader key={index} {...args}>
+                            {column}
+                        </TableHeader>
+                    ))}
+                </TableRow>
+            </TableHead>
+        );
+    },
+};

--- a/packages/jokul/src/components/table/styles/_table-header.scss
+++ b/packages/jokul/src/components/table/styles/_table-header.scss
@@ -22,14 +22,6 @@
     text-align: left;
     white-space: nowrap;
 
-    &--align-center {
-        text-align: center;
-    }
-
-    &--align-right {
-        text-align: right;
-    }
-
     &--bold {
         font-weight: var(--jkl-typography-weight-bold);
     }
@@ -47,6 +39,14 @@
         display: flex;
         gap: var(--jkl-spacing-4);
         align-items: center;
+
+        &[data-align="center"] {
+            justify-content: center;
+        }
+
+        &[data-align="right"] {
+            justify-content: end;
+        }
     }
 
     @mixin _responsive-table-header {


### PR DESCRIPTION
Align blir ikke satt riktig i dag, denne PR-en fikser det 😸 

I [versjon 3.4.0 oppdaterte vi ikonene](https://github.com/fremtind/jokul/releases/tag/%40fremtind%2Fjokul%403.4.0), dette er ikke tatt med ned til de eldre pakkene, så dersom man ønsker bug fiksen her på eldre versjoner må denne endringen også dras inn for å gjøre overgangen smooth tror jeg.