### PR TITLE
Juster høyden til Expander i ExpandableTableRow

### DIFF
--- a/.changeset/giant-otters-dance.md
+++ b/.changeset/giant-otters-dance.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Tilpasser størrelsen på `Expander` når den brukes i `ExpandableTableRow`, slik at ikke raden blir så høy når density er satt til compact.

--- a/packages/jokul/src/components/table/styles/_table-cell.scss
+++ b/packages/jokul/src/components/table/styles/_table-cell.scss
@@ -4,12 +4,14 @@
     @include jkl.declare-font-variables("jkl-table-cell", "body");
 
     --jkl-table-cell-padding: var(--jkl-spacing-12);
+    --jkl-table-expand-padding: var(--jkl-spacing-16);
 }
 
 @include jkl.compact-density-variables {
     @include jkl.declare-font-variables("jkl-table-cell", "small");
 
     --jkl-table-cell-padding: var(--jkl-spacing-8);
+    --jkl-table-expand-padding: var(--jkl-spacing-8);
 }
 
 .jkl-table-cell {
@@ -73,6 +75,8 @@
         align-items: center;
         width: fit-content;
         margin-left: auto;
+        margin-block: calc(var(--jkl-table-cell-padding) * -1);
+        padding: var(--jkl-table-expand-padding);
     }
 }
 


### PR DESCRIPTION
## 💬 Endringer

Tilpasser størrelsen på `Expander` når den brukes i `ExpandableTableRow`, slik at ikke raden blir så høy når density er satt til compact.

## 🩹 Løser følgende issues

Closes #5587 
