### PR TITLE
Forenkle og standardisere Dockerfile for MCP-server

### DIFF
--- a/Dockerfile.mcp-server
+++ b/Dockerfile.mcp-server
@@ -20,7 +20,6 @@ WORKDIR /app
 # Enable the repository's pinned pnpm version via corepack.
 RUN npm install -g corepack
 RUN corepack enable
-RUN corepack prepare pnpm@10.21.0 --activate
 
 # Copy the entire monorepo (respects .dockerignore).
 # Having all package.json files available lets pnpm resolve the workspace graph.


### PR DESCRIPTION
## 💬 Endringer

- Oppdatert `Dockerfile.mcp-server` slik at både build- og runtime-steg bruker samme Node 22 UBI-baseimage
- Erstattet global installasjon av pnpm med corepack og repoets låste pnpm-versjon
- Ryddet opp i Dockerfile-en ved å samle felles baseoppsett i ett steg
- Fjernet utdatert CA-oppsett som ikke lenger var i bruk
