### PR TITLE
Fiks manglende avhengighet i typografi-plugin for Tailwind

### DIFF
--- a/.changeset/strict-jobs-change.md
+++ b/.changeset/strict-jobs-change.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en bug der man kunne få en manglende avhengighet til pakken `change-case` ved bruk av Jøkul sin typografi-plugin for Tailwind 3. Den relevante koden er nå pakket med i Jøkul.

--- a/packages/jokul/vite.build.config.mjs
+++ b/packages/jokul/vite.build.config.mjs
@@ -15,7 +15,14 @@ export default defineConfig({
             devDeps: true,
             peerDeps: true,
             optDeps: true,
-            exclude: ["clsx", "dayjs", "nanoid", "react-is", "downshift"],
+            exclude: [
+                "clsx",
+                "change-case",
+                "dayjs",
+                "nanoid",
+                "react-is",
+                "downshift",
+            ],
         }),
         react(),
         dts({


### PR DESCRIPTION
## 💬 Endringer

Fikser en bug der man kunne få en manglende avhengighet til pakken `change-case` ved bruk av Jøkul sin typografi-plugin for Tailwind 3. Den relevante koden er nå pakket med i Jøkul.
