### PR TITLE
chore: slutt å bruke deprecated sass-funksjon 'if'

### DIFF
--- a/.changeset/bumpy-rice-dream.md
+++ b/.changeset/bumpy-rice-dream.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+slutter å bruke deprecated sass-funksjon 'if'

--- a/packages/jokul/src/core/jkl/_convert.scss
+++ b/packages/jokul/src/core/jkl/_convert.scss
@@ -33,15 +33,21 @@
         "9": 9,
     );
 
-    @for $i from if($minus, 2, 1) through string.length($value) {
+    $start: 1;
+    @if $minus {
+        $start: 2;
+    }
+
+    @for $i from $start through string.length($value) {
         $character: string.slice($value, $i, $i);
 
         @if not(list.index(map.keys($numbers), $character) or $character == ".")
         {
-            @return to-length(
-                if($minus, -$result, $result),
-                string.slice($value, $i)
-            );
+            $signed-result: $result;
+            @if $minus {
+                $signed-result: -$result;
+            }
+            @return to-length($signed-result, string.slice($value, $i));
         }
 
         @if $character == "." {
@@ -54,7 +60,10 @@
         }
     }
 
-    @return if($minus, -$result, $result);
+    @if $minus {
+        @return -$result;
+    }
+    @return $result;
 }
 
 /// Add `$unit` to `$value`


### PR DESCRIPTION
## 💬 Endringer

Kjørte `npx sass-migrator if-function /Users/bjoerne.oma/dev/jokul/packages/jokul/src/core/jkl/_convert.scss` for å migrere bort fra deprecated sass-funksjon 'if'.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #5955 
