### PR TITLE
Fiks feil variabel i delte stiler for inputs

### DIFF
--- a/.changeset/deep-melons-try.md
+++ b/.changeset/deep-melons-try.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feildefinert variabel i CSS for inputfelter som kunne føre til byggfeil hos brukere av Jøkul.

--- a/packages/jokul/src/shared/input/styles/shared-input-styles.scss
+++ b/packages/jokul/src/shared/input/styles/shared-input-styles.scss
@@ -9,7 +9,7 @@
     --jkl-text-input-action-button-size: var(--jkl-unit-60);
     --jkl-text-input-action-button-icon-size: var(--jkl-unit-30);
     --jkl-text-input-action-button-padding: var(--jkl-unit-10) 0;
-    --jkl-text-input-action-button-focus-position: var(jkl-unit-05);
+    --jkl-text-input-action-button-focus-position: var(--jkl-unit-05);
     --text-color: var(--jkl-color-text-default);
     --background-color: var(--jkl-color-background-input-base);
     --border-color: var(--jkl-color-border-input);


### PR DESCRIPTION
## 💬 Endringer

Fikser en feildefinert variabel i CSS for inputfelter som kunne føre til byggfeil hos brukere av Jøkul.
