### PR TITLE
Gjør om logikken til status i portalen

### DIFF
--- a/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeader.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeader.tsx
@@ -1,138 +1,86 @@
 "use client";
 
-import { Card } from "@fremtind/jokul/card";
+import { PortableText } from "@/components/portable-text/PortableText";
+import type { Jokul_component } from "@/sanity/types";
 import { Flex } from "@fremtind/jokul/flex";
-import jokul from "@fremtind/jokul/package.json";
-import { ComponentHeaderLink } from "./ComponentHeaderLink";
-
+import { Link as JklLink } from "@fremtind/jokul/link";
 import { Message } from "@fremtind/jokul/message";
+import jokul from "@fremtind/jokul/package.json";
 import styles from "./componentHeader.module.scss";
 
-type ComponentHeaderProps = {
-    links?: {
-        figma?: string;
-        github?: string;
-        storybook?: string;
-    };
-    name?: string;
-    description?: string;
-    status?: {
-        value?: string;
-        statusDescription?: string;
-    };
-};
+type ComponentHeaderProps = Pick<
+    Jokul_component,
+    "name" | "status" | "short_description"
+>;
 
 export const ComponentHeader = ({
-    links,
     name,
-    description,
+    short_description,
     status,
 }: ComponentHeaderProps) => {
+    const statusToMessageMapping = (status: Jokul_component["status"]) => {
+        switch (status?.value) {
+            case "deprecated":
+                return {
+                    variant: "warning",
+                    title: "Deprecated",
+                    replacementText: "Bruk heller ",
+                };
+            case "beta":
+                return {
+                    variant: "info",
+                    title: "Beta",
+                    replacementText: "Vurder ",
+                };
+            case "removed":
+                return {
+                    variant: "error",
+                    title: "Fjernet",
+                    replacementText: "Erstattet med ",
+                };
+            default:
+                return;
+        }
+    };
+
     return (
-        <Card variant="low" asChild>
-            <Flex as="header" className={styles.header}>
-                <div>
-                    {name && (
-                        <h1 className={styles.name} lang="en">
-                            {name}{" "}
-                            <span className="jkl-text-small">
-                                v{jokul.version}
-                            </span>
-                        </h1>
-                    )}
-                    {description && (
-                        <p className={styles.short_description}>
-                            {description}
-                        </p>
-                    )}
-                    {status?.value && (
-                        <div className={styles.status}>
-                            <Message
-                                variant={
-                                    status.value === "deprecated"
-                                        ? "warning"
-                                        : "info"
-                                }
-                                title={
-                                    status.value === "deprecated"
-                                        ? "Deprecated"
-                                        : "Beta"
-                                }
-                            >
-                                {status.statusDescription}
-                            </Message>
-                        </div>
-                    )}
-                </div>
-                {links && (
-                    <Flex gap="s" className={styles.external_links}>
-                        {links.storybook && (
-                            <ComponentHeaderLink
-                                name="Storybook"
-                                href={links.storybook}
-                                icon={
-                                    <svg
-                                        className="jkl-icon"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        width="24"
-                                        height="24"
-                                        viewBox="0 0 180 180"
-                                    >
-                                        <path
-                                            d="M161.818 8.439c.011.186.017.374.017.561v161c0 4.97-4.034 9-9.01 9a9.02 9.02 0 01-.404-.01l-120.264-5.394a9.005 9.005 0 01-8.6-8.653l-5.55-147.751c-.184-4.88 3.562-9.015 8.441-9.32l98.607-6.156-.844 20.286c-.01.26.055.516.186.738l.087.13c.42.553 1.187.69 1.769.335l.114-.078 7.888-5.977 6.663 5.243a1.345 1.345 0 002.174-.972l.001-.13L142.37.636l9.893-.618c4.967-.31 9.244 3.46 9.555 8.42zm-69.185 22.02c-23.455 0-36.596 12.724-36.596 31.81 0 33.243 44.913 33.879 44.913 52.011 0 5.09-2.495 8.112-7.985 8.112l-.486-.006c-6.795-.166-9.487-3.928-9.162-16.05 0-2.69-27.28-3.53-28.112 0-2.118 30.066 16.635 38.738 38.093 38.738 20.793 0 37.095-11.07 37.095-31.112 0-35.628-45.579-34.674-45.579-52.329 0-7.044 5.156-8.08 8.332-8.111l.698.006c3.393.09 8.743 1.282 8.27 13.94 0 3.5 23.612 1.823 26.782-.637 0-23.843-12.809-36.373-36.263-36.373z"
-                                            fill="currentColor"
-                                        />
-                                    </svg>
-                                }
-                            />
-                        )}
-                        {links.github && (
-                            <ComponentHeaderLink
-                                name="Github"
-                                href={links.github}
-                                icon={
-                                    <svg
-                                        className="jkl-icon"
-                                        width="24"
-                                        height="24"
-                                        fill="none"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            clipRule="evenodd"
-                                            d="M12 2C6.48 2 2 6.58 2 12.25c0 4.54 2.87 8.37 6.84 9.73.5.1.68-.22.68-.5l-.01-1.9c-2.79.62-3.37-1.22-3.37-1.22-.44-1.18-1.1-1.49-1.1-1.49-.92-.63.06-.63.06-.63 1 .07 1.54 1.06 1.54 1.06.9 1.56 2.34 1.12 2.92.84a2.2 2.2 0 0 1 .63-1.37c-2.22-.24-4.56-1.12-4.56-5.06 0-1.12.4-2.04 1.03-2.75-.1-.25-.45-1.3.1-2.72 0 0 .84-.27 2.75 1.06a9.47 9.47 0 0 1 5 0c1.9-1.33 2.75-1.06 2.75-1.06.55 1.41.2 2.47.1 2.72a3.97 3.97 0 0 1 1.03 2.75c0 3.94-2.34 4.8-4.58 5.06.37.32.68.93.68 1.9l-.01 2.82c0 .27.18.6.68.5A10.23 10.23 0 0 0 22 12.24 10.11 10.11 0 0 0 12 2z"
-                                            fill="currentColor"
-                                        />
-                                    </svg>
-                                }
-                            />
-                        )}
-                        {links.figma && (
-                            <ComponentHeaderLink
-                                name="Figma"
-                                href={links.figma}
-                                icon={
-                                    <svg
-                                        className="jkl-icon"
-                                        width="24"
-                                        height="24"
-                                        fill="none"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            clipRule="evenodd"
-                                            d="M6.71 8.87A3.72 3.72 0 0 1 8.77 2h6.46a3.72 3.72 0 0 1 2.06 6.87 3.72 3.72 0 0 1-2.06 6.87h-.07c-.98 0-1.88-.38-2.55-.99v3.48A3.8 3.8 0 0 1 8.79 22a3.72 3.72 0 0 1-2.07-6.87 3.72 3.72 0 0 1 0-6.26zm5.9 3.13c0 1.4 1.14 2.53 2.55 2.53h.07c1.4 0 2.55-1.13 2.55-2.53s-1.14-2.53-2.55-2.53h-.07A2.54 2.54 0 0 0 12.61 12zm-1.22-2.53H8.77A2.54 2.54 0 0 0 6.22 12c0 1.4 1.14 2.52 2.54 2.53h2.63V9.47zm-2.62 6.27a2.54 2.54 0 0 0-2.55 2.52c0 1.4 1.15 2.53 2.57 2.53 1.43 0 2.6-1.15 2.6-2.56v-2.5H8.77zm2.62-7.48H8.77a2.54 2.54 0 0 1-2.55-2.52c0-1.4 1.14-2.53 2.55-2.53h2.62v5.05zm3.84 0h-2.62V3.21h2.62c1.4 0 2.55 1.13 2.55 2.53s-1.14 2.52-2.55 2.52z"
-                                            fill="currentColor"
-                                        />
-                                    </svg>
-                                }
-                            />
-                        )}
-                    </Flex>
+        <Flex as="header" className={styles.header}>
+            <div>
+                {name && (
+                    <h1 className={styles.name} lang="en">
+                        {name}{" "}
+                        <span className="jkl-text-small">v{jokul.version}</span>
+                    </h1>
                 )}
-            </Flex>
-        </Card>
+                {short_description && (
+                    <p className={styles.short_description}>
+                        {short_description}
+                    </p>
+                )}
+                {status && status.value !== "stable" && (
+                    <div className={styles.status}>
+                        {/* @ts-ignore */}
+                        <Message {...statusToMessageMapping(status)}>
+                            {status.description && (
+                                <PortableText blocks={status.description} />
+                            )}
+                            {status.replacement && (
+                                <p className={styles.replacement}>
+                                    {
+                                        statusToMessageMapping(status)
+                                            ?.replacementText
+                                    }
+                                    <JklLink
+                                        href={`${status.replacement.slug}`}
+                                    >
+                                        {status.replacement.name}
+                                    </JklLink>
+                                </p>
+                            )}
+                        </Message>
+                    </div>
+                )}
+            </div>
+        </Flex>
     );
 };

--- a/portal/src/app/(frontend)/komponenter/[slug]/components/componentHeader.module.scss
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/componentHeader.module.scss
@@ -18,12 +18,8 @@
     .status {
         margin-top: var(--jkl-unit-80);
 
-        span {
-            font-size: 1.25rem;
-        }
-
-        p {
-            font-size: 1.125rem;
+        .replacement {
+            margin-block-start: var(--jkl-unit-10);
         }
     }
 

--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -73,11 +73,7 @@ export default async function Page({ params }: Props) {
                     Komponenter
                 </NavLink>
 
-                <ComponentHeader
-                    name={component?.name}
-                    description={component?.short_description}
-                    status={component.status}
-                />
+                <ComponentHeader {...component} />
 
                 {component.documentation_article && <ComponentNav />}
 

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -2907,20 +2907,230 @@
                 "of": [
                   {
                     "type": "string",
-                    "value": "deprecated"
+                    "value": "stable"
                   },
                   {
                     "type": "string",
                     "value": "beta"
+                  },
+                  {
+                    "type": "string",
+                    "value": "deprecated"
+                  },
+                  {
+                    "type": "string",
+                    "value": "removed"
                   }
                 ]
               },
               "optional": true
             },
-            "statusDescription": {
+            "description": {
               "type": "objectAttribute",
               "value": {
-                "type": "string"
+                "type": "array",
+                "of": {
+                  "type": "object",
+                  "attributes": {
+                    "children": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "array",
+                        "of": {
+                          "type": "object",
+                          "attributes": {
+                            "marks": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "array",
+                                "of": {
+                                  "type": "string"
+                                }
+                              },
+                              "optional": true
+                            },
+                            "text": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              },
+                              "optional": true
+                            },
+                            "_type": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string",
+                                "value": "span"
+                              }
+                            }
+                          },
+                          "rest": {
+                            "type": "object",
+                            "attributes": {
+                              "_key": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "optional": true
+                    },
+                    "style": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "string",
+                            "value": "normal"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h1"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h2"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h3"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h4"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h5"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h6"
+                          },
+                          {
+                            "type": "string",
+                            "value": "blockquote"
+                          }
+                        ]
+                      },
+                      "optional": true
+                    },
+                    "listItem": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "string",
+                            "value": "bullet"
+                          },
+                          {
+                            "type": "string",
+                            "value": "number"
+                          }
+                        ]
+                      },
+                      "optional": true
+                    },
+                    "markDefs": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "array",
+                        "of": {
+                          "type": "object",
+                          "attributes": {
+                            "href": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              },
+                              "optional": true
+                            },
+                            "_type": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string",
+                                "value": "link"
+                              }
+                            }
+                          },
+                          "rest": {
+                            "type": "object",
+                            "attributes": {
+                              "_key": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "optional": true
+                    },
+                    "level": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "number"
+                      },
+                      "optional": true
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "block"
+                      }
+                    }
+                  },
+                  "rest": {
+                    "type": "object",
+                    "attributes": {
+                      "_key": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "optional": true
+            },
+            "replacement": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "jokul_component"
               },
               "optional": true
             }

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -19,6 +19,13 @@ export const componentBySlugQuery =
             ...example_card,
             "story": example_card.story->
         },
+        status {
+            ...,
+            replacement -> {
+                name,
+                "slug": slug.current,
+            },
+        },
         documentation_article[]{
             ...,
             _type == "jokul_code" => {

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -57,18 +57,31 @@ export const component = defineType({
             fields: [
                 defineField({
                     name: "value",
-                    title: "Status",
+                    title: "Nåværende status",
                     type: "string",
                     options: {
-                        list: ["deprecated", "beta"],
-                        layout: "dropdown",
+                        list: [
+                            { value: "stable", title: "Stabil" },
+                            { value: "beta", title: "Beta" },
+                            { value: "deprecated", title: "Deprecated" },
+                            { value: "removed", title: "Fjernet" },
+                        ],
                     },
+                    initialValue: "stable",
                 }),
                 defineField({
-                    name: "statusDescription",
-                    title: "Statusbeskrivelse",
-                    type: "text",
-                    hidden: ({ parent }) => !parent?.value,
+                    name: "description",
+                    title: "Forklaring",
+                    type: "array",
+                    of: [{ type: "block" }],
+                    hidden: ({ parent }) => parent?.value === "stable",
+                }),
+                defineField({
+                    name: "replacement",
+                    title: "Erstatning",
+                    type: "reference",
+                    to: [{ type: "jokul_component" }],
+                    hidden: ({ parent }) => parent?.value === "stable",
                 }),
             ],
         }),


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

- **Man kan velge en komponent som erstatter en deprecated eller fjernet komponent**
- Statusbeskrivelsen støtter nå riktekst, først og fremst for å kunne lenke til relevant dokumentasjon der det trengs (eksempel på dette lagt ved nederst i beskrivelsen her).
- Man kan nå velge stabil som status igjen
- Man kan også velge fjernet som status
- Logikken i visning av status i studio er ryddet opp i

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #NNNN

## Bilder

Autosuggest er brukt som eksempel på en komponent med status for enkelhetens skyld, tekstene stemmer ikke for komponenten, men viser mulighetsrommet med endringene i denne PR-en.

| Forklaring | Eksempel |
|--------|--------|
| Status: Stabil | <img width="736" height="828" alt="image" src="https://github.com/user-attachments/assets/2a6b5a07-d62b-4e9c-81f2-fc990507bbb3" /> |
| Status: Stabil (i portalen) | <img width="1331" height="907" alt="image" src="https://github.com/user-attachments/assets/907f8b00-1bec-402f-8f06-11643b98a28b" /> |
| Status: Deprecated (med erstatning) | <img width="683" height="725" alt="image" src="https://github.com/user-attachments/assets/0d40e484-4bb0-4e0c-82ed-1cb071bf08c6" /> |
| Status: Deprecated (med erstatning) [i portalen] | <img width="1352" height="1012" alt="image" src="https://github.com/user-attachments/assets/05bf4c4e-a59c-4b26-879a-5601eb85e051" /> |
| Status: Fjernet (med erstatning) [i portalen] | <img width="1343" height="948" alt="image" src="https://github.com/user-attachments/assets/25476f6c-73a9-49ec-b73a-822b39370a46" /> | 
| Status: Beta (uten erstatning) [i portalen]. Med lenke til github skjema for tilbakemelding. | <img width="1333" height="937" alt="image" src="https://github.com/user-attachments/assets/51f46b54-cc9b-40b7-8f34-83a23bbc6733" /> | 
