### PR TITLE
fix(search): inkluder search-with-submit-button-stiler automatisk

### DIFF
--- a/.changeset/search-button-style-export.md
+++ b/.changeset/search-button-style-export.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Stilene for søkefeltet med søkeknapp (`search-with-submit-button`) er nå inkludert automatisk når du importerer søkefeltet. Det er ikke lenger nødvendig å importere `search-with-submit-button.scss` separat – det holder å importere søkefeltstilene.

--- a/packages/jokul/src/components/search/styles/search.scss
+++ b/packages/jokul/src/components/search/styles/search.scss
@@ -1,5 +1,6 @@
 @use "../../../core/jkl/index" as jkl;
 @use "../../../components/icon/styles/base-styles" as icon;
+@use "search-with-submit-button";
 
 .jkl-search {
     --icon-size: var(--jkl-text-input-height);


### PR DESCRIPTION
Stiler for søkefeltet med søkeknapp er nå inkludert via `@use` i search.scss, slik at man slipper å importere search-with-submit-button separat.

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #NNNN
