### PR TITLE
Legg til markdown-sider for endringslogg og migrering i portalen

### DIFF
--- a/portal/src/app/(frontend)/_content-pages/components/AnchorIconButton.tsx
+++ b/portal/src/app/(frontend)/_content-pages/components/AnchorIconButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { CopyIcon } from "@fremtind/jokul/icon";
+import styles from "../content-page.module.scss";
+
+interface AnchorIconButtonProps {
+    href: string;
+}
+
+export const AnchorIconButton = ({ href }: AnchorIconButtonProps) => (
+    <Button
+        as="a"
+        href={href}
+        variant="ghost"
+        icon={<CopyIcon />}
+        aria-label="Lenke til release"
+        title="Lenke til release"
+        className={styles.releaseLink}
+    />
+);

--- a/portal/src/app/(frontend)/_content-pages/components/MarkdownBlocks.tsx
+++ b/portal/src/app/(frontend)/_content-pages/components/MarkdownBlocks.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { AnchorIconButton } from "./AnchorIconButton";
+import { SimpleCodeBlock } from "./SimpleCodeBlock";
+import type { MarkdownBlock } from "../lib/markdown.types";
+import { MarkdownInlineContent } from "./MarkdownInlineContent";
+import styles from "../content-page.module.scss";
+
+interface MarkdownBlocksProps {
+    blocks: MarkdownBlock[];
+}
+
+const renderBlock = (block: MarkdownBlock, index: number): ReactNode => {
+    if (block.type === "heading") {
+        if (block.level === 2) {
+            return (
+                <div
+                    key={index}
+                    id={block.id}
+                    className={styles.releaseHeading}
+                >
+                    <h2 className={styles.releaseTitle}>{block.text}</h2>
+                    {block.id ? (
+                        <AnchorIconButton href={`#${block.id}`} />
+                    ) : null}
+                </div>
+            );
+        }
+
+        if (block.level === 3) {
+            return <h3 key={index}>{block.text}</h3>;
+        }
+
+        return <h4 key={index}>{block.text}</h4>;
+    }
+
+    if (block.type === "list") {
+        return (
+            <ul key={index}>
+                {block.items.map((item, itemIndex) => (
+                    <li key={itemIndex}>
+                        <MarkdownInlineContent text={item.join(" ")} />
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+
+    if (block.type === "code") {
+        return (
+            <div key={index} className={styles.codeBlockWrapper}>
+                <SimpleCodeBlock code={block.code} language={block.language} />
+            </div>
+        );
+    }
+
+    return (
+        <p key={index}>
+            <MarkdownInlineContent text={block.lines.join(" ")} />
+        </p>
+    );
+};
+
+export const MarkdownBlocks = ({ blocks }: MarkdownBlocksProps) =>
+    blocks.map((block, index) => renderBlock(block, index));

--- a/portal/src/app/(frontend)/_content-pages/components/MarkdownInlineContent.tsx
+++ b/portal/src/app/(frontend)/_content-pages/components/MarkdownInlineContent.tsx
@@ -1,0 +1,81 @@
+import { Link } from "@fremtind/jokul/link";
+import type { ReactNode } from "react";
+
+const GITHUB_REPOSITORY_URL = "https://github.com/fremtind/jokul";
+
+const renderExternalLink = (href: string, children: ReactNode, key: string) => (
+    <Link key={key} href={href} target="_blank" rel="noopener noreferrer">
+        {children}
+    </Link>
+);
+
+const renderLinkedText = (text: string) => {
+    const nodes: ReactNode[] = [];
+    const pattern =
+        /(\[([^\]]+)\]\((https?:\/\/[^)\s]+)\))|(https?:\/\/[^\s)]+)|(?<!\w)#(\d+)\b|\b([0-9a-f]{7})\b(?=:)/g;
+    let lastIndex = 0;
+    let match = pattern.exec(text);
+
+    while (match) {
+        if (match.index > lastIndex) {
+            nodes.push(text.slice(lastIndex, match.index));
+        }
+
+        if (match[2] && match[3]) {
+            nodes.push(
+                renderExternalLink(
+                    match[3],
+                    match[2],
+                    `${match.index}-markdown`,
+                ),
+            );
+        } else if (match[4]) {
+            nodes.push(
+                renderExternalLink(match[4], match[4], `${match.index}-url`),
+            );
+        } else if (match[5]) {
+            nodes.push(
+                renderExternalLink(
+                    `${GITHUB_REPOSITORY_URL}/issues/${match[5]}`,
+                    `#${match[5]}`,
+                    `${match.index}-issue`,
+                ),
+            );
+        } else if (match[6]) {
+            nodes.push(
+                renderExternalLink(
+                    `${GITHUB_REPOSITORY_URL}/commit/${match[6]}`,
+                    match[6],
+                    `${match.index}-commit`,
+                ),
+            );
+        }
+
+        lastIndex = pattern.lastIndex;
+        match = pattern.exec(text);
+    }
+
+    if (lastIndex < text.length) {
+        nodes.push(text.slice(lastIndex));
+    }
+
+    return nodes;
+};
+
+interface MarkdownInlineContentProps {
+    text: string;
+}
+
+export const MarkdownInlineContent = ({
+    text,
+}: MarkdownInlineContentProps) => {
+    const segments = text.split(/(`[^`]+`)/g).filter(Boolean);
+
+    return segments.map((segment, index) => {
+        if (segment.startsWith("`") && segment.endsWith("`")) {
+            return <code key={index}>{segment.slice(1, -1)}</code>;
+        }
+
+        return <span key={index}>{renderLinkedText(segment)}</span>;
+    });
+};

--- a/portal/src/app/(frontend)/_content-pages/components/MarkdownTableOfContents.tsx
+++ b/portal/src/app/(frontend)/_content-pages/components/MarkdownTableOfContents.tsx
@@ -1,0 +1,27 @@
+import { TableOfContents } from "@fremtind/jokul/table-of-contents";
+import type { MarkdownHeadingBlock } from "../lib/markdown.types";
+import styles from "../content-page.module.scss";
+
+interface MarkdownTableOfContentsProps {
+    items: MarkdownHeadingBlock[];
+    label: string;
+}
+
+export const MarkdownTableOfContents = ({
+    items,
+    label,
+}: MarkdownTableOfContentsProps) => {
+    if (!items.length) {
+        return null;
+    }
+
+    return (
+        <TableOfContents className={styles.toc} label={label}>
+            {items.map((item) => (
+                <TableOfContents.Link key={item.id} href={`#${item.id}`}>
+                    {item.text}
+                </TableOfContents.Link>
+            ))}
+        </TableOfContents>
+    );
+};

--- a/portal/src/app/(frontend)/_content-pages/components/SimpleCodeBlock.tsx
+++ b/portal/src/app/(frontend)/_content-pages/components/SimpleCodeBlock.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { CheckIcon, CopyIcon } from "@fremtind/jokul/icon";
+import { useEffect, useState } from "react";
+import styles from "../content-page.module.scss";
+
+interface SimpleCodeBlockProps {
+    code: string;
+    language?: string;
+}
+
+export const SimpleCodeBlock = ({
+    code,
+    language,
+}: SimpleCodeBlockProps) => {
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!copied) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            setCopied(false);
+        }, 2000);
+
+        return () => {
+            window.clearTimeout(timeout);
+        };
+    }, [copied]);
+
+    return (
+        <div className={styles.codeBlock}>
+            <div className={styles.codeBlockHeader}>
+                <span className={styles.codeBlockLanguage}>
+                    {language ? `.${language}` : "Kode"}
+                </span>
+                <Button
+                    variant="ghost"
+                    icon={copied ? <CheckIcon /> : <CopyIcon />}
+                    aria-label={copied ? "Kopiert" : "Kopier kode"}
+                    data-size="small"
+                    data-density="compact"
+                    onClick={() => {
+                        void navigator.clipboard.writeText(code);
+                        setCopied(true);
+                    }}
+                />
+            </div>
+            <pre className={styles.codeBlockContent}>
+                <code>{code}</code>
+            </pre>
+        </div>
+    );
+};

--- a/portal/src/app/(frontend)/_content-pages/content-page.module.scss
+++ b/portal/src/app/(frontend)/_content-pages/content-page.module.scss
@@ -1,0 +1,84 @@
+@use "@fremtind/jokul/styles/core/jkl";
+
+.toc {
+    width: 100%;
+    margin-block-end: jkl.$spacing-xl;
+    max-width: 60ch;
+
+    :global(.jkl-table-of-contents-title),
+    :global(.jkl-table-of-contents-item) {
+        max-width: none;
+    }
+}
+
+.releaseHeading {
+    display: flex;
+    align-items: center;
+    gap: jkl.$spacing-s;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.releaseTitle {
+    margin: 0;
+}
+
+.releaseLink {
+    max-width: none;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.releaseHeading:hover .releaseLink,
+.releaseHeading:focus-within .releaseLink,
+.releaseLink:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.codeBlockWrapper {
+    max-width: 100%;
+}
+
+.codeBlock {
+    border: 1px solid jkl.$color-border-separator;
+    border-radius: jkl.$border-radius-m;
+    background-color: jkl.$color-background-container-low;
+    overflow: hidden;
+}
+
+.codeBlockHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: jkl.$spacing-s;
+    padding: jkl.$spacing-s jkl.$spacing-m;
+    border-bottom: 1px solid jkl.$color-border-separator;
+    background-color: jkl.$color-background-container;
+}
+
+.codeBlockLanguage {
+    color: jkl.$color-text-subdued;
+
+    @include jkl.text-style("text-small");
+    @include jkl.use-font-family("Fremtind Grotesk Mono");
+}
+
+.codeBlockContent {
+    margin: 0;
+    padding: jkl.$spacing-m;
+    overflow-x: auto;
+
+    code {
+        display: block;
+        background: none;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
+        white-space: pre;
+
+        @include jkl.use-font-family("Fremtind Grotesk Mono");
+        @include jkl.text-style("text-small");
+    }
+}

--- a/portal/src/app/(frontend)/_content-pages/lib/markdown.data.ts
+++ b/portal/src/app/(frontend)/_content-pages/lib/markdown.data.ts
@@ -1,0 +1,11 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parseMarkdownBlocks } from "./markdown.parser";
+
+export const getJokulPackageDocumentPath = (fileName: string) =>
+    path.join(process.cwd(), "..", "packages", "jokul", fileName);
+
+export const getMarkdownBlocks = async (filePath: string) => {
+    const markdown = await readFile(filePath, "utf-8");
+    return parseMarkdownBlocks(markdown);
+};

--- a/portal/src/app/(frontend)/_content-pages/lib/markdown.parser.ts
+++ b/portal/src/app/(frontend)/_content-pages/lib/markdown.parser.ts
@@ -1,0 +1,148 @@
+import type { MarkdownBlock, MarkdownHeadingBlock } from "./markdown.types";
+
+const toHeadingId = (text: string) =>
+    `release-${text
+        .toLowerCase()
+        .replace(/[^\d.]+/g, "")
+        .replaceAll(".", "-")}`;
+
+export const isMajorRelease = (text: string) => /^\d+\.0\.0$/.test(text);
+
+export const getMajorReleases = (blocks: MarkdownBlock[]) =>
+    blocks.filter(
+        (block): block is MarkdownHeadingBlock =>
+            block.type === "heading" &&
+            block.level === 2 &&
+            Boolean(block.id) &&
+            isMajorRelease(block.text),
+    );
+
+export const getLevelTwoHeadings = (blocks: MarkdownBlock[]) =>
+    blocks.filter(
+        (block): block is MarkdownHeadingBlock =>
+            block.type === "heading" &&
+            block.level === 2 &&
+            Boolean(block.id),
+    );
+
+export const parseMarkdownBlocks = (content: string): MarkdownBlock[] => {
+    const normalizedContent = content.replace(/^# .+\n+/, "");
+    const lines = normalizedContent.split(/\r?\n/);
+    const blocks: MarkdownBlock[] = [];
+    let paragraphLines: string[] = [];
+    let listItems: string[][] = [];
+    let codeLines: string[] = [];
+    let codeLanguage: string | undefined;
+    let inCodeBlock = false;
+
+    const flushParagraph = () => {
+        if (!paragraphLines.length) {
+            return;
+        }
+
+        blocks.push({
+            type: "paragraph",
+            lines: paragraphLines,
+        });
+        paragraphLines = [];
+    };
+
+    const flushList = () => {
+        if (!listItems.length) {
+            return;
+        }
+
+        blocks.push({
+            type: "list",
+            items: listItems,
+        });
+        listItems = [];
+    };
+
+    const flushCodeBlock = () => {
+        if (!codeLines.length && !codeLanguage) {
+            return;
+        }
+
+        blocks.push({
+            type: "code",
+            code: codeLines.join("\n"),
+            language: codeLanguage,
+        });
+        codeLines = [];
+        codeLanguage = undefined;
+    };
+
+    for (const line of lines) {
+        const trimmedLine = line.trimEnd();
+        const fenceMatch = trimmedLine.match(/^```(\w+)?\s*$/);
+        const headingMatch = trimmedLine.match(
+            /^(#{1,4})\s+(?:\[)?([^\](]+?)(?:\]\([^)]+\))?(?:\s+\(\d{4}-\d{2}-\d{2}\))?$/,
+        );
+
+        if (fenceMatch) {
+            if (inCodeBlock) {
+                flushCodeBlock();
+                inCodeBlock = false;
+                continue;
+            }
+
+            flushParagraph();
+            flushList();
+            inCodeBlock = true;
+            codeLanguage = fenceMatch[1];
+            continue;
+        }
+
+        if (inCodeBlock) {
+            codeLines.push(line);
+            continue;
+        }
+
+        if (!trimmedLine) {
+            flushParagraph();
+            flushList();
+            continue;
+        }
+
+        if (headingMatch) {
+            flushParagraph();
+            flushList();
+            const headingLevel = Math.min(
+                4,
+                Math.max(2, headingMatch[1].length),
+            ) as 2 | 3 | 4;
+
+            blocks.push({
+                type: "heading",
+                level: headingLevel,
+                text: headingMatch[2].trim(),
+                id:
+                    headingLevel === 2
+                        ? toHeadingId(headingMatch[2].trim())
+                        : undefined,
+            });
+            continue;
+        }
+
+        if (trimmedLine.startsWith("- ")) {
+            flushParagraph();
+            listItems.push([trimmedLine.slice(2)]);
+            continue;
+        }
+
+        if (/^\s+/.test(line) && listItems.length) {
+            listItems[listItems.length - 1].push(trimmedLine.trim());
+            continue;
+        }
+
+        flushList();
+        paragraphLines.push(trimmedLine);
+    }
+
+    flushParagraph();
+    flushList();
+    flushCodeBlock();
+
+    return blocks;
+};

--- a/portal/src/app/(frontend)/_content-pages/lib/markdown.types.ts
+++ b/portal/src/app/(frontend)/_content-pages/lib/markdown.types.ts
@@ -1,0 +1,28 @@
+export type MarkdownHeadingBlock = {
+    type: "heading";
+    level: 2 | 3 | 4;
+    text: string;
+    id?: string;
+};
+
+export type MarkdownListBlock = {
+    type: "list";
+    items: string[][];
+};
+
+export type MarkdownParagraphBlock = {
+    type: "paragraph";
+    lines: string[];
+};
+
+export type MarkdownCodeBlock = {
+    type: "code";
+    code: string;
+    language?: string;
+};
+
+export type MarkdownBlock =
+    | MarkdownHeadingBlock
+    | MarkdownListBlock
+    | MarkdownParagraphBlock
+    | MarkdownCodeBlock;

--- a/portal/src/app/(frontend)/endringslogg/page.tsx
+++ b/portal/src/app/(frontend)/endringslogg/page.tsx
@@ -1,0 +1,35 @@
+import { OverviewHeader } from "@/components/overview/header";
+import type { Metadata } from "next";
+import { MarkdownBlocks } from "../_content-pages/components/MarkdownBlocks";
+import { MarkdownTableOfContents } from "../_content-pages/components/MarkdownTableOfContents";
+import {
+    getJokulPackageDocumentPath,
+    getMarkdownBlocks,
+} from "../_content-pages/lib/markdown.data";
+import { getMajorReleases } from "../_content-pages/lib/markdown.parser";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+    title: "Endringslogg",
+};
+
+export default async function ChangelogPage() {
+    const changelogBlocks = await getMarkdownBlocks(
+        getJokulPackageDocumentPath("CHANGELOG.md"),
+    );
+    const majorReleases = getMajorReleases(changelogBlocks);
+
+    return (
+        <>
+            <OverviewHeader title="Endringslogg" />
+            <MarkdownTableOfContents
+                items={majorReleases}
+                label="Store releaser"
+            />
+            <article className="prose">
+                <MarkdownBlocks blocks={changelogBlocks} />
+            </article>
+        </>
+    );
+}

--- a/portal/src/app/(frontend)/migrering/page.tsx
+++ b/portal/src/app/(frontend)/migrering/page.tsx
@@ -1,0 +1,32 @@
+import { OverviewHeader } from "@/components/overview/header";
+import type { Metadata } from "next";
+import { MarkdownBlocks } from "../_content-pages/components/MarkdownBlocks";
+import { MarkdownTableOfContents } from "../_content-pages/components/MarkdownTableOfContents";
+import {
+    getJokulPackageDocumentPath,
+    getMarkdownBlocks,
+} from "../_content-pages/lib/markdown.data";
+import { getLevelTwoHeadings } from "../_content-pages/lib/markdown.parser";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+    title: "Migrering",
+};
+
+export default async function MigrationGuidePage() {
+    const migrationBlocks = await getMarkdownBlocks(
+        getJokulPackageDocumentPath("MIGRATION.md"),
+    );
+    const sections = getLevelTwoHeadings(migrationBlocks);
+
+    return (
+        <>
+            <OverviewHeader title="Migrering" />
+            <MarkdownTableOfContents items={sections} label="Seksjoner" />
+            <article className="prose">
+                <MarkdownBlocks blocks={migrationBlocks} />
+            </article>
+        </>
+    );
+}


### PR DESCRIPTION
## Oppsummering
- legg til en ny `/endringslogg`-side i portalen som viser `packages/jokul/CHANGELOG.md` med TOC, kodeblokker og ankerlenker per release
- legg til en ny `/migrering`-side i portalen som viser `packages/jokul/MIGRATION.md` med samme oppsett og seksjonsbasert TOC
- flytt delt logikk for markdown-baserte innholdssider til `app/(frontend)/_content-pages` for enklere vedlikehold

## Testing
- kjørt `pnpm build:portal`