### PR TITLE
Fiks lav kontrast i Combobox

### DIFF
--- a/.changeset/slimy-masks-admire.md
+++ b/.changeset/slimy-masks-admire.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en bug der teksten i valgene i `Combobox` hadde for lav kontrast i mørkt tema.

--- a/packages/jokul/src/components/combobox/styles/combobox.scss
+++ b/packages/jokul/src/components/combobox/styles/combobox.scss
@@ -90,7 +90,6 @@
             top: calc(100% - 1px);
             overflow-y: auto;
             position: absolute;
-            color: var(--jkl-color-text-default);
             z-index: jkl.$z-index--dropdown;
             left: jkl.rem(-1px);
             right: jkl.rem(-1px);
@@ -110,6 +109,7 @@
             display: flex;
             align-items: center;
             border: 0;
+            color: var(--jkl-color-text-default);
             background-color: var(--jkl-color-background-interactive);
             transition-property: color, background-color;
             cursor: pointer;


### PR DESCRIPTION
## 💬 Endringer

Fikser en bug der teksten i valgene i `Combobox` hadde for lav kontrast i mørkt tema.

## 🩹 Løser følgende issues

Closes #5826 
