### PR TITLE
feat: Oppdaterte eksempel-block til å ta inn story

### DIFF
--- a/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentExampleCard.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentExampleCard.tsx
@@ -1,21 +1,35 @@
-import styles from "./componentExampleCard.module.scss";
+"use client";
 
-type ComponentExampleCard = {
-    name: string;
-    imageUrl: string;
+import { ExampleItem } from "@/components/portable-text/examples/ExampleItem";
+import type { Jokul_examples, Jokul_story } from "@/sanity/types";
+import { Flex } from "@fremtind/jokul/flex";
+
+import "portal/src/components/portable-text/examples/examples.scss";
+
+type ExampleCardValue = {
+    story?: Jokul_story | null;
 };
 
-export const ComponentExampleCard = ({
-    name,
-    imageUrl,
-}: ComponentExampleCard) => {
+type Props = {
+    value?: ExampleCardValue;
+};
+
+export const ComponentExampleCard = ({ value }: Props) => {
+    if (!value?.story) {
+        return null;
+    }
+
+    const { story } = value;
+
     return (
-        <div className={styles.example_card_image_wrapper}>
-            <img
-                className={styles.example_card_image}
-                src={imageUrl}
-                alt={name}
-            />
-        </div>
+        <Flex direction="column" gap="s">
+            <div className="examples">
+                <ExampleItem
+                    example={{
+                        ...story,
+                    }}
+                />
+            </div>
+        </Flex>
     );
 };

--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -60,6 +60,8 @@ export default async function Page({ params }: Props) {
         return source?.asset?._ref ? builder.image(source).url() : undefined;
     }
 
+    console.log("component.example_card", component.example_card);
+
     return (
         <article className={styles.article}>
             <div className={styles.articleHeader}>
@@ -152,10 +154,7 @@ export default async function Page({ params }: Props) {
             {component.name && (
                 <div className="prose">
                     {component?.example_card && (
-                        <ComponentExampleCard
-                            name={component.name}
-                            imageUrl={urlFor(component.example_card) ?? ""}
-                        />
+                        <ComponentExampleCard value={component.example_card} />
                     )}
                     {component.considerations && (
                         <ComponentConsiderations

--- a/portal/src/components/portable-text/examples/ExampleItem.tsx
+++ b/portal/src/components/portable-text/examples/ExampleItem.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const ExampleItem = ({ example }: Props) => {
     const STORYBOOK_URL = process.env.NEXT_PUBLIC_STORYBOOK_BASE_URL;
-    const { title, id, description, height, inert } = example;
+    const { name, id, description, height, inert } = example;
 
     const backgroundColor = undefined;
     const theme = undefined;
@@ -18,7 +18,7 @@ export const ExampleItem = ({ example }: Props) => {
 
     const exampleHeight = typeof height === "number" ? `${height}` : undefined;
 
-    if (!id || !title) {
+    if (!id || !name) {
         return null;
     }
 
@@ -26,7 +26,7 @@ export const ExampleItem = ({ example }: Props) => {
         <Card padding="m" className="example" variant="outlined">
             <iframe
                 inert={inert}
-                title={title}
+                title={name}
                 src={`${STORYBOOK_URL}/iframe.html?viewMode=story&id=${id}&globals=backgrounds.value:${backgroundColor};theme:${theme};density:${density}`}
                 style={
                     exampleHeight
@@ -37,7 +37,7 @@ export const ExampleItem = ({ example }: Props) => {
                 }
             />
             <div className="info">
-                <p className="title">{title}</p>
+                <p className="title">{name}</p>
                 {description && <p className="description">{description}</p>}
                 {STORYBOOK_URL && (
                     <Link
@@ -47,7 +47,7 @@ export const ExampleItem = ({ example }: Props) => {
                         external={true}
                         target="_blank"
                     >
-                        Se <span className="jkl-sr-only">{title}</span> i{" "}
+                        Se <span className="jkl-sr-only">{name}</span> i{" "}
                         <span lang="en">Storybook</span>
                     </Link>
                 )}

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -1584,175 +1584,6 @@
     }
   },
   {
-    "name": "jokul_story",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "jokul_story"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "height": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "union",
-          "of": [
-            {
-              "type": "number",
-              "value": 100
-            },
-            {
-              "type": "number",
-              "value": 200
-            },
-            {
-              "type": "number",
-              "value": 300
-            },
-            {
-              "type": "number",
-              "value": 400
-            },
-            {
-              "type": "number",
-              "value": 500
-            },
-            {
-              "type": "number",
-              "value": 600
-            },
-            {
-              "type": "number",
-              "value": 700
-            },
-            {
-              "type": "number",
-              "value": 800
-            },
-            {
-              "type": "number",
-              "value": 900
-            },
-            {
-              "type": "number",
-              "value": 1000
-            }
-          ]
-        },
-        "optional": true
-      },
-      "inert": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "boolean"
-        },
-        "optional": true
-      },
-      "code": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "code"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "code",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "code"
-          }
-        },
-        "language": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "filename": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "code": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "highlightedLines": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "number"
-            }
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
     "name": "jokul_examples",
     "type": "type",
     "value": {
@@ -3122,7 +2953,7 @@
         "value": {
           "type": "object",
           "attributes": {
-            "asset": {
+            "story": {
               "type": "objectAttribute",
               "value": {
                 "type": "object",
@@ -3148,39 +2979,9 @@
                     "optional": true
                   }
                 },
-                "dereferencesTo": "sanity.imageAsset"
+                "dereferencesTo": "jokul_story"
               },
               "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
             }
           }
         },
@@ -3916,6 +3717,175 @@
               }
             }
           }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "code",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "code"
+          }
+        },
+        "language": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "filename": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "highlightedLines": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "number"
+            }
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "jokul_story",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "jokul_story"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "height": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "number",
+              "value": 100
+            },
+            {
+              "type": "number",
+              "value": 200
+            },
+            {
+              "type": "number",
+              "value": 300
+            },
+            {
+              "type": "number",
+              "value": 400
+            },
+            {
+              "type": "number",
+              "value": 500
+            },
+            {
+              "type": "number",
+              "value": 600
+            },
+            {
+              "type": "number",
+              "value": 700
+            },
+            {
+              "type": "number",
+              "value": 800
+            },
+            {
+              "type": "number",
+              "value": 900
+            },
+            {
+              "type": "number",
+              "value": 1000
+            }
+          ]
+        },
+        "optional": true
+      },
+      "inert": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
+      "code": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "code"
         },
         "optional": true
       }

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -15,8 +15,9 @@ export const componentBySlugQuery =
     defineQuery(`*[_type == "jokul_component" && slug.current == $slug][0] {
         ...,
         "slug": slug.current,
-        "component_example_card": component_example_card{
-            "url": asset->url
+        "example_card": {
+            ...example_card,
+            "story": example_card.story->
         },
         documentation_article[]{
             ...,

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -1,3 +1,4 @@
+import { StorySelector } from "@/sanity/components/StorySelector";
 import {
     CheckmarkCircleIcon,
     CloseCircleIcon,
@@ -95,8 +96,18 @@ export const component = defineType({
         defineField({
             name: "example_card",
             title: "Eksempel",
-            type: "image",
-            group: "documentation",
+            type: "object",
+            fields: [
+                defineField({
+                    name: "story",
+                    title: "Velg story",
+                    type: "reference",
+                    to: [{ type: "jokul_story" }],
+                    options: {
+                        filter: '_type == "jokul_story"',
+                    },
+                }),
+            ],
         }),
         defineField({
             name: "considerations",

--- a/portal/src/sanity/schemas/documents/story.tsx
+++ b/portal/src/sanity/schemas/documents/story.tsx
@@ -10,17 +10,18 @@ export const story = defineType({
     icon: BlockElementIcon,
     fields: [
         defineField({
+            name: "name",
+            title: "Navn på story",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
             name: "id",
             title: "Story",
             type: "string",
             components: {
                 input: StorySelector,
             },
-        }),
-        defineField({
-            name: "title",
-            title: "Tittel",
-            type: "string",
         }),
         defineField({
             name: "description",
@@ -58,19 +59,19 @@ export const story = defineType({
     ],
     preview: {
         select: {
-            id: "id",
+            name: "name",
             title: "title",
             description: "description",
             height: "height",
             inert: "inert",
         },
-        prepare({ title, description, height }) {
+        prepare({ name, title, description, height }) {
             const desc = description ? description : "Ingen beskrivelse";
 
             return {
-                title: title ? title : "Story",
+                title: name || "Story",
                 subtitle: `${height}px: ${desc}`,
-                media: <small>{title.charAt(0)}</small>,
+                media: <small>{name.charAt(0)}</small>,
             };
         },
     },

--- a/portal/src/sanity/schemas/examples.ts
+++ b/portal/src/sanity/schemas/examples.ts
@@ -13,7 +13,6 @@ export const examples = defineType({
         defineField({
             name: "title",
             type: "string",
-            initialValue: "Eksempler",
             group: "content",
         }),
         defineField({
@@ -47,7 +46,7 @@ export const examples = defineType({
     ],
     preview: {
         select: {
-            title: "title",
+            title: "name",
             example1: "examples.0.title",
             example2: "examples.1.title",
             example3: "examples.2.title",

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -244,28 +244,6 @@ export type Jokul_storybook = {
   height?: number;
 };
 
-export type Jokul_story = {
-  _id: string;
-  _type: "jokul_story";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  id?: string;
-  title?: string;
-  description?: string;
-  height?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
-  inert?: boolean;
-  code?: Code;
-};
-
-export type Code = {
-  _type: "code";
-  language?: string;
-  filename?: string;
-  code?: string;
-  highlightedLines?: Array<number>;
-};
-
 export type Jokul_examples = {
   _type: "jokul_examples";
   title?: string;
@@ -457,16 +435,12 @@ export type Jokul_component = {
   categories?: Array<string>;
   keywords?: Array<string>;
   example_card?: {
-    asset?: {
+    story?: {
       _ref: string;
       _type: "reference";
       _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      [internalGroqTypeReferenceTo]?: "jokul_story";
     };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
   };
   considerations?: Array<{
     title?: string;
@@ -572,6 +546,28 @@ export type Jokul_component = {
   };
 };
 
+export type Code = {
+  _type: "code";
+  language?: string;
+  filename?: string;
+  code?: string;
+  highlightedLines?: Array<number>;
+};
+
+export type Jokul_story = {
+  _id: string;
+  _type: "jokul_story";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+  id?: string;
+  description?: string;
+  height?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000;
+  inert?: boolean;
+  code?: Code;
+};
+
 export type TableRow = {
   _type: "tableRow";
   cells?: Array<string>;
@@ -673,7 +669,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_story | Code | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | SanityImageCrop | SanityImageHotspot | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | Code | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -741,7 +737,7 @@ export type BlogPostBySlugQueryResult = {
     _type: "jokul_examples";
     title: string | null;
     examples: Array<{
-      title: string | null;
+      title: null;
       id: string | null;
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
@@ -964,7 +960,7 @@ export type ComponentsQueryResult = Array<{
   categories: Array<string> | null;
 }>;
 // Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "component_example_card": component_example_card{            "url": asset->url        },        documentation_article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert,                  code                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        }    }
+// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "example_card": {            ...example_card,            "story": example_card.story->        },        documentation_article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert,                  code                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        }    }
 export type ComponentBySlugQueryResult = {
   _id: string;
   _type: "jokul_component";
@@ -980,17 +976,20 @@ export type ComponentBySlugQueryResult = {
   };
   categories?: Array<string>;
   keywords?: Array<string>;
-  example_card?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
+  example_card: {
+    story: {
+      _id: string;
+      _type: "jokul_story";
+      _createdAt: string;
+      _updatedAt: string;
+      _rev: string;
+      name?: string;
+      id?: string;
+      description?: string;
+      height?: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+      inert?: boolean;
+      code?: Code;
+    } | null;
   };
   considerations?: Array<{
     title?: string;
@@ -1222,7 +1221,7 @@ export type ComponentBySlugQueryResult = {
     _type: "jokul_examples";
     title: string | null;
     examples: Array<{
-      title: string | null;
+      title: null;
       id: string | null;
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
@@ -1317,7 +1316,6 @@ export type ComponentBySlugQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
   };
-  component_example_card: null;
 } | null;
 // Variable: componentCardQuery
 // Query: *[_type == "jokul_component" && defined(slug.current) && slug.current == $componentSlug] {        name,        short_description,        "slug": slug.current,        figma_image,        image,        imageDark,        related_components,        categories,    }[0]
@@ -1457,7 +1455,7 @@ export type FundamentalsBySlugQueryResult = {
     _type: "jokul_examples";
     title: string | null;
     examples: Array<{
-      title: string | null;
+      title: null;
       id: string | null;
       description: string | null;
       height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
@@ -1526,7 +1524,7 @@ declare module "@sanity/client" {
     "*[_type == \"jokul_blog_post\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n  },\n  },\n    }": BlogPostBySlugQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    stories[]->{\n      storyName,\n      storyId,\n      storyDescription,\n    },\n  },\n  },\n    }": KomIGangQueryResult;
     "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    categories\n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"component_example_card\": component_example_card{\n            \"url\": asset->url\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
+    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
     "*[_type == \"jokul_component\" && defined(slug.current) && slug.current == $componentSlug] {\n        name,\n        short_description,\n        \"slug\": slug.current,\n        figma_image,\n        image,\n        imageDark,\n        related_components,\n        categories,\n    }[0]": ComponentCardQueryResult;
     "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        image,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": FundamentalsQueryResult;
     "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n            },\n        },\n    }": FundamentalsBySlugQueryResult;


### PR DESCRIPTION
Oppdatere eksempel-block til å hente Stories. Valgte å ikke fjerne alle mulighetene som finnes i jokul_story, da hovedeksempelet alltid skal ligge øverst og man trenger derfor mulighet til å opprette ny story, justere høyde osv.