### PR TITLE
Legg til codemod for importmigrering

### DIFF
--- a/.changeset/lovely-ravens-draw.md
+++ b/.changeset/lovely-ravens-draw.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legg til `jokul codemod` for å migrere gamle importstier til Jøkul 5 sin nye struktur for stiler og utilities.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,12 +21,12 @@ pnpm add @fremtind/jokul
 Always import core styles before using any components:
 
 ```tsx
-import "@fremtind/jokul/styles/core/core.scss";
+import "@fremtind/jokul/styles/base.scss";
 ```
 
 Or in SCSS:
 ```scss
-@use "@fremtind/jokul/styles/core/core";
+@use "@fremtind/jokul/styles/base";
 ```
 
 ### 2. Fonts
@@ -35,7 +35,7 @@ Make font files available at `/fonts` on your server. Font files are located at:
 `node_modules/@fremtind/jokul/src/fonts/`
 
 ```scss
-@use "@fremtind/jokul/styles/fonts" with (
+@use "@fremtind/jokul/styles/theme/fonts" with (
     $webfonts-dir: "path/to/node_modules/@fremtind/jokul/src/fonts"
 );
 ```
@@ -95,7 +95,7 @@ import { formatTelefonnummer, formatKontonummer, formatValuta } from "@fremtind/
 ### Core Types
 
 ```tsx
-import type { WithChildren } from "@fremtind/jokul/core";
+import type { WithChildren } from "@fremtind/jokul/utilities";
 ```
 
 ## Theming
@@ -189,7 +189,7 @@ export default {
 
 ```css
 @import "tailwindcss";
-@import "@fremtind/jokul/tailwind/v4";
+@import "@fremtind/jokul/styles/tailwind";
 ```
 
 ### Tailwind Classes
@@ -280,7 +280,7 @@ import { Modal, ModalContainer, ModalHeader, ModalContent, ModalActions } from "
 Use text styles via SCSS mixins or Tailwind classes:
 
 ```scss
-@use "@fremtind/jokul/styles/core/jkl";
+@use "@fremtind/jokul/styles/jkl";
 
 .my-heading {
     @include jkl.text-style("heading-1");

--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -1,6 +1,7 @@
 # @fremtind/jokul
 
 -   [Migrering til monopakke](#migrering-til-monopakke)
+-   [Codemods](#codemods)
 -   [React-komponenter](#react-komponenter)
 -   [Stilark](#stilark)
 -   [Fonter](#fonter)
@@ -11,6 +12,28 @@
 ## Migrering til `@fremtind/jokul`
 
 Dersom du bruker dagens pakkestruktur med pakker for hver komponent har vi laget en [migrasjonsguide](./MIGRATION.md) for hvordan du går over til å bruke `@fremtind/jokul`.
+
+## Codemods
+
+Hvis du oppgraderer til `5.0.0` eller nyere kan du bruke codemoden vår for å oppdatere importstier til dagens struktur.
+
+Primær-CLI-et er `jokul`, og codemods kjøres som `jokul codemod`. Hvordan du starter det avhenger av package manageren din:
+
+```bash
+# pnpm
+pnpm exec jokul codemod --dry-run
+pnpm exec jokul codemod
+
+# npm
+npx jokul codemod --dry-run
+npx jokul codemod
+
+# Valgfritt: begrens kjøringen til bestemte mapper
+jokul codemod src app --dry-run
+jokul codemod src app
+```
+
+Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt.
 
 ## React-komponenter
 
@@ -42,14 +65,14 @@ Det finnes en del grunnleggende stiler som må med for at ting skal fungere rikt
 kan du importere med
 
 ```scss
-@use "@fremtind/jokul/styles/core/core";
+@use "@fremtind/jokul/styles/base";
 ```
 
 eller i ts/js
 
 ```tsx
 // Finnes også ferdig bygget, med filendelsene .css og .min.css
-import "@fremtind/jokul/styles/core/core.scss";
+import "@fremtind/jokul/styles/base.scss";
 ```
 
 ### Stiler for komponenter
@@ -79,14 +102,14 @@ import "@fremtind/jokul/styles/components/[komponent]/[komponent].min.css";
 Du kan importere stilarkene for alle Jøkulkomponentene på en gang med
 
 ```scss
-@use "@fremtind/jokul/styles";
+@use "@fremtind/jokul/styles/components.scss";
 ```
 
 eller i ts/js
 
 ```tsx
 // Finnes også ferdig bygget, med filendelsene .css og .min.css
-import "@fremtind/jokul/styles/styles.scss";
+import "@fremtind/jokul/styles/components.scss";
 ```
 
 Vær obs på at du da kan få med en del mer stilark enn du trenger så vurder dette opp mot
@@ -105,7 +128,7 @@ Dette gjør du med
 ```scss
 // Variabelen `$webfonts-dir` angir hvor på disk filene ligger.
 // Hvis den ikke spesifiseres vil stilarket se etter fontfilene i mappen `/fonts`.
-@use "@fremtind/jokul/styles/fonts" with (
+@use "@fremtind/jokul/styles/theme/fonts" with (
     $webfonts-dir: "relative/path/to/node_modules/@fremtind/jokul/src/fonts"
 );
 ```
@@ -187,7 +210,7 @@ Dersom du bruker versjon 4 av Tailwind laster du inn vårt theme rett etter impo
 
 ```css
 @import "tailwindcss";
-@import "@fremtind/jokul/tailwind/v4";
+@import "@fremtind/jokul/styles/tailwind";
 ```
 
 ### Farger

--- a/packages/jokul/bin/jokul.mjs
+++ b/packages/jokul/bin/jokul.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runJokulCli } from "./run-jokul-cli.mjs";
+
+try {
+    process.exit(await runJokulCli());
+} catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+}

--- a/packages/jokul/bin/run-jokul-cli.mjs
+++ b/packages/jokul/bin/run-jokul-cli.mjs
@@ -1,0 +1,63 @@
+import { runImportPathsCodemod } from "../codemods/import-paths.mjs";
+
+function printCodemodHelp(commandName) {
+    console.log(`Jøkul codemods
+
+Bruk:
+  ${commandName} [import-paths] [--dry-run] [--verbose] [sti ...]
+
+Eksempler:
+  ${commandName}
+  ${commandName} --dry-run
+  ${commandName} src app
+  ${commandName} import-paths src app README.md --dry-run
+`);
+}
+
+async function runCodemodCommand(args, commandName) {
+    const [firstArg, ...rest] = args;
+
+    if (firstArg === "--help" || firstArg === "-h") {
+        printCodemodHelp(commandName);
+        return 0;
+    }
+
+    if (!firstArg) {
+        await runImportPathsCodemod([]);
+        return 0;
+    }
+
+    if (firstArg === "import-paths") {
+        await runImportPathsCodemod(rest);
+        return 0;
+    }
+
+    await runImportPathsCodemod(args);
+    return 0;
+}
+
+export async function runJokulCli(argv = process.argv.slice(2)) {
+    const [command, ...rest] = argv;
+
+    if (!command || command === "--help" || command === "-h") {
+        console.log(`Jøkul kommandolinje
+
+Bruk:
+  jokul codemod [import-paths] [--dry-run] [--verbose] [sti ...]
+
+Eksempler:
+  jokul codemod
+  jokul codemod --dry-run
+  jokul codemod src app
+  jokul codemod import-paths src app README.md --dry-run
+`);
+        return 0;
+    }
+
+    if (command !== "codemod") {
+        console.error(`Ukjent kommando: ${command}`);
+        return 1;
+    }
+
+    return runCodemodCommand(rest, "jokul codemod");
+}

--- a/packages/jokul/codemods/__tests__/import-paths.test.mjs
+++ b/packages/jokul/codemods/__tests__/import-paths.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { transformImportPaths } from "../import-paths.mjs";
+
+test("migrates core, styles and utilities imports", () => {
+    const source = `
+import "@fremtind/jokul/styles/core/core.scss";
+import "@fremtind/jokul/styles/styles.scss";
+import type { WithChildren } from "@fremtind/jokul/core";
+`;
+
+    const result = transformImportPaths(source, "/tmp/example.ts");
+
+    assert.equal(
+        result.text.includes('import "@fremtind/jokul/styles/base.scss";'),
+        true,
+    );
+    assert.equal(
+        result.text.includes('import "@fremtind/jokul/styles/components.scss";'),
+        true,
+    );
+    assert.equal(
+        result.text.includes(
+            'import type { WithChildren } from "@fremtind/jokul/utilities";',
+        ),
+        true,
+    );
+});
+
+test("moves configured font imports ahead of base styles", () => {
+    const source = `@use "@fremtind/jokul/styles/core";
+@use "@fremtind/jokul/styles/fonts" with (
+    $webfonts-dir: "../../src/fonts"
+);
+`;
+
+    const result = transformImportPaths(source, "/tmp/global.scss");
+
+    assert.match(
+        result.text,
+        /^@use "@fremtind\/jokul\/styles\/theme\/fonts" with \([\s\S]*?\);\n@use "@fremtind\/jokul\/styles\/base\.scss";/m,
+    );
+    assert.equal(result.reordered, true);
+});
+
+test("migrates internal relative core jkl imports", () => {
+    const source = `@use "../../../core/jkl";
+`;
+
+    const result = transformImportPaths(
+        source,
+        "/tmp/components/modal/styles/_layout.scss",
+    );
+
+    assert.equal(result.text, '@use "../../../styles/jkl";\n');
+});
+
+test("rewrites beta style imports when the beta component is used in the same file", () => {
+    const source = `
+import { BETA_Select } from "@fremtind/jokul/select";
+import "@fremtind/jokul/styles/components/select/_index.scss";
+`;
+
+    const result = transformImportPaths(source, "/tmp/example.tsx");
+
+    assert.equal(
+        result.text.includes(
+            '@fremtind/jokul/styles/components/beta/select/_index.scss',
+        ),
+        true,
+    );
+    assert.deepEqual(result.warnings, []);
+});
+
+test("warns when beta style imports are ambiguous", () => {
+    const source = `
+import "@fremtind/jokul/styles/components/nav-link";
+`;
+
+    const result = transformImportPaths(source, "/tmp/example.scss");
+
+    assert.equal(result.changed, false);
+    assert.equal(result.warnings.length, 1);
+});

--- a/packages/jokul/codemods/import-paths.mjs
+++ b/packages/jokul/codemods/import-paths.mjs
@@ -1,0 +1,393 @@
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const TEXT_EXTENSIONS = new Set([
+    ".cjs",
+    ".css",
+    ".cts",
+    ".js",
+    ".jsx",
+    ".md",
+    ".mdx",
+    ".mjs",
+    ".mts",
+    ".sass",
+    ".scss",
+    ".ts",
+    ".tsx",
+]);
+
+const IGNORED_DIRECTORIES = new Set([
+    ".changeset",
+    ".git",
+    ".github",
+    ".next",
+    ".turbo",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "storybook-static",
+]);
+
+const IGNORED_FILE_PATTERNS = [
+    "/packages/jokul/CHANGELOG.md",
+    "/packages/jokul/MIGRATION.md",
+    "/packages/jokul/build-styles.mjs",
+    "/packages/jokul/bin/",
+    "/packages/jokul/codemods/",
+];
+
+const DIRECT_REPLACEMENTS = [
+    [
+        "@fremtind/jokul/styles/core/core.min.css",
+        "@fremtind/jokul/styles/base.min.css",
+    ],
+    [
+        "@fremtind/jokul/styles/core/core.css",
+        "@fremtind/jokul/styles/base.css",
+    ],
+    [
+        "@fremtind/jokul/styles/core/core.scss",
+        "@fremtind/jokul/styles/base.scss",
+    ],
+    ["@fremtind/jokul/styles/core/core", "@fremtind/jokul/styles/base"],
+    [
+        "@fremtind/jokul/styles/styles.min.css",
+        "@fremtind/jokul/styles/components.min.css",
+    ],
+    ["@fremtind/jokul/styles/styles.css", "@fremtind/jokul/styles/components.css"],
+    [
+        "@fremtind/jokul/styles/styles.scss",
+        "@fremtind/jokul/styles/components.scss",
+    ],
+    ["@fremtind/jokul/styles/styles", "@fremtind/jokul/styles/components"],
+    [
+        "@fremtind/jokul/styles/core/jkl/index",
+        "@fremtind/jokul/styles/jkl",
+    ],
+    ["@fremtind/jokul/styles/core/jkl", "@fremtind/jokul/styles/jkl"],
+    [
+        "@fremtind/jokul/styles/fonts/webfonts.scss",
+        "@fremtind/jokul/styles/theme/fonts",
+    ],
+    [
+        "@fremtind/jokul/styles/fonts/webfonts",
+        "@fremtind/jokul/styles/theme/fonts",
+    ],
+    ["@fremtind/jokul/styles/fonts", "@fremtind/jokul/styles/theme/fonts"],
+    ["../../../core/jkl/index", "../../../styles/jkl"],
+    ["../../../core/jkl", "../../../styles/jkl"],
+    ["../../core/jkl/index", "../../styles/jkl"],
+    ["../../core/jkl", "../../styles/jkl"],
+    ["../core/jkl/index", "../styles/jkl"],
+    ["../core/jkl", "../styles/jkl"],
+    ["@fremtind/jokul/tailwind/v4", "@fremtind/jokul/styles/tailwind"],
+    ["@fremtind/jokul/styles/core", "@fremtind/jokul/styles/base.scss"],
+    ["@fremtind/jokul/styles", "@fremtind/jokul/styles/components.scss"],
+    ["@fremtind/jokul/core", "@fremtind/jokul/utilities"],
+].sort(([a], [b]) => b.length - a.length);
+
+const BETA_STYLE_MIGRATIONS = [
+    {
+        component: "DescriptionList",
+        betaIdentifiers: ["BETA_DescriptionList", "BETA_DescriptionListItem"],
+        replacements: [
+            [
+                "@fremtind/jokul/styles/components/description-list/_index.scss",
+                "@fremtind/jokul/styles/components/beta/description-list/_index.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/description-list/description-list.scss",
+                "@fremtind/jokul/styles/components/beta/description-list/description-list.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/description-list",
+                "@fremtind/jokul/styles/components/beta/description-list",
+            ],
+        ],
+    },
+    {
+        component: "NavLink",
+        betaIdentifiers: ["BETA_NavLink"],
+        replacements: [
+            [
+                "@fremtind/jokul/styles/components/nav-link/_index.scss",
+                "@fremtind/jokul/styles/components/beta/nav-link/_index.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/nav-link/nav-link.scss",
+                "@fremtind/jokul/styles/components/beta/nav-link/navlink.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/nav-link",
+                "@fremtind/jokul/styles/components/beta/nav-link",
+            ],
+        ],
+    },
+    {
+        component: "Select",
+        betaIdentifiers: ["BETA_Select"],
+        replacements: [
+            [
+                "@fremtind/jokul/styles/components/select/_index.scss",
+                "@fremtind/jokul/styles/components/beta/select/_index.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/select/select.scss",
+                "@fremtind/jokul/styles/components/beta/select/select.scss",
+            ],
+            [
+                "@fremtind/jokul/styles/components/select",
+                "@fremtind/jokul/styles/components/beta/select",
+            ],
+        ],
+    },
+];
+
+function shouldIgnoreFile(filePath) {
+    const normalizedPath = filePath.split(path.sep).join("/");
+
+    return IGNORED_FILE_PATTERNS.some((pattern) =>
+        normalizedPath.includes(pattern),
+    );
+}
+
+function shouldIgnoreDirectory(directoryPath) {
+    return IGNORED_DIRECTORIES.has(path.basename(directoryPath));
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceSpecifier(text, from, to) {
+    const pattern = new RegExp(
+        `(?<![A-Za-z0-9_./-])${escapeRegExp(from)}(?![A-Za-z0-9_./-])`,
+        "g",
+    );
+
+    let count = 0;
+    const next = text.replace(pattern, () => {
+        count += 1;
+        return to;
+    });
+
+    return { text: next, count };
+}
+
+function applyDirectReplacements(text) {
+    let next = text;
+    let replacements = 0;
+
+    for (const [from, to] of DIRECT_REPLACEMENTS) {
+        const result = replaceSpecifier(next, from, to);
+        next = result.text;
+        replacements += result.count;
+    }
+
+    return { text: next, replacements };
+}
+
+function applyBetaStyleReplacements(text) {
+    let next = text;
+    let replacements = 0;
+    const warnings = [];
+
+    for (const migration of BETA_STYLE_MIGRATIONS) {
+        const mentionsBeta = migration.betaIdentifiers.some((identifier) =>
+            next.includes(identifier),
+        );
+
+        const hasOldSpecifier = migration.replacements.some(([from]) =>
+            new RegExp(
+                `(?<![A-Za-z0-9_./-])${escapeRegExp(from)}(?![A-Za-z0-9_./-])`,
+            ).test(next),
+        );
+
+        if (!hasOldSpecifier) {
+            continue;
+        }
+
+        if (!mentionsBeta) {
+            warnings.push(
+                `Manuell vurdering: gammel stilimport for ${migration.component} kan peke på enten stabil eller beta-variant.`,
+            );
+            continue;
+        }
+
+        for (const [from, to] of migration.replacements) {
+            const result = replaceSpecifier(next, from, to);
+            next = result.text;
+            replacements += result.count;
+        }
+    }
+
+    return { text: next, replacements, warnings };
+}
+
+function reorderConfiguredFontImport(text) {
+    const fontImportPattern =
+        /^@use\s+["']@fremtind\/jokul\/styles\/theme\/fonts["'][\s\S]*?;\s*/m;
+    const baseImportPattern =
+        /^@use\s+["']@fremtind\/jokul\/styles\/base(?:\.scss)?["'][^;]*;\s*/m;
+
+    const fontMatch = fontImportPattern.exec(text);
+    const baseMatch = baseImportPattern.exec(text);
+
+    if (!fontMatch || !baseMatch || fontMatch.index < baseMatch.index) {
+        return { text, reordered: false };
+    }
+
+    const withoutFontImport =
+        text.slice(0, fontMatch.index) +
+        text.slice(fontMatch.index + fontMatch[0].length);
+    const nextBaseMatch = baseImportPattern.exec(withoutFontImport);
+
+    if (!nextBaseMatch) {
+        return { text, reordered: false };
+    }
+
+    const nextText =
+        withoutFontImport.slice(0, nextBaseMatch.index) +
+        fontMatch[0] +
+        withoutFontImport.slice(nextBaseMatch.index);
+
+    return { text: nextText, reordered: true };
+}
+
+export function transformImportPaths(text, filePath = "") {
+    const direct = applyDirectReplacements(text);
+    const beta = applyBetaStyleReplacements(direct.text);
+    let next = beta.text;
+    let reordered = false;
+
+    if (/\.(sass|scss)$/i.test(filePath)) {
+        const reorderedResult = reorderConfiguredFontImport(next);
+        next = reorderedResult.text;
+        reordered = reorderedResult.reordered;
+    }
+
+    return {
+        text: next,
+        changed: next !== text,
+        replacements: direct.replacements + beta.replacements,
+        warnings: beta.warnings,
+        reordered,
+    };
+}
+
+async function collectFiles(targetPath, collected) {
+    const stats = await stat(targetPath);
+
+    if (stats.isDirectory()) {
+        if (shouldIgnoreDirectory(targetPath)) {
+            return collected;
+        }
+
+        const entries = await readdir(targetPath, { withFileTypes: true });
+        const sortedEntries = [...entries].sort((a, b) =>
+            a.name.localeCompare(b.name),
+        );
+
+        for (const entry of sortedEntries) {
+            if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) {
+                continue;
+            }
+
+            await collectFiles(path.join(targetPath, entry.name), collected);
+        }
+
+        return collected;
+    }
+
+    if (TEXT_EXTENSIONS.has(path.extname(targetPath)) && !shouldIgnoreFile(targetPath)) {
+        collected.push(targetPath);
+    }
+
+    return collected;
+}
+
+function parseArguments(rawArgs) {
+    const options = {
+        dryRun: false,
+        verbose: false,
+    };
+    const targets = [];
+
+    for (const arg of rawArgs) {
+        if (arg === "--dry-run") {
+            options.dryRun = true;
+            continue;
+        }
+
+        if (arg === "--verbose") {
+            options.verbose = true;
+            continue;
+        }
+
+        if (arg === "--help" || arg === "-h") {
+            throw new Error(
+                "Bruk: jokul codemod [import-paths] [sti ...] [--dry-run] [--verbose]",
+            );
+        }
+
+        targets.push(arg);
+    }
+
+    return {
+        options,
+        targets: targets.length > 0 ? targets : ["."],
+    };
+}
+
+export async function runImportPathsCodemod(rawArgs = []) {
+    const { options, targets } = parseArguments(rawArgs);
+    const files = [];
+
+    for (const target of targets) {
+        await collectFiles(path.resolve(target), files);
+    }
+
+    const uniqueFiles = [...new Set(files)].sort((a, b) => a.localeCompare(b));
+    let changedFiles = 0;
+    let changedSpecifiers = 0;
+    let reorderedFiles = 0;
+    const warnings = [];
+
+    for (const filePath of uniqueFiles) {
+        const source = await readFile(filePath, "utf-8");
+        const result = transformImportPaths(source, filePath);
+
+        for (const warning of result.warnings) {
+            warnings.push(`${filePath}: ${warning}`);
+        }
+
+        if (!result.changed) {
+            continue;
+        }
+
+        changedFiles += 1;
+        changedSpecifiers += result.replacements;
+        reorderedFiles += result.reordered ? 1 : 0;
+
+        if (!options.dryRun) {
+            await writeFile(filePath, result.text, "utf-8");
+        }
+
+        if (options.verbose || options.dryRun) {
+            console.log(`${options.dryRun ? "Ville endret" : "Endret"} ${filePath}`);
+        }
+    }
+
+    if (warnings.length > 0) {
+        console.warn("\nFiler som trenger manuell oppfølging:");
+        for (const warning of warnings) {
+            console.warn(`- ${warning}`);
+        }
+    }
+
+    console.log(
+        `\n${options.dryRun ? "Dry run ferdig" : "Codemod ferdig"}: ${changedFiles} filer, ${changedSpecifiers} erstattede imports${reorderedFiles > 0 ? `, ${reorderedFiles} justerte font-importrekkefølger` : ""}.`,
+    );
+}

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -10,7 +10,17 @@
     "keywords": [],
     "license": "MIT",
     "sideEffects": ["*.css", "*.scss"],
-    "files": ["./build", "./styles", "./src/fonts", "./package.json"],
+    "files": [
+        "./bin",
+        "./build",
+        "./codemods",
+        "./styles",
+        "./src/fonts",
+        "./package.json"
+    ],
+    "bin": {
+        "jokul": "./bin/jokul.mjs"
+    },
     "exports": {
         "./package.json": "./package.json",
         "./styles/*": "./styles/*",

--- a/packages/jokul/src/components/checkbox/styles/checkbox.scss
+++ b/packages/jokul/src/components/checkbox/styles/checkbox.scss
@@ -54,7 +54,7 @@
         &__input:is(:hover, :active) + &__label,
         &__label:hover,
         &__label:active {
-            --jkl-icon-weight: #{jkl.$icon-weight-bold};
+            --jkl-icon-weight: #{jkl.$font-weight-bold};
         }
 
         &__input:checked + &__label::before {

--- a/packages/jokul/src/components/modal/styles/_layout.scss
+++ b/packages/jokul/src/components/modal/styles/_layout.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     /* Base layout */

--- a/packages/jokul/src/components/modal/styles/_modal-base.scss
+++ b/packages/jokul/src/components/modal/styles/_modal-base.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     .jkl-modal {

--- a/packages/jokul/src/components/modal/styles/_motion.scss
+++ b/packages/jokul/src/components/modal/styles/_motion.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     .jkl-modal-container--slide-in {

--- a/packages/jokul/src/components/modal/styles/_overlay.scss
+++ b/packages/jokul/src/components/modal/styles/_overlay.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     .jkl-modal-overlay {

--- a/packages/jokul/src/components/modal/styles/_parts.scss
+++ b/packages/jokul/src/components/modal/styles/_parts.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     .jkl-modal-header {

--- a/packages/jokul/src/components/modal/styles/_placement.scss
+++ b/packages/jokul/src/components/modal/styles/_placement.scss
@@ -1,4 +1,4 @@
-@use "../../../core/jkl";
+@use "../../../styles/jkl";
 
 @layer jokul.components {
     /* Placement: bottom */

--- a/packages/jokul/src/components/radio-button/styles/radio-button.scss
+++ b/packages/jokul/src/components/radio-button/styles/radio-button.scss
@@ -47,7 +47,7 @@
         &__input:is(:hover, :active) + &__label,
         &__label:hover,
         &__label:active {
-            --jkl-icon-weight: #{jkl.$icon-weight-bold};
+            --jkl-icon-weight: #{jkl.$font-weight-bold};
         }
 
         &__input:checked + &__label::before {
@@ -60,8 +60,8 @@
 
         & + &,
         /* Ta høyde for at det rendres support label etter radio button inntil videre */
-       .jkl-dormant-form-support-label + &,
-       .jkl-form-support-label + & {
+        .jkl-dormant-form-support-label + &,
+        .jkl-form-support-label + & {
             margin-top: 0.75lh;
         }
 

--- a/packages/mcp-server/src/handlers/prompts.ts
+++ b/packages/mcp-server/src/handlers/prompts.ts
@@ -41,7 +41,7 @@ Please help me:
 4. Ensure accessibility requirements are met
 
 Remember these Jøkul guidelines:
-- Always import core styles: import "@fremtind/jokul/styles/core/core.scss"
+- Always import core styles: import "@fremtind/jokul/styles/base.scss"
 - Use data-size on container elements, NOT as component props
 - Use data-theme for light/dark mode
 - All form components require a label prop

--- a/packages/mcp-server/src/handlers/tools.ts
+++ b/packages/mcp-server/src/handlers/tools.ts
@@ -411,7 +411,7 @@ export function registerTools(server: McpServer): void {
                     content: [
                         {
                             type: "text",
-                            text: `import type { ${item} } from "@fremtind/jokul/core";`,
+                            text: `import type { ${item} } from "@fremtind/jokul/utilities";`,
                         },
                     ],
                 };

--- a/packages/mcp-server/src/utils/documentation.ts
+++ b/packages/mcp-server/src/utils/documentation.ts
@@ -51,7 +51,7 @@ pnpm add @fremtind/jokul
 ### 1. Core Styles (Required)
 
 \`\`\`tsx
-import "@fremtind/jokul/styles/core/core.scss";
+import "@fremtind/jokul/styles/base.scss";
 \`\`\`
 
 ### 2. Vite Configuration

--- a/portal/src/app/(frontend)/global.scss
+++ b/portal/src/app/(frontend)/global.scss
@@ -1,8 +1,8 @@
-@use "@fremtind/jokul/styles/core";
-@use "@fremtind/jokul/styles/fonts" with ($webfonts-dir: "../../src/fonts"
+@use "@fremtind/jokul/styles/theme/fonts" with ($webfonts-dir: "../../src/fonts"
     // Dette er relativt til webfonts.sccs-fila i jokul-pakka
 );
-@use "@fremtind/jokul/styles/styles";
+@use "@fremtind/jokul/styles/base";
+@use "@fremtind/jokul/styles/components";
 @use "@fremtind/jokul/styles/jkl";
 
 * {

--- a/portal/src/components/layout/header/navigation/search/search.module.scss
+++ b/portal/src/components/layout/header/navigation/search/search.module.scss
@@ -1,4 +1,4 @@
-@use "@fremtind/jokul/styles/core/jkl";
+@use "@fremtind/jokul/styles/jkl";
 
 .description {
     -webkit-box-orient: vertical;


### PR DESCRIPTION
## Eksperiment: codemod for importmigrering

Denne PR-en kom ut av en prat vi hadde internt i teamet om codemods og hvordan vi best kan støtte team i større migreringer.

Som en del av den pågående pre-release-flyten for neste major av `@fremtind/jokul` (se [tokens-refactor.md](https://github.com/fremtind/jokul/blob/release/next/.changeset/tokens-refactor.md)) har jeg laget en **eksperimentell codemod for importmigrering**.

Tanken er å utforske om dette kan være et nyttig hjelpemiddel for team som skal oppdatere importstier til den nye strukturen.

Dette er først og fremst ment som et **eksperiment og et læringsgrunnlag**, ikke noe vi nødvendigvis må få ut eller gjøre til en offisiell del av releasen.

### Hva som er gjort

* legger til CLI for importmigrering
* tester automatisk migrering av gamle importstier til ny Jøkul-struktur
* oppdaterer intern dokumentasjon og interne imports som fortsatt brukte gamle stier
* legger til tester for codemoden