### PR TITLE
docs(changeset): Fikser overflow og skalering av ikonet i ToggleSwitch

### DIFF
--- a/.changeset/thick-dancers-carry.md
+++ b/.changeset/thick-dancers-carry.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser overflow og skalering av ikonet i ToggleSwitch

--- a/packages/jokul/src/components/toggle-switch/stories/ToggleSwitch.stories.tsx
+++ b/packages/jokul/src/components/toggle-switch/stories/ToggleSwitch.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import React from "react";
+import { Card } from "../../card/index.js";
+import { Flex } from "../../flex/index.js";
+import { Message } from "../../message/index.js";
 import { ToggleSwitch as ToggleSwitchComponent } from "../ToggleSwitch.js";
+import "../../card/styles/_index.scss";
+import "../../flex/styles/_index.scss";
+import "../../message/styles/_index.scss";
 import "../styles/_index.scss";
 
 const meta = {
@@ -10,9 +17,54 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const ToggleSwitch: Story = {
-    args: {
-        children: "Mørk modus",
-        "aria-pressed": false,
+export const ByttTemaForInnhold: Story = {
+    render: () => {
+        const [darkMode, setDarkMode] = React.useState(false);
+
+        return (
+            <Card padding="l" data-theme={darkMode ? "dark" : "light"}>
+                <Flex direction="column" gap="l">
+                    <Flex
+                        justifyContent="space-between"
+                        alignItems="center"
+                        gap="m"
+                        wrap="wrap"
+                    >
+                        <Flex direction="column" gap="2xs">
+                            <h2 className="jkl-heading-3">
+                                Tema for innholdet
+                            </h2>
+                            <p className="jkl-body">
+                                Denne bryteren oppdaterer temaet med en gang for
+                                innholdet i eksempelet under.
+                            </p>
+                        </Flex>
+                        <ToggleSwitchComponent
+                            aria-pressed={darkMode}
+                            onChange={(_, pressed) => setDarkMode(pressed)}
+                        >
+                            Mørkt modus
+                        </ToggleSwitchComponent>
+                    </Flex>
+
+                    {darkMode ? "Mørkt tema aktivt" : "Lyst tema aktivt"}
+
+                    <Flex direction="column" gap="s">
+                        <div>
+                            <p className="jkl-heading-5">Forsikringsoversikt</p>
+                            <p className="jkl-body">
+                                Reiseforsikringen din er aktiv, og du er dekket
+                                for avbestilling, forsinket bagasje og medisinsk
+                                hjelp på reise.
+                            </p>
+                        </div>
+                        <Message variant="info" title="Status">
+                            Neste fornyelse er 14. august, og det er ingen
+                            utestående endringer på avtalen.
+                        </Message>
+                    </Flex>
+                </Flex>
+            </Card>
+        );
     },
 };

--- a/packages/jokul/src/components/toggle-switch/styles/toggle-switch.scss
+++ b/packages/jokul/src/components/toggle-switch/styles/toggle-switch.scss
@@ -7,7 +7,7 @@
     --jkl-toggle-switch-width: var(--jkl-unit-60);
     --jkl-toggle-switch-knob-size: var(--jkl-unit-30);
     --border-width: #{jkl.rem(1px)};
-    --switch-padding: #{jkl.rem(4px)};
+    --switch-padding: var(--jkl-unit-05);
     --knob-position: 0;
     --switch-border-color: var(--jkl-color-border-action);
     --indicator-color: var(--jkl-color-background-container-high);
@@ -66,7 +66,6 @@
     --jkl-toggle-switch-height: var(--jkl-unit-40);
     --jkl-toggle-switch-width: var(--jkl-unit-60);
     --jkl-toggle-switch-knob-size: var(--jkl-unit-30);
-    --jkl-toggle-switch-indicator-spacing: 0;
 
     position: relative;
     box-sizing: border-box;
@@ -116,13 +115,7 @@
         position: absolute;
         top: 50%;
         right: 100%;
-        margin-right: var(--jkl-toggle-switch-indicator-spacing);
+        font-size: var(--jkl-unit-20);
         transform: translate(0, -50%);
-
-        & > .jkl-icon__icon {
-            // Uten dette får ikonet feil alignment. Mulig bug i ikonpakken?
-            position: absolute;
-            inset: 0;
-        }
     }
 }


### PR DESCRIPTION
## 💬 Endringer

Fikset en feil som gjorde at ikonet ikke skalerte riktig i medium og large, og fikser sånn at ikonet i small ikke havner utenfor togglen.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5848 
