### PR TITLE
Skru av uønsket fontskalering i MacOS

### DIFF
--- a/.changeset/yellow-trains-scream.md
+++ b/.changeset/yellow-trains-scream.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+Skrur av uønsket fontskalering i MacOS
+
+Begrens fontskalering for Apple-enheter til bare å gjelde enheter med touch som hovedinput (som iPhone) for å unngå uønskede effekter i Safari i MacOS.

--- a/packages/jokul/src/core/styles/global/_base-class.scss
+++ b/packages/jokul/src/core/styles/global/_base-class.scss
@@ -3,9 +3,11 @@
 @layer jokul.global {
     /* Legger til støtte for fontskalering via OS-innstillinger på Apple-enheter */
     @supports (font: -apple-system-body) {
-        :root {
-            /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-            font: -apple-system-body;
+        @media (pointer: coarse) {
+            :root {
+                /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+                font: -apple-system-body;
+            }
         }
     }
 


### PR DESCRIPTION
## 💬 Endringer

Skrur av uønsket fontskalering i MacOS

Begrenser fontskalering for Apple-enheter til bare å gjelde enheter med touch som hovedinput (som iPhone) for å unngå uønskede effekter i Safari i MacOS.
