### PR TITLE
Juster marginer for label og description

### DIFF
--- a/.changeset/loud-doors-drop.md
+++ b/.changeset/loud-doors-drop.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Justerer marginer for `label` og `description` for skjemafelter til å stemme bedre med ønsket uttrykk.

--- a/packages/jokul/src/components/input-group/styles/_labels.scss
+++ b/packages/jokul/src/components/input-group/styles/_labels.scss
@@ -91,9 +91,13 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
     .jkl-input-group-description {
         @include jkl.text-style("text-medium");
         color: var(--jkl-color-text-subdued);
-        margin: var(--jkl-label-medium-margin);
+        margin-block-end: var(--jkl-spacing-8);
         max-inline-size: 50ch;
         text-wrap: pretty;
+    }
+
+    .jkl-label:has(+ .jkl-input-group-description) {
+        margin-block-end: var(--jkl-spacing-4);
     }
 
     @keyframes #{$_support-icon-entrance-animation-name} {


### PR DESCRIPTION
## 💬 Endringer

Viser seg at vi hadde en bug i avstanden under `description` i skjemafelter (variabelen som var brukt var kun definert i label-komponenten). Fikser det ved å oppdatere spacing til verdiene brukt i Figma.
