### PR TITLE
Bytt ut `date-fns` med `dayjs` for behandling av datoer i kalenderen.

### DIFF
--- a/.changeset/orange-buttons-work.md
+++ b/.changeset/orange-buttons-work.md
@@ -1,0 +1,9 @@
+---
+"@fremtind/jokul": minor
+---
+
+Bytt ut `date-fns` med `dayjs` for behandling av datoer i kalenderen.
+
+For å gjøre oss klare for å droppe CommonJS i biblioteket bytter vi vekk fra `date-fns` for å håndtere datoer i kalenderen i `DatePicker`. Pakken har en del feil i genereringen av typer, som gjør at man kan få feil ved import/bygg avhengig av om man bruker CJS eller ESM.
+
+Siden `date-fns` var en relativt stor pakke var den behandlet som en _optional dependency_, slik at du selv måtte installere den for å bruke `DatePicker`. `dayjs` er en så liten pakke at vi har bygget inn relevant kode i kalenderen. Dermed får du én avhengighet mindre av å bruke Jøkul 🎉

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -648,7 +648,6 @@
         "@floating-ui/react": "0.24.1 - 0.27",
         "@react-aria/toast": "3.0.0-beta.18",
         "@react-stately/toast": "3.0.0-beta.7",
-        "date-fns": "2.30.0 - 4",
         "react-a11y-dialog": "^6.2.0",
         "tailwindcss": "^3.4.17"
     },
@@ -664,6 +663,7 @@
         "change-case": "^5.4.4",
         "cssnano": "^7.1.0",
         "cssnano-preset-lite": "^4.0.4",
+        "dayjs": "^1.11.19",
         "glob": "^11.0.3",
         "ink": "^5.1.0",
         "ink-select-input": "^6.0.0",

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { startOfDay } from "date-fns";
+import dayjs from "dayjs";
 import React, {
     type ChangeEvent,
     type FocusEvent,
@@ -70,11 +70,11 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
 
         const disableBeforeDate = parseDateString(disableBefore);
         const minDate = disableBeforeDate
-            ? startOfDay(disableBeforeDate)
+            ? dayjs(disableBeforeDate).startOf("day").toDate()
             : undefined;
         const disableAfterDate = parseDateString(disableAfter);
         const maxDate = disableAfterDate
-            ? startOfDay(disableAfterDate)
+            ? dayjs(disableAfterDate).startOf("day").toDate()
             : undefined;
 
         const [date, setDate] = useState(

--- a/packages/jokul/src/components/datepicker/internal/useCalendar.ts
+++ b/packages/jokul/src/components/datepicker/internal/useCalendar.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 /***
  * MIT License
  *
@@ -21,7 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { startOfDay } from "date-fns";
 import React, { useState } from "react";
 import {
     type CalendarMonth,
@@ -171,7 +171,7 @@ export type UseCalendarResult = {
 };
 
 export function useCalendar({
-    date = startOfDay(new Date()),
+    date = dayjs().startOf("day").toDate(),
     maxDate,
     minDate,
     monthsToDisplay = 1,

--- a/packages/jokul/vite.build.config.mjs
+++ b/packages/jokul/vite.build.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
             devDeps: true,
             peerDeps: true,
             optDeps: true,
-            exclude: ["clsx", "nanoid", "react-is", "downshift"],
+            exclude: ["clsx", "dayjs", "nanoid", "react-is", "downshift"],
         }),
         react(),
         dts({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       cssnano-preset-lite:
         specifier: ^4.0.4
         version: 4.0.4(postcss@8.5.6)
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.19
       glob:
         specifier: ^11.0.3
         version: 11.0.3
@@ -334,9 +337,6 @@ importers:
       '@react-stately/toast':
         specifier: 3.0.0-beta.7
         version: 3.0.0-beta.7(react@18.3.1)
-      date-fns:
-        specifier: 2.30.0 - 4
-        version: 4.1.0
       react-a11y-dialog:
         specifier: ^6.2.0
         version: 6.2.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5304,6 +5304,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -17144,6 +17147,8 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  dayjs@1.11.19: {}
+
   de-indent@1.0.2: {}
 
   debounce@1.2.1: {}
@@ -17615,8 +17620,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.7
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -17638,7 +17643,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -17649,22 +17654,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17675,7 +17680,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 💬 Endringer

For å gjøre oss klare for å droppe CommonJS i biblioteket bytter vi vekk fra `date-fns` for å håndtere datoer i kalenderen i `DatePicker`. Pakken har en del feil i genereringen av typer, som gjør at man kan få feil ved import/bygg avhengig av om man bruker CJS eller ESM.

Siden `date-fns` var en relativt stor pakke var den behandlet som en _optional dependency_, slik at du selv måtte installere den for å bruke `DatePicker`. `dayjs` er en så liten pakke at vi har bygget inn relevant kode i kalenderen. Dermed får du én avhengighet mindre av å bruke Jøkul 🎉
