### PR TITLE
Fiks feil i komponentkortene

### DIFF
--- a/.changeset/shaky-bobcats-scream.md
+++ b/.changeset/shaky-bobcats-scream.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Fikser en feil der bildene i komponentkortene i portalen ble kuttet av nederst.

--- a/portal/src/components/component-card/component-card.module.scss
+++ b/portal/src/components/component-card/component-card.module.scss
@@ -34,9 +34,9 @@
     width: 100%;
     aspect-ratio: var(--aspect-ratio);
     overflow: hidden;
+    margin-block-start: var(--jkl-unit-20);
 
     img {
-        margin-block-start: var(--jkl-unit-20);
         width: 100%;
         height: auto;
         object-fit: cover;


### PR DESCRIPTION
## 💬 Endringer

Fikser en feil der bildene i komponentkortene i portalen ble kuttet av nederst.
