### PR TITLE
ux: date picker formatterer ikke lenger 6-sifra datoer

### DIFF
--- a/.changeset/calm-planes-switch.md
+++ b/.changeset/calm-planes-switch.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+DatePicker formatterer ikke lenger 6-sifrede datoer som `dd.mm.aa`.

--- a/packages/jokul/src/components/datepicker/DatePicker.test.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.test.tsx
@@ -63,7 +63,7 @@ describe("Datepicker", () => {
         );
     });
 
-    it("formats 6-digit compact dates while typing", async () => {
+    it("does not format 6-digit compact dates while typing", async () => {
         const changeHandler = vi.fn();
 
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
@@ -75,13 +75,13 @@ describe("Datepicker", () => {
             await userEvent.type(input, "011220");
         });
 
-        expect(input).toHaveProperty("value", "01.12.20");
+        expect(input).toHaveProperty("value", "011220");
         expect(changeHandler).toHaveBeenLastCalledWith(
             expect.anything(),
-            new Date(2020, 11, 1),
+            null,
             {
-                error: null,
-                value: "01.12.20",
+                error: "WRONG_FORMAT",
+                value: "011220",
             },
         );
     });
@@ -109,7 +109,7 @@ describe("Datepicker", () => {
         );
     });
 
-    it("keeps 6-digit compact dates valid and reformats correctly after backspacing and finishing", async () => {
+    it("keeps 6-digit compact dates unformatted and reformats when completed to 8 digits", async () => {
         const changeHandler = vi.fn();
 
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
@@ -118,13 +118,13 @@ describe("Datepicker", () => {
 
         await userEvent.type(input, "011220");
 
-        expect(input).toHaveProperty("value", "01.12.20");
+        expect(input).toHaveProperty("value", "011220");
         expect(changeHandler).toHaveBeenLastCalledWith(
             expect.anything(),
-            new Date(2020, 11, 1),
+            null,
             {
-                error: null,
-                value: "01.12.20",
+                error: "WRONG_FORMAT",
+                value: "011220",
             },
         );
 
@@ -153,18 +153,14 @@ describe("Datepicker", () => {
         );
     });
 
-    it("removes punctuation when a 7th digit makes a formatted 6-digit date invalid", async () => {
+    it("keeps 7-digit compact dates unformatted", async () => {
         const changeHandler = vi.fn();
 
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
 
         const input = getByTestId("jkl-datepicker__input");
 
-        await userEvent.type(input, "011220");
-
-        expect(input).toHaveProperty("value", "01.12.20");
-
-        await userEvent.type(input, "1");
+        await userEvent.type(input, "0112201");
 
         expect(input).toHaveProperty("value", "0112201");
         expect(input).not.toHaveValue(expect.stringMatching(/[./-]/));
@@ -178,7 +174,7 @@ describe("Datepicker", () => {
         );
     });
 
-    it("reports stripped event.target.value when backspacing a formatted 6-digit date into an invalid value", async () => {
+    it("reports raw event.target.value when backspacing a 6-digit compact date", async () => {
         const changeHandler = vi.fn();
 
         const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
@@ -198,32 +194,6 @@ describe("Datepicker", () => {
             {
                 error: "WRONG_FORMAT",
                 value: "01122",
-            },
-        );
-    });
-
-    it("removes trailing punctuation when backspacing a formatted 6-digit date down to 4 digits", async () => {
-        const changeHandler = vi.fn();
-
-        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
-
-        const input = getByTestId("jkl-datepicker__input");
-
-        await userEvent.type(input, "111120");
-        await userEvent.type(input, "{backspace}{backspace}");
-
-        const eventTarget = changeHandler.mock.lastCall?.[0]
-            .target as HTMLInputElement;
-
-        expect(input).toHaveProperty("value", "1111");
-        expect(input).not.toHaveValue(expect.stringMatching(/[./-]/));
-        expect(eventTarget.value).toBe("1111");
-        expect(changeHandler).toHaveBeenLastCalledWith(
-            expect.anything(),
-            null,
-            {
-                error: "WRONG_FORMAT",
-                value: "1111",
             },
         );
     });
@@ -451,10 +421,7 @@ describe("Datepicker", () => {
         const initialValue = "01.12.2019";
 
         const { getByTestId } = render(
-            <DatePicker
-                defaultValue={initialValue}
-                onChange={changeHandler}
-            />,
+            <DatePicker defaultValue={initialValue} onChange={changeHandler} />,
         );
 
         const input = getByTestId("jkl-datepicker__input");

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -11,12 +11,12 @@ import React, {
     useState,
 } from "react";
 import { flushSync } from "react-dom";
+import { formatDateString } from "../../utilities/formatters/date/formatDate.js";
 import { IconButton } from "../icon-button/IconButton.js";
 import { CalendarIcon } from "../icon/icons/CalendarIcon.js";
 import { InputGroup } from "../input-group/InputGroup.js";
 import Popover from "../popover/Popover.js";
 import { BaseTextInput } from "../text-input/BaseTextInput.js";
-import { formatDateString } from "../../utilities/formatters/date/formatDate.js";
 import { Calendar } from "./internal/Calendar.js";
 import { type DateInfo, getInitialDate } from "./internal/utils.js";
 import type { DatePickerProps, DateValidationError } from "./types.js";
@@ -43,9 +43,7 @@ const normalizeInputValue = (rawValue: string) => {
     });
     const rawValueWithoutTrailingPunctuation = rawValue.replace(/\D+$/, "");
     const compactDateCandidate =
-        digits.length === 6 || digits.length === 8
-            ? formatDateString(digits)
-            : rawValue;
+        digits.length === 8 ? formatDateString(digits) : rawValue;
     const validCompactDate = parseDateString(compactDateCandidate)
         ? compactDateCandidate
         : null;
@@ -223,14 +221,12 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                     setInputValue(e.currentTarget, formattedValue);
                 }
 
-                const {
-                    date: nextDate,
-                    error: nextError,
-                } = getInputValidationState({
-                    value: formattedValue,
-                    minDate,
-                    maxDate,
-                });
+                const { date: nextDate, error: nextError } =
+                    getInputValidationState({
+                        value: formattedValue,
+                        minDate,
+                        maxDate,
+                    });
 
                 if (nextDate && !nextError) {
                     setShowCalendar(false);


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Å formattere datoer på 6 siffer endret ux-en i mange løsninger, som har backends som bare aksepterer 8-sifra datoer. Det var ikke en endring i API-et, men en uønska endring i formatteringsreglen, som kunne gjøre at brukere kunne forlate feltet før datoen var riktig.

Eksempelvis hvis en bruker skal skrive inn 20.03.2026, og begynner å skrive 20.03.20, så ville den formatteres, men ikke være riktig, men allikvel formatteres.