### PR TITLE
fix: la eksplisitt open-prop overstyre context på Expander

### DIFF
--- a/.changeset/fix-expandablepanel-context-leak.md
+++ b/.changeset/fix-expandablepanel-context-leak.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fiks: `Expander` plukket opp open-state fra et omkringliggende `ExpandablePanel`. Konsekvensen var at f.eks. ekspanderbare tabellrader inne i et åpent panel viste pil opp selv om raden var lukket.
+
+Eksplisitt `open`-prop på `Expander` overstyrer nå alltid context-verdien. Context brukes bare når `open`-propen er utelatt. Lukker [#5565](https://github.com/fremtind/jokul/issues/5565).

--- a/packages/jokul/src/components/expander/Expander.test.tsx
+++ b/packages/jokul/src/components/expander/Expander.test.tsx
@@ -1,0 +1,75 @@
+import { act, render } from "@testing-library/react";
+import UserEventModule from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ExpandablePanel } from "./ExpandablePanel.js";
+import { Expander } from "./Expander.js";
+
+// https://github.com/testing-library/user-event/issues/1146
+// @ts-ignore typecheck liker ikke at default muligens ikke finnes
+const userEvent = UserEventModule.default ?? UserEventModule;
+
+describe("Expander", () => {
+    it("respekterer eksplisitt `open={false}` selv inne i et åpent ExpandablePanel", () => {
+        const { getAllByRole } = render(
+            <ExpandablePanel defaultOpen>
+                <ExpandablePanel.Header>Panel-tittel</ExpandablePanel.Header>
+                <ExpandablePanel.Content>
+                    <Expander as="button" open={false}>
+                        Lukket Expander
+                    </Expander>
+                </ExpandablePanel.Content>
+            </ExpandablePanel>,
+        );
+
+        const closedExpander = getAllByRole("button", {
+            name: "Lukket Expander",
+        })[0];
+
+        expect(closedExpander.className).not.toContain("jkl-expander--open");
+    });
+
+    it("arver context-state når `open` ikke er satt", () => {
+        const { getByText } = render(
+            <ExpandablePanel defaultOpen>
+                <ExpandablePanel.Header>Panel-tittel</ExpandablePanel.Header>
+            </ExpandablePanel>,
+        );
+
+        const header = getByText("Panel-tittel").closest(".jkl-expander");
+        expect(header?.className).toContain("jkl-expander--open");
+    });
+
+    it("kontrollert Expander toggler ikke omkringliggende ExpandablePanel ved klikk", async () => {
+        const onPanelOpenChange = vi.fn();
+        const onInnerClick = vi.fn();
+
+        const { getByRole } = render(
+            <ExpandablePanel
+                defaultOpen
+                onOpenChange={onPanelOpenChange}
+                data-testid="outer-panel"
+            >
+                <ExpandablePanel.Header>Ytre panel</ExpandablePanel.Header>
+                <ExpandablePanel.Content>
+                    <Expander
+                        as="button"
+                        open={false}
+                        onClick={onInnerClick}
+                    >
+                        Indre Expander
+                    </Expander>
+                </ExpandablePanel.Content>
+            </ExpandablePanel>,
+        );
+
+        await act(async () => {
+            await userEvent.click(
+                getByRole("button", { name: "Indre Expander" }),
+            );
+        });
+
+        expect(onInnerClick).toHaveBeenCalledTimes(1);
+        expect(onPanelOpenChange).not.toHaveBeenCalled();
+    });
+});

--- a/packages/jokul/src/components/expander/Expander.tsx
+++ b/packages/jokul/src/components/expander/Expander.tsx
@@ -39,11 +39,22 @@ export const Expander = React.forwardRef(function Expander<
     const internalRef = useRef<HTMLElement>();
     useImperativeHandle(ref, () => internalRef.current, []);
 
-    const isOpen = controlledOpen || contextOpen;
+    // Når `open`-propen er satt eier konsumenten state-en og Expander er
+    // kontrollert. Da skal vi ikke arve verken visning eller toggle-callback
+    // fra et omkringliggende ExpandablePanel — ellers ville klikk på en
+    // nestet Expander også togglet panelet.
+    const isControlled = typeof controlledOpen === "boolean";
+    const isOpen = isControlled ? controlledOpen : contextOpen;
 
     const Chevron = expandDirection === "up" ? ChevronUpIcon : ChevronDownIcon;
 
     useEffect(() => {
+        // Kontrollert Expander skal være helt isolert fra et eventuelt
+        // omkringliggende ExpandablePanel — hverken state, klikk eller
+        // høyde-rapportering skal arve oppover. Hopp over måling slik at
+        // panel-headerens fokuscontainer ikke får raden sin høyde.
+        if (isControlled) return;
+
         const observer = new ResizeObserver(() => {
             // Default to 64 if the height can not be read because that is
             // the height of the default summary element. In a custom component
@@ -56,7 +67,7 @@ export const Expander = React.forwardRef(function Expander<
             return () => observer.disconnect();
         }
         return () => {};
-    }, [setExpanderHeight]);
+    }, [isControlled, setExpanderHeight]);
 
     return (
         <El
@@ -73,7 +84,9 @@ export const Expander = React.forwardRef(function Expander<
             {...(as === "button" ? { type: rest.type || "button" } : {})}
             onClick={(e) => {
                 e.preventDefault();
-                onToggle();
+                if (!isControlled) {
+                    onToggle();
+                }
                 onClick?.(e);
             }}
             {...rest}

--- a/packages/jokul/src/components/expander/stories/ExpandablePanel.stories.tsx
+++ b/packages/jokul/src/components/expander/stories/ExpandablePanel.stories.tsx
@@ -368,3 +368,151 @@ export const ExpandablePanelLongTitle: Story = {
         });
     },
 };
+
+/**
+ * Regresjonstest for [#5565](https://github.com/fremtind/jokul/issues/5565):
+ * et åpent `ExpandablePanel` med en liste over forsikringer — hver
+ * forsikring har sin egen kontrollerte `Expander` som viser detaljer.
+ * Hver indre Expander styrer kun sin egen state, og klikk på dem skal
+ * ikke lukke det ytre panelet.
+ */
+export const ExpandablePanelNestedExpanders: Story = {
+    name: "Nestet Expander leser sin egen state",
+    args: {
+        variant: "stroke",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: "50dvw", padding: "24px" }}>
+                <div style={{ width: "min(100%, 36rem)" }}>
+                    <Story />
+                </div>
+            </div>
+        ),
+    ],
+    render: (args) => {
+        const forsikringer = [
+            {
+                key: "bil",
+                navn: "Bilforsikring",
+                pris: "412 kr / mnd",
+                detaljer:
+                    "Kasko med leiebil. Egenandel 4 000 kr. Avtalenummer FT-2026-487312.",
+            },
+            {
+                key: "hus",
+                navn: "Husforsikring",
+                pris: "289 kr / mnd",
+                detaljer:
+                    "Innbo og bygning. Egenandel 6 000 kr. Avtalenummer FT-2026-119041.",
+            },
+            {
+                key: "reise",
+                navn: "Reiseforsikring",
+                pris: "98 kr / mnd",
+                detaljer:
+                    "Familie, hele verden, hele året. Egenandel 1 500 kr. Avtalenummer FT-2026-552207.",
+            },
+        ];
+
+        const ForsikringsRad = ({
+            forsikring,
+        }: {
+            forsikring: (typeof forsikringer)[number];
+        }) => {
+            const [open, setOpen] = React.useState(false);
+            const detailsId = `details-${forsikring.key}`;
+            return (
+                <div
+                    style={{
+                        borderTop: "1px solid rgba(0,0,0,.12)",
+                        paddingBlock: "8px",
+                    }}
+                >
+                    <Expander
+                        as="button"
+                        open={open}
+                        onClick={() => setOpen((v) => !v)}
+                        data-testid={`row-${forsikring.key}`}
+                        aria-expanded={open}
+                        aria-controls={detailsId}
+                        style={{ width: "100%" }}
+                    >
+                        <Flex
+                            direction="row"
+                            justifyContent="space-between"
+                            style={{ flex: 1 }}
+                        >
+                            <span>{forsikring.navn}</span>
+                            <span>{forsikring.pris}</span>
+                        </Flex>
+                    </Expander>
+                    {open && (
+                        <p
+                            id={detailsId}
+                            style={{
+                                margin: "8px 0 0",
+                                paddingInline: "8px",
+                                color: "var(--jkl-color-text-subdued)",
+                            }}
+                            data-testid={`details-${forsikring.key}`}
+                        >
+                            {forsikring.detaljer}
+                        </p>
+                    )}
+                </div>
+            );
+        };
+
+        return (
+            <ExpandablePanel {...args} defaultOpen>
+                <ExpandablePanel.Header data-testid="outer-trigger">
+                    Forsikringene dine (3)
+                </ExpandablePanel.Header>
+                <ExpandablePanel.Content>
+                    <Flex direction="column" gap="none">
+                        {forsikringer.map((f) => (
+                            <ForsikringsRad key={f.key} forsikring={f} />
+                        ))}
+                    </Flex>
+                </ExpandablePanel.Content>
+            </ExpandablePanel>
+        );
+    },
+    play: async ({ canvas, canvasElement, userEvent, step }) => {
+        await step(
+            "Alle radene er lukket selv om panelet er åpent",
+            async () => {
+                const bil = canvas.getByTestId("row-bil");
+                const hus = canvas.getByTestId("row-hus");
+                const reise = canvas.getByTestId("row-reise");
+
+                expect(bil.className).not.toContain("jkl-expander--open");
+                expect(hus.className).not.toContain("jkl-expander--open");
+                expect(reise.className).not.toContain("jkl-expander--open");
+            },
+        );
+
+        await step(
+            "Klikk på en rad åpner kun den raden, ikke det ytre panelet",
+            async () => {
+                const bilRad = canvas.getByTestId("row-bil");
+                const outerPanel = canvasElement.querySelector(
+                    "[data-testid='jkl-expand-section']",
+                ) as HTMLDetailsElement;
+
+                await userEvent.click(bilRad);
+
+                expect(bilRad.className).toContain("jkl-expander--open");
+                expect(canvas.getByTestId("details-bil")).toBeInTheDocument();
+                // Det ytre panelet skal fortsatt være åpent
+                expect(outerPanel.open).toBe(true);
+
+                // Naborader er fortsatt lukket
+                expect(canvas.getByTestId("row-hus").className).not.toContain(
+                    "jkl-expander--open",
+                );
+            },
+        );
+    },
+};


### PR DESCRIPTION
## Endringer

- `Expander` introduserer `isControlled = typeof open === "boolean"`. Når kontrollert: leser kun `open`-prop, hopper over context-callbacks og høyde-effekt.

## Lukker

Closes #5565 