### PR TITLE
Juster label-margin og description-tekst i InputGroup/FieldGroup

### DIFF
--- a/.changeset/sharp-moons-itch.md
+++ b/.changeset/sharp-moons-itch.md
@@ -1,0 +1,6 @@
+---
+"@fremtind/jokul": patch
+---
+
+- Flyttet margin‑justering for label med `description` til en eksplisitt label‑modifier, slik at den gjelder både InputGroup og FieldGroup.
+- Endret tekststørrelse for `.jkl-input-group-description` fra `medium` til `small` for å samsvare med Figma.

--- a/packages/jokul/src/components/input-group/FieldGroup.tsx
+++ b/packages/jokul/src/components/input-group/FieldGroup.tsx
@@ -42,7 +42,13 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
             aria-describedby={describedBy}
         >
             <legend className="jkl-field-group__legend">
-                <Label {...labelProps}>
+                <Label
+                    {...labelProps}
+                    className={clsx(
+                        labelProps?.className,
+                        description && "jkl-label--with-description",
+                    )}
+                >
                     {tooltip ? (
                         <>
                             <span style={{ whiteSpace: "normal" }}>

--- a/packages/jokul/src/components/input-group/InputGroup.tsx
+++ b/packages/jokul/src/components/input-group/InputGroup.tsx
@@ -69,6 +69,10 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
                     htmlFor={uid}
                     srOnly={inline}
                     {...labelProps}
+                    className={clsx(
+                        labelProps?.className,
+                        description && "jkl-label--with-description",
+                    )}
                     style={{
                         whiteSpace: hasTooltip ? "nowrap" : undefined,
                         ...labelProps?.style,

--- a/packages/jokul/src/components/input-group/styles/_labels.scss
+++ b/packages/jokul/src/components/input-group/styles/_labels.scss
@@ -2,8 +2,10 @@
 @use "../../../core/jkl";
 
 $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.unique-id(
+)
+}
 
-    )};
+;
 
 @layer jokul.components {
     .jkl-dormant-form-support-label {
@@ -17,8 +19,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
 
         --jkl-form-support-label-margin: var(--jkl-unit-10) 0 0;
         --jkl-form-support-label-icon-size: #{$_icon-size};
-        --jkl-form-support-label-icon-margin: 0 -#{$_icon-size} -#{jkl.rem(6px)}
-            0;
+        --jkl-form-support-label-icon-margin: 0 -#{$_icon-size} -#{jkl.rem(6px)} 0;
         --color: var(--jkl-color-text-subdued);
 
         @include jkl.text-style("text-small");
@@ -36,10 +37,8 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
             height: var(--jkl-form-support-label-icon-size);
             margin: var(--jkl-form-support-label-icon-margin);
 
-            @include jkl.forced-colors-svg-fallback(
-                $stroke: CanvasText,
-                $fill: Canvas
-            );
+            @include jkl.forced-colors-svg-fallback($stroke: CanvasText,
+                $fill: Canvas);
         }
 
         &--error,
@@ -48,9 +47,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
             --color: var(--jkl-color-text-default);
 
             .jkl-form-support-label__icon {
-                animation: jkl.timing("lazy") cubic-bezier(0, 0, 0.3, 1)
-                    jkl.timing("expressive")
-                    $_support-icon-entrance-animation-name forwards;
+                animation: jkl.timing("lazy") cubic-bezier(0, 0, 0.3, 1) jkl.timing("expressive") $_support-icon-entrance-animation-name forwards;
             }
         }
 
@@ -89,14 +86,14 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
     }
 
     .jkl-input-group-description {
-        @include jkl.text-style("text-medium");
+        @include jkl.text-style("text-small");
         color: var(--jkl-color-text-subdued);
         margin-block-end: var(--jkl-spacing-8);
         max-inline-size: 50ch;
         text-wrap: pretty;
     }
 
-    .jkl-label:has(+ .jkl-input-group-description) {
+    .jkl-label--with-description {
         margin-block-end: var(--jkl-spacing-4);
     }
 


### PR DESCRIPTION
- Flyttet margin‑justering for label med `description` til en eksplisitt label‑modifier, slik at den gjelder både InputGroup og FieldGroup.
- Endret tekststørrelse for `.jkl-input-group-description` fra `medium` til `small` for å samsvare med Figma.
