### PR TITLE
Bedre håndtering av kodeeksempler i portalen

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,9 @@ importers:
       '@sanity/client':
         specifier: ^7.14.1
         version: 7.14.1(debug@4.4.3)
+      '@sanity/code-input':
+        specifier: ^6.0.4
+        version: 6.0.4(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@4.22.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.14(@types/react@18.3.1))(@types/node@24.10.9)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/icons':
         specifier: ^3.7.0
         version: 3.7.4(react@18.3.1)
@@ -1602,14 +1605,38 @@ packages:
   '@codemirror/commands@6.10.1':
     resolution: {integrity: sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q==}
 
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
   '@codemirror/lang-javascript@6.2.4':
     resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
 
   '@codemirror/language@6.11.3':
     resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
 
   '@codemirror/language@6.12.1':
     resolution: {integrity: sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==}
+
+  '@codemirror/legacy-modes@6.5.2':
+    resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
 
   '@codemirror/lint@6.9.2':
     resolution: {integrity: sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==}
@@ -2835,17 +2862,35 @@ packages:
   '@lezer/common@1.5.0':
     resolution: {integrity: sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==}
 
+  '@lezer/css@1.3.0':
+    resolution: {integrity: sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
   '@lezer/lr@1.4.3':
     resolution: {integrity: sha512-yenN5SqAxAPv/qMnpWW0AT7l+SxVrgG+u0tNsRQWqbrz66HIl8DnEbBObvy21J5K7+I1v7gsAnlE2VQ5yYVSeA==}
 
   '@lezer/lr@1.4.8':
     resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3728,6 +3773,15 @@ packages:
   '@sanity/client@7.14.1':
     resolution: {integrity: sha512-lCDx0vuNUgg9FL2E5Hiv1q7u6iHd1Z+jjMZAaYtfzzFPoBKOiyZlaFwqyLVHRyTbwnXQdIGDPmx2AvfBTbGQsQ==}
     engines: {node: '>=20'}
+
+  '@sanity/code-input@6.0.4':
+    resolution: {integrity: sha512-FElNmJ+dN5L6phxp+/sFbHB/4TxEvHZykImGIvRagerh5p2FdBH8v6zvKFA1RLnu+5t2m8QWyBOStjuBMtqWvg==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+      sanity: ^3 || ^4.0.0-0 || ^5
+      styled-components: ^5.2 || ^6
 
   '@sanity/codegen@4.22.0':
     resolution: {integrity: sha512-lelH3qBZXG6fgHRF+aWQ6Wx8rFQEhubTrXqdG7XH4dHUbb1f/dx66wqvx92/6iG89KXHUY2oT7AsHbY1kHYrOw==}
@@ -4612,6 +4666,13 @@ packages:
       '@codemirror/language': '>=6.0.0'
       '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/codemirror-themes@4.25.4':
+    resolution: {integrity: sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==}
+    peerDependencies:
+      '@codemirror/language': '>=6.0.0'
       '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
 
@@ -13836,9 +13897,9 @@ snapshots:
 
   '@codemirror/autocomplete@6.20.0':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.8
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
       '@lezer/common': 1.5.0
 
   '@codemirror/commands@6.10.0':
@@ -13855,15 +13916,72 @@ snapshots:
       '@codemirror/view': 6.39.12
       '@lezer/common': 1.5.0
 
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@lezer/common': 1.5.0
+      '@lezer/css': 1.3.0
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+      '@lezer/common': 1.5.0
+      '@lezer/css': 1.3.0
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.1
+      '@lezer/java': 1.1.3
+
   '@codemirror/lang-javascript@6.2.4':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.1
       '@codemirror/lint': 6.9.2
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.8
-      '@lezer/common': 1.3.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+      '@lezer/common': 1.5.0
       '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.1
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+      '@lezer/common': 1.5.0
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@lezer/common': 1.5.0
+      '@lezer/php': 1.0.5
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@codemirror/language@6.11.3':
     dependencies:
@@ -13883,10 +14001,14 @@ snapshots:
       '@lezer/lr': 1.4.8
       style-mod: 4.1.3
 
+  '@codemirror/legacy-modes@6.5.2':
+    dependencies:
+      '@codemirror/language': 6.12.1
+
   '@codemirror/lint@6.9.2':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.8
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
@@ -15239,23 +15361,58 @@ snapshots:
 
   '@lezer/common@1.5.0': {}
 
+  '@lezer/css@1.3.0':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
   '@lezer/highlight@1.2.3':
     dependencies:
-      '@lezer/common': 1.3.0
+      '@lezer/common': 1.5.0
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@lezer/javascript@1.5.4':
     dependencies:
-      '@lezer/common': 1.3.0
+      '@lezer/common': 1.5.0
       '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@lezer/lr@1.4.3':
     dependencies:
-      '@lezer/common': 1.3.0
+      '@lezer/common': 1.5.0
 
   '@lezer/lr@1.4.8':
     dependencies:
       '@lezer/common': 1.5.0
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -16222,6 +16379,41 @@ snapshots:
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+
+  '@sanity/code-input@6.0.4(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(sanity@4.22.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.14(@types/react@18.3.1))(@types/node@24.10.9)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.10.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/language': 6.12.1
+      '@codemirror/legacy-modes': 6.5.2
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+      '@juggle/resize-observer': 3.4.0
+      '@lezer/highlight': 1.2.3
+      '@sanity/icons': 3.7.4(react@18.3.1)
+      '@sanity/incompatible-plugin': 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)
+      '@uiw/react-codemirror': 4.25.3(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.12)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      sanity: 4.22.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.14(@types/react@18.3.1))(@types/node@24.10.9)(@types/react-dom@18.3.1)(@types/react@18.3.1)(immer@10.2.0)(jiti@2.6.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.2)
+      styled-components: 6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/runtime'
+      - '@codemirror/lint'
+      - '@codemirror/theme-one-dark'
+      - '@emotion/is-prop-valid'
+      - codemirror
+      - react-is
 
   '@sanity/codegen@4.22.0':
     dependencies:
@@ -17494,24 +17686,57 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
-      '@codemirror/commands': 6.10.0
+      '@codemirror/commands': 6.10.1
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.9.2
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.8
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.1)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.0
+      '@codemirror/commands': 6.10.1
+      '@codemirror/language': 6.12.1
+      '@codemirror/lint': 6.9.2
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+
+  '@uiw/codemirror-themes@4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)':
+    dependencies:
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.12
+
   '@uiw/react-codemirror@4.25.3(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.8)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@codemirror/commands': 6.10.0
+      '@codemirror/commands': 6.10.1
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.3
       '@codemirror/view': 6.38.8
-      '@uiw/codemirror-extensions-basic-setup': 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.0)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)
+      '@uiw/codemirror-extensions-basic-setup': 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)
+      codemirror: 6.0.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
+  '@uiw/react-codemirror@4.25.3(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.12)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@codemirror/commands': 6.10.1
+      '@codemirror/state': 6.5.4
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.39.12
+      '@uiw/codemirror-extensions-basic-setup': 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.1)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)
       codemirror: 6.0.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -19711,7 +19936,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -19744,7 +19969,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19759,7 +19984,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/portal/package.json
+++ b/portal/package.json
@@ -20,6 +20,7 @@
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.1.6",
         "@portabletext/react": "^5.0.0",
+        "@sanity/code-input": "^6.0.4",
         "@portabletext/types": "^3.0.1",
         "@sanity/client": "^7.14.1",
         "@sanity/icons": "^3.7.0",

--- a/portal/sanity.config.ts
+++ b/portal/sanity.config.ts
@@ -1,5 +1,6 @@
 import { dataset, projectId } from "@/sanity/env";
 import { schemaTypes } from "@/sanity/schemas";
+import { codeInput } from "@sanity/code-input";
 import { nbNOLocale } from "@sanity/locale-nb-no";
 import { table } from "@sanity/table";
 import { visionTool } from "@sanity/vision";
@@ -18,6 +19,7 @@ export default defineConfig({
         visionTool(),
         nbNOLocale(),
         table(),
+        codeInput(),
         presentationTool({
             previewUrl: {
                 previewMode: {

--- a/portal/src/app/(frontend)/blog/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/blog/[slug]/page.tsx
@@ -5,12 +5,13 @@ import { blogPostBySlugQuery } from "@/sanity/queries/blog";
 
 import { ArticleHeader } from "@/components/article/header";
 import { logger } from "logger";
+import type { Metadata } from "next";
 
 type Props = {
     params: Promise<{ slug: string }>;
 };
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const slug = (await params).slug;
 
     const { data: blogPost } = await sanityFetch({

--- a/portal/src/app/(frontend)/fundamenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/fundamenter/[slug]/page.tsx
@@ -5,12 +5,13 @@ import { fundamentalsBySlugQuery } from "@/sanity/queries/fundamentals";
 import { logger } from "logger";
 
 import { ArticleHeader } from "@/components/article/header";
+import type { Metadata } from "next";
 
 type Props = {
     params: Promise<{ slug: string }>;
 };
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const slug = (await params).slug;
 
     const { data: fundamental } = await sanityFetch({

--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -62,7 +62,7 @@ li {
 
 code,
 samp {
-    @include jkl.use-font-family("Fremtind Grotesk Mono");
+    font-family: monospace;
 }
 
 main {
@@ -117,17 +117,17 @@ article header {
         @include jkl.text-style("heading-5");
     }
 
-    code,
-    samp {
-        @include jkl.use-font-family("Fremtind Grotesk Mono");
-    }
-
     code {
         display: inline-block;
         background-color: var(--jkl-color-background-container-low);
         font-size: 0.9em;
         padding: 0 var(--jkl-unit-10);
-        border-radius: jkl.rem(2px);
+        border-radius: var(--jkl-border-radius-xs);
+        border: 1px solid var(--jkl-color-border-separator);
+    }
+
+    pre code {
+        border: none;
     }
 }
 

--- a/portal/src/app/studio/layout.tsx
+++ b/portal/src/app/studio/layout.tsx
@@ -1,4 +1,6 @@
-export const metadata = {
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
     title: "Jøkul Portal Studio",
     description:
         "Velkommen til Jøkul Portal Studio. Her kan du redigere innholdet på Portalen.",

--- a/portal/src/components/portable-text/PortableText.tsx
+++ b/portal/src/components/portable-text/PortableText.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExampleList } from "@/components/portable-text/examples/ExampleList";
+import { NewCodeBlock } from "@/components/portable-text/new-code-block/CodeBlock";
 import { QuestionsAndAnswers } from "@/components/portable-text/q-and-a/QuestionsAndAnswers";
 import { client } from "@/sanity/lib/client";
 import type { PortableTextReactComponents } from "@portabletext/react";
@@ -39,6 +40,7 @@ function urlFor(source: SanityImageObject) {
 const jokulBlockTypes = {
     jokul_examples: ExampleList,
     jokul_componentKortFortalt: KortFortalt,
+    jokul_code: NewCodeBlock,
     jokul_codeBlock: CodeBlock,
     jokul_linkCard: LinkCard,
     jokul_doAndDont: DoAndDont,

--- a/portal/src/components/portable-text/new-code-block/CodeBlock.tsx
+++ b/portal/src/components/portable-text/new-code-block/CodeBlock.tsx
@@ -1,0 +1,79 @@
+import fremtindTheme from "@/components/portable-text/code-block/fremtindTheme";
+import fremtindThemeDark from "@/components/portable-text/code-block/fremtindThemeDark";
+import type { Jokul_code } from "@/sanity/types";
+import { Button } from "@fremtind/jokul/button";
+import { useBrowserPreferences } from "@fremtind/jokul/hooks";
+import { CheckIcon, CopyIcon } from "@fremtind/jokul/icon";
+import type { PortableTextTypeComponentProps } from "next-sanity";
+import React, { useEffect, useState } from "react";
+import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import html from "react-syntax-highlighter/dist/esm/languages/prism/markup";
+import scss from "react-syntax-highlighter/dist/esm/languages/prism/scss";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import styles from "./code-block.module.scss";
+
+SyntaxHighlighter.registerLanguage("scss", scss);
+SyntaxHighlighter.registerLanguage("tsx", tsx);
+SyntaxHighlighter.registerLanguage("html", html);
+
+export const NewCodeBlock: React.FC<
+    PortableTextTypeComponentProps<Jokul_code>
+> = ({ value }) => {
+    const { title, code } = value;
+
+    if (!code || !code.language || !code.code) {
+        return null;
+    }
+
+    const { prefersColorScheme } = useBrowserPreferences();
+    const [style, setStyle] = useState(fremtindTheme);
+    const [copied, setCopied] = useState<boolean>(false);
+
+    useEffect(
+        () =>
+            setStyle(
+                prefersColorScheme === "dark"
+                    ? fremtindThemeDark
+                    : fremtindTheme,
+            ),
+        [prefersColorScheme],
+    );
+
+    return (
+        <div className={styles.codeBlock} data-language={code.language}>
+            <header className={styles.info} data-size="small">
+                <p className={styles.title}>{title} </p>
+                <span className={styles.language}>.{code.language}</span>
+                <Button
+                    className={styles.copyButton}
+                    variant="ghost"
+                    icon={copied ? <CheckIcon /> : <CopyIcon />}
+                    aria-label={copied ? "Kopiert" : "Kopier"}
+                    onClick={() => {
+                        try {
+                            navigator.clipboard.writeText(code.code || "");
+                            setCopied(true);
+                            setTimeout(() => {
+                                setCopied(false);
+                            }, 2000);
+                        } catch {
+                            console.warn("Klarte ikke kopiere teksten");
+                        }
+                    }}
+                />
+            </header>
+            <SyntaxHighlighter
+                style={style}
+                codeTagProps={{
+                    style: {},
+                    className: styles.codeBlockCode,
+                    tabIndex: 0,
+                }}
+                language={code.language}
+                className={styles.code}
+            >
+                {code.code.toString()}
+            </SyntaxHighlighter>
+        </div>
+    );
+};

--- a/portal/src/components/portable-text/new-code-block/code-block.module.scss
+++ b/portal/src/components/portable-text/new-code-block/code-block.module.scss
@@ -1,0 +1,62 @@
+@use '@fremtind/jokul/styles/core/jkl';
+
+.codeBlock {
+    background: var(--jkl-color-background-container-high);
+    border-radius: var(--jkl-border-radius-s);
+    overflow: hidden;
+    min-width: 60ch;
+    width: max-content;
+    max-width: 100%;
+
+    pre, code {
+        background: none!important;
+        padding: 0;
+        margin: 0;
+        border: none;
+    }
+
+    pre {
+        padding: var(--jkl-spacing-s) var(--jkl-spacing-m);
+        overflow-x: scroll;
+        scrollbar-width: none;
+        width: max-content;
+        max-width: 100%;
+        @include jkl.text-style("text-small");
+    }
+
+    .info {
+        margin: 0;
+        padding: var(--jkl-spacing-xs) var(--jkl-spacing-xs) var(--jkl-spacing-xs) var(--jkl-spacing-l);
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: center;
+        border-block-end: 1px solid var(--jkl-color-border-separator);
+
+        .title {
+            @include jkl.text-style("text-small") {
+                font-weight: var(--jkl-typography-font-weight-bold);
+            }
+        }
+
+        .language {
+            color: var(--jkl-color-text-subdued);
+
+            @include jkl.text-style("text-small") {
+                font-family: monospace;
+            };
+
+            &::after {
+                content: "";
+                height: 100%;
+                margin-inline-end: 1ch;
+                padding-inline-end: 2ch;
+                border-inline-end: 1px solid var(--jkl-color-border-separator);
+            }
+        }
+
+        .copyButton {
+            color: currentColor;
+            border-radius: var(--jkl-border-radius-xs);
+        }
+    }
+}

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -684,6 +684,21 @@
                 },
                 "rest": {
                   "type": "inline",
+                  "name": "jokul_code"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
                   "name": "jokul_codeBlock"
                 }
               },
@@ -1610,6 +1625,61 @@
           "type": "boolean"
         },
         "optional": true
+      },
+      "code": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "code"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "code",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "code"
+          }
+        },
+        "language": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "filename": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "highlightedLines": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "number"
+            }
+          },
+          "optional": true
+        }
       }
     }
   },
@@ -1755,6 +1825,37 @@
           "type": "objectAttribute",
           "value": {
             "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "jokul_code",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "jokul_code"
+          }
+        },
+        "title": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "code"
           },
           "optional": true
         }
@@ -2109,6 +2210,21 @@
                       }
                     }
                   }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_code"
                 }
               },
               {
@@ -2670,6 +2786,21 @@
                       }
                     }
                   }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_code"
                 }
               },
               {
@@ -3356,6 +3487,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_componentKortFortalt"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_code"
                 }
               },
               {

--- a/portal/src/sanity/queries/blog.ts
+++ b/portal/src/sanity/queries/blog.ts
@@ -24,6 +24,12 @@ export const blogPostBySlugQuery = defineQuery(
     `*[_type == "jokul_blog_post" && slug.current == $slug][0] {...,
     article[]{
             ...,
+            _type == "jokul_code" => {
+                ...,
+                title,
+                code,
+                language,
+          },
             _type == "jokul_examples" => {
     ...,
     title,
@@ -32,7 +38,8 @@ export const blogPostBySlugQuery = defineQuery(
                   id,
                   description,
                   height,
-                  inert
+                  inert,
+                  code
                 },
   },
   },

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -20,6 +20,12 @@ export const componentBySlugQuery =
         },
         documentation_article[]{
             ...,
+            _type == "jokul_code" => {
+                ...,
+                title,
+                code,
+                language,
+          },
             _type == "jokul_examples" => {
                 ...,
                 title,
@@ -28,7 +34,8 @@ export const componentBySlugQuery =
                   id,
                   description,
                   height,
-                  inert
+                  inert,
+                  code
                 },
               },
             _type == "jokul_componentKortFortalt" => {

--- a/portal/src/sanity/queries/fundamentals.ts
+++ b/portal/src/sanity/queries/fundamentals.ts
@@ -14,6 +14,12 @@ export const fundamentalsBySlugQuery = defineQuery(
     `*[_type == "jokul_fundamentals" && slug.current == $slug][0] {...,
     article[]{
             ...,
+            _type == "jokul_code" => {
+                ...,
+                title,
+                code,
+                language,
+          },
             _type == "jokul_examples" => {
                 ...,
                 title,
@@ -22,7 +28,8 @@ export const fundamentalsBySlugQuery = defineQuery(
                   id,
                   description,
                   height,
-                  inert
+                  inert,
+                  code
                 },
             },
         },

--- a/portal/src/sanity/schemas/code.tsx
+++ b/portal/src/sanity/schemas/code.tsx
@@ -1,0 +1,33 @@
+import { CodeIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+export const code = defineType({
+    name: "jokul_code",
+    title: "Kode",
+    type: "object",
+    icon: CodeIcon,
+    fields: [
+        defineField({
+            name: "title",
+            type: "string",
+            title: "Tittel",
+        }),
+        defineField({
+            name: "code",
+            title: "Kode",
+            type: "code",
+        }),
+    ],
+    preview: {
+        select: {
+            title: "title",
+            language: "code.language",
+        },
+        prepare({ title, language }) {
+            return {
+                title,
+                media: () => <small>.{language}</small>,
+            };
+        },
+    },
+});

--- a/portal/src/sanity/schemas/codeBlock.ts
+++ b/portal/src/sanity/schemas/codeBlock.ts
@@ -4,6 +4,9 @@ export const codeBlock = defineType({
     name: "jokul_codeBlock",
     title: "Kodeblokk",
     type: "object",
+    deprecated: {
+        reason: "Bruk den nye blokken",
+    },
     fields: [
         defineField({
             name: "language",

--- a/portal/src/sanity/schemas/codeExample.ts
+++ b/portal/src/sanity/schemas/codeExample.ts
@@ -5,6 +5,9 @@ export const codeExample = defineType({
     name: "jokul_codeExample",
     title: "Kodeeksempel",
     type: "object",
+    deprecated: {
+        reason: "Bruk den nye blokken",
+    },
     fields: [
         defineField({
             name: "showEditor",

--- a/portal/src/sanity/schemas/documents/blogPost.ts
+++ b/portal/src/sanity/schemas/documents/blogPost.ts
@@ -55,6 +55,7 @@ export const blogPost = defineType({
                 { type: "block" },
                 { type: "jokul_linkCard" },
                 { type: "image" },
+                { type: "jokul_code" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_examples" },
                 { type: "jokul_table" },

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -186,6 +186,7 @@ export const component = defineType({
                 { type: "image" },
                 { type: "jokul_componentProps" },
                 { type: "jokul_componentKortFortalt" },
+                { type: "jokul_code" },
                 { type: "jokul_codeExample" },
                 { type: "jokul_examples" },
                 { type: "jokul_codeBlock" },

--- a/portal/src/sanity/schemas/documents/fundamentals.ts
+++ b/portal/src/sanity/schemas/documents/fundamentals.ts
@@ -42,6 +42,7 @@ export const fundamentals = defineType({
                 { type: "block" },
                 { type: "jokul_linkCard" },
                 { type: "image" },
+                { type: "jokul_code" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_examples" },
                 { type: "jokul_doAndDont" },

--- a/portal/src/sanity/schemas/documents/story.tsx
+++ b/portal/src/sanity/schemas/documents/story.tsx
@@ -47,6 +47,14 @@ export const story = defineType({
                 "Fjerner mulighet for å kunne trykke, sveipe eller gjøre handlinger i eksempelet.",
             initialValue: false,
         }),
+        {
+            title: "Kodeeksempel",
+            name: "code",
+            type: "code",
+            initialValue: {
+                language: "tsx",
+            },
+        },
     ],
     preview: {
         select: {
@@ -62,7 +70,7 @@ export const story = defineType({
             return {
                 title: title ? title : "Story",
                 subtitle: `${height}px: ${desc}`,
-                media: <p>{title.charAt(0)}</p>,
+                media: <small>{title.charAt(0)}</small>,
             };
         },
     },

--- a/portal/src/sanity/schemas/documents/temaside.ts
+++ b/portal/src/sanity/schemas/documents/temaside.ts
@@ -48,6 +48,7 @@ export const temaside = defineType({
                 { type: "block" },
                 { type: "jokul_linkCard" },
                 { type: "image" },
+                { type: "jokul_code" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_examples" },
                 { type: "jokul_table" },

--- a/portal/src/sanity/schemas/index.ts
+++ b/portal/src/sanity/schemas/index.ts
@@ -1,4 +1,5 @@
 import { temaside } from "@/sanity/schemas/documents/temaside";
+import { code } from "./code";
 import { codeBlock } from "./codeBlock";
 import { codeExample } from "./codeExample";
 import { componentProps } from "./componentProps";
@@ -19,6 +20,7 @@ export const schemaTypes = [
     blogPost,
     temaside,
     componentProps,
+    code,
     codeExample,
     codeBlock,
     examples,

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -99,6 +99,8 @@ export type Jokul_fundamentals = {
     _key: string;
   } | {
     _key: string;
+  } & Jokul_code | {
+    _key: string;
   } & Jokul_codeBlock | {
     _key: string;
   } & Jokul_examples | {
@@ -240,6 +242,15 @@ export type Jokul_story = {
   description?: string;
   height?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
   inert?: boolean;
+  code?: Code;
+};
+
+export type Code = {
+  _type: "code";
+  language?: string;
+  filename?: string;
+  code?: string;
+  highlightedLines?: Array<number>;
 };
 
 export type Jokul_examples = {
@@ -265,6 +276,12 @@ export type Jokul_codeExample = {
   _type: "jokul_codeExample";
   showEditor?: boolean;
   codeExample?: string;
+};
+
+export type Jokul_code = {
+  _type: "jokul_code";
+  title?: string;
+  code?: Code;
 };
 
 export type Jokul_componentProps = {
@@ -313,6 +330,8 @@ export type Jokul_temaside = {
     _type: "image";
     _key: string;
   } | {
+    _key: string;
+  } & Jokul_code | {
     _key: string;
   } & Jokul_codeBlock | {
     _key: string;
@@ -386,6 +405,8 @@ export type Jokul_blog_post = {
     _type: "image";
     _key: string;
   } | {
+    _key: string;
+  } & Jokul_code | {
     _key: string;
   } & Jokul_codeBlock | {
     _key: string;
@@ -480,6 +501,8 @@ export type Jokul_component = {
   } & Jokul_componentProps | {
     _key: string;
   } & Jokul_componentKortFortalt | {
+    _key: string;
+  } & Jokul_code | {
     _key: string;
   } & Jokul_codeExample | {
     _key: string;
@@ -631,7 +654,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_story | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_story | Code | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -643,7 +666,7 @@ export type BlogPostsQueryResult = Array<{
   date: string;
 }>;
 // Variable: blogPostBySlugQuery
-// Query: *[_type == "jokul_blog_post" && slug.current == $slug][0] {...,    article[]{            ...,            _type == "jokul_examples" => {    ...,    title,    examples[]->{                  title,                  id,                  description,                  height,                  inert                },  },  },    }
+// Query: *[_type == "jokul_blog_post" && slug.current == $slug][0] {...,    article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {    ...,    title,    examples[]->{                  title,                  id,                  description,                  height,                  inert,                  code                },  },  },    }
 export type BlogPostBySlugQueryResult = {
   _id: string;
   _type: "jokul_blog_post";
@@ -685,6 +708,12 @@ export type BlogPostBySlugQueryResult = {
     _key: string;
   } | {
     _key: string;
+    _type: "jokul_code";
+    title: string | null;
+    code: Code | null;
+    language: null;
+  } | {
+    _key: string;
     _type: "jokul_codeBlock";
     language?: string;
     code?: string;
@@ -698,6 +727,7 @@ export type BlogPostBySlugQueryResult = {
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
       inert: boolean | null;
+      code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
   } | {
@@ -788,6 +818,11 @@ export type KomIGangQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
     _key: string;
+  } | {
+    _key: string;
+    _type: "jokul_code";
+    title?: string;
+    code?: Code;
   } | {
     _key: string;
     _type: "jokul_codeBlock";
@@ -898,7 +933,7 @@ export type ComponentsQueryResult = Array<{
   categories: Array<string> | null;
 }>;
 // Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "component_example_card": component_example_card{            "url": asset->url        },        documentation_article[]{            ...,            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        }    }
+// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "component_example_card": component_example_card{            "url": asset->url        },        documentation_article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert,                  code                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        }    }
 export type ComponentBySlugQueryResult = {
   _id: string;
   _type: "jokul_component";
@@ -994,6 +1029,13 @@ export type ComponentBySlugQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
     _key: string;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_code";
+    title: string | null;
+    code: Code | null;
+    language: null;
     markDefs: null;
   } | {
     _key: string;
@@ -1154,6 +1196,7 @@ export type ComponentBySlugQueryResult = {
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
       inert: boolean | null;
+      code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
     markDefs: null;
@@ -1292,7 +1335,7 @@ export type FundamentalsQueryResult = Array<{
   date: string;
 }>;
 // Variable: fundamentalsBySlugQuery
-// Query: *[_type == "jokul_fundamentals" && slug.current == $slug][0] {...,    article[]{            ...,            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert                },            },        },    }
+// Query: *[_type == "jokul_fundamentals" && slug.current == $slug][0] {...,    article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert,                  code                },            },        },    }
 export type FundamentalsBySlugQueryResult = {
   _id: string;
   _type: "jokul_fundamentals";
@@ -1331,6 +1374,12 @@ export type FundamentalsBySlugQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
     _key: string;
+  } | {
+    _key: string;
+    _type: "jokul_code";
+    title: string | null;
+    code: Code | null;
+    language: null;
   } | {
     _key: string;
     _type: "jokul_codeBlock";
@@ -1375,6 +1424,7 @@ export type FundamentalsBySlugQueryResult = {
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
       inert: boolean | null;
+      code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
   } | {
@@ -1435,13 +1485,13 @@ import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     "*[_type == \"jokul_blog_post\"]{\n        name,\n        slug,\n        short_description,\n        \"date\": _createdAt,\n        _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert\n                },\n          },\n    } | order(_createdAt desc)": BlogPostsQueryResult;
-    "*[_type == \"jokul_blog_post\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert\n                },\n  },\n  },\n    }": BlogPostBySlugQueryResult;
+    "*[_type == \"jokul_blog_post\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n  },\n  },\n    }": BlogPostBySlugQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    stories[]->{\n      storyName,\n      storyId,\n      storyDescription,\n    },\n  },\n  },\n    }": KomIGangQueryResult;
     "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    categories\n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"component_example_card\": component_example_card{\n            \"url\": asset->url\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
+    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"component_example_card\": component_example_card{\n            \"url\": asset->url\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
     "*[_type == \"jokul_component\" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        \"slug\": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components,\n        categories,\n    }[0]": ComponentCardQueryResult;
     "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        image,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": FundamentalsQueryResult;
-    "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert\n                },\n            },\n        },\n    }": FundamentalsBySlugQueryResult;
+    "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n            },\n        },\n    }": FundamentalsBySlugQueryResult;
     "*[_type == \"jokul_example\"]{\n    title,\n    id,\n    description,\n    height,\n    inert,\n} | order(name)": ExamplesQueryResult;
   }
 }


### PR DESCRIPTION
Valgte å ikke oppdatere React versjonen da dette medførte masse drit som egentlig burde fikses i en egen PR.

|  - | Eksempel |
|--------|--------|
| Før i portalen | <img width="1349" height="713" alt="Skjermbilde 2026-01-28 kl  3 45 49 pm" src="https://github.com/user-attachments/assets/eec34f4f-58eb-4ffe-82d0-14e83f055a88" /> |
| Etter i portalen | <img width="1343" height="423" alt="Skjermbilde 2026-01-28 kl  3 46 03 pm" src="https://github.com/user-attachments/assets/fb73ed90-1286-4299-bdcf-016a51a03249" /> |
| Nytt i Sanity | <img width="672" height="679" alt="Skjermbilde 2026-01-28 kl  3 46 47 pm" src="https://github.com/user-attachments/assets/2d6587f4-b11a-4755-b403-81c97658ab75" />
