### PR TITLE
chore: oppdater Figma Code Connect-filer

### DIFF
--- a/packages/jokul/src/components/breadcrumb/Breadcrumb.figma.tsx
+++ b/packages/jokul/src/components/breadcrumb/Breadcrumb.figma.tsx
@@ -18,7 +18,10 @@ figma.connect(
             'import { BreadcrumbItem } from "@fremtind/jokul/components/breadcrumb";',
         ],
         props: {
-            isLastElement: figma.boolean("Current"),
+            isLastElement: figma.enum("Current", {
+                True: true,
+                False: false,
+            }),
         },
         example: (props) => <BreadcrumbItem {...props}>Hei</BreadcrumbItem>,
     },

--- a/packages/jokul/src/components/help/Help.figma.tsx
+++ b/packages/jokul/src/components/help/Help.figma.tsx
@@ -11,33 +11,9 @@ figma.connect(
             nested: figma.nestedProps("Help Popover", {
                 children: figma.string("Text"),
             }),
-            buttonText: figma.textContent("Label"),
-            iconPosition: figma.enum("Text", {
-                None: "none",
-                // Disse er omvendt siden man styrer tekst-
-                // posisjon i Figma, men ikonposisjon i kode
-                Left: "right",
-                Right: "left",
-            }),
         },
-        example: (props) => {
-            if (props.iconPosition === "none") {
-                return (
-                    <Help buttonText={props.buttonText}>
-                        {props.nested.children}
-                    </Help>
-                );
-            }
-
-            return (
-                <Help
-                    buttonText={props.buttonText}
-                    iconPosition={props.iconPosition}
-                    showButtonText={true}
-                >
-                    {props.nested.children}
-                </Help>
-            );
-        },
+        example: (props) => (
+            <Help buttonText="Hjelp">{props.nested.children}</Help>
+        ),
     },
 );

--- a/packages/jokul/src/components/icon/icons/code-connect/ArrowDownIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ArrowDownIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ArrowDownIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ArrowLeftIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ArrowLeftIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ArrowLeftIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ArrowRightIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ArrowRightIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ArrowRightIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ArrowUpIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ArrowUpIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ArrowUpIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/CalendarIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/CalendarIcon.figma.tsx
@@ -18,9 +18,6 @@ figma.connect(
             'import { CalendarIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/CheckIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/CheckIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { CheckIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ChevronDownIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ChevronDownIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ChevronDownIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ChevronLeftIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ChevronLeftIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ChevronLeftIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ChevronRightIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ChevronRightIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ChevronRightIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ChevronUpIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ChevronUpIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ChevronUpIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/CloseIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/CloseIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { CloseIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/CopyIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/CopyIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { CopyIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/DotsIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/DotsIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { DotsIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/DragIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/DragIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { DragIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/HamburgerIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/HamburgerIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { HamburgerIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/InfoIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/InfoIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { InfoIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/LinkIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/LinkIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { LinkIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/MinusIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/MinusIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { MinusIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/OpenInNewIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/OpenInNewIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { OpenInNewIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/PenIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/PenIcon.figma.tsx
@@ -8,9 +8,6 @@ figma.connect(
     {
         imports: ['import { PenIcon } from "@fremtind/jokul/components/icon";'],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/PlusIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/PlusIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { PlusIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/QuestionIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/QuestionIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { QuestionIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/SearchIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/SearchIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { SearchIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/SuccessIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/SuccessIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { SuccessIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ThumbDownIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ThumbDownIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ThumbDownIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/ThumbUpIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/ThumbUpIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { ThumbUpIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/TrashCanIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/TrashCanIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { TrashCanIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/icon/icons/code-connect/WarningIcon.figma.tsx
+++ b/packages/jokul/src/components/icon/icons/code-connect/WarningIcon.figma.tsx
@@ -10,9 +10,6 @@ figma.connect(
             'import { WarningIcon } from "@fremtind/jokul/components/icon";',
         ],
         props: {
-            bold: figma.enum("Weight", {
-                Bold: true,
-            }),
             variant: figma.enum("Size", {
                 Medium: "medium",
                 Small: "small",

--- a/packages/jokul/src/components/input-group/SupportLabel.figma.tsx
+++ b/packages/jokul/src/components/input-group/SupportLabel.figma.tsx
@@ -10,11 +10,11 @@ figma.connect(
             'import { SupportLabel } from "@fremtind/jokul/components/input-group";',
         ],
         props: {
-            labelType: figma.enum("Variant", {
+            labelType: figma.enum("Type", {
                 Help: "help",
                 Error: "error",
             }),
-            label: figma.enum("Variant", {
+            label: figma.enum("Type", {
                 Help: figma.textContent("Support Text"),
                 Error: figma.textContent("Error Text"),
             }),

--- a/packages/jokul/src/components/message/Message.figma.tsx
+++ b/packages/jokul/src/components/message/Message.figma.tsx
@@ -16,7 +16,7 @@ figma.connect(
                 true: figma.string("Title"),
                 false: undefined,
             }),
-            variant: figma.enum("Variant", {
+            variant: figma.enum("Type", {
                 Error: "error",
                 Warning: "warning",
                 Success: "success",

--- a/packages/jokul/src/components/system-message/SystemMessage.figma.tsx
+++ b/packages/jokul/src/components/system-message/SystemMessage.figma.tsx
@@ -12,11 +12,10 @@ figma.connect(
         props: {
             children: figma.string("Text"),
             dismissable: figma.boolean("Dismissable"),
-            variant: figma.enum("Variant", {
+            variant: figma.enum("Type", {
                 Info: "info",
                 Warning: "warning",
                 Error: "error",
-                Success: "success",
             }),
         },
         example: (props) => <SystemMessage {...props} />,

--- a/packages/jokul/src/components/tag/Tag.figma.tsx
+++ b/packages/jokul/src/components/tag/Tag.figma.tsx
@@ -9,7 +9,7 @@ figma.connect(
         imports: ['import { Tag } from "@fremtind/jokul/components/tag";'],
         props: {
             children: figma.string("Text"),
-            variant: figma.enum("Variant", {
+            variant: figma.enum("Type", {
                 Error: "error",
                 Warning: "warning",
                 Success: "success",


### PR DESCRIPTION
## Summary
- Figma-komponenter har endret property-navn/-typer, så `figma:test:ci` feilet
- Oppdaterer Code Connect-filer til å matche gjeldende Figma-komponenter

## Endringer
- **Tag, SystemMessage, Message, SupportLabel**: `Variant` → `Type`
- **SystemMessage**: fjerner `Success`-variant som ikke finnes lenger
- **28 ikon-filer**: fjerner `Weight`-prop (Bold) som ikke lenger finnes på ikonene. `ErrorIcon` beholder Weight siden den fortsatt har den
- **Help**: fjerner `iconPosition` (`figma.enum("Text", …)`) og `buttonText` (`figma.textContent("Label")`) som ikke finnes lenger. Example forenklet
- **BreadcrumbItem**: `Current` er en VARIANT, ikke BOOLEAN — bytter `figma.boolean` til `figma.enum`

## Test plan
- [ ] `pnpm figma:test:ci` er grønn i CI (krever `FIGMA_ACCESS_TOKEN`)
- [ ] Lokalt: ingen "Validation failed"-meldinger fra `figma connect publish --dry-run`