### PR TITLE
fix: ugyldige stiler i Select og DatePicker

### DIFF
--- a/.changeset/fair-icons-shop.md
+++ b/.changeset/fair-icons-shop.md
@@ -1,0 +1,9 @@
+---
+"@fremtind/jokul": patch
+---
+
+Retter feil i stilarkene for komponenter:
+
+- Fikser ugyldig CSS-bruk av `var(transparent)` i beta-select ved å bruke en gyldig transparent verdi.
+- Fikser datepicker-kalenderstilene ved å sikre gyldige custom properties og regelplassering, slik at bygging/parsing ikke feiler.
+

--- a/packages/jokul/src/components-beta/select/styles/select.scss
+++ b/packages/jokul/src/components-beta/select/styles/select.scss
@@ -6,7 +6,7 @@
 
 .jkl-select--beta {
     --border-color: var(--jkl-color-border-input);
-    --background-color: var(transparent);
+    --background-color: transparent;
     --color: var(--jkl-color-text-default);
     --box-shadow: 0 0 0 jkl.rem(1px) transparent;
     --border-width: #{jkl.rem(1px)};

--- a/packages/jokul/src/components/datepicker/styles/_calendar-date-button.scss
+++ b/packages/jokul/src/components/datepicker/styles/_calendar-date-button.scss
@@ -1,13 +1,13 @@
 @use "../../../core/jkl";
 
 @layer jokul.components {
-    // Custom tweaks for iPhone SE
-    @include jkl.screen-to(375px) {
-        --jkl-calendar-date-size: var(--jkl-unit-40);
-    }
-
     .jkl-calendar-date-button {
         --jkl-calendar-date-size: var(--jkl-unit-50);
+
+        // Custom tweaks for iPhone SE
+        @include jkl.screen-to(375px) {
+            --jkl-calendar-date-size: var(--jkl-unit-40);
+        }
 
         @include jkl.text-style("text-small");
 

--- a/packages/jokul/src/components/datepicker/styles/_calendar.scss
+++ b/packages/jokul/src/components/datepicker/styles/_calendar.scss
@@ -1,15 +1,14 @@
 @use "../../../core/jkl";
 
 @layer jokul.components {
-
-    // Custom tweaks for iPhone SE
-    @include jkl.screen-to(375px) {
-        --jkl-calendar-padding: var(--jkl-unit-05) var(--jkl-unit-10) var(--jkl-unit-20);
-    }
-
     .jkl-calendar {
         --jkl-calendar-padding: var(--jkl-unit-15) var(--jkl-unit-20) var(--jkl-unit-20);
         --jkl-calendar-gap: var(--jkl-unit-15);
+
+        // Custom tweaks for iPhone SE
+        @include jkl.screen-to(375px) {
+            --jkl-calendar-padding: var(--jkl-unit-05) var(--jkl-unit-10) var(--jkl-unit-20);
+        }
 
         display: block;
         background-color: var(--jkl-color-background-container-high);


### PR DESCRIPTION
Retter feil i stilarkene for komponenter:

- Fikser ugyldig CSS-bruk av `var(transparent)` i beta-select ved å bruke en gyldig transparent verdi.
- Fikser datepicker-kalenderstilene ved å sikre gyldige custom properties og regelplassering, slik at bygging/parsing ikke feiler.