### PR TITLE
Juster title og title-small til ny heading-skala

### DIFF
--- a/.changeset/cyan-geckos-carry.md
+++ b/.changeset/cyan-geckos-carry.md
@@ -1,0 +1,10 @@
+---
+"@fremtind/jokul": patch
+---
+
+Justerer typografiskalaen for `title` og `title-small` slik at de matcher oppdatert heading-skala fra design (#5837).
+
+- `title` bruker nå `--jkl-font-size-8` (tidligere `--jkl-font-size-10`), tilsvarende nivå som `heading-1`.
+- `title-small` bruker nå `--jkl-font-size-7` (tidligere `--jkl-font-size-9`), tilsvarende nivå som `heading-2`.
+
+Endrer input-group-description fra `text-medium` til `text-small` for å bedre matche designet. Dette påvirker beskrivelsen under input-felt i skjemakomponenter, og gjør teksten litt mindre for bedre visuell balanse.

--- a/packages/jokul/src/components/input-group/styles/_labels.scss
+++ b/packages/jokul/src/components/input-group/styles/_labels.scss
@@ -2,8 +2,10 @@
 @use "../../../core/jkl";
 
 $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.unique-id(
+)
+}
 
-    )};
+;
 
 @layer jokul.components {
     .jkl-dormant-form-support-label {
@@ -17,8 +19,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
 
         --jkl-form-support-label-margin: var(--jkl-unit-10) 0 0;
         --jkl-form-support-label-icon-size: #{$_icon-size};
-        --jkl-form-support-label-icon-margin: 0 -#{$_icon-size} -#{jkl.rem(6px)}
-            0;
+        --jkl-form-support-label-icon-margin: 0 -#{$_icon-size} -#{jkl.rem(6px)} 0;
         --color: var(--jkl-color-text-subdued);
 
         @include jkl.text-style("text-small");
@@ -36,10 +37,8 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
             height: var(--jkl-form-support-label-icon-size);
             margin: var(--jkl-form-support-label-icon-margin);
 
-            @include jkl.forced-colors-svg-fallback(
-                $stroke: CanvasText,
-                $fill: Canvas
-            );
+            @include jkl.forced-colors-svg-fallback($stroke: CanvasText,
+                $fill: Canvas);
         }
 
         &--error,
@@ -48,9 +47,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
             --color: var(--jkl-color-text-default);
 
             .jkl-form-support-label__icon {
-                animation: jkl.timing("lazy") cubic-bezier(0, 0, 0.3, 1)
-                    jkl.timing("expressive")
-                    $_support-icon-entrance-animation-name forwards;
+                animation: jkl.timing("lazy") cubic-bezier(0, 0, 0.3, 1) jkl.timing("expressive") $_support-icon-entrance-animation-name forwards;
             }
         }
 
@@ -89,7 +86,7 @@ $_support-icon-entrance-animation-name: jkl-support-icon-entrance-#{string.uniqu
     }
 
     .jkl-input-group-description {
-        @include jkl.text-style("text-medium");
+        @include jkl.text-style("text-small");
         color: var(--jkl-color-text-subdued);
         margin-block-end: var(--jkl-spacing-8);
         max-inline-size: 50ch;

--- a/packages/jokul/src/core/jkl/_typography.scss
+++ b/packages/jokul/src/core/jkl/_typography.scss
@@ -9,13 +9,13 @@
 /// @access private - forwardes ikke ut av modulen, men er tilgjengelig ved direkteimport. KUN FOR INTERN BRUK I JØKUL.
 $text-styles: (
     "title": (
-        "font-size": var(--jkl-font-size-10),
+        "font-size": var(--jkl-font-size-8),
         "line-height": var(--jkl-line-height-tight),
         "font-weight": $typography-weight-normal,
         "--jkl-icon-weight": $icon-weight-normal,
     ),
     "title-small": (
-        "font-size": var(--jkl-font-size-9),
+        "font-size": var(--jkl-font-size-7),
         "line-height": var(--jkl-line-height-tight),
         "font-weight": $typography-weight-normal,
         "--jkl-icon-weight": $icon-weight-normal,

--- a/packages/jokul/src/core/tokens/legacy/typography.tokens.json
+++ b/packages/jokul/src/core/tokens/legacy/typography.tokens.json
@@ -59,7 +59,7 @@
             "title": {
                 "small": {
                     "fontSize": {
-                        "value": "{typography.font.size.10}"
+                        "value": "{typography.font.size.8}"
                     },
                     "lineHeight": {
                         "value": "{typography.line.height.tight}"
@@ -70,7 +70,7 @@
                 },
                 "base": {
                     "fontSize": {
-                        "value": "{typography.font.size.10}"
+                        "value": "{typography.font.size.8}"
                     },
                     "lineHeight": {
                         "value": "{typography.line.height.tight}"
@@ -83,7 +83,7 @@
             "title-small": {
                 "small": {
                     "fontSize": {
-                        "value": "{typography.font.size.9}"
+                        "value": "{typography.font.size.7}"
                     },
                     "lineHeight": {
                         "value": "{typography.line.height.tight}"
@@ -94,7 +94,7 @@
                 },
                 "base": {
                     "fontSize": {
-                        "value": "{typography.font.size.9}"
+                        "value": "{typography.font.size.7}"
                     },
                     "lineHeight": {
                         "value": "{typography.line.height.tight}"


### PR DESCRIPTION
## 💬 Endringer

Oppdaterer typografistørrelser i tråd med avklaringer fra design/Figma i #5837.

## Endringer
- `title`: `jkl-font-size-10` -> `jkl-font-size-8`
- `title-small`: `jkl-font-size-9` -> `jkl-font-size-7`
 
## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5837 
