### PR TITLE
Erstatt egen implementasjon av tabell med sanity versjonen

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       '@sanity/locale-nb-no':
         specifier: ^1.1.19
         version: 1.1.27(sanity@4.15.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.2(@sanity/schema@4.15.0(@types/react@18.3.1)(debug@4.4.3))(@sanity/types@4.15.0(@types/react@18.3.1)))(@types/node@24.10.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1))
+      '@sanity/table':
+        specifier: ^2.0.1
+        version: 2.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@4.15.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.2(@sanity/schema@4.15.0(@types/react@18.3.1)(debug@4.4.3))(@sanity/types@4.15.0(@types/react@18.3.1)))(@types/node@24.10.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/ui':
         specifier: ^3.1.11
         version: 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -3103,6 +3106,12 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@sanity/incompatible-plugin@1.0.5':
+    resolution: {integrity: sha512-9JGAacbElUPy9Chghd+sllIiM3jAcraZdD65bWYWUVKkghOsf1L/+jFLz1rcAuvrA9o2s7Y+T75BNcXuLwRcvw==}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+
   '@sanity/insert-menu@2.1.0':
     resolution: {integrity: sha512-vzl1jxkPYoEm8Hxin4KOT1gVTecUIKGgO9uxmd9Ur/BTsZatmBsO8jLvBKHgDa2JtHM1oJJhBQIbXUD3zIUvuQ==}
     engines: {node: '>=20.19'}
@@ -3213,6 +3222,13 @@ packages:
 
   '@sanity/signed-urls@2.0.1':
     resolution: {integrity: sha512-/u++FnDbaXDWHiHxG1Q4rbGsKRPf6lmTKsXeZ3bbbty/kNHDhVRUA5mRA+TtXlbPrse4ksv3a2vAerKNUNDZOw==}
+
+  '@sanity/table@2.0.1':
+    resolution: {integrity: sha512-+zLvXZOdll1a80YYyzWCUeDzQzq9OHsht9I1O13/QmKqcfqgMpgmDKzpw9zgplyq5pwtOH4g+uATAgms/yDQ2w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: 18.3.1
+      sanity: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@sanity/telemetry@0.8.1':
     resolution: {integrity: sha512-YybPb6s3IO2HmHZ4dLC3JCX+IAwAnVk5/qmhH4CWbC3iL/VsikRbz4FfOIIIt0cj2UOKrahL/wpSPBR/3quQzg==}
@@ -14541,6 +14557,11 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@sanity/incompatible-plugin@1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@sanity/insert-menu@2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.15.0(@types/react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@sanity/icons': 3.7.4(react@18.3.1)
@@ -14772,6 +14793,19 @@ snapshots:
     dependencies:
       '@noble/ed25519': 3.0.0
       '@noble/hashes': 2.0.1
+
+  '@sanity/table@2.0.1(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@4.15.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.2(@sanity/schema@4.15.0(@types/react@18.3.1)(debug@4.4.3))(@sanity/types@4.15.0(@types/react@18.3.1)))(@types/node@24.10.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@sanity/icons': 3.7.4(react@18.3.1)
+      '@sanity/incompatible-plugin': 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      react: 18.3.1
+      sanity: 4.15.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.2(@sanity/schema@4.15.0(@types/react@18.3.1)(debug@4.4.3))(@sanity/types@4.15.0(@types/react@18.3.1)))(@types/node@24.10.1)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-dom
+      - react-is
+      - styled-components
 
   '@sanity/telemetry@0.8.1(react@18.3.1)':
     dependencies:

--- a/portal/package.json
+++ b/portal/package.json
@@ -25,6 +25,7 @@
         "@sanity/icons": "^3.7.0",
         "@sanity/image-url": "^2.0.2",
         "@sanity/locale-nb-no": "^1.1.19",
+        "@sanity/table": "^2.0.1",
         "@sanity/ui": "^3.1.11",
         "@sanity/vision": "^4.15.0",
         "@types/mdx": "^2.0.13",

--- a/portal/sanity.config.ts
+++ b/portal/sanity.config.ts
@@ -1,6 +1,7 @@
 import { dataset, projectId } from "@/sanity/env";
 import { schemaTypes } from "@/sanity/schemas";
 import { nbNOLocale } from "@sanity/locale-nb-no";
+import { table } from "@sanity/table";
 import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { presentationTool } from "sanity/presentation";
@@ -16,6 +17,7 @@ export default defineConfig({
         structureTool(),
         visionTool(),
         nbNOLocale(),
+        table(),
         presentationTool({
             previewUrl: {
                 previewMode: {

--- a/portal/src/components/portable-text/table/Table.tsx
+++ b/portal/src/components/portable-text/table/Table.tsx
@@ -1,63 +1,72 @@
 import type { Jokul_table } from "@/sanity/types";
+import { Button } from "@fremtind/jokul/button";
 import { Flex } from "@fremtind/jokul/flex";
+import { CopyIcon } from "@fremtind/jokul/icon";
 import {
+    Table as JklTable,
     TableBody,
     TableCaption,
     TableCell,
     TableHead,
     TableHeader,
     TableRow,
-    Table as TokensTable,
 } from "@fremtind/jokul/table";
 import type { PortableTextTypeComponentProps } from "@portabletext/react";
 import type { FC } from "react";
 
-import styles from "./table.module.scss";
-
 export const Table: FC<PortableTextTypeComponentProps<Jokul_table>> = ({
     value,
 }) => {
-    if (!value?.head?.length && !value?.body?.length) return null;
+    const { table, caption, show_caption, copy_button, sticky_header } = value;
+
+    if (!table?.rows?.some((row) => row.cells?.some((cell) => cell)))
+        return null;
+
+    const headerRow = table?.rows[0].cells;
 
     return (
-        <Flex gap="m">
-            <TokensTable
-                className={styles.table}
-                caption={<TableCaption srOnly>Tabell</TableCaption>}
-                fullWidth
-            >
-                {value.head && value.head.length > 0 && (
-                    <TableHead>
-                        {value.head.map((row) => (
-                            <TableRow key={row._key}>
-                                {row.cells?.map((cell, cellIndex) => (
-                                    <TableHeader key={cellIndex}>
-                                        {cell}
-                                    </TableHeader>
-                                ))}
-                            </TableRow>
+        <JklTable
+            fullWidth
+            caption={
+                <TableCaption srOnly={!show_caption}>{caption}</TableCaption>
+            }
+        >
+            {headerRow && (
+                <TableHead sticky={sticky_header}>
+                    <TableRow>
+                        {headerRow.map((cell) => (
+                            <TableHeader key={cell}>{cell}</TableHeader>
                         ))}
-                    </TableHead>
-                )}
-
-                {value.body && value.body.length > 0 && (
-                    <TableBody>
-                        {value.body.map((row) => (
-                            <TableRow key={row._key}>
-                                {row.cells?.map((cell, cellIndex) => (
-                                    <TableCell key={cellIndex}>
-                                        {cell.startsWith("jkl") ? (
-                                            <code>{cell}</code>
-                                        ) : (
-                                            <>{cell}</>
-                                        )}
-                                    </TableCell>
-                                ))}
-                            </TableRow>
+                    </TableRow>
+                </TableHead>
+            )}
+            <TableBody>
+                {table.rows?.slice(1).map((row) => (
+                    <TableRow key={row._key}>
+                        {row.cells?.map((cell, index) => (
+                            <TableCell key={cell}>
+                                <Flex gap="xs">
+                                    <p>{cell}</p>
+                                    {copy_button && index === 0 && (
+                                        <Button
+                                            variant="ghost"
+                                            icon={<CopyIcon />}
+                                            aria-label={`Kopier ${cell}`}
+                                            data-size="small"
+                                            data-density="compact"
+                                            onClick={(_) => {
+                                                navigator.clipboard.writeText(
+                                                    cell.toString(),
+                                                );
+                                            }}
+                                        />
+                                    )}
+                                </Flex>
+                            </TableCell>
                         ))}
-                    </TableBody>
-                )}
-            </TokensTable>
-        </Flex>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </JklTable>
     );
 };

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -67,83 +67,39 @@
             "value": "jokul_table"
           }
         },
-        "head": {
+        "caption": {
           "type": "objectAttribute",
           "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "cells": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "array",
-                    "of": {
-                      "type": "string"
-                    }
-                  },
-                  "optional": true
-                },
-                "_type": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string",
-                    "value": "head_row"
-                  }
-                }
-              },
-              "rest": {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
+            "type": "string"
           },
           "optional": true
         },
-        "body": {
+        "table": {
           "type": "objectAttribute",
           "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "cells": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "array",
-                    "of": {
-                      "type": "string"
-                    }
-                  },
-                  "optional": true
-                },
-                "_type": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string",
-                    "value": "body_row"
-                  }
-                }
-              },
-              "rest": {
-                "type": "object",
-                "attributes": {
-                  "_key": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
+            "type": "inline",
+            "name": "table"
+          },
+          "optional": true
+        },
+        "show_caption": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        },
+        "sticky_header": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        },
+        "copy_button": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
           },
           "optional": true
         }
@@ -1790,6 +1746,21 @@
                   "type": "inline",
                   "name": "jokul_storybook"
                 }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_table"
+                }
               }
             ]
           }
@@ -2320,6 +2291,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_storybook"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_table"
                 }
               }
             ]
@@ -2992,6 +2978,21 @@
                   "type": "inline",
                   "name": "jokul_messageBox"
                 }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_table"
+                }
               }
             ]
           }
@@ -3218,6 +3219,70 @@
           }
         },
         "optional": true
+      }
+    }
+  },
+  {
+    "name": "table",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "table"
+          }
+        },
+        "rows": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "rest": {
+                "type": "inline",
+                "name": "tableRow"
+              }
+            }
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "tableRow",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "tableRow"
+          }
+        },
+        "cells": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "string"
+            }
+          },
+          "optional": true
+        }
       }
     }
   },

--- a/portal/src/sanity/schemas/blogPost.ts
+++ b/portal/src/sanity/schemas/blogPost.ts
@@ -57,6 +57,7 @@ export const blogPost = defineType({
                 { type: "image" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_storybook" },
+                { type: "jokul_table" },
             ],
         }),
     ],

--- a/portal/src/sanity/schemas/component.ts
+++ b/portal/src/sanity/schemas/component.ts
@@ -191,6 +191,7 @@ export const component = defineType({
                 { type: "jokul_codeBlock" },
                 { type: "jokul_doAndDont" },
                 { type: "jokul_messageBox" },
+                { type: "jokul_table" },
             ],
         }),
         defineField({

--- a/portal/src/sanity/schemas/table.ts
+++ b/portal/src/sanity/schemas/table.ts
@@ -1,52 +1,65 @@
+import { DocumentSheetIcon } from "@sanity/icons";
 import { defineType } from "sanity";
 
 export const table = defineType({
     name: "jokul_table",
     title: "Tabell",
     type: "object",
+    icon: DocumentSheetIcon,
+    groups: [
+        { name: "content", title: "Innhold", default: true },
+        { name: "options", title: "Valg" },
+    ],
     fields: [
         {
-            name: "head",
-            title: "Tabell-header",
-            type: "array",
-            of: [
-                {
-                    type: "object",
-                    name: "head_row",
-                    fields: [
-                        {
-                            name: "cells",
-                            title: "Kolonner",
-                            type: "array",
-                            of: [{ type: "string" }],
-                        },
-                    ],
-                },
-            ],
+            name: "caption",
+            title: "Caption",
+            type: "string",
+            group: "content",
         },
         {
-            name: "body",
-            title: "Tabellrader",
-            type: "array",
-            of: [
-                {
-                    type: "object",
-                    name: "body_row",
-                    fields: [
-                        {
-                            name: "cells",
-                            title: "Kolonner",
-                            type: "array",
-                            of: [{ type: "string" }],
-                        },
-                    ],
-                },
-            ],
+            name: "table",
+            title: "Tabell",
+            type: "table",
+            description: "Husk at første rad blir titler",
+            group: "content",
+        },
+        {
+            name: "show_caption",
+            title: "Vis caption",
+            description: "Viser caption-feltet visuelt på siden",
+            type: "boolean",
+            group: "options",
+        },
+        {
+            name: "sticky_header",
+            title: "Sticky header",
+            description: "Holder headeren synlig ved scrolling.",
+            type: "boolean",
+            group: "options",
+        },
+        {
+            name: "copy_button",
+            title: "Enkel kopiering",
+            description:
+                "Viser en knapp ved siden av verdien i første kolonne for enkel kopiering av verdien.",
+            type: "boolean",
+            group: "options",
         },
     ],
+    initialValue: {
+        show_caption: false,
+        sticky_header: true,
+        copy_button: false,
+    },
     preview: {
-        prepare() {
-            return { title: "Tabell" };
+        select: {
+            title: "caption",
+        },
+        prepare({ title }) {
+            return {
+                title: title ? title : "Tabell",
+            };
         },
     },
 });

--- a/portal/src/sanity/schemas/temaside.ts
+++ b/portal/src/sanity/schemas/temaside.ts
@@ -50,6 +50,7 @@ export const temaside = defineType({
                 { type: "image" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_storybook" },
+                { type: "jokul_table" },
             ],
         }),
         defineField({

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -22,16 +22,11 @@ export type Jokul_messageBox = {
 
 export type Jokul_table = {
   _type: "jokul_table";
-  head?: Array<{
-    cells?: Array<string>;
-    _type: "head_row";
-    _key: string;
-  }>;
-  body?: Array<{
-    cells?: Array<string>;
-    _type: "body_row";
-    _key: string;
-  }>;
+  caption?: string;
+  table?: Table;
+  show_caption?: boolean;
+  sticky_header?: boolean;
+  copy_button?: boolean;
 };
 
 export type Jokul_fundamentals = {
@@ -277,7 +272,9 @@ export type Jokul_temaside = {
     _key: string;
   } & Jokul_codeBlock | {
     _key: string;
-  } & Jokul_storybook>;
+  } & Jokul_storybook | {
+    _key: string;
+  } & Jokul_table>;
   related_components?: Array<{
     _ref: string;
     _type: "reference";
@@ -346,7 +343,9 @@ export type Jokul_blog_post = {
     _key: string;
   } & Jokul_codeBlock | {
     _key: string;
-  } & Jokul_storybook>;
+  } & Jokul_storybook | {
+    _key: string;
+  } & Jokul_table>;
 };
 
 export type Jokul_component = {
@@ -435,7 +434,9 @@ export type Jokul_component = {
     _key: string;
   } & Jokul_doAndDont | {
     _key: string;
-  } & Jokul_messageBox>;
+  } & Jokul_messageBox | {
+    _key: string;
+  } & Jokul_table>;
   related_components?: {
     components?: Array<{
       _ref: string;
@@ -474,6 +475,18 @@ export type Jokul_component = {
     crop?: SanityImageCrop;
     _type: "image";
   };
+};
+
+export type Table = {
+  _type: "table";
+  rows?: Array<{
+    _key: string;
+  } & TableRow>;
+};
+
+export type TableRow = {
+  _type: "tableRow";
+  cells?: Array<string>;
 };
 
 export type SanityImagePaletteSwatch = {
@@ -572,7 +585,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Jokul_component | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Jokul_component | Table | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -602,6 +615,8 @@ export type BlogPostBySlugQueryResult = {
   } & Jokul_linkCard | {
     _key: string;
   } & Jokul_storybook | {
+    _key: string;
+  } & Jokul_table | {
     children?: Array<{
       marks?: Array<string>;
       text?: string;
@@ -651,6 +666,8 @@ export type KomIGangQueryResult = {
   } & Jokul_linkCard | {
     _key: string;
   } & Jokul_storybook | {
+    _key: string;
+  } & Jokul_table | {
     children?: Array<{
       marks?: Array<string>;
       text?: string;
@@ -984,6 +1001,15 @@ export type ComponentBySlugQueryResult = {
     _type: "jokul_storybook";
     story?: Jokul_storybookStory;
     code?: Jokul_codeBlock;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_table";
+    caption?: string;
+    table?: Table;
+    show_caption?: boolean;
+    sticky_header?: boolean;
+    copy_button?: boolean;
     markDefs: null;
   }> | null;
   related_components: {


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Sanity har som beskrevet i issuet tatt inn en community plugin i sine offisielle blocks (kinda). Denne PR-en erstatter derfor en spesifikk implementasjon av token tables med en generell table block.

Funksjonalitet:
1. Caption
2. Tabell
3. Valgmuligheter for 
  1. Å vis/skjule caption
  2. Sticky header
  3. Kopieringsknapp ved første kolonne

NB: Det er ikke skrevet migrasjoner for innholdet som allerede eksisterte i portalen fordi uhm... orka ikke... det er jo litt dumt...

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5656

## Eksempelbilder

### Studio

<img width="698" height="644" alt="Skjermbilde 2026-01-19 kl  1 59 13 pm" src="https://github.com/user-attachments/assets/8650a684-767d-4f2b-b1be-b4b7371f4444" />

<img width="674" height="615" alt="Skjermbilde 2026-01-19 kl  1 59 23 pm" src="https://github.com/user-attachments/assets/c4bddf93-520a-4cc1-ba29-d53fe1557801" />

<img width="673" height="552" alt="Skjermbilde 2026-01-19 kl  1 59 17 pm" src="https://github.com/user-attachments/assets/a8e81887-b509-46e2-9325-b725d873b7fc" />

### Portalen

<img width="1469" height="1106" alt="Skjermbilde 2026-01-19 kl  1 59 44 pm" src="https://github.com/user-attachments/assets/aca3b261-fb63-410b-8c55-79a2e7fd4cf8" />


