### PR TITLE
Sync høyde for portal-header og sticky table-head

### DIFF
--- a/.changeset/quick-ants-exist.md
+++ b/.changeset/quick-ants-exist.md
@@ -1,0 +1,6 @@
+---
+"portal": patch
+---
+
+Innfører `--portal-header-height` til å justere sticky table-headere slik at det ikke
+overlapper portal headeren.

--- a/packages/jokul/src/components/table/styles/_table-head.scss
+++ b/packages/jokul/src/components/table/styles/_table-head.scss
@@ -19,7 +19,7 @@
         &--sticky {
             & > .jkl-table-row {
                 position: sticky;
-                top: 0;
+                top: var(--jkl-table-head-sticky-offset, 0);
                 z-index: 1;
                 background-color: var(--jkl-table-head-sticky-color);
 

--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -1,10 +1,13 @@
 @use "@fremtind/jokul/styles/core";
-@use "@fremtind/jokul/styles/fonts" with (
-    $webfonts-dir: "../../src/fonts"
-        // Dette er relativt til webfonts.sccs-fila i jokul-pakka
+@use "@fremtind/jokul/styles/fonts" with ($webfonts-dir: "../../src/fonts"
+    // Dette er relativt til webfonts.sccs-fila i jokul-pakka
 );
 @use "@fremtind/jokul/styles/styles";
 @use "@fremtind/jokul/styles/core/jkl";
+
+* {
+    box-sizing: border-box;
+}
 
 html {
     scroll-behavior: smooth;
@@ -18,10 +21,14 @@ body {
 }
 
 .jkl-portal-layout {
+    --portal-header-height: #{jkl.rem(80px)};
+
     max-width: var(--max-width);
     margin-inline: auto;
 
     @media (width >=940px) {
+        --portal-header-height: #{jkl.rem(90px)};
+
         padding: 0;
 
         main {

--- a/portal/src/components/header/header.module.scss
+++ b/portal/src/components/header/header.module.scss
@@ -3,13 +3,14 @@
 
 .header {
     display: grid;
+    place-items: center start;
     grid-template-columns: repeat(2, 1fr);
-    justify-items: start;
     padding: var(--jkl-unit-20);
     position: sticky;
     top: 0;
     background-color: var(--jkl-color-background-page-variant);
-    z-index: 1;
+    z-index: 2;
+    min-height: var(--portal-header-height);
 
     p {
         justify-self: end;

--- a/portal/src/components/portable-text/table/table.module.scss
+++ b/portal/src/components/portable-text/table/table.module.scss
@@ -1,5 +1,6 @@
 @use "@fremtind/jokul/styles/core/jkl";
 
 .table {
+    --jkl-table-head-sticky-offset: var(--portal-header-height);
     max-width: 55ch;
 }


### PR DESCRIPTION
## 💬 Endringer

Innfører `--portal-header-height` til å justere sticky table-headere slik at de ikke
overlapper portal headeren.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5717 
