### PR TITLE
Gjeninnfør storybook-blokk i Sanity (deprecated)

### DIFF
--- a/portal/src/components/portable-text/PortableText.tsx
+++ b/portal/src/components/portable-text/PortableText.tsx
@@ -3,6 +3,7 @@
 import { ExampleList } from "@/components/portable-text/examples/ExampleList";
 import { NewCodeBlock } from "@/components/portable-text/new-code-block/CodeBlock";
 import { QuestionsAndAnswers } from "@/components/portable-text/q-and-a/QuestionsAndAnswers";
+import { Storybook } from "@/components/portable-text/storybook-story/Storybook";
 import { client } from "@/sanity/lib/client";
 import type { PortableTextReactComponents } from "@portabletext/react";
 import { PortableText as PortableTextReact } from "@portabletext/react";
@@ -39,6 +40,7 @@ function urlFor(source: SanityImageObject) {
 
 const jokulBlockTypes = {
     jokul_examples: ExampleList,
+    jokul_storybook: Storybook,
     jokul_componentKortFortalt: KortFortalt,
     jokul_code: NewCodeBlock,
     jokul_codeBlock: CodeBlock,

--- a/portal/src/components/portable-text/storybook-story/Storybook.tsx
+++ b/portal/src/components/portable-text/storybook-story/Storybook.tsx
@@ -1,0 +1,74 @@
+import { CodeBlock } from "@/components/portable-text/code-block";
+import type { Jokul_storybook } from "@/sanity/types";
+import { Card } from "@fremtind/jokul/card";
+import { ExpandablePanel, Expander } from "@fremtind/jokul/expander";
+import { Flex } from "@fremtind/jokul/flex";
+import { Link } from "@fremtind/jokul/link";
+import type { PortableTextTypeComponentProps } from "next-sanity";
+import NextLink from "next/link";
+import React, { type FC } from "react";
+
+import "./storybook.scss";
+
+export const Storybook: FC<PortableTextTypeComponentProps<Jokul_storybook>> = ({
+    value,
+}) => {
+    const STORYBOOK_URL = process.env.NEXT_PUBLIC_STORYBOOK_BASE_URL;
+
+    const story = value.story;
+    const codeExample = value.code;
+    const height = value.height;
+
+    const storybookExampleHeight =
+        typeof height === "number" ? `${height}` : undefined;
+
+    if (!story) {
+        return null;
+    }
+
+    return (
+        <Flex
+            as={Card}
+            direction="column"
+            gap="s"
+            padding="m"
+            className="storybook-card"
+        >
+            <Flex alignItems="center" justifyContent="space-between" gap="m">
+                {STORYBOOK_URL && (
+                    <Link
+                        as={NextLink}
+                        href={`${STORYBOOK_URL}/?path=/story/${story.storyId}&globals=backgrounds.value:page;backgrounds.grid:!false`}
+                        className={"jkl-link"}
+                        external={true}
+                    >
+                        {story.storyName}
+                    </Link>
+                )}
+            </Flex>
+            <iframe
+                title={story.storyName}
+                className="storybook-example"
+                style={
+                    storybookExampleHeight
+                        ? ({
+                              "--storybook-example-height":
+                                  storybookExampleHeight,
+                          } as React.CSSProperties)
+                        : undefined
+                }
+                src={`${STORYBOOK_URL}/iframe.html?viewMode=story&id=${story.storyId}&globals=backgrounds.value:page;backgrounds.grid:!false`}
+            />
+            {codeExample?.code && (
+                <ExpandablePanel variant="fill">
+                    <Expander>Kode</Expander>
+                    <ExpandablePanel.Content>
+                        <CodeBlock language={codeExample.language}>
+                            {codeExample.code.toString()}
+                        </CodeBlock>
+                    </ExpandablePanel.Content>
+                </ExpandablePanel>
+            )}
+        </Flex>
+    );
+};

--- a/portal/src/components/portable-text/storybook-story/storybook.scss
+++ b/portal/src/components/portable-text/storybook-story/storybook.scss
@@ -1,0 +1,10 @@
+@use "@fremtind/jokul/styles/core/jkl";
+
+.storybook-example {
+    border: 0;
+    width: 100%;
+    max-width: 100%;
+    max-height: calc(var(--storybook-example-height, 360) * #{jkl.rem(1px)});
+    border-radius: jkl.rem(4px);
+    min-height: jkl.rem(120px);
+}

--- a/portal/src/sanity/components/StorybookStoryInput.tsx
+++ b/portal/src/sanity/components/StorybookStoryInput.tsx
@@ -1,0 +1,94 @@
+import { Label, Select, Stack } from "@sanity/ui";
+import React, { useEffect, useState, useCallback, useId } from "react";
+import { set, unset } from "sanity";
+import type { ObjectInputProps } from "sanity";
+
+export function StorybookInput(props: ObjectInputProps) {
+    const { value, onChange, id } = props;
+    const [stories, setStories] = useState<
+        Record<string, Array<{ id: string; name: string; title: string }>>
+    >({});
+    const [loading, setLoading] = useState<boolean>(true);
+    const fieldId = useId();
+    const fieldKey = /_key==\"(?<key>\w+)\"/g.exec(id)?.groups?.key;
+
+    const findStoryById = useCallback(
+        (storyId: string) => {
+            for (const componentStories of Object.values(stories)) {
+                const found = componentStories.find(
+                    (story) => story.id === storyId,
+                );
+                if (found) {
+                    return found;
+                }
+            }
+            return null;
+        },
+        [stories],
+    );
+
+    useEffect(() => {
+        async function fetchData() {
+            try {
+                const storiesResult = await fetch("/api/stories", {
+                    cache: "no-store",
+                });
+                const stories = await storiesResult.json();
+                setStories(stories);
+            } catch (error) {
+                console.error("Failed to fetch options:", error);
+            } finally {
+                setLoading(false);
+            }
+        }
+        fetchData();
+    }, []);
+
+    const handleChange = React.useCallback(
+        (event: React.FormEvent<HTMLSelectElement> | undefined) => {
+            const selectedValue = event?.currentTarget.value;
+            const story = findStoryById(selectedValue || "");
+
+            if (selectedValue && story) {
+                onChange(
+                    set({
+                        storyId: selectedValue,
+                        storyName: story.name,
+                        _key: `${fieldKey}-${selectedValue}`,
+                    }),
+                );
+            } else {
+                onChange(unset());
+            }
+        },
+        [onChange, findStoryById, fieldKey],
+    );
+
+    return (
+        <Stack space={2}>
+            <Label htmlFor={`storybook-story-${fieldId}`}>
+                Velg story fra Storybook
+            </Label>
+            <Select
+                onChange={handleChange}
+                disabled={loading}
+                value={value?.storyId}
+                id={`storybook-story-${fieldId}`}
+            >
+                <option value="">-- Velg en verdi --</option>
+                {Object.entries(stories)
+                    // Sorter alfabetisk etter komponentnavn
+                    .sort((a, b) => a[0].localeCompare(b[0]))
+                    .map(([componentName, stories]) => (
+                        <optgroup label={componentName} key={componentName}>
+                            {stories.map(({ id, name }) => (
+                                <option key={id} value={id}>
+                                    {name}
+                                </option>
+                            ))}
+                        </optgroup>
+                    ))}
+            </Select>
+        </Stack>
+    );
+}

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -1515,6 +1515,75 @@
     }
   },
   {
+    "name": "jokul_storybookStory",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "jokul_storybookStory"
+          }
+        },
+        "storyId": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "storyName": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "jokul_storybook",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "jokul_storybook"
+          }
+        },
+        "story": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "jokul_storybookStory"
+          },
+          "optional": true
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "jokul_codeBlock"
+          },
+          "optional": true
+        },
+        "height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "jokul_story",
     "type": "document",
     "attributes": {
@@ -2269,6 +2338,21 @@
                 },
                 "rest": {
                   "type": "inline",
+                  "name": "jokul_storybook"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
                   "name": "jokul_table"
                 }
               },
@@ -2831,6 +2915,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_examples"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_storybook"
                 }
               },
               {
@@ -3532,6 +3631,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_examples"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_storybook"
                 }
               },
               {

--- a/portal/src/sanity/schemas/documents/blogPost.ts
+++ b/portal/src/sanity/schemas/documents/blogPost.ts
@@ -58,6 +58,7 @@ export const blogPost = defineType({
                 { type: "jokul_code" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_examples" },
+                { type: "jokul_storybook" },
                 { type: "jokul_table" },
                 { type: "jokul_qa" },
             ],

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -189,6 +189,7 @@ export const component = defineType({
                 { type: "jokul_code" },
                 { type: "jokul_codeExample" },
                 { type: "jokul_examples" },
+                { type: "jokul_storybook" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_doAndDont" },
                 { type: "jokul_messageBox" },

--- a/portal/src/sanity/schemas/documents/temaside.ts
+++ b/portal/src/sanity/schemas/documents/temaside.ts
@@ -51,6 +51,7 @@ export const temaside = defineType({
                 { type: "jokul_code" },
                 { type: "jokul_codeBlock" },
                 { type: "jokul_examples" },
+                { type: "jokul_storybook" },
                 { type: "jokul_table" },
                 { type: "jokul_qa" },
             ],

--- a/portal/src/sanity/schemas/index.ts
+++ b/portal/src/sanity/schemas/index.ts
@@ -13,6 +13,7 @@ import { kortFortalt } from "./kortFortalt";
 import { linkCard } from "./linkCard";
 import { messageBox } from "./messageBox";
 import { questionsAndAnswers } from "./questionsAndAnswers";
+import { storybook, storybookStory } from "./storybook";
 import { table } from "./table";
 
 export const schemaTypes = [
@@ -25,6 +26,8 @@ export const schemaTypes = [
     codeBlock,
     examples,
     story,
+    storybook,
+    storybookStory,
     kortFortalt,
     linkCard,
     doAndDont,

--- a/portal/src/sanity/schemas/storybook.ts
+++ b/portal/src/sanity/schemas/storybook.ts
@@ -1,0 +1,81 @@
+import { ComponentIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+import { StorybookInput } from "../components/StorybookStoryInput";
+export const storybook = defineType({
+    name: "jokul_storybook",
+    title: "Eksempel fra Storybook",
+    type: "object",
+    icon: ComponentIcon,
+    deprecated: {
+        reason: "Bruk den nye Eksempler modulen",
+    },
+    fields: [
+        defineField({
+            name: "story",
+            title: "Velg story",
+            description: "Velg story fra Storybook",
+            type: "jokul_storybookStory",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "code",
+            title: "Eksempelkode",
+            type: "jokul_codeBlock",
+            options: {
+                collapsed: true,
+            },
+        }),
+        defineField({
+            name: "height",
+            title: "Høyde på eksempel (px)",
+            initialValue: 360,
+            description:
+                "Valgfri høyde på Storybook-eksempelet. Bruk lavere verdi for små eksempler.",
+            type: "number",
+            validation: (Rule) => Rule.min(120).max(1200),
+        }),
+    ],
+    preview: {
+        select: {
+            title: "story.storyName",
+        },
+        prepare({ title }) {
+            return {
+                title: title ? title : "Story uten navn",
+            };
+        },
+    },
+});
+
+export const storybookStory = defineType({
+    name: "jokul_storybookStory",
+    title: "Story fra Storybook",
+    type: "object",
+    fields: [
+        defineField({
+            name: "storyId",
+            title: "ID for story",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "storyName",
+            title: "Navn på story",
+            type: "string",
+            readOnly: true,
+        }),
+    ],
+    components: {
+        input: StorybookInput,
+    },
+    preview: {
+        select: {
+            storyName: "storyName",
+        },
+        prepare(select) {
+            return {
+                title: select.storyName,
+            };
+        },
+    },
+});

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -231,6 +231,19 @@ export type Jokul_componentKortFortalt = {
   }>;
 };
 
+export type Jokul_storybookStory = {
+  _type: "jokul_storybookStory";
+  storyId?: string;
+  storyName?: string;
+};
+
+export type Jokul_storybook = {
+  _type: "jokul_storybook";
+  story?: Jokul_storybookStory;
+  code?: Jokul_codeBlock;
+  height?: number;
+};
+
 export type Jokul_story = {
   _id: string;
   _type: "jokul_story";
@@ -337,6 +350,8 @@ export type Jokul_temaside = {
     _key: string;
   } & Jokul_examples | {
     _key: string;
+  } & Jokul_storybook | {
+    _key: string;
   } & Jokul_table | {
     _key: string;
   } & Jokul_qa>;
@@ -411,6 +426,8 @@ export type Jokul_blog_post = {
   } & Jokul_codeBlock | {
     _key: string;
   } & Jokul_examples | {
+    _key: string;
+  } & Jokul_storybook | {
     _key: string;
   } & Jokul_table | {
     _key: string;
@@ -507,6 +524,8 @@ export type Jokul_component = {
   } & Jokul_codeExample | {
     _key: string;
   } & Jokul_examples | {
+    _key: string;
+  } & Jokul_storybook | {
     _key: string;
   } & Jokul_codeBlock | {
     _key: string;
@@ -654,7 +673,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_story | Code | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_story | Code | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -769,6 +788,12 @@ export type BlogPostBySlugQueryResult = {
     }>;
   } | {
     _key: string;
+    _type: "jokul_storybook";
+    story?: Jokul_storybookStory;
+    code?: Jokul_codeBlock;
+    height?: number;
+  } | {
+    _key: string;
     _type: "jokul_table";
     caption?: string;
     table?: Table;
@@ -878,6 +903,12 @@ export type KomIGangQueryResult = {
       _type: "faqitem";
       _key: string;
     }>;
+  } | {
+    _key: string;
+    _type: "jokul_storybook";
+    story?: Jokul_storybookStory;
+    code?: Jokul_codeBlock;
+    height?: number;
   } | {
     _key: string;
     _type: "jokul_table";
@@ -1206,6 +1237,13 @@ export type ComponentBySlugQueryResult = {
     messageType?: "error" | "info" | "success" | "warning";
     title?: string;
     message?: string;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_storybook";
+    story?: Jokul_storybookStory;
+    code?: Jokul_codeBlock;
+    height?: number;
     markDefs: null;
   }> | null;
   related_components: {


### PR DESCRIPTION
## 💬 Endringer

Gjeninnfører den gamle Storybook‑eksempelblokken fordi vi fortsatt har innhold i sanity som bruker den. Før vi kan fjerne den helt, må Sanity Studio være oppdatert til å bruke den nye eksempler‑modulen/blokken.
