### PR TITLE
docs(changeset): utdyp brand-farger i tokens-refactor

### DIFF
--- a/.changeset/tokens-refactor.md
+++ b/.changeset/tokens-refactor.md
@@ -46,6 +46,10 @@ Samtidig som vi faser ut de gamle fargene faser vi også ut mixins for å define
 }
 ```
 
+## Brand-spesifikke fargetemaer
+
+Jøkul eksporterer nå også brand-spesifikke fargetemaer for `dnb`, `eika` og `sparebank1`. Disse genereres fra token-definisjonene og er tilgjengelige som egne theme-filer under `@fremtind/jokul/styles/theme/brands/...`.
+
 ## Nye importstier for Tailwind
 
 Importstiene for Jøkul sitt Tailwind-oppsett er endret


### PR DESCRIPTION
## Hva er gjort

- utvidet changeset-teksten i tokens-refactor med informasjon om brand-spesifikke fargetemaer
- presisert at token-refaktoren også omfatter egne theme-filer for DNB, Eika og SpareBank 1

## Hvorfor

Endringene fra setup-color-tokens (PR #5887) er allerede en del av prerelease-sporet på release/next, men de ble ikke beskrevet tydelig nok i den eksisterende changeset-teksten.

Det ble ikke opprettet en egen changeset for setup-color-tokens, men det viste seg også å være unødvendig siden [tokens-refactor.md](https://github.com/fremtind/jokul/blob/release/next/.changeset/tokens-refactor.md) allerede dekker samme refaktorarbeid. Derfor oppdaterer denne PR-en den eksisterende changeset-en i stedet for å introdusere en ny.