### PR TITLE
Legg til tellestrategi for TextArea-counter

### DIFF
--- a/.changeset/funny-cars-exercise.md
+++ b/.changeset/funny-cars-exercise.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": minor
+---
+
+La til støtte for valgbare tellestrategier i telleren til `TextArea`.
+
+`counter`-propen støtter nå `strategy: "characters" | "bytes"`, slik at integrasjoner med bytebaserte grenser kan telle UTF-8-bytes. Eksisterende tegnbasert oppførsel er fortsatt standard.

--- a/packages/jokul/src/components/text-area/BaseTextArea.tsx
+++ b/packages/jokul/src/components/text-area/BaseTextArea.tsx
@@ -7,6 +7,7 @@ import React, {
     useRef,
     useState,
 } from "react";
+import { getCounterValue } from "./counter.js";
 import type { BaseTextAreaProps } from "./types.js";
 
 export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
@@ -14,6 +15,7 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
         const {
             autoExpand,
             counter,
+            defaultValue,
             onBlur,
             onFocus,
             rows = 7,
@@ -26,21 +28,25 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
             ...rest
         } = props;
 
-        const [counterCurrent, setCounterCurrent] = useState(() => {
-            if (typeof value === "undefined") {
-                return 0;
-            }
+        const strategy = counter?.strategy ?? "characters";
+        const isControlled = typeof value !== "undefined";
 
-            if (typeof value === "number") {
-                return String(value).length;
-            }
-
-            return value.length;
-        });
+        const [uncontrolledValue, setUncontrolledValue] =
+            useState(defaultValue);
         const [textAreaFocused, setTextAreaFocused] = useState(false);
         const internalRef = useRef<HTMLTextAreaElement>(null);
         const textAreaRef =
             (ref as RefObject<HTMLTextAreaElement>) || internalRef;
+
+        // Hvis feltet styres utenfra bruker vi `value`, ellers holder vi styr på verdien selv.
+        const textAreaValue = isControlled ? value : uncontrolledValue;
+        const textAreaValueProps = isControlled ? { value } : { defaultValue };
+
+        const counterCurrent = getCounterValue(textAreaValue, strategy);
+        const counterTotal: number = counter?.maxLength || 0;
+        const progressCurrent: number = counterTotal - counterCurrent;
+        const isOverLimit = Boolean(counter && counterCurrent > counterTotal);
+        const invalid = Boolean(ariaInvalid || isOverLimit);
 
         // biome-ignore lint/correctness/useExhaustiveDependencies: counterCurrent trengs for å lytte på tekstendringer i textarea for auto-expand funksjonalitet
         useEffect(() => {
@@ -51,14 +57,20 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
                     return;
                 }
 
-                if (textAreaFocused || value) {
+                if (textAreaFocused || textAreaValue) {
                     textAreaElement.style.height = "auto"; // Sett til auto før scrollhøyden leses, sånn at redusering av høyde ved sletting av tekst fungerer
                     textAreaElement.style.height = `${textAreaElement.scrollHeight}px`;
                 } else {
                     textAreaElement.style.height = "";
                 }
             }
-        }, [autoExpand, textAreaRef, value, textAreaFocused, counterCurrent]);
+        }, [
+            autoExpand,
+            textAreaRef,
+            textAreaValue,
+            textAreaFocused,
+            counterCurrent,
+        ]);
 
         function handleOnFocus(e: FocusEvent<HTMLTextAreaElement>) {
             setTextAreaFocused(true);
@@ -75,26 +87,20 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
         }
 
         function handleOnChange(e: ChangeEvent<HTMLTextAreaElement>) {
-            setCounterCurrent(e.target.value.length);
+            if (!isControlled) {
+                setUncontrolledValue(e.target.value);
+            }
+
             if (onChange) {
                 onChange(e);
             }
         }
-
-        const counterTotal: number = counter?.maxLength || 0;
-        const progressCurrent: number = counterTotal - counterCurrent;
         function calculatePercentage(current: number, total: number): number {
             if (current <= 0) {
                 return 0;
             }
             return total === 0 ? 0 : (current * 100) / total;
         }
-        const counterLabel =
-            counter && counterCurrent > counterTotal
-                ? `Du har skrevet ${counterCurrent - counterTotal} tegn for mye`
-                : undefined;
-
-        const invalid = Boolean(ariaInvalid || counterLabel);
 
         const overflowStyle = {
             overflowX: autoExpand ? "hidden" : undefined, // Must set overflowX hidden for Firefox https://stackoverflow.com/a/22700700
@@ -115,7 +121,7 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
                     ref={textAreaRef}
                     style={{ ...style, ...overflowStyle }}
                     placeholder={placeholder}
-                    value={value}
+                    {...textAreaValueProps}
                     {...rest}
                 />
                 {counter && (

--- a/packages/jokul/src/components/text-area/TextArea.test.tsx
+++ b/packages/jokul/src/components/text-area/TextArea.test.tsx
@@ -32,6 +32,92 @@ describe("TextArea", () => {
 
         expect(textArea.getAttribute("placeholder")).toEqual(" ");
     });
+
+    it("uses character counting by default", () => {
+        render(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 4 }}
+                value="😀😀"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/4\s*\/\s*4/)).toBeInTheDocument();
+    });
+
+    it("supports counting UTF-8 bytes", () => {
+        render(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 4, strategy: "bytes" }}
+                value="😀"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/4\s*\/\s*4/)).toBeInTheDocument();
+    });
+
+    it("updates the counter when a controlled value changes", () => {
+        const { rerender } = render(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 10 }}
+                value="hei"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/3\s*\/\s*10/)).toBeInTheDocument();
+
+        rerender(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 10 }}
+                value="heihei"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/6\s*\/\s*10/)).toBeInTheDocument();
+    });
+
+    it("updates the counter when the strategy changes for a controlled value", () => {
+        const { rerender } = render(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 6 }}
+                value="æøå"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/3\s*\/\s*6/)).toBeInTheDocument();
+
+        rerender(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 6, strategy: "bytes" }}
+                value="æøå"
+                readOnly
+            />,
+        );
+
+        expect(screen.getByText(/6\s*\/\s*6/)).toBeInTheDocument();
+    });
+
+    it("uses defaultValue for the counter in uncontrolled mode", () => {
+        render(
+            <TextArea
+                label="testing"
+                counter={{ maxLength: 10, strategy: "bytes" }}
+                defaultValue="æøå"
+            />,
+        );
+
+        expect(screen.getByText(/6\s*\/\s*10/)).toBeInTheDocument();
+    });
 });
 
 describe("a11y", () => {

--- a/packages/jokul/src/components/text-area/counter.ts
+++ b/packages/jokul/src/components/text-area/counter.ts
@@ -1,0 +1,25 @@
+import type { CounterStrategy } from "./types.js";
+
+const textEncoder = new TextEncoder();
+
+export function getCounterValue(
+    value: string | number | readonly string[] | undefined,
+    strategy: CounterStrategy = "characters",
+): number {
+    if (typeof value === "undefined") {
+        return 0;
+    }
+
+    const normalizedValue =
+        typeof value === "string"
+            ? value
+            : Array.isArray(value)
+              ? value.join("")
+              : String(value);
+
+    if (strategy === "bytes") {
+        return textEncoder.encode(normalizedValue).length;
+    }
+
+    return normalizedValue.length;
+}

--- a/packages/jokul/src/components/text-area/stories/TextArea.stories.tsx
+++ b/packages/jokul/src/components/text-area/stories/TextArea.stories.tsx
@@ -60,6 +60,18 @@ export const AutoExpand: Story = {
     },
 };
 
+export const ByteCounter: Story = {
+    args: {
+        label: "Melding til ekstern tjeneste",
+        description: "Brukes når en integrasjon håndhever en bytegrense.",
+        counter: {
+            maxLength: 4096,
+            strategy: "bytes",
+            hideProgress: false,
+        },
+    },
+};
+
 export const _Error: Story = {
     args: {
         errorLabel: "Du må beskrive skaden for å fortsette",

--- a/packages/jokul/src/components/text-area/types.ts
+++ b/packages/jokul/src/components/text-area/types.ts
@@ -1,9 +1,30 @@
 import type { TextareaHTMLAttributes } from "react";
 import type { InputGroupProps } from "../input-group/types.js";
 
+export type CounterStrategy = "characters" | "bytes";
+
 export type Counter = {
-    /** Antall tegn før telleren når maksimum og vi viser en feilmelding */
+    /**
+     * Maksverdi for telleren.
+     *
+     * Enheten avhenger av `strategy`:
+     * - `"characters"`: antall tegn
+     * - `"bytes"`: antall UTF-8-bytes
+     */
     maxLength: number;
+    /**
+     * Bestemmer hva telleren måler.
+     *
+     * - "characters" teller tekst på samme måte som i dag og er standard
+     * - "bytes" teller antall UTF-8-bytes, for usecaser der backend eller API
+     *   håndhever en bytegrense
+     *
+     * Unngå å kombinere `strategy="bytes"` med native `maxLength` på
+     * `<textarea>`, siden nettleseren fortsatt håndhever `maxLength` som tegn.
+     *
+     * @default "characters"
+     */
+    strategy?: CounterStrategy;
     /**
      * Med teller vises en progress-bar i bunnen av tekstfeltet som krymper
      * ned fra 100% (null tegn skrevet) til 0% (maks antall tegn skrevet).


### PR DESCRIPTION
## Hva er gjort

- lagt til støtte for valgbare tellestrategier i TextArea-counteren
- beholdt eksisterende tegnbasert oppførsel som standard
- lagt til støtte for strategy: "bytes" for integrasjoner som må forholde seg til bytegrenser

## Hvorfor

Vi har et usecase der teksten sendes videre til et API som håndhever en bytegrense. Da trenger vi å kunne telle på samme måte i frontend uten å endre standardoppførselen i designsystemet.