### PR TITLE
fix(select-beta): replace invalid var(transparent) with transparent

### DIFF
--- a/.changeset/fix-beta-select-transparent.md
+++ b/.changeset/fix-beta-select-transparent.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+fix(select-beta): replace invalid `var(transparent)` with `transparent` in beta Select styles
+
+`var()` requires a CSS custom property name starting with `--`. Using `var(transparent)` is invalid and causes a parse error in strict CSS parsers such as Turbopack.

--- a/packages/jokul/src/components-beta/select/styles/select.scss
+++ b/packages/jokul/src/components-beta/select/styles/select.scss
@@ -6,7 +6,7 @@
 
 .jkl-select--beta {
     --border-color: var(--jkl-color-border-input);
-    --background-color: var(transparent);
+    --background-color: transparent;
     --color: var(--jkl-color-text-default);
     --box-shadow: 0 0 0 jkl.rem(1px) transparent;
     --border-width: #{jkl.rem(1px)};


### PR DESCRIPTION
## Problem

`--background-color: var(transparent)` in `packages/jokul/src/components-beta/select/styles/select.scss` is invalid CSS. The `var()` function requires a custom property name starting with `--`, not a bare keyword like `transparent`. This causes a parse error:

```
Unexpected token Ident("transparent")
```

This was observed with Turbopack but is also technically invalid per the CSS spec and would fail in other strict parsers.

## Fix

Replace `var(transparent)` with `transparent` directly.

```diff
- --background-color: var(transparent);
+ --background-color: transparent;
```