### PR TITLE
Pre-monopakke! fix: fjern uønsket fontskalering i MacOS Safari

### DIFF
--- a/packages/core/core.scss
+++ b/packages/core/core.scss
@@ -33,8 +33,10 @@
 
 :root {
     @supports (font: -apple-system-body) {
-        /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-        font: -apple-system-body;
+        @media (pointer: coarse) {
+            /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+            font: -apple-system-body;
+        }
     }
 
     @each $level, $values in typography.$text-styles {


### PR DESCRIPTION
## 💬 Endringer

Fjerner uønsket fontskalering i Safari i MacOS
