### PR TITLE
docs(changeset): Gjør det mulig å skrive punktum i dato-felt igjen

### DIFF
--- a/.changeset/solid-yaks-bake.md
+++ b/.changeset/solid-yaks-bake.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Gjør det mulig å skrive punktum i dato-felt igjen

--- a/packages/jokul/src/components/datepicker/DatePicker.test.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.test.tsx
@@ -38,6 +38,84 @@ describe("Datepicker", () => {
         expect(input).toHaveProperty("value", "24.12.2019");
     });
 
+    it('keeps manually typed dots while entering "11.03.1997"', async () => {
+        const changeHandler = vi.fn();
+
+        const { getByTestId } = render(<DatePicker onChange={changeHandler} />);
+
+        const input = getByTestId("jkl-datepicker__input");
+
+        await userEvent.type(input, "11.");
+
+        expect(input).toHaveProperty("value", "11.");
+        expect(changeHandler).toHaveBeenLastCalledWith(
+            expect.anything(),
+            null,
+            {
+                error: "WRONG_FORMAT",
+                value: "11.",
+            },
+        );
+
+        await userEvent.type(input, "03.");
+
+        expect(input).toHaveProperty("value", "11.03.");
+        expect(changeHandler).toHaveBeenLastCalledWith(
+            expect.anything(),
+            null,
+            {
+                error: "WRONG_FORMAT",
+                value: "11.03.",
+            },
+        );
+
+        await userEvent.type(input, "1997");
+
+        expect(input).toHaveProperty("value", "11.03.1997");
+        expect(changeHandler).toHaveBeenLastCalledWith(
+            expect.anything(),
+            new Date(1997, 2, 11),
+            {
+                error: null,
+                value: "11.03.1997",
+            },
+        );
+    });
+
+    it("keeps manually typed dots after a controlled value update to compact input", async () => {
+        const ControlledDatePicker = () => {
+            const [value, setValue] = React.useState("");
+
+            return (
+                <>
+                    <DatePicker
+                        value={value}
+                        onChange={(_, __, meta) => setValue(meta.value)}
+                    />
+                    <button type="button" onClick={() => setValue("11")}>
+                        Set compact value
+                    </button>
+                </>
+            );
+        };
+
+        const { getByTestId, getByText } = render(<ControlledDatePicker />);
+
+        const input = getByTestId("jkl-datepicker__input");
+
+        await userEvent.type(input, "01122019");
+
+        expect(input).toHaveProperty("value", "01.12.2019");
+
+        await userEvent.click(getByText("Set compact value"));
+
+        expect(input).toHaveProperty("value", "11");
+
+        await userEvent.type(input, ".");
+
+        expect(input).toHaveProperty("value", "11.");
+    });
+
     it("fires onChange method on edit input", async () => {
         const changeHandler = vi.fn();
 

--- a/packages/jokul/src/components/datepicker/DatePicker.tsx
+++ b/packages/jokul/src/components/datepicker/DatePicker.tsx
@@ -36,7 +36,10 @@ const setInputValue = (input: HTMLInputElement, value: string) => {
     }
 };
 
-const normalizeInputValue = (rawValue: string) => {
+const normalizeInputValue = (
+    rawValue: string,
+    shouldStripAutoFormatting: boolean,
+) => {
     const digits = rawValue.replace(/\D/g, "");
     const partialCompactDate = formatDateString(digits, {
         partial: true,
@@ -48,6 +51,7 @@ const normalizeInputValue = (rawValue: string) => {
         ? compactDateCandidate
         : null;
     const shouldRemoveFormatting =
+        shouldStripAutoFormatting &&
         rawValue !== digits &&
         rawValueWithoutTrailingPunctuation === partialCompactDate &&
         parseDateString(rawValue) === undefined &&
@@ -156,6 +160,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
 
         const iconButtonRef = useRef<HTMLButtonElement | null>(null);
         const inputRef = useRef<HTMLInputElement | null>(null);
+        const didAutoFormatCompactInputRef = useRef(false);
 
         // Hjelper for å gjøre det enklere å både forwarde refen men også bruke den selv internt
         const unifiedInputRef = useCallback(
@@ -215,11 +220,21 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         const handleChange = useCallback(
             (e: ChangeEvent<HTMLInputElement>) => {
                 const rawValue = e.currentTarget.value;
-                const formattedValue = normalizeInputValue(rawValue);
+                const formattedValue = normalizeInputValue(
+                    rawValue,
+                    didAutoFormatCompactInputRef.current,
+                );
 
                 if (formattedValue !== rawValue) {
                     setInputValue(e.currentTarget, formattedValue);
                 }
+
+                const digits = rawValue.replace(/\D/g, "");
+                didAutoFormatCompactInputRef.current =
+                    rawValue === digits &&
+                    formattedValue === formatDateString(digits) &&
+                    formattedValue !== rawValue &&
+                    parseDateString(formattedValue) !== undefined;
 
                 const { date: nextDate, error: nextError } =
                     getInputValidationState({
@@ -278,6 +293,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
                 if (inputRef.current) {
                     const node = inputRef.current;
 
+                    didAutoFormatCompactInputRef.current = false;
                     node.value = formatInput(date);
 
                     // Simulér et change-event så APIet blir så likt som mulig en endring av inputfeltet


### PR DESCRIPTION
## 💬 Endringer

- Legger til en regresjonstest for manuelt skrevne skilletegn i `DatePicker`, og verifiserer mellomtilstandene `11.`, `11.03.` og `11.03.1997`.
- Oppdaterer formatteringslogikken slik at punktum brukeren skriver selv beholdes mens datoen tastes.
- Beholder eksisterende støtte for kompakt input som `11031997`, og stripper bare punktum når feltet tidligere ble autoformatert fra kompakt input.

## 🤔 Hvorfor

- Dagens normalisering fjernet punktum under innskriving selv om `11.03.1997` fortsatt skal være en gyldig måte å skrive dato på.
- Det gjorde skriveopplevelsen dårligere og skjulte en regresjon som sluttverdi-tester alene ikke fanget.
- Den nye testen låser mellomtilstandene, slik at vi fanger samme feil neste gang formatteringen endres.

## ✅ Verifisering

- `pnpm --filter "@fremtind/jokul" exec vitest run --config vite.test.config.mjs src/components/datepicker/DatePicker.test.tsx`
- `pnpm exec biome check packages/jokul/src/components/datepicker/DatePicker.tsx packages/jokul/src/components/datepicker/DatePicker.test.tsx`

## 🩹 Løser følgende issues

- Ingen koblet issue for denne endringen.
