### PR TITLE
fix(file): rett tekstfarge for File-feil i dark mode

### DIFF
--- a/.changeset/bright-files-heal.md
+++ b/.changeset/bright-files-heal.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Retter tekstfargen i `File`-komponenten ved error state i dark mode.

--- a/packages/jokul/src/components/file/stories/File.stories.tsx
+++ b/packages/jokul/src/components/file/stories/File.stories.tsx
@@ -91,6 +91,13 @@ export const FileLoading: Story = {
     },
 };
 
+export const FileError: Story = {
+    name: "Fil med feil",
+    args: {
+        state: "error",
+    },
+};
+
 export const MultifileLoading: Story = {
     name: "Filopplasting (flere filer)",
     args: {

--- a/packages/jokul/src/components/file/styles/file.scss
+++ b/packages/jokul/src/components/file/styles/file.scss
@@ -24,7 +24,7 @@
                 color
             );
 
-            color: var(--jkl-color-text-default);
+            color: var(--text-color);
             padding: var(--jkl-file-padding);
             border: var(--border);
             border-radius: var(--border-radius);
@@ -164,6 +164,7 @@
         from {
             transform: rotate(0turn);
         }
+
         to {
             transform: rotate(1turn);
         }


### PR DESCRIPTION
## Hva er endret

- retter tekstfargen i `File`-komponenten når `state="error"` brukes i dark mode
- legger til en egen Storybook-story for error state, slik at tilstanden er enklere å verifisere
- legger til changeset for patch-release

## Hvorfor

Issue #5939 beskriver at `File`-komponenten viser feil tekstfarge i error state i dark mode.

## Root cause

`File` satte `--text-color` til alert-fargen i error state, men `.jkl-file__content` brukte fortsatt `color: var(--jkl-color-text-default)`. Dermed ble overstyringen ignorert, og teksten fikk feil farge i dark mode.

## Effekt

Error state i `File` bruker nå riktig tekstfarge i dark mode, og komponenten oppfører seg konsistent med resten av alert-stylingen.

Closes #5939
