### PR TITLE
Rett layer for InputPanel‑stilene

### DIFF
--- a/.changeset/strong-experts-sin.md
+++ b/.changeset/strong-experts-sin.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+InputPanel‑stilene ligger nå i `@layer jokul.components`, slik at de ikke kolliderer med Tailwind sitt reserverte `components`‑layer.

--- a/packages/jokul/src/components/input-panel/styles/input-panel.scss
+++ b/packages/jokul/src/components/input-panel/styles/input-panel.scss
@@ -1,6 +1,6 @@
 @use "../../../core/jkl" as jkl;
 
-@layer components {
+@layer jokul.components {
     .jkl-input-panel {
         --outer-border-color: var(--jkl-color-border-input);
         --outer-border-thickness: #{jkl.rem(1px)};
@@ -29,6 +29,7 @@
                 display: flex;
                 height: 100%;
                 align-items: center;
+
                 @include jkl.use-font-variables("jkl-checkbox");
             }
 
@@ -54,8 +55,8 @@
             padding-inline: var(--jkl-spacing-m);
             padding-block-end: var(--jkl-spacing-none);
             line-height: initial;
-            @include jkl.use-font-variables("jkl-checkbox");
 
+            @include jkl.use-font-variables("jkl-checkbox");
             @include jkl.motion;
             transition-property: height;
         }


### PR DESCRIPTION
## 💬 Endringer

InputPanel‑stilene ligger nå i `@layer jokul.components`, slik at de ikke kolliderer med Tailwind sitt reserverte `components`‑layer.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5755 
