### PR TITLE
Forbedre Expander-stories for å vise API bedre

### DIFF
--- a/packages/jokul/src/components/expander/stories/Expander.stories.tsx
+++ b/packages/jokul/src/components/expander/stories/Expander.stories.tsx
@@ -1,75 +1,123 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React from "react";
+import { userEvent, within } from "storybook/test";
 import { CalendarIcon } from "../../icon/index.js";
 import { ExpandablePanel } from "../ExpandablePanel.js";
 import { ExpandablePanelContent } from "../ExpandablePanelContent.js";
 import { Expander } from "../Expander.js";
 import "../styles/_index.scss";
 
-const meta: Meta = {
+const expanderTestId = "expander-trigger";
+
+const meta = {
     title: "Komponenter/Expander",
-    component: ExpandablePanel,
+    component: Expander,
+    subcomponents: { ExpandablePanel, ExpandablePanelContent },
     args: {
         expandDirection: "down",
         icon: <CalendarIcon />,
     },
     argTypes: {
         expandDirection: {
-            control: "select",
+            control: "radio",
             options: ["up", "down"],
         },
     },
-};
-
-export default meta;
-
-type Story = StoryObj<typeof Expander>;
-
-export const ExpanderStory: Story = {
-    name: "Expander",
-    render: (args) => {
+    decorators: [
+        (Story) => (
+            <div style={{ width: "32rem", maxWidth: "100%" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        await userEvent.click(canvas.getByTestId(expanderTestId));
+    },
+    render: ({ expandDirection, icon }) => {
         const [isOpen, setIsOpen] = React.useState(false);
 
         return (
-            <>
+            <div style={{ display: "grid", gap: "16px" }}>
                 <Expander
-                    {...args}
+                    data-testid={expanderTestId}
+                    expandDirection={expandDirection}
+                    icon={icon}
                     open={isOpen}
-                    onClick={() => setIsOpen(!isOpen)}
+                    onClick={() => setIsOpen((open) => !open)}
                 >
-                    Klikk på meg for å {isOpen ? "lukke" : "åpne"}!
+                    Se hva reiseforsikringen dekker
                 </Expander>
-                {isOpen && (
-                    <div>Hei, jeg er innholdet som vises når du åpner meg!</div>
-                )}
-            </>
+                {isOpen ? (
+                    <div>
+                        Du er dekket for forsinket bagasje, avbestilling ved
+                        akutt sykdom og egenandel på leiebil opptil 15 000
+                        kroner.
+                    </div>
+                ) : null}
+            </div>
         );
+    },
+} satisfies Meta<typeof Expander>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StandaloneControlled: Story = {
+    name: "Kontrollert uten panel",
+    parameters: {
+        docs: {
+            source: {
+                code: `const [isOpen, setIsOpen] = React.useState(false);
+
+return (
+    <>
+        <Expander
+            icon={<CalendarIcon />}
+            open={isOpen}
+            onClick={() => setIsOpen((open) => !open)}
+        >
+            Se hva reiseforsikringen dekker
+        </Expander>
+        {isOpen ? (
+            <div>
+                Du er dekket for forsinket bagasje, avbestilling ved akutt
+                sykdom og egenandel på leiebil opptil 15 000 kroner.
+            </div>
+        ) : null}
+    </>
+);`,
+            },
+        },
     },
 };
 
 /**
  * Expander brukes i ExpandablePanel, men kan også brukes alene dersom du ønsker et annet uttrykk.
  */
-export const ExpanderInPanel: Story = {
-    args: {
-        expandDirection: "down",
-    },
-    decorators: [
-        (Story) => (
-            <div>
-                <Story />
-            </div>
-        ),
-    ],
-    render: (args) => (
-        <ExpandablePanel style={{ width: "50cqi" }}>
-            <Expander {...args}>Når er det vi faktisk er åpne?</Expander>
-            <ExpandablePanelContent>Hei</ExpandablePanelContent>
+export const InExpandablePanel: Story = {
+    name: "I utvidbart panel",
+    render: ({ expandDirection, icon }) => (
+        <ExpandablePanel style={{ width: "min(100%, 32rem)" }}>
+            <Expander
+                data-testid={expanderTestId}
+                expandDirection={expandDirection}
+                icon={icon}
+            >
+                Hva dekker leiebilforsikringen?
+            </Expander>
+            <ExpandablePanelContent>
+                Forsikringen dekker skade, tyveri og egenandel når bilen er leid
+                på ferie i Norden eller EU og leieforholdet er betalt med kortet
+                ditt.
+            </ExpandablePanelContent>
         </ExpandablePanel>
     ),
 };
 
-export const ExpanderFlipped: Story = {
+export const OpensUp: Story = {
+    name: "Åpner oppover",
     args: {
         expandDirection: "up",
     },
@@ -77,21 +125,30 @@ export const ExpanderFlipped: Story = {
         (Story) => (
             <div
                 style={{
-                    height: "100dvh",
+                    minHeight: "100dvh",
                     display: "flex",
-                    flexDirection: "column",
                     alignItems: "center",
                     justifyContent: "flex-end",
+                    padding: "24px",
                 }}
             >
                 <Story />
             </div>
         ),
     ],
-    render: (args) => (
-        <ExpandablePanel style={{ width: "100cqi" }}>
-            <Expander {...args}>Når er det vi faktisk er åpne?</Expander>
-            <ExpandablePanelContent>Hei</ExpandablePanelContent>
+    render: ({ expandDirection, icon }) => (
+        <ExpandablePanel style={{ width: "min(100%, 32rem)" }}>
+            <Expander
+                data-testid={expanderTestId}
+                expandDirection={expandDirection}
+                icon={icon}
+            >
+                Se kontaktvalg i bunnmenyen
+            </Expander>
+            <ExpandablePanelContent>
+                Ring oss pa 55 55 55 55, start chat med skadehjelp eller be om
+                at en rådgiver ringer deg tilbake innen 15 minutter.
+            </ExpandablePanelContent>
         </ExpandablePanel>
     ),
 };


### PR DESCRIPTION
## Oppsummering
- gjør Expander-stories enklere å lese og kopiere
- bruker automatisk åpning i play-funksjonen
- gjør panel-eksemplene mer konkrete