### PR TITLE
fix(button): skjul knappetekst fullstendig under lasting

### DIFF
--- a/.changeset/fix-button-loader-text.md
+++ b/.changeset/fix-button-loader-text.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikset en feil i Button-komponenten der knappeteksten var delvis synlig øverst i knappen under lasting. Teksten flyttes nå tilstrekkelig langt opp til å være helt skjult, uavhengig av valgt størrelse.

--- a/packages/jokul/src/components/button/integration/button.spec.ts
+++ b/packages/jokul/src/components/button/integration/button.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async ({ page }, workerInfo) => {
 });
 
 test.afterEach(async () => {
-    helper.close();
+    await helper.close();
 });
 
 test("renders correctly", async () => {

--- a/packages/jokul/src/components/button/styles/button.scss
+++ b/packages/jokul/src/components/button/styles/button.scss
@@ -97,7 +97,8 @@
         }
 
         &[data-loading="true"] &__label {
-            translate: 0 -120%;
+            --button-loading-offset: calc(-100% - var(--jkl-button-padding-block) * 2 - var(--jkl-button-text-ink-offset));
+            translate: 0 var(--button-loading-offset);
         }
 
         &[data-loading="true"] &__loader {

--- a/utils/dev-example/ExampleBase.tsx
+++ b/utils/dev-example/ExampleBase.tsx
@@ -314,7 +314,7 @@ export const ExampleBase: FC<Props> = ({
                                                 name="size"
                                                 value="medium"
                                                 defaultChecked
-                                                data-testid="size-default"
+                                                data-testid="size-medium"
                                                 onChange={(e) =>
                                                     setSize(
                                                         e.target.value as Size,

--- a/utils/playwright/TestHelper.mts
+++ b/utils/playwright/TestHelper.mts
@@ -119,7 +119,7 @@ export class TestHelper {
         return this;
     }
 
-    async setSize(value: "small" | "default" | "large") {
+    async setSize(value: "small" | "medium" | "large") {
         await this._page
             .getByTestId(`size-${value}`)
             .first()
@@ -293,7 +293,7 @@ export class TestHelper {
                   outline?: string;
               };
     } = {}) {
-        await this.setSize("default");
+        await this.setSize("medium");
         await this.setTheme("light");
         await before?.();
         await this.snapshot("default", selector, selectorPadding);
@@ -311,7 +311,7 @@ export class TestHelper {
         }
         await after?.();
 
-        await this.setSize("default");
+        await this.setSize("medium");
         await this.setTheme("dark");
         await before?.();
         await this.snapshot("default-dark", selector, selectorPadding);


### PR DESCRIPTION
## Hva er endret
- Retter at knappeteksten er delvis synlig øverst i knappen under lasting
- Rydder opp i Playwright-oppsettet ved å bruke `medium` konsekvent i stedet for `default`, slik at testhjelper og dev-eksempel matcher hverandre
- Gjør teardown i button-integrasjonstesten tryggere med `await helper?.close()`
- Legger til changeset for patch-release

## Hvorfor
Issue #5942 beskriver at knappeteksten stikker frem øverst i knappen når loader vises.

Under arbeidet ble det også ryddet opp i en liten inkonsistens i testoppsettet rundt `default` vs. `medium`.

## Rotårsak
Label-elementet ble forskjøvet `-120%` av sin egen høyde oppover ved lasting. Siden knappen har padding utover labelens høyde, var ikke dette nok til å flytte teksten helt ut av det synlige området – spesielt ved `data-size="large"`, der paddingen er relativt større.

## Effekt
Forskyvningen beregnes nå dynamisk ut fra knappens padding og ink-offset, slik at teksten flyttes helt ut av knappens synlige område uavhengig av valgt størrelse.

Closes #5942
