### PR TITLE
Add theme builder to portal

### DIFF
--- a/.changeset/silent-seas-march.md
+++ b/.changeset/silent-seas-march.md
@@ -1,0 +1,7 @@
+---
+"portal": patch
+---
+
+La til en ny `/theme-builder`-flate i portalen for å utforske og redigere fargetokens.
+
+Løsningen bygger på `color.tokens.json`, bruker Jøkul-komponenter i editor og forhåndsvisning, og støtter både visuell redigering og redigering i rå JSON.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 .DS_Store
 .stylelintcache
 **/public/fonts
+portal/public/images
 **/vite.build.config.mjs.timestamp-*
 test-results/
 playwright-report/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "lint:fix": "biome check --write --reporter=summary",
         "lint:ci": "biome lint --reporter=github",
         "ci:test": "run-p test lint:ci typecheck",
-        "test": "pnpm --filter \"@fremtind/jokul\" test",
+        "test": "pnpm --filter \"@fremtind/jokul\" test && pnpm --filter portal test",
         "changeset": "changeset",
         "release:version": "changeset version",
         "release:pre:enter": "changeset pre enter next",

--- a/packages/jokul/stories/patterns/Detaljside.stories.tsx
+++ b/packages/jokul/stories/patterns/Detaljside.stories.tsx
@@ -78,8 +78,7 @@ export const Detaljside: Story = {
                                     className="jkl-heading-2"
                                     style={
                                         {
-                                            "text-box":
-                                                "trim-both cap alphabetic",
+                                            textBox: "trim-both cap alphabetic",
                                         } as CSSProperties
                                     }
                                 >
@@ -172,8 +171,7 @@ export const DetaljsideMedUlikeSizes: Story = {
                                     className="jkl-heading-2"
                                     style={
                                         {
-                                            "text-box":
-                                                "trim-both cap alphabetic",
+                                            textBox: "trim-both cap alphabetic",
                                         } as CSSProperties
                                     }
                                 >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/nextjs':
         specifier: 10.1.11
-        version: 10.1.11(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
+        version: 10.1.11(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12)(next@16.1.6(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
       '@storybook/react-vite':
         specifier: 10.1.11
         version: 10.1.11(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
@@ -426,6 +426,9 @@ importers:
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
+      colorjs.io:
+        specifier: 0.6.1
+        version: 0.6.1
       cookies-next:
         specifier: ^6.0.0
         version: 6.1.1(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react@18.3.1)
@@ -481,15 +484,24 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
         version: 16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
 
 packages:
 
@@ -5791,6 +5803,9 @@ packages:
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
+  colorjs.io@0.6.1:
+    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -7271,6 +7286,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -11610,6 +11626,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv7@0.4.4:
@@ -12285,8 +12302,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -12301,7 +12318,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -12327,7 +12344,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -12340,7 +12357,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -12375,8 +12392,8 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
@@ -12398,15 +12415,15 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12422,16 +12439,16 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12446,7 +12463,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
@@ -12457,7 +12474,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12466,7 +12483,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12475,7 +12492,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12484,7 +12501,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12500,7 +12517,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12513,15 +12530,15 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.28.4':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/helpers@7.28.6':
     dependencies:
@@ -12530,7 +12547,7 @@ snapshots:
 
   '@babel/parser@7.28.5':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -12539,43 +12556,43 @@ snapshots:
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -12584,7 +12601,7 @@ snapshots:
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.0)
     transitivePeerDependencies:
@@ -12593,8 +12610,8 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12617,7 +12634,7 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -12632,12 +12649,12 @@ snapshots:
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -12657,12 +12674,12 @@ snapshots:
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12672,101 +12689,101 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12783,7 +12800,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -12800,17 +12817,17 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12837,7 +12854,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -12853,11 +12870,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12876,8 +12893,8 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
 
   '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12888,16 +12905,16 @@ snapshots:
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12905,7 +12922,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12916,18 +12933,18 @@ snapshots:
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
@@ -12938,17 +12955,17 @@ snapshots:
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -12964,7 +12981,7 @@ snapshots:
   '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12984,7 +13001,7 @@ snapshots:
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12992,7 +13009,7 @@ snapshots:
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -13000,25 +13017,25 @@ snapshots:
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13028,17 +13045,17 @@ snapshots:
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13048,42 +13065,42 @@ snapshots:
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13098,10 +13115,10 @@ snapshots:
   '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13118,16 +13135,16 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13135,7 +13152,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
@@ -13146,17 +13163,17 @@ snapshots:
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13198,7 +13215,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -13206,7 +13223,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
@@ -13214,7 +13231,7 @@ snapshots:
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13224,7 +13241,7 @@ snapshots:
   '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -13232,7 +13249,7 @@ snapshots:
   '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -13248,18 +13265,18 @@ snapshots:
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13276,7 +13293,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13292,12 +13309,12 @@ snapshots:
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
     dependencies:
@@ -13323,25 +13340,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -13380,7 +13387,7 @@ snapshots:
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
     dependencies:
@@ -13391,7 +13398,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13402,12 +13409,12 @@ snapshots:
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -13424,17 +13431,17 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -13450,39 +13457,39 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -13493,7 +13500,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
@@ -13502,18 +13509,18 @@ snapshots:
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13525,19 +13532,19 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -13700,15 +13707,15 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.28.5)':
@@ -13772,9 +13779,9 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
@@ -13784,12 +13791,12 @@ snapshots:
 
   '@babel/traverse@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.0
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -17231,7 +17238,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/nextjs@10.1.11(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))':
+  '@storybook/nextjs@10.1.11(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12)(next@16.1.6(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.93.3)(sass@1.94.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))(webpack-hot-middleware@2.26.1)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -17255,7 +17262,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0)
+      next: 16.1.6(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
       postcss: 8.5.6
       postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12))
@@ -17509,24 +17516,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -17993,9 +18000,9 @@ snapshots:
 
   '@vitejs/plugin-react@4.7.0(vite@7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -18005,13 +18012,25 @@ snapshots:
 
   '@vitejs/plugin-react@4.7.0(vite@7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -18043,13 +18062,21 @@ snapshots:
     optionalDependencies:
       vite: 7.2.2(@types/node@18.19.130)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -18577,7 +18604,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -19109,6 +19136,8 @@ snapshots:
   colorette@2.0.20: {}
 
   colorjs.io@0.5.2: {}
+
+  colorjs.io@0.6.1: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -20131,7 +20160,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -20154,7 +20183,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -20169,14 +20198,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -20191,7 +20220,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20790,7 +20819,7 @@ snapshots:
 
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.25.12)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
@@ -21900,7 +21929,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -21912,7 +21941,7 @@ snapshots:
 
   jest-message-util@30.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@jest/types': 30.2.0
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -21941,10 +21970,10 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -22043,7 +22072,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -22070,7 +22099,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.3
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -23008,6 +23037,32 @@ snapshots:
       - svelte
       - typescript
 
+  next@16.1.6(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0):
+    dependencies:
+      '@next/env': 16.1.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.19
+      caniuse-lite: 1.0.30001767
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.56.1
+      sass: 1.94.0
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0):
     dependencies:
       '@next/env': 16.1.6
@@ -23383,7 +23438,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -24013,9 +24068,9 @@ snapshots:
 
   react-docgen@7.1.1:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
       '@types/doctrine': 0.0.9
@@ -24028,7 +24083,7 @@ snapshots:
 
   react-docgen@8.0.2:
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@types/babel__core': 7.20.5
@@ -25440,6 +25495,13 @@ snapshots:
       stylis: 4.3.2
       tslib: 2.6.2
 
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.28.5
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -26236,13 +26298,34 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -26341,6 +26424,24 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.2
 
+  vite@7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.2.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.94.0
+      sass-embedded: 1.93.3
+      terser: 5.44.1
+      tsx: 4.20.6
+      yaml: 2.8.2
+
   vitest-axe@0.1.0(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)):
     dependencies:
       aria-query: 5.3.2
@@ -26351,11 +26452,11 @@ snapshots:
       redent: 3.0.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -26373,7 +26474,50 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.2(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.9)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.10.9
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.0)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@25.2.0)(jiti@1.21.7)(sass-embedded@1.93.3)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/portal/next.config.mjs
+++ b/portal/next.config.mjs
@@ -5,6 +5,15 @@ const nextConfig = {
     // Your Next.js config here
     pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 
+    // Theme-builderen importerer Storybook-stories fra `packages/jokul/stories/`
+    // og fontfiler fra `packages/jokul/src/`. Begge ligger utenfor `portal/`
+    // — eksplisitt opt-in til ekstern-katalog kompilering trengs for at
+    // builds (særlig isolerte CI-installs) skal plukke dem opp.
+    experimental: {
+        externalDir: true,
+    },
+    transpilePackages: ["@fremtind/jokul"],
+
     async redirects() {
         return [
             {
@@ -13,6 +22,20 @@ const nextConfig = {
                 permanent: false,
             },
         ];
+    },
+
+    webpack: (config) => {
+        // Match Storybook/Vite ESM resolution: let `.js` and `.jsx` imports
+        // fall through to `.ts`/`.tsx` source files. Needed when the portal
+        // imports Storybook story files that use ESM-style `.js`/`.jsx`
+        // import paths.
+        config.resolve = config.resolve ?? {};
+        config.resolve.extensionAlias = {
+            ...(config.resolve.extensionAlias ?? {}),
+            ".js": [".js", ".ts", ".tsx"],
+            ".jsx": [".jsx", ".tsx"],
+        };
+        return config;
     },
 };
 

--- a/portal/package.json
+++ b/portal/package.json
@@ -6,6 +6,12 @@
     "license": "MIT",
     "type": "module",
     "scripts": {
+        "predev": "pnpm sync-assets",
+        "prebuild": "pnpm sync-assets",
+        "test": "vitest run --config vite.test.config.mjs",
+        "sync-assets": "pnpm sync-fonts && pnpm sync-images",
+        "sync-fonts": "mkdir -p public/fonts && cp -R ../packages/jokul/src/fonts/brands/fremtind/. public/fonts/",
+        "sync-images": "mkdir -p public/images && cp -R ../storybook-public/images/. public/images/",
         "build": "cross-env NODE_OPTIONS=--no-deprecation next build --webpack",
         "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev -p 3333 --webpack",
         "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev -p 3333 --webpack",
@@ -20,9 +26,9 @@
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.1.6",
         "@portabletext/react": "^5.0.0",
-        "@sanity/code-input": "^6.0.4",
         "@portabletext/types": "^3.0.1",
         "@sanity/client": "^7.14.1",
+        "@sanity/code-input": "^6.0.4",
         "@sanity/icons": "^3.7.0",
         "@sanity/image-url": "^2.0.3",
         "@sanity/locale-nb-no": "^1.1.29",
@@ -30,6 +36,7 @@
         "@sanity/ui": "^3.1.11",
         "@sanity/vision": "^4.22.0",
         "@types/mdx": "^2.0.13",
+        "colorjs.io": "0.6.1",
         "cookies-next": "^6.0.0",
         "cross-env": "^10.1.0",
         "dompurify": "^3.3.1",
@@ -50,9 +57,12 @@
         "@types/node": "^24.10.9",
         "@types/react": "^18.3.20",
         "@types/react-dom": "^18.3.6",
+        "@vitejs/plugin-react": "^4.7.0",
         "eslint": "^9.39.2",
         "eslint-config-next": "16.1.6",
-        "typescript": "^5.8.3"
+        "jsdom": "^26.1.0",
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.4"
     },
     "engines": {
         "node": ">=21.0.0"

--- a/portal/src/app/(frontend)/temabygger/global.scss
+++ b/portal/src/app/(frontend)/temabygger/global.scss
@@ -1,0 +1,14 @@
+.jkl-theme-builder-layout {
+    min-height: 100dvh;
+    background-color: var(--jkl-color-background-page);
+}
+
+.jkl-theme-builder-main {
+    max-width: 1600px;
+    margin-inline: auto;
+    padding: var(--jkl-spacing-16);
+
+    @media (width >=940px) {
+        padding: var(--jkl-spacing-24);
+    }
+}

--- a/portal/src/app/(frontend)/temabygger/layout.tsx
+++ b/portal/src/app/(frontend)/temabygger/layout.tsx
@@ -1,0 +1,17 @@
+import "./global.scss";
+import { ThemeBuilderProvider } from "@/components/theme-builder/ThemeBuilderProvider";
+import { tokensFromSchema } from "@/components/theme-builder/tokens";
+
+type ThemeBuilderLayoutProps = {
+    children: React.ReactNode;
+};
+
+export default function ThemeBuilderLayout({
+    children,
+}: ThemeBuilderLayoutProps) {
+    return (
+        <ThemeBuilderProvider baseTokens={tokensFromSchema()}>
+            {children}
+        </ThemeBuilderProvider>
+    );
+}

--- a/portal/src/app/(frontend)/temabygger/page.tsx
+++ b/portal/src/app/(frontend)/temabygger/page.tsx
@@ -1,0 +1,5 @@
+import { ThemeBuilder } from "@/components/theme-builder/ThemeBuilder";
+
+export default function ThemeBuilderPage() {
+    return <ThemeBuilder />;
+}

--- a/portal/src/components/theme-builder/ThemeBuilder.tsx
+++ b/portal/src/components/theme-builder/ThemeBuilder.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import {
+    Modal,
+    ModalCloseButton,
+    ModalContainer,
+    ModalHeader,
+    ModalOverlay,
+    ModalTitle,
+    useModal,
+} from "@fremtind/jokul/modal";
+import { useState } from "react";
+import { useThemeBuilder } from "./ThemeBuilderProvider";
+import { DEFAULT_DISPLAY_STATE, type DisplayState } from "./displayAttributes";
+import { EditorRoot } from "./editor/EditorRoot";
+import { PageHeader } from "./layout/PageHeader";
+import { WorkspaceTabs } from "./layout/WorkspaceTabs";
+
+const EDITOR_TITLE = "Editor";
+
+/**
+ * Toppnivå-side for theme-builder. Editoren ligger i en høyre-festet Modal;
+ * workspace-en under viser fanene fra {@link WorkspaceTabs}. Display-staten
+ * (theme/brand/size) eies her men sendes inn til demo-fanen — øvrige faner
+ * inspiserer tokens, ikke det rendrede chromet, og ignorerer den.
+ */
+export function ThemeBuilder() {
+    const { tokens } = useThemeBuilder();
+    const [display, setDisplay] = useState<DisplayState>(DEFAULT_DISPLAY_STATE);
+    const [instance, { title, overlay, container, modal, closeButton }] =
+        useModal({ title: EDITOR_TITLE, role: "dialog" });
+
+    return (
+        <Flex direction="column" gap="l">
+            <PageHeader onOpenEditor={() => instance?.show()} />
+            <ModalContainer {...container} placement="right" slideIn>
+                <ModalOverlay {...overlay} transparent={true} />
+                <Modal {...modal} padding={24}>
+                    <ModalHeader>
+                        <ModalTitle {...title}>{EDITOR_TITLE}</ModalTitle>
+                        <ModalCloseButton {...closeButton} />
+                    </ModalHeader>
+                    <EditorRoot />
+                </Modal>
+            </ModalContainer>
+            <WorkspaceTabs
+                tokens={tokens}
+                display={display}
+                onDisplayChange={setDisplay}
+            />
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/ThemeBuilderProvider.tsx
+++ b/portal/src/components/theme-builder/ThemeBuilderProvider.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import {
+    type PropsWithChildren,
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import {
+    type ColorToken,
+    type ThemeMode,
+    tokenKey,
+    tokensToSchema,
+} from "./tokens";
+import { normalizeHex, tokensEqual, tokensHaveErrors } from "./utils";
+
+const STORAGE_KEY = "jkl.theme-builder.draft.v1";
+const HISTORY_LIMIT = 50;
+const EXPORT_FILE_NAME = "color.custom-brand.tokens.json";
+
+type DraftSnapshot = {
+    tokens: ColorToken[];
+};
+
+/**
+ * Den offentlige formen til theme-builder-konteksten. Les state og kjør
+ * mutasjoner fra hvilken som helst etterkommer via {@link useThemeBuilder}.
+ */
+type ThemeBuilderContextValue = {
+    /** Aktiv token-state (den redigerbare arbeidskopien av strukturen). */
+    tokens: ColorToken[];
+    /** Pretty-printed JSON av nåværende tokens, klar for kopi/nedlasting. */
+    exportValue: string;
+    /** Foreslått filnavn for eksport. */
+    fileName: string;
+    /** Sann når et eller flere tokens har ugyldig heks-verdi. */
+    hasValidationErrors: boolean;
+    /** Sann når arbeidskopien er endret fra opprinnelig lastede tokens. */
+    isDirty: boolean;
+    /** Settet med `tokenKey`-strenger for tokens som skiller seg fra basen. */
+    editedTokenKeys: ReadonlySet<string>;
+    /** Filter-streng (case-insensitiv match mot `group.role`). */
+    filter: string;
+    setFilter: (next: string) => void;
+    /** Vis kun tokens som er endret fra basen. */
+    showOnlyEdited: boolean;
+    setShowOnlyEdited: (next: boolean) => void;
+    canUndo: boolean;
+    canRedo: boolean;
+    undo: () => void;
+    redo: () => void;
+    copyExport: () => Promise<void>;
+    downloadExport: () => void;
+    /** Tilbakestiller tokens til opprinnelig sett. */
+    reset: () => void;
+    /** Bytter alle tokens — brukes av JSON-editoren etter vellykket parse. */
+    replaceTokens: (tokens: ColorToken[]) => void;
+    /** Oppdaterer én (token, mode) heks-verdi. `tokenId` er `tokenKey(token)`. */
+    updateToken: (tokenId: string, mode: ThemeMode, value: string) => void;
+};
+
+const ThemeBuilderContext = createContext<ThemeBuilderContextValue | null>(
+    null,
+);
+
+type ThemeBuilderProviderProps = PropsWithChildren<{
+    baseTokens: ColorToken[];
+}>;
+
+/**
+ * Wrapper rundt theme-builder-siden, og eier den redigerbare token-staten.
+ * `baseTokens` er opprinnelig snapshot — brukes som starttilstand og
+ * sammenligningsgrunnlag for `isDirty`/`reset`.
+ *
+ * Provideren støtter også undo/redo, automatisk lagring i `localStorage`,
+ * og filter for å begrense synlige tokens.
+ */
+export function ThemeBuilderProvider({
+    baseTokens,
+    children,
+}: ThemeBuilderProviderProps) {
+    const [tokens, setTokensState] = useState(baseTokens);
+    const [history, setHistory] = useState<DraftSnapshot[]>([]);
+    const [future, setFuture] = useState<DraftSnapshot[]>([]);
+    const [filter, setFilter] = useState("");
+    const [showOnlyEdited, setShowOnlyEdited] = useState(false);
+    const hydrated = useRef(false);
+
+    // --- Hydrer fra localStorage én gang per session ---
+    useEffect(() => {
+        if (hydrated.current) return;
+        hydrated.current = true;
+        if (typeof window === "undefined") return;
+        try {
+            const raw = window.localStorage.getItem(STORAGE_KEY);
+            if (!raw) return;
+            const draft = JSON.parse(raw) as DraftSnapshot;
+            if (Array.isArray(draft.tokens)) {
+                setTokensState(draft.tokens);
+            }
+        } catch {
+            // Ignorer korrupt draft.
+        }
+    }, []);
+
+    // --- Persistér til localStorage ved hver endring ---
+    useEffect(() => {
+        if (!hydrated.current || typeof window === "undefined") return;
+        try {
+            window.localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({ tokens }),
+            );
+        } catch {
+            // Quota eller private-mode — ignorer.
+        }
+    }, [tokens]);
+
+    const snapshot = useCallback((): DraftSnapshot => ({ tokens }), [tokens]);
+
+    const pushHistory = useCallback((snap: DraftSnapshot) => {
+        setHistory((h) => [...h.slice(-HISTORY_LIMIT + 1), snap]);
+        setFuture([]);
+    }, []);
+
+    const commit = useCallback(
+        (next: { tokens: ColorToken[] }) => {
+            const before = snapshot();
+            setTokensState(next.tokens);
+            pushHistory(before);
+        },
+        [pushHistory, snapshot],
+    );
+
+    const updateToken = useCallback(
+        (tokenId: string, mode: ThemeMode, value: string) => {
+            const next = tokens.map((token) =>
+                tokenKey(token) === tokenId
+                    ? { ...token, [mode]: normalizeHex(value) }
+                    : token,
+            );
+            commit({ tokens: next });
+        },
+        [tokens, commit],
+    );
+
+    const replaceTokens = useCallback(
+        (next: ColorToken[]) => {
+            commit({ tokens: next });
+        },
+        [commit],
+    );
+
+    const reset = useCallback(() => {
+        commit({ tokens: baseTokens });
+    }, [baseTokens, commit]);
+
+    const undo = useCallback(() => {
+        setHistory((h) => {
+            if (h.length === 0) return h;
+            const previous = h[h.length - 1];
+            setFuture((f) => [...f, { tokens }]);
+            setTokensState(previous.tokens);
+            return h.slice(0, -1);
+        });
+    }, [tokens]);
+
+    const redo = useCallback(() => {
+        setFuture((f) => {
+            if (f.length === 0) return f;
+            const next = f[f.length - 1];
+            setHistory((h) => [...h, { tokens }]);
+            setTokensState(next.tokens);
+            return f.slice(0, -1);
+        });
+    }, [tokens]);
+
+    // --- Avledede verdier ---
+    const exportValue = useMemo(
+        () => JSON.stringify(tokensToSchema(tokens), null, 4),
+        [tokens],
+    );
+    const hasValidationErrors = useMemo(
+        () => tokensHaveErrors(tokens),
+        [tokens],
+    );
+    const isDirty = useMemo(
+        () => !tokensEqual(tokens, baseTokens),
+        [tokens, baseTokens],
+    );
+    const editedTokenKeys = useMemo(() => {
+        const baseByKey = new Map(baseTokens.map((t) => [tokenKey(t), t]));
+        const edited = new Set<string>();
+        for (const t of tokens) {
+            const base = baseByKey.get(tokenKey(t));
+            if (!base) continue;
+            const changed = Object.keys(t).some(
+                (k) =>
+                    k !== "variant" &&
+                    k !== "group" &&
+                    k !== "role" &&
+                    (t as Record<string, string>)[k] !==
+                        (base as Record<string, string>)[k],
+            );
+            if (changed) edited.add(tokenKey(t));
+        }
+        return edited;
+    }, [tokens, baseTokens]);
+
+    // --- Eksport-handlere (med fallback ved manglende clipboard-permission) ---
+    const copyExport = useCallback(async () => {
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(exportValue);
+                return;
+            }
+            if (!fallbackCopyToClipboard(exportValue)) {
+                throw new Error("Clipboard API utilgjengelig");
+            }
+        } catch (error) {
+            if (!fallbackCopyToClipboard(exportValue)) {
+                console.error("Kunne ikke kopiere eksporten.", error);
+                window.alert(
+                    "Kunne ikke kopiere automatisk. Bruk Last ned i stedet.",
+                );
+            }
+        }
+    }, [exportValue]);
+
+    const downloadExport = useCallback(() => {
+        const blob = new Blob([exportValue], {
+            type: "application/json;charset=utf-8",
+        });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = EXPORT_FILE_NAME;
+        document.body.append(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+    }, [exportValue]);
+
+    const value = useMemo<ThemeBuilderContextValue>(
+        () => ({
+            copyExport,
+            downloadExport,
+            exportValue,
+            fileName: EXPORT_FILE_NAME,
+            hasValidationErrors,
+            isDirty,
+            editedTokenKeys,
+            filter,
+            setFilter,
+            showOnlyEdited,
+            setShowOnlyEdited,
+            canUndo: history.length > 0,
+            canRedo: future.length > 0,
+            undo,
+            redo,
+            replaceTokens,
+            reset,
+            tokens,
+            updateToken,
+        }),
+        [
+            copyExport,
+            downloadExport,
+            exportValue,
+            hasValidationErrors,
+            isDirty,
+            editedTokenKeys,
+            filter,
+            showOnlyEdited,
+            history.length,
+            future.length,
+            undo,
+            redo,
+            replaceTokens,
+            reset,
+            tokens,
+            updateToken,
+        ],
+    );
+
+    return (
+        <ThemeBuilderContext.Provider value={value}>
+            {children}
+        </ThemeBuilderContext.Provider>
+    );
+}
+
+/**
+ * Skjult `<textarea>` + `document.execCommand("copy")` som fallback når
+ * Clipboard API ikke er tilgjengelig (ikke-secure context, manglende
+ * permissions, etc.). Returnerer `true` hvis kopieringen lyktes.
+ */
+function fallbackCopyToClipboard(value: string): boolean {
+    if (typeof document === "undefined") return false;
+    const textArea = document.createElement("textarea");
+    textArea.value = value;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "fixed";
+    textArea.style.opacity = "0";
+    textArea.style.pointerEvents = "none";
+    document.body.append(textArea);
+    textArea.focus();
+    textArea.select();
+    let didCopy = false;
+    try {
+        didCopy = document.execCommand("copy");
+    } catch {
+        didCopy = false;
+    }
+    textArea.remove();
+    return didCopy;
+}
+
+/** Hook for å lese state og mutasjoner fra nærmeste `ThemeBuilderProvider`. */
+export function useThemeBuilder() {
+    const context = useContext(ThemeBuilderContext);
+
+    if (!context) {
+        throw new Error(
+            "useThemeBuilder must be used within ThemeBuilderProvider",
+        );
+    }
+
+    return context;
+}

--- a/portal/src/components/theme-builder/TokenFilter.tsx
+++ b/portal/src/components/theme-builder/TokenFilter.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import { Search } from "@fremtind/jokul/search";
+import { ToggleSwitch } from "@fremtind/jokul/toggle-switch";
+import { useThemeBuilder } from "./ThemeBuilderProvider";
+
+/**
+ * Søkefelt + "vis kun endrede"-toggle for å begrense token-lista.
+ * Begge styrer felles state i provideren slik at filtreringen er konsistent
+ * mellom editor (visuell) og Farge-tokens-fanen.
+ */
+export function TokenFilter() {
+    const { filter, setFilter, showOnlyEdited, setShowOnlyEdited, isDirty } =
+        useThemeBuilder();
+
+    return (
+        <Flex direction="row" wrap="wrap" alignItems="center" gap="m">
+            <Search
+                label="Filtrer tokens"
+                labelProps={{ srOnly: true }}
+                placeholder="text.default, background, …"
+                icon="filter_list"
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
+                data-size="small"
+            />
+            <ToggleSwitch
+                aria-pressed={showOnlyEdited}
+                disabled={!isDirty}
+                onChange={(_event, pressed) => setShowOnlyEdited(pressed)}
+            >
+                Vis kun endrede
+            </ToggleSwitch>
+        </Flex>
+    );
+}
+
+/** Felles filter-predikat. Tomt filter slipper alt gjennom. */
+export function tokenMatchesFilter(
+    token: { group: string; role: string },
+    filter: string,
+): boolean {
+    if (!filter.trim()) return true;
+    const path = `${token.group}.${token.role}`;
+    return path.toLowerCase().includes(filter.trim().toLowerCase());
+}

--- a/portal/src/components/theme-builder/displayAttributes.ts
+++ b/portal/src/components/theme-builder/displayAttributes.ts
@@ -1,0 +1,102 @@
+import { THEME_MODES } from "./tokens";
+
+/**
+ * Liste over støttede merker, utledet fra brand-token-mappa
+ * `packages/jokul/src/tokens/brands/`.
+ *
+ * `jokul` er base-merket og leveres uten separat JSON. Øvrige merker hentes
+ * via webpack `require.context` på `color.<brand>.tokens.json`-filene, så
+ * lista holdes automatisk i synk med hvilke merker som er definert i JSON.
+ * Legges en ny `color.foo.tokens.json` til, dukker `foo` opp her — uten
+ * koderedigering.
+ */
+const BRANDS: readonly string[] = (() => {
+    const jokul = "jokul";
+    try {
+        const ctx = (
+            require as unknown as {
+                context: (
+                    dir: string,
+                    deep: boolean,
+                    pattern: RegExp,
+                ) => { keys: () => string[] };
+            }
+        ).context(
+            "../../../../packages/jokul/src/tokens/brands",
+            false,
+            /^\.\/color\.[\w-]+\.tokens\.json$/,
+        );
+        const derived = ctx
+            .keys()
+            .map((key) => key.match(/color\.([\w-]+)\.tokens\.json$/)?.[1])
+            .filter((value): value is string => Boolean(value))
+            .filter((brand) => brand !== jokul)
+            .sort();
+        return [jokul, ...derived];
+    } catch {
+        // require.context er ikke tilgjengelig (f.eks. ved typecheck uten
+        // webpack). Fall tilbake til den kjente lista — den dekker dagens
+        // merker, og build-en vil uansett feile hvis noen JSON-fil mangler
+        // siden `transpilePackages` krever at de finnes.
+        return [jokul, "dnb", "eika", "sparebank1"];
+    }
+})();
+
+/**
+ * Register over `data-*`-attributter som styrer visningen, og som theme-builder
+ * eksponerer via popoveren over workspace-en.
+ *
+ * Legg til en ny attributt her, så dukker den opp som en kontroll automatisk.
+ * `key` blir det rendrede `data-<key>`-attributtet, og {@link DisplayState}
+ * utledes fra denne lista.
+ *
+ * Hvor verdiene kommer fra er opp til hver entry: theme speiler
+ * {@link THEME_MODES} (utledet fra `color.tokens.json`), brand utledes fra
+ * `tokens/brands/`-mappa, og size er CSS-data-attributter som ikke har
+ * en JSON-kilde — de matcher Jøkuls `[data-size]`-stiler.
+ */
+export const DATA_ATTRIBUTES = [
+    {
+        key: "theme",
+        label: "Color theme",
+        values: THEME_MODES as readonly string[],
+        default: THEME_MODES[0] as string,
+    },
+    {
+        key: "brand",
+        label: "Brand",
+        values: BRANDS,
+        default: BRANDS[0],
+    },
+    {
+        key: "size",
+        label: "Size",
+        values: ["small", "medium", "large"] as readonly string[],
+        default: "medium",
+    },
+] as const satisfies readonly {
+    key: string;
+    label: string;
+    values: readonly string[];
+    default: string;
+}[];
+
+export type DisplayAttributeKey = (typeof DATA_ATTRIBUTES)[number]["key"];
+
+/** Aktivt valg per data-attributt. */
+export type DisplayState = Record<DisplayAttributeKey, string>;
+
+/** Starttilstand — `default`-verdien for hver attributt. */
+export const DEFAULT_DISPLAY_STATE: DisplayState = Object.fromEntries(
+    DATA_ATTRIBUTES.map((attr) => [attr.key, attr.default]),
+) as DisplayState;
+
+/**
+ * Bygger `data-*`-objektet som skal spredes på wrapper-elementet, slik at
+ * etterkommerne (Jøkul-stiler) plukker opp gjeldende valg.
+ */
+export function dataAttributes(state: DisplayState): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(state).map(([key, value]) => [`data-${key}`, value]),
+    );
+}

--- a/portal/src/components/theme-builder/editor/ColorField.tsx
+++ b/portal/src/components/theme-builder/editor/ColorField.tsx
@@ -1,0 +1,54 @@
+import { TextInput } from "@fremtind/jokul/text-input";
+import { memo } from "react";
+import { type ColorToken, type ThemeMode, tokenKey } from "../tokens";
+import { colorInputValue, hexErrorLabel } from "../utils";
+import type { TokenChangeHandler } from "./types";
+
+import styles from "./editor.module.scss";
+
+type ColorFieldProps = {
+    mode: ThemeMode;
+    token: ColorToken;
+    onTokenChange: TokenChangeHandler;
+};
+
+/**
+ * Kompakt fargevelger + heks-input-par for én (token, mode).
+ */
+export const ColorField = memo(function ColorField({
+    mode,
+    token,
+    onTokenChange,
+}: ColorFieldProps) {
+    const value = token[mode];
+    const id = tokenKey(token);
+    const tokenPath = `${token.group}.${token.role} ${mode}`;
+
+    return (
+        <div className={styles.colorField}>
+            <input
+                className={styles.colorPicker}
+                type="color"
+                aria-label={`${tokenPath} — fargevelger`}
+                value={colorInputValue(value)}
+                onChange={(event) =>
+                    onTokenChange(id, mode, event.target.value)
+                }
+            />
+            <TextInput
+                className={styles.hexInput}
+                label={`${tokenPath} — heks-verdi`}
+                labelProps={{ srOnly: true }}
+                data-size="small"
+                value={value}
+                maxLength={7}
+                spellCheck={false}
+                autoComplete="off"
+                errorLabel={hexErrorLabel(value)}
+                onChange={(event) =>
+                    onTokenChange(id, mode, event.target.value)
+                }
+            />
+        </div>
+    );
+});

--- a/portal/src/components/theme-builder/editor/EditorPanel.tsx
+++ b/portal/src/components/theme-builder/editor/EditorPanel.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import type { ColorToken, EditorMode } from "../tokens";
+import { EditorTopBar } from "./EditorTopBar";
+import { JsonEditor } from "./JsonEditor";
+import { VisualEditor } from "./VisualEditor";
+import type { TokenChangeHandler } from "./types";
+
+type EditorPanelProps = {
+    editorMode: EditorMode;
+    jsonError?: string;
+    jsonValue: string;
+    onEditorModeChange: (mode: EditorMode) => void;
+    onJsonValueChange: (value: string) => void;
+    onJsonCommit: () => void;
+    onTokenChange: TokenChangeHandler;
+    tokens: ColorToken[];
+};
+
+/**
+ * Tilstandsløs editor-body: top bar (utgangspunkt + modusvelger) og innhold
+ * (visuell eller JSON-editor). Tilbakestill- og eksport-knapper rendres av
+ * den omliggende Modal-en i `ModalActions`.
+ */
+export function EditorPanel({
+    editorMode,
+    jsonError,
+    jsonValue,
+    onEditorModeChange,
+    onJsonValueChange,
+    onJsonCommit,
+    onTokenChange,
+    tokens,
+}: EditorPanelProps) {
+    return (
+        <Flex direction="column" gap="m" data-editor-mode={editorMode}>
+            <EditorTopBar
+                editorMode={editorMode}
+                onEditorModeChange={onEditorModeChange}
+            />
+            {editorMode === "visual" ? (
+                <VisualEditor tokens={tokens} onTokenChange={onTokenChange} />
+            ) : (
+                <JsonEditor
+                    value={jsonValue}
+                    error={jsonError}
+                    onChange={onJsonValueChange}
+                    onCommit={onJsonCommit}
+                />
+            )}
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/editor/EditorRoot.tsx
+++ b/portal/src/components/theme-builder/editor/EditorRoot.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { Flex } from "@fremtind/jokul/flex";
+import { CopyIcon, Icon } from "@fremtind/jokul/icon";
+import { ModalActions, ModalBody } from "@fremtind/jokul/modal";
+import { useState } from "react";
+import { useThemeBuilder } from "../ThemeBuilderProvider";
+import type { EditorMode } from "../tokens";
+import { parseEditorJson } from "../utils";
+import { EditorPanel } from "./EditorPanel";
+
+import styles from "./editor.module.scss";
+
+/**
+ * Eier editorens lokale UI-state (modus, JSON-utkast, parsefeil) og rendrer
+ * Modal-ens body- og actions-slots. Actions-raden har to grupper:
+ * Tilbakestill til venstre, Kopier/Last ned til høyre.
+ */
+export function EditorRoot() {
+    const {
+        canRedo,
+        canUndo,
+        copyExport,
+        downloadExport,
+        exportValue,
+        hasValidationErrors,
+        redo,
+        replaceTokens,
+        reset,
+        tokens,
+        undo,
+        updateToken,
+    } = useThemeBuilder();
+
+    const [editorMode, setEditorMode] = useState<EditorMode>("visual");
+    const [jsonDraft, setJsonDraft] = useState(exportValue);
+    const [jsonError, setJsonError] = useState<string>();
+
+    const exportBlocked = hasValidationErrors || Boolean(jsonError);
+
+    const handleEditorModeChange = (next: EditorMode) => {
+        setEditorMode(next);
+        if (next === "json") setJsonDraft(exportValue);
+        setJsonError(undefined);
+    };
+
+    const handleJsonValueChange = (next: string) => {
+        setJsonDraft(next);
+        // Live parse-feedback uten å committe — committen skjer ved blur,
+        // ellers re-renderer hele provider-treet på hvert tastetrykk.
+        const result = parseEditorJson(next);
+        setJsonError(result.ok ? undefined : result.error);
+    };
+
+    const handleJsonCommit = () => {
+        const result = parseEditorJson(jsonDraft);
+        if (!result.ok) {
+            setJsonError(result.error);
+            return;
+        }
+        setJsonError(undefined);
+        replaceTokens(result.tokens);
+    };
+
+    const handleReset = () => {
+        reset();
+        setEditorMode("visual");
+        setJsonError(undefined);
+    };
+
+    return (
+        <>
+            <ModalBody>
+                <EditorPanel
+                    editorMode={editorMode}
+                    jsonError={jsonError}
+                    jsonValue={jsonDraft}
+                    onEditorModeChange={handleEditorModeChange}
+                    onJsonValueChange={handleJsonValueChange}
+                    onJsonCommit={handleJsonCommit}
+                    onTokenChange={updateToken}
+                    tokens={tokens}
+                />
+            </ModalBody>
+            <ModalActions className={styles.editorFooter}>
+                <Flex
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap="m"
+                    fill
+                >
+                    <Flex
+                        className={styles.footerGroup}
+                        alignItems="center"
+                        gap="2xs"
+                    >
+                        <Button
+                            variant="ghost"
+                            icon={<Icon bold>restart_alt</Icon>}
+                            onClick={handleReset}
+                        >
+                            Tilbakestill
+                        </Button>
+                        <span
+                            aria-hidden="true"
+                            className={styles.footerDivider}
+                        />
+                        <Button
+                            variant="ghost"
+                            data-size="small"
+                            icon={<Icon bold>undo</Icon>}
+                            aria-label="Angre"
+                            title="Angre"
+                            disabled={!canUndo}
+                            onClick={undo}
+                        />
+                        <Button
+                            variant="ghost"
+                            data-size="small"
+                            icon={<Icon bold>redo</Icon>}
+                            aria-label="Gjør om"
+                            title="Gjør om"
+                            disabled={!canRedo}
+                            onClick={redo}
+                        />
+                    </Flex>
+                    <Flex
+                        className={styles.footerGroup}
+                        alignItems="center"
+                        gap="2xs"
+                    >
+                        <Button
+                            variant="ghost"
+                            disabled={exportBlocked}
+                            icon={<CopyIcon bold />}
+                            onClick={copyExport}
+                        >
+                            Kopier
+                        </Button>
+                        <Button
+                            variant="primary"
+                            disabled={exportBlocked}
+                            icon={<Icon bold>download</Icon>}
+                            onClick={downloadExport}
+                        >
+                            Last ned
+                        </Button>
+                    </Flex>
+                </Flex>
+            </ModalActions>
+        </>
+    );
+}

--- a/portal/src/components/theme-builder/editor/EditorTopBar.tsx
+++ b/portal/src/components/theme-builder/editor/EditorTopBar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import {
+    SegmentedControl,
+    SegmentedControlButton,
+} from "@fremtind/jokul/segmented-control";
+import type { EditorMode } from "../tokens";
+
+import styles from "./editor.module.scss";
+
+type EditorTopBarProps = {
+    editorMode: EditorMode;
+    onEditorModeChange: (mode: EditorMode) => void;
+};
+
+const EDITOR_MODES: EditorMode[] = ["visual", "json"];
+
+/**
+ * Editor-topbar: kun modusvelger (visuell vs. JSON). Tilbakestill, undo/redo
+ * og eksport-kontroller ligger i omliggende `ModalActions`.
+ */
+export function EditorTopBar({
+    editorMode,
+    onEditorModeChange,
+}: EditorTopBarProps) {
+    return (
+        <Flex
+            className={styles.editorTopBar}
+            justifyContent="end"
+            alignItems="center"
+        >
+            <SegmentedControl legend="Redigeringsmodus">
+                {EDITOR_MODES.map((m) => (
+                    <SegmentedControlButton
+                        key={m}
+                        name="theme-builder-editor-mode"
+                        value={m}
+                        checked={editorMode === m}
+                        onChange={() => onEditorModeChange(m)}
+                    >
+                        {m}
+                    </SegmentedControlButton>
+                ))}
+            </SegmentedControl>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/editor/JsonEditor.tsx
+++ b/portal/src/components/theme-builder/editor/JsonEditor.tsx
@@ -1,0 +1,38 @@
+import { TextArea } from "@fremtind/jokul/text-area";
+
+import styles from "./editor.module.scss";
+
+type JsonEditorProps = {
+    value: string;
+    error?: string;
+    onChange: (value: string) => void;
+    /** Kalles ved blur — committer JSON-en til provider-staten. */
+    onCommit: () => void;
+};
+
+/**
+ * Rå JSON-editor for fargetokens. Live parse-feedback ved hver tastetrykk;
+ * faktisk commit til provider-staten skjer ved blur for å unngå at hele
+ * provider-treet re-renderer for hvert tegn.
+ */
+export function JsonEditor({
+    value,
+    error,
+    onChange,
+    onCommit,
+}: JsonEditorProps) {
+    return (
+        <TextArea
+            className={styles.jsonEditor}
+            label="Fargetokens JSON"
+            labelProps={{ srOnly: true }}
+            value={value}
+            spellCheck={false}
+            errorLabel={error}
+            rows={10}
+            style={{ minHeight: "min(60vh, 32rem)" }}
+            onChange={(event) => onChange(event.target.value)}
+            onBlur={onCommit}
+        />
+    );
+}

--- a/portal/src/components/theme-builder/editor/TokenRow.tsx
+++ b/portal/src/components/theme-builder/editor/TokenRow.tsx
@@ -1,0 +1,52 @@
+import { type CSSProperties, memo } from "react";
+import { type ColorToken, THEME_MODES } from "../tokens";
+import { ColorField } from "./ColorField";
+import type { TokenChangeHandler } from "./types";
+
+import styles from "./editor.module.scss";
+
+type TokenRowProps = {
+    token: ColorToken;
+    onTokenChange: TokenChangeHandler;
+};
+
+/**
+ * Kompakt token-rad: navn til venstre, ett `ColorField` per `THEME_MODES`-entry
+ * til høyre. Iterasjonen gjør at oppsettet følger token-skjemaet automatisk
+ * hvis JSON-en en gang får flere/færre theme-moduser.
+ *
+ * Memoiseres så bare den raden hvis token faktisk endret seg re-rendrer når
+ * tokens-arrayen i provider-en byttes ut. `updateToken`-callbacken er stabil
+ * via `useCallback`, så shallow-prop-likhet er nok.
+ */
+export const TokenRow = memo(function TokenRow({
+    token,
+    onTokenChange,
+}: TokenRowProps) {
+    const tokenName = `${token.group}.${token.role}`;
+
+    return (
+        <div className={styles.tokenRow}>
+            <code className={styles.tokenTitle} title={tokenName}>
+                {tokenName}
+            </code>
+            <div
+                className={styles.tokenControls}
+                style={
+                    {
+                        "--theme-mode-count": THEME_MODES.length,
+                    } as CSSProperties
+                }
+            >
+                {THEME_MODES.map((mode) => (
+                    <ColorField
+                        key={mode}
+                        mode={mode}
+                        token={token}
+                        onTokenChange={onTokenChange}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+});

--- a/portal/src/components/theme-builder/editor/VariantSection.tsx
+++ b/portal/src/components/theme-builder/editor/VariantSection.tsx
@@ -1,0 +1,60 @@
+import { ExpandablePanel } from "@fremtind/jokul/expander";
+import { Text } from "@fremtind/jokul/typography";
+import type { CSSProperties } from "react";
+import {
+    type ColorToken,
+    type ColorVariant,
+    THEME_MODES,
+    tokenKey,
+} from "../tokens";
+import { TokenRow } from "./TokenRow";
+import type { TokenChangeHandler } from "./types";
+
+import styles from "./editor.module.scss";
+
+type VariantSectionProps = {
+    variant: ColorVariant;
+    tokens: ColorToken[];
+    defaultOpen?: boolean;
+    onTokenChange: TokenChangeHandler;
+};
+
+/** Utvidbar seksjon for én fargevariant. */
+export function VariantSection({
+    variant,
+    tokens,
+    defaultOpen = false,
+    onTokenChange,
+}: VariantSectionProps) {
+    return (
+        <ExpandablePanel variant="stroke" defaultOpen={defaultOpen}>
+            <ExpandablePanel.Header>{variant}</ExpandablePanel.Header>
+            <ExpandablePanel.Content>
+                <div className={styles.tokenList}>
+                    <div
+                        className={styles.tokenColumnHeaders}
+                        aria-hidden="true"
+                        style={
+                            {
+                                "--theme-mode-count": THEME_MODES.length,
+                            } as CSSProperties
+                        }
+                    >
+                        {THEME_MODES.map((mode) => (
+                            <Text key={mode} as="span" size="xs">
+                                {mode}
+                            </Text>
+                        ))}
+                    </div>
+                    {tokens.map((token) => (
+                        <TokenRow
+                            key={tokenKey(token)}
+                            token={token}
+                            onTokenChange={onTokenChange}
+                        />
+                    ))}
+                </div>
+            </ExpandablePanel.Content>
+        </ExpandablePanel>
+    );
+}

--- a/portal/src/components/theme-builder/editor/VisualEditor.tsx
+++ b/portal/src/components/theme-builder/editor/VisualEditor.tsx
@@ -1,0 +1,64 @@
+import { Flex } from "@fremtind/jokul/flex";
+import { useMemo } from "react";
+import { useThemeBuilder } from "../ThemeBuilderProvider";
+import { TokenFilter, tokenMatchesFilter } from "../TokenFilter";
+import {
+    COLOR_VARIANTS,
+    type ColorToken,
+    type ColorVariant,
+    tokenKey,
+} from "../tokens";
+import { VariantSection } from "./VariantSection";
+import type { TokenChangeHandler } from "./types";
+
+import styles from "./editor.module.scss";
+
+type VisualEditorProps = {
+    tokens: ColorToken[];
+    onTokenChange: TokenChangeHandler;
+};
+
+/**
+ * Visuell editor — én utvidbar seksjon per fargevariant; den første er åpen
+ * som standard. Seksjonene står tett mot hverandre (uten mellomrom) slik at
+ * borderne kollapser i én sammenhengende stabel.
+ *
+ * Filteret og "vis kun endrede"-toggle deles med tokens-fanen via
+ * provider-staten, og varianter uten matchende tokens skjules helt.
+ */
+export function VisualEditor({ tokens, onTokenChange }: VisualEditorProps) {
+    const { filter, showOnlyEdited, editedTokenKeys } = useThemeBuilder();
+
+    const tokensByVariant = useMemo(() => {
+        const map = new Map<ColorVariant, ColorToken[]>();
+        for (const variant of COLOR_VARIANTS) map.set(variant, []);
+        for (const token of tokens) {
+            if (showOnlyEdited && !editedTokenKeys.has(tokenKey(token)))
+                continue;
+            if (!tokenMatchesFilter(token, filter)) continue;
+            map.get(token.variant)?.push(token);
+        }
+        return map;
+    }, [tokens, filter, showOnlyEdited, editedTokenKeys]);
+
+    return (
+        <Flex direction="column" gap="m">
+            <TokenFilter />
+            <div className={styles.variantStack}>
+                {COLOR_VARIANTS.map((variant, index) => {
+                    const variantTokens = tokensByVariant.get(variant) ?? [];
+                    if (variantTokens.length === 0) return null;
+                    return (
+                        <VariantSection
+                            key={variant}
+                            variant={variant}
+                            defaultOpen={index === 0}
+                            tokens={variantTokens}
+                            onTokenChange={onTokenChange}
+                        />
+                    );
+                })}
+            </div>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/editor/editor.module.scss
+++ b/portal/src/components/theme-builder/editor/editor.module.scss
@@ -1,0 +1,124 @@
+@use "@fremtind/jokul/styles/jkl";
+
+.editorTopBar {
+    border-block-end: 1px solid var(--jkl-color-border-subdued);
+    padding-block-end: var(--jkl-spacing-16);
+}
+
+.fileNameHint {
+    color: var(--jkl-color-text-subdued);
+    font-variant-numeric: tabular-nums;
+}
+
+.editorFooter {
+    margin-block-start: var(--jkl-spacing-24);
+    padding-block-start: var(--jkl-spacing-16);
+    border-block-start: 1px solid var(--jkl-color-border-subdued);
+}
+
+.footerGroup {
+    padding: var(--jkl-spacing-4) var(--jkl-spacing-8);
+    border-radius: var(--jkl-border-radius-s);
+    background-color: var(--jkl-color-background-subdued);
+}
+
+.footerDivider {
+    display: inline-block;
+    inline-size: 1px;
+    block-size: 1.5rem;
+    margin-inline: var(--jkl-spacing-4);
+    background-color: var(--jkl-color-border-subdued);
+}
+
+.variantStack {
+    display: flex;
+    flex-direction: column;
+}
+
+.variantStack > * + * {
+    margin-block-start: -1px;
+}
+
+.tokenList {
+    display: grid;
+    gap: var(--jkl-spacing-4);
+}
+
+.tokenColumnHeaders {
+    display: grid;
+    grid-template-columns: repeat(var(--theme-mode-count, 2), minmax(0, 1fr));
+    gap: var(--jkl-spacing-8);
+    margin-inline-start: auto;
+    color: var(--jkl-color-text-subdued);
+
+    @include jkl.text-style("text-micro");
+
+    @media (width >= 720px) {
+        inline-size: max(50%, 12rem);
+    }
+}
+
+.tokenRow {
+    display: grid;
+    gap: var(--jkl-spacing-8);
+    align-items: center;
+    min-width: 0;
+    padding-block: var(--jkl-spacing-4);
+
+    @media (width >= 720px) {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+}
+
+.tokenTitle {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
+
+    @include jkl.text-style("text-micro");
+}
+
+.tokenControls {
+    display: grid;
+    grid-template-columns: repeat(var(--theme-mode-count, 2), minmax(0, 1fr));
+    gap: var(--jkl-spacing-8);
+    min-width: 0;
+}
+
+.colorField {
+    display: grid;
+    grid-template-columns: auto minmax(6rem, 1fr);
+    gap: var(--jkl-spacing-4);
+    align-items: center;
+    min-width: 0;
+}
+
+.hexInput {
+    min-inline-size: 0;
+    inline-size: 100%;
+}
+
+.colorPicker {
+    inline-size: 1.75rem;
+    block-size: 1.75rem;
+    padding: 0;
+    border: 1px solid var(--jkl-color-border-subdued);
+    border-radius: var(--jkl-border-radius-s);
+    background-color: var(--jkl-color-background-container);
+    cursor: pointer;
+
+    &::-webkit-color-swatch-wrapper {
+        padding: 0.125rem;
+    }
+
+    &::-webkit-color-swatch {
+        border: none;
+        border-radius: calc(var(--jkl-border-radius-s) - 0.125rem);
+    }
+
+    &:focus-visible {
+        outline: var(--jkl-border-width) solid var(--jkl-color-border-action);
+        outline-offset: 2px;
+    }
+}

--- a/portal/src/components/theme-builder/editor/types.ts
+++ b/portal/src/components/theme-builder/editor/types.ts
@@ -1,0 +1,8 @@
+import type { ThemeMode } from "../tokens";
+
+/** Felles callback-signatur for alle editor-felter som muterer et token. */
+export type TokenChangeHandler = (
+    tokenId: string,
+    mode: ThemeMode,
+    value: string,
+) => void;

--- a/portal/src/components/theme-builder/layout/DisplayPopover.tsx
+++ b/portal/src/components/theme-builder/layout/DisplayPopover.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { Flex } from "@fremtind/jokul/flex";
+import { Icon } from "@fremtind/jokul/icon";
+import { Popover } from "@fremtind/jokul/popover";
+import {
+    SegmentedControl,
+    SegmentedControlButton,
+} from "@fremtind/jokul/segmented-control";
+import { useState } from "react";
+import { DATA_ATTRIBUTES, type DisplayState } from "../displayAttributes";
+
+type DisplayPopoverProps = {
+    state: DisplayState;
+    onChange: (next: DisplayState) => void;
+};
+
+/**
+ * Ghost-knapp som åpner en popover med én SegmentedControl per entry i
+ * {@link DATA_ATTRIBUTES}. Legger du til en ny data-attributt der, dukker
+ * det opp en ny kontroll her uten andre endringer.
+ */
+export function DisplayPopover({ state, onChange }: DisplayPopoverProps) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <Popover.Trigger asChild>
+                <Button
+                    variant="ghost"
+                    onClick={() => setOpen((value) => !value)}
+                    aria-expanded={open}
+                    aria-haspopup="dialog"
+                    icon={<Icon>brush</Icon>}
+                >
+                    Visningsmodus
+                </Button>
+            </Popover.Trigger>
+            <Popover.Content padding={24}>
+                <Flex direction="column" gap="m">
+                    {DATA_ATTRIBUTES.map((attr) => (
+                        <SegmentedControl key={attr.key} legend={attr.label}>
+                            {attr.values.map((value) => (
+                                <SegmentedControlButton
+                                    key={value}
+                                    name={`display-${attr.key}`}
+                                    value={value}
+                                    checked={state[attr.key] === value}
+                                    onChange={() =>
+                                        onChange({
+                                            ...state,
+                                            [attr.key]: value,
+                                        })
+                                    }
+                                >
+                                    {value}
+                                </SegmentedControlButton>
+                            ))}
+                        </SegmentedControl>
+                    ))}
+                </Flex>
+            </Popover.Content>
+        </Popover>
+    );
+}

--- a/portal/src/components/theme-builder/layout/PageHeader.tsx
+++ b/portal/src/components/theme-builder/layout/PageHeader.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { Flex } from "@fremtind/jokul/flex";
+import { Tag } from "@fremtind/jokul/tag";
+import { Title } from "@fremtind/jokul/typography";
+import { useThemeBuilder } from "../ThemeBuilderProvider";
+
+type PageHeaderProps = {
+    onOpenEditor: () => void;
+};
+
+/**
+ * Toppen av siden: tittel til venstre, primary-knappen for "Rediger tokens"
+ * til høyre. Visningsmodus-popoveren ligger inni demo-fanen siden den kun
+ * påvirker innholdet der. En liten "Endret"-tag dukker opp på knappen når
+ * arbeidskopien skiller seg fra basen.
+ */
+export function PageHeader({ onOpenEditor }: PageHeaderProps) {
+    const { isDirty } = useThemeBuilder();
+
+    return (
+        <Flex
+            justifyContent="space-between"
+            alignItems="center"
+            wrap="wrap"
+            gap="m"
+        >
+            <Title as="h1" size="xl">
+                Temabygger
+            </Title>
+            <Flex alignItems="center" gap="s">
+                {isDirty && <Tag variant="info">Endret</Tag>}
+                <Button variant="primary" onClick={onOpenEditor}>
+                    Rediger tokens
+                </Button>
+            </Flex>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/layout/WorkspaceTabs.tsx
+++ b/portal/src/components/theme-builder/layout/WorkspaceTabs.tsx
@@ -1,0 +1,40 @@
+import { Flex } from "@fremtind/jokul/flex";
+import { Tab, TabList, TabPanel, Tabs } from "@fremtind/jokul/tabs";
+import type { DisplayState } from "../displayAttributes";
+import { PreviewPanel } from "../preview/PreviewPanel";
+import type { ColorToken } from "../tokens";
+import { TokensList } from "../tokens-list/TokensList";
+
+type WorkspaceTabsProps = {
+    tokens: ColorToken[];
+    display: DisplayState;
+    onDisplayChange: (next: DisplayState) => void;
+};
+
+/** Workspace med to faner: token-listing og live demo-preview. */
+export function WorkspaceTabs({
+    tokens,
+    display,
+    onDisplayChange,
+}: WorkspaceTabsProps) {
+    return (
+        <Flex direction="column" gap="l">
+            <Tabs defaultTab={0}>
+                <TabList aria-label="Temabyggerinnhold">
+                    <Tab>Demo</Tab>
+                    <Tab>Farge-tokens</Tab>
+                </TabList>
+                <TabPanel>
+                    <PreviewPanel
+                        display={display}
+                        onDisplayChange={onDisplayChange}
+                        tokens={tokens}
+                    />
+                </TabPanel>
+                <TabPanel>
+                    <TokensList tokens={tokens} />
+                </TabPanel>
+            </Tabs>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/preview/DemoForm.tsx
+++ b/portal/src/components/theme-builder/preview/DemoForm.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { type ReactNode, memo } from "react";
+
+// Storybook-storyene ligger utenfor `portal/`. Ved å gjenbruke dem holdes
+// demoen i synk med det designere og utviklere ser i Storybook selv. Hele
+// `Skjermbilder/`-mappa er hentet inn — legges en ny pattern-story til der,
+// utvides DEMO_STORIES her med den.
+import {
+    Forsikringsoversikt as ForsikringsoversiktStory,
+    Hjem as HjemStory,
+} from "@jokul-stories/patterns/Bedriftsmarked.stories";
+import {
+    DetaljsideMedUlikeSizes as DetaljsideMedUlikeSizesStory,
+    Detaljside as DetaljsideStory,
+    SmartDelay as SmartDelayStory,
+} from "@jokul-stories/patterns/Detaljside.stories";
+import { ErstatningsBeregner as ErstatningsBeregnerStory } from "@jokul-stories/patterns/ErstatningsBeregner.stories";
+import { _Flyt as FlytStory } from "@jokul-stories/patterns/Flyt.stories";
+import {
+    HvaErBoligensAdresse as HvaErBoligensAdresseStory,
+    NårBleBoligenBygget as NårBleBoligenByggetStory,
+    SkalDuLeieUtBoligen as SkalDuLeieUtBoligenStory,
+} from "@jokul-stories/patterns/Kjopsflyt.stories";
+
+/**
+ * Storybook-stories har en `render(args, context) => ReactNode`. Vi leser
+ * hverken args eller context — vi rendrer storyen som en React-komponent.
+ * En variadisk signatur lar oss godta Storybooks strenge typer uten å lyve
+ * om verdier (som `as never` ville gjort).
+ */
+type StorybookStory = {
+    // biome-ignore lint/suspicious/noExplicitAny: Storybook-stories har strengere args/context-typer enn vi trenger her
+    render?: (...args: any[]) => ReactNode;
+};
+
+/** Storybook "Skjermbilder"-demoer tilgjengelige i preview, nøklet på id. */
+export const DEMO_STORIES: {
+    id: string;
+    label: string;
+    story: StorybookStory;
+}[] = [
+    { id: "detaljside", label: "Detaljside", story: DetaljsideStory },
+    {
+        id: "detaljside-sizes",
+        label: "Detaljside — ulike størrelser",
+        story: DetaljsideMedUlikeSizesStory,
+    },
+    { id: "smart-delay", label: "SmartDelay", story: SmartDelayStory },
+    { id: "hjem", label: "Bedrift — hjem", story: HjemStory },
+    {
+        id: "forsikringsoversikt",
+        label: "Forsikringsoversikt",
+        story: ForsikringsoversiktStory,
+    },
+    {
+        id: "erstatning",
+        label: "Erstatningsberegner",
+        story: ErstatningsBeregnerStory,
+    },
+    { id: "flyt", label: "Flyt", story: FlytStory },
+    {
+        id: "boligen-bygget",
+        label: "Når ble boligen bygget?",
+        story: NårBleBoligenByggetStory,
+    },
+    {
+        id: "boligens-adresse",
+        label: "Hva er boligens adresse?",
+        story: HvaErBoligensAdresseStory,
+    },
+    {
+        id: "leie-ut",
+        label: "Skal du leie ut boligen?",
+        story: SkalDuLeieUtBoligenStory,
+    },
+];
+
+type DemoFormProps = {
+    storyId: string;
+};
+
+/**
+ * Rendrer Storybook-storyen som matcher `storyId` (faller tilbake til den første).
+ *
+ * Memoiseres på `storyId` slik at story-rendringen (potensielt tung — noen
+ * stories har egen `useState`/internt arbeid) ikke kjøres om igjen for hver
+ * fargeendring i editoren.
+ */
+export const DemoForm = memo(function DemoForm({ storyId }: DemoFormProps) {
+    const selected =
+        DEMO_STORIES.find((s) => s.id === storyId) ?? DEMO_STORIES[0];
+    return <>{selected.story.render?.()}</>;
+});

--- a/portal/src/components/theme-builder/preview/DemoToolbar.tsx
+++ b/portal/src/components/theme-builder/preview/DemoToolbar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Card } from "@fremtind/jokul/card";
+import { Chip } from "@fremtind/jokul/chip";
+import { Flex } from "@fremtind/jokul/flex";
+import { Title } from "@fremtind/jokul/typography";
+import type { DisplayState } from "../displayAttributes";
+import { DisplayPopover } from "../layout/DisplayPopover";
+import { DEMO_STORIES } from "./DemoForm";
+
+import styles from "./preview.module.scss";
+
+type DemoToolbarProps = {
+    storyId: string;
+    onStoryChange: (id: string) => void;
+    display: DisplayState;
+    onDisplayChange: (next: DisplayState) => void;
+};
+
+/**
+ * Chrome over live preview-en — visuelt markert som utenfor demoen via en
+ * stiplet kant og dempet bakgrunn, slik at brukeren ikke forveksler den med
+ * den rendrede storyen. Holder også visningsmodus-popoveren siden den bare
+ * påvirker innholdet i demo-fanen.
+ */
+export function DemoToolbar({
+    storyId,
+    onStoryChange,
+    display,
+    onDisplayChange,
+}: DemoToolbarProps) {
+    return (
+        <Flex>
+            <Flex
+                as="fieldset"
+                wrap="wrap"
+                gap="xs"
+                className={styles.demoChipGroup}
+            >
+                <legend className={styles.srOnly}>Velg demo</legend>
+                {DEMO_STORIES.map((story) => (
+                    <Chip
+                        key={story.id}
+                        variant="filter"
+                        selected={story.id === storyId}
+                        onClick={() => onStoryChange(story.id)}
+                    >
+                        {story.label}
+                    </Chip>
+                ))}
+            </Flex>
+            <div>
+                <Title size="s" srOnly>
+                    Verktøy
+                </Title>
+                <DisplayPopover state={display} onChange={onDisplayChange} />
+            </div>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/preview/PreviewPanel.tsx
+++ b/portal/src/components/theme-builder/preview/PreviewPanel.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import { useState } from "react";
+import { type DisplayState, dataAttributes } from "../displayAttributes";
+import type { ColorToken } from "../tokens";
+import { DEMO_STORIES, DemoForm } from "./DemoForm";
+import { DemoToolbar } from "./DemoToolbar";
+import { PreviewScope } from "./PreviewScope";
+
+import styles from "./preview.module.scss";
+
+type PreviewPanelProps = {
+    display: DisplayState;
+    onDisplayChange: (next: DisplayState) => void;
+    tokens: ColorToken[];
+};
+
+/**
+ * Demo-fanen: en toolbar (utenfor demo-chrome-et) for å velge story og
+ * visningsmodus, så den valgte storyen rendret inni et scope som anvender
+ * gjeldende `data-*`-visningsattributter og live tokens.
+ */
+export function PreviewPanel({
+    display,
+    onDisplayChange,
+    tokens,
+}: PreviewPanelProps) {
+    const [storyId, setStoryId] = useState(DEMO_STORIES[0].id);
+
+    return (
+        <Flex direction="column" gap="m">
+            <DemoToolbar
+                storyId={storyId}
+                onStoryChange={setStoryId}
+                display={display}
+                onDisplayChange={onDisplayChange}
+            />
+            <div className={styles.previewSurface} {...dataAttributes(display)}>
+                <PreviewScope tokens={tokens}>
+                    <DemoForm storyId={storyId} />
+                </PreviewScope>
+            </div>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/preview/PreviewScope.tsx
+++ b/portal/src/components/theme-builder/preview/PreviewScope.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { type PropsWithChildren, useMemo } from "react";
+import type { ColorToken } from "../tokens";
+import { buildPreviewStyle } from "../utils";
+
+type PreviewScopeProps = PropsWithChildren<{
+    className?: string;
+    tokens: ColorToken[];
+}>;
+
+/**
+ * Scoper de live tokens (som CSS-variabler) til sitt eget undertre.
+ *
+ * `data-theme` settes på et høyere wrapper-element av `PreviewPanel` via
+ * `dataAttributes(display)`, så denne komponenten holder seg til å eksponere
+ * token-verdiene som CSS-variabler.
+ */
+export function PreviewScope({
+    children,
+    className,
+    tokens,
+}: PreviewScopeProps) {
+    const previewStyle = useMemo(() => buildPreviewStyle(tokens), [tokens]);
+
+    return (
+        <div className={className} style={previewStyle}>
+            {children}
+        </div>
+    );
+}

--- a/portal/src/components/theme-builder/preview/preview.module.scss
+++ b/portal/src/components/theme-builder/preview/preview.module.scss
@@ -1,0 +1,23 @@
+.demoChipGroup {
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+.srOnly {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+.previewSurface {
+    display: grid;
+    gap: var(--jkl-spacing-24);
+    padding: var(--jkl-spacing-24);
+    border-radius: var(--jkl-border-radius-l);
+    border: 1px solid var(--jkl-color-border-subdued);
+    background-color: var(--jkl-color-background-page);
+}

--- a/portal/src/components/theme-builder/tokens-list/ContrastSummary.tsx
+++ b/portal/src/components/theme-builder/tokens-list/ContrastSummary.tsx
@@ -1,0 +1,120 @@
+import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { Tag } from "@fremtind/jokul/tag";
+import { Text, Title } from "@fremtind/jokul/typography";
+import type { ContrastRating } from "../utils";
+import type { RatingCounts } from "./countRatings";
+
+import styles from "./tokens-list.module.scss";
+
+type ContrastSummaryProps = {
+    counts: RatingCounts;
+};
+
+const RATINGS: {
+    rating: ContrastRating;
+    /** Tekstlig label brukt av skjermlesere når symbolet ikke er nok. */
+    spokenLabel: string;
+    description: string;
+    wcag: string;
+    tag: "success" | "warning" | "error";
+}[] = [
+    {
+        rating: "AAA",
+        spokenLabel: "AAA",
+        description: "Tekst — bestått høyeste nivå",
+        wcag: "WCAG 2.1 SC 1.4.6 (≥ 7:1)",
+        tag: "success",
+    },
+    {
+        rating: "AA",
+        spokenLabel: "AA",
+        description: "Tekst — bestått minimumskravet",
+        wcag: "WCAG 2.1 SC 1.4.3 (≥ 4.5:1)",
+        tag: "success",
+    },
+    {
+        rating: "A",
+        spokenLabel: "A",
+        description: "Grafisk innhold — bestått",
+        wcag: "WCAG 2.1 SC 1.4.11 (≥ 3:1)",
+        tag: "warning",
+    },
+    {
+        rating: "✕",
+        spokenLabel: "Ikke bestått",
+        description: "Ikke bestått — for lav kontrast",
+        wcag: "Under terskelen for tilhørende WCAG-krav",
+        tag: "error",
+    },
+];
+
+/**
+ * Status-rad som viser hvor mange (token, mode)-par havner i hver kategori,
+ * inkludert kort forklaring av hva hver vurdering betyr og lenke til
+ * relevant WCAG-suksesskriterium via inline-popoverene i tabellen.
+ *
+ * Bruker en kategorisert `<ul>`-liste fremfor `DescriptionList` siden hver
+ * rad er en egen kategori-måling, ikke en term/definisjon-paring.
+ */
+export function ContrastSummary({ counts }: ContrastSummaryProps) {
+    const total = RATINGS.reduce((sum, { rating }) => sum + counts[rating], 0);
+    const failing = counts["✕"];
+
+    return (
+        <Card asChild padding="m">
+            <Flex direction="column" gap="s">
+                <Flex direction="column" gap="2xs">
+                    <Title as="h2" size="s">
+                        Kontrast-vurderinger
+                    </Title>
+                    <Text size="s">
+                        {`${total} (token, modus)-par evaluert mot deres "naturlige" par i samme variant. ${
+                            failing === 0
+                                ? "Alle par passerer."
+                                : `${failing} par feiler kravet.`
+                        } Klikk en vurdering i tabellen under for å se fargene side om side og hvilket WCAG-suksesskriterium som gjelder.`}
+                    </Text>
+                </Flex>
+                <ul
+                    className={styles.contrastSummaryList}
+                    aria-label="Kontrastnivåer fordelt på antall par"
+                >
+                    {RATINGS.map(
+                        ({ rating, spokenLabel, description, wcag, tag }) => (
+                            <li
+                                key={rating}
+                                className={styles.contrastSummaryItem}
+                            >
+                                <Flex
+                                    alignItems="center"
+                                    justifyContent="space-between"
+                                    gap="m"
+                                    wrap="wrap"
+                                >
+                                    <Flex alignItems="center" gap="s">
+                                        <Tag
+                                            variant={tag}
+                                            aria-label={spokenLabel}
+                                        >
+                                            <span aria-hidden="true">
+                                                {rating}
+                                            </span>
+                                        </Tag>
+                                        <Flex direction="column" gap="2xs">
+                                            <Text size="s">{description}</Text>
+                                            <Text size="xs">{wcag}</Text>
+                                        </Flex>
+                                    </Flex>
+                                    <Text size="m" bold>
+                                        {`${counts[rating]} par`}
+                                    </Text>
+                                </Flex>
+                            </li>
+                        ),
+                    )}
+                </ul>
+            </Flex>
+        </Card>
+    );
+}

--- a/portal/src/components/theme-builder/tokens-list/TokenSwatch.tsx
+++ b/portal/src/components/theme-builder/tokens-list/TokenSwatch.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import { Link } from "@fremtind/jokul/link";
+import { Popover } from "@fremtind/jokul/popover";
+import { Text } from "@fremtind/jokul/typography";
+import { type CSSProperties, useState } from "react";
+import type { ColorGroup, RoleEntry } from "../tokens";
+import type { ContrastEvaluation } from "../utils";
+
+import styles from "./tokens-list.module.scss";
+
+type TokenSwatchProps = {
+    group: ColorGroup;
+    value: string;
+    contrast?: ContrastEvaluation;
+    /** Tokenet kontrasten beregnes mot — brukes som bakgrunn i forhåndsvisningen. */
+    reference?: { token: RoleEntry; value: string };
+};
+
+/**
+ * Inline rolle-eksempel + heks-kode + WCAG-vurdering.
+ *
+ * Selve forhåndsvisningen plasserer tokenet i sin "naturlige" rolle:
+ *
+ * - `background.*` — fargeblokk
+ * - `text.*` — "Aa" i denne fargen, oppå referansens farge
+ * - `border.*` — boks med denne kantfargen, oppå referansens farge
+ *
+ * Klikk på kontrast-hinten åpner en popover med en stor versjon av paret og
+ * lenke til relevant WCAG-suksesskriterium.
+ */
+export function TokenSwatch({
+    group,
+    value,
+    contrast,
+    reference,
+}: TokenSwatchProps) {
+    return (
+        <Flex inline alignItems="center" gap="s">
+            <RolePreview
+                group={group}
+                value={value}
+                pairValue={reference?.value}
+                size="small"
+            />
+            <code>{value}</code>
+            {contrast?.kind === "measured" && (
+                <ContrastHintButton
+                    evaluation={contrast}
+                    group={group}
+                    value={value}
+                    reference={reference}
+                />
+            )}
+        </Flex>
+    );
+}
+
+type RolePreviewProps = {
+    group: ColorGroup;
+    value: string;
+    pairValue?: string;
+    size: "small" | "large";
+};
+
+/** Rolle-spesifikk visuell representasjon av tokenet, i to størrelser. */
+function RolePreview({ group, value, pairValue, size }: RolePreviewProps) {
+    const sizeClass =
+        size === "large"
+            ? styles.tokensListPreviewLarge
+            : styles.tokensListPreviewSmall;
+
+    if (group === "text") {
+        return (
+            <span
+                className={`${styles.tokensListTextPreview} ${sizeClass}`}
+                style={
+                    {
+                        "--theme-builder-preview-color": value,
+                        "--theme-builder-preview-bg":
+                            pairValue ?? "transparent",
+                    } as CSSProperties
+                }
+                aria-hidden="true"
+            >
+                Aa
+            </span>
+        );
+    }
+    if (group === "border") {
+        return (
+            <span
+                className={`${styles.tokensListBorderPreview} ${sizeClass}`}
+                style={
+                    {
+                        "--theme-builder-preview-color": value,
+                        "--theme-builder-preview-bg":
+                            pairValue ?? "transparent",
+                    } as CSSProperties
+                }
+                aria-hidden="true"
+            />
+        );
+    }
+    return (
+        <span
+            className={`${styles.tokensListSwatch} ${sizeClass}`}
+            style={{ "--theme-builder-swatch-color": value } as CSSProperties}
+            aria-hidden="true"
+        />
+    );
+}
+
+type ContrastHintButtonProps = {
+    evaluation: Extract<ContrastEvaluation, { kind: "measured" }>;
+    group: ColorGroup;
+    value: string;
+    reference?: { token: RoleEntry; value: string };
+};
+
+function ContrastHintButton({
+    evaluation,
+    group,
+    value,
+    reference,
+}: ContrastHintButtonProps) {
+    const [open, setOpen] = useState(false);
+    const { rating, scope, minimum } = evaluation.status;
+    const visibleLabel = `(${rating} ${scope} ${formatRatio(evaluation.ratio)})`;
+    const spokenRating = rating === "✕" ? "Ikke bestått" : rating;
+    const ariaLabel = `Kontrast: ${spokenRating} ${scope}, ${formatRatio(evaluation.ratio)} til 1`;
+
+    if (!reference) {
+        return (
+            <span
+                className={styles.tokensListContrast}
+                data-passes={evaluation.passes}
+                aria-label={ariaLabel}
+            >
+                <span aria-hidden="true">{visibleLabel}</span>
+            </span>
+        );
+    }
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <Popover.Trigger asChild>
+                <button
+                    type="button"
+                    className={styles.tokensListContrastButton}
+                    data-passes={evaluation.passes}
+                    onClick={() => setOpen((value) => !value)}
+                    aria-expanded={open}
+                    aria-haspopup="dialog"
+                    aria-label={ariaLabel}
+                >
+                    <span aria-hidden="true">{visibleLabel}</span>
+                </button>
+            </Popover.Trigger>
+            <Popover.Content padding={16}>
+                <Flex direction="column" gap="m">
+                    <RolePreview
+                        group={group}
+                        value={value}
+                        pairValue={reference.value}
+                        size="large"
+                    />
+                    <Flex direction="column" gap="2xs">
+                        <Text size="xs">Mot</Text>
+                        <Flex alignItems="center" gap="s">
+                            <code>
+                                {`${reference.token.group}.${reference.token.role}`}
+                            </code>
+                            <code>{reference.value}</code>
+                        </Flex>
+                    </Flex>
+                    <Flex direction="column" gap="2xs">
+                        <Text size="xs">Krav</Text>
+                        <Text size="s">
+                            {scope === "tekst"
+                                ? `Tekstkontrast (≥ ${formatRatio(minimum)}:1 for AA, ≥ 7:1 for AAA)`
+                                : `Grafisk kontrast (≥ ${formatRatio(minimum)}:1)`}
+                        </Text>
+                        <Link
+                            href={wcagUrl(scope, evaluation.status.rating)}
+                            external
+                        >
+                            {wcagLabel(scope, evaluation.status.rating)}
+                        </Link>
+                    </Flex>
+                </Flex>
+            </Popover.Content>
+        </Popover>
+    );
+}
+
+const formatRatio = (value: number): string =>
+    value.toFixed(2).replace(/\.00$/, "");
+
+/** WCAG-suksesskriteriet som best beskriver et (scope, rating)-par. */
+function wcagUrl(scope: "tekst" | "grafisk", rating: string): string {
+    if (scope === "tekst" && rating === "AAA") {
+        return "https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html";
+    }
+    if (scope === "tekst") {
+        return "https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html";
+    }
+    return "https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html";
+}
+
+function wcagLabel(scope: "tekst" | "grafisk", rating: string): string {
+    if (scope === "tekst" && rating === "AAA") return "WCAG 2.1 SC 1.4.6";
+    if (scope === "tekst") return "WCAG 2.1 SC 1.4.3";
+    return "WCAG 2.1 SC 1.4.11";
+}

--- a/portal/src/components/theme-builder/tokens-list/TokensList.tsx
+++ b/portal/src/components/theme-builder/tokens-list/TokensList.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Flex } from "@fremtind/jokul/flex";
+import { useMemo } from "react";
+import { useThemeBuilder } from "../ThemeBuilderProvider";
+import { TokenFilter, tokenMatchesFilter } from "../TokenFilter";
+import { COLOR_VARIANTS, type ColorToken, tokenKey } from "../tokens";
+import { ContrastSummary } from "./ContrastSummary";
+import { VariantTable } from "./VariantTable";
+import { countRatings } from "./countRatings";
+
+type TokensListProps = {
+    tokens: ColorToken[];
+};
+
+/**
+ * Skrivbeskyttet listing av alle tokens, speiler JSON-strukturen. Toppen av
+ * fanen oppsummerer kontrast-vurderingene per token; én Jøkul `Table` per
+ * variant følger.
+ *
+ * Filtrerings-staten deles med editoren — søker du etter "background.page"
+ * her, finner du de samme radene begge steder.
+ */
+export function TokensList({ tokens }: TokensListProps) {
+    const { filter, showOnlyEdited, editedTokenKeys } = useThemeBuilder();
+
+    const filteredTokens = useMemo(() => {
+        if (!filter && !showOnlyEdited) return tokens;
+        return tokens.filter((t) => {
+            if (showOnlyEdited && !editedTokenKeys.has(tokenKey(t)))
+                return false;
+            return tokenMatchesFilter(t, filter);
+        });
+    }, [tokens, filter, showOnlyEdited, editedTokenKeys]);
+
+    const counts = useMemo(() => countRatings(tokens), [tokens]);
+
+    return (
+        <Flex direction="column" gap="2xl">
+            <ContrastSummary counts={counts} />
+            <TokenFilter />
+            <Flex direction="column" gap="2xl">
+                {COLOR_VARIANTS.map((variant) => {
+                    const variantTokens = filteredTokens.filter(
+                        (t) => t.variant === variant,
+                    );
+                    if (variantTokens.length === 0) return null;
+                    return (
+                        <VariantTable
+                            key={variant}
+                            variant={variant}
+                            tokens={variantTokens}
+                            allTokens={tokens}
+                        />
+                    );
+                })}
+            </Flex>
+        </Flex>
+    );
+}

--- a/portal/src/components/theme-builder/tokens-list/VariantTable.tsx
+++ b/portal/src/components/theme-builder/tokens-list/VariantTable.tsx
@@ -1,0 +1,119 @@
+import {
+    Table,
+    TableBody,
+    TableCaption,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@fremtind/jokul/table";
+import { useMemo } from "react";
+import {
+    type ColorToken,
+    type ColorVariant,
+    THEME_MODES,
+    type ThemeMode,
+    tokenKey,
+} from "../tokens";
+import { evaluateColorContrast } from "../utils";
+import { TokenSwatch } from "./TokenSwatch";
+import { contrastReference } from "./contrastReference";
+
+type VariantTableProps = {
+    variant: ColorVariant;
+    tokens: ColorToken[];
+    allTokens: ColorToken[];
+};
+
+/**
+ * Jøkul Table med én rad per token i én variant. Hver verdi-celle viser et
+ * rolle-eksempel, heks-kode og en klikkbar WCAG-kontrast-hint mot tokenets
+ * naturlige par (se {@link contrastReference}).
+ */
+export function VariantTable({
+    variant,
+    tokens,
+    allTokens,
+}: VariantTableProps) {
+    const tokensByKey = useMemo(
+        () => new Map(allTokens.map((t) => [tokenKey(t), t])),
+        [allTokens],
+    );
+
+    return (
+        <Table
+            fullWidth
+            collapseToList
+            caption={<TableCaption srOnly={false}>{variant}</TableCaption>}
+        >
+            <TableHead>
+                <TableRow>
+                    <TableHeader scope="col">group</TableHeader>
+                    <TableHeader scope="col">role</TableHeader>
+                    {THEME_MODES.map((mode) => (
+                        <TableHeader key={mode} scope="col">
+                            {mode}
+                        </TableHeader>
+                    ))}
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {tokens.map((token) => {
+                    const reference = contrastReference(token);
+                    const referenceToken = reference
+                        ? tokensByKey.get(tokenKey(reference.against))
+                        : undefined;
+
+                    return (
+                        <TableRow key={`${token.group}.${token.role}`}>
+                            <TableCell data-th="group">
+                                <code>{token.group}</code>
+                            </TableCell>
+                            <TableCell data-th="role">
+                                <code>{token.role}</code>
+                            </TableCell>
+                            {THEME_MODES.map((mode) => (
+                                <TableCell key={mode} data-th={mode}>
+                                    <TokenSwatch
+                                        group={token.group}
+                                        value={token[mode]}
+                                        contrast={evaluateContrastFor(
+                                            token,
+                                            reference,
+                                            referenceToken,
+                                            mode,
+                                        )}
+                                        reference={
+                                            reference && referenceToken
+                                                ? {
+                                                      token: reference.against,
+                                                      value: referenceToken[
+                                                          mode
+                                                      ],
+                                                  }
+                                                : undefined
+                                        }
+                                    />
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+}
+
+function evaluateContrastFor(
+    token: ColorToken,
+    reference: ReturnType<typeof contrastReference>,
+    referenceToken: ColorToken | undefined,
+    mode: ThemeMode,
+) {
+    if (!reference || !referenceToken) return undefined;
+    return evaluateColorContrast(
+        token[mode],
+        referenceToken[mode],
+        reference.requirementId,
+    );
+}

--- a/portal/src/components/theme-builder/tokens-list/contrastReference.test.ts
+++ b/portal/src/components/theme-builder/tokens-list/contrastReference.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+    COLOR_ROLES,
+    COLOR_VARIANTS,
+    type ColorRole,
+    ROLE_ENTRIES,
+    tokensFromSchema,
+} from "../tokens";
+import { contrastReference } from "./contrastReference";
+
+const tokens = tokensFromSchema();
+const tokenAt = (variant: string, group: string, role: string) => {
+    const found = tokens.find(
+        (t) => t.variant === variant && t.group === group && t.role === role,
+    );
+    if (!found) throw new Error(`Mangler token ${variant}.${group}.${role}`);
+    return found;
+};
+
+describe("contrastReference — JSON-koblede paringsregler", () => {
+    it("paringer `text.on-X` mot `background.X` for hver paret rolle i JSON-en", () => {
+        const onRoles = (COLOR_ROLES.text ?? []).filter((r) =>
+            r.startsWith("on-"),
+        );
+        for (const onRole of onRoles) {
+            const backingRole = onRole.slice("on-".length) as ColorRole;
+            for (const variant of COLOR_VARIANTS) {
+                const ref = contrastReference(tokenAt(variant, "text", onRole));
+                expect(ref).not.toBeNull();
+                expect(ref).toEqual({
+                    against: {
+                        variant,
+                        group: "background",
+                        role: backingRole,
+                    },
+                    requirementId: "text",
+                });
+            }
+        }
+    });
+
+    it("paringer `background.X` mot `text.on-X` (omvendt) — kun når paret eksisterer", () => {
+        for (const role of COLOR_ROLES.background ?? []) {
+            const onRole = `on-${role}` as ColorRole;
+            const hasPair = COLOR_ROLES.text?.includes(onRole);
+            for (const variant of COLOR_VARIANTS) {
+                const ref = contrastReference(
+                    tokenAt(variant, "background", role),
+                );
+                if (hasPair) {
+                    expect(ref).toEqual({
+                        against: { variant, group: "text", role: onRole },
+                        requirementId: "text",
+                    });
+                } else {
+                    expect(ref).toBeNull();
+                }
+            }
+        }
+    });
+
+    it("øvrige `text.*` (ikke on-*) måles mot `background.page` med `text`-krav", () => {
+        const otherTexts = (COLOR_ROLES.text ?? []).filter(
+            (r) => !r.startsWith("on-"),
+        );
+        for (const role of otherTexts) {
+            for (const variant of COLOR_VARIANTS) {
+                const ref = contrastReference(tokenAt(variant, "text", role));
+                expect(ref?.against).toEqual({
+                    variant,
+                    group: "background",
+                    role: COLOR_ROLES.background?.includes("page" as ColorRole)
+                        ? "page"
+                        : COLOR_ROLES.background?.[0],
+                });
+                expect(ref?.requirementId).toBe("text");
+            }
+        }
+    });
+
+    it("`border.*` måles mot `background.page` med `ui`-krav", () => {
+        for (const role of COLOR_ROLES.border ?? []) {
+            for (const variant of COLOR_VARIANTS) {
+                const ref = contrastReference(tokenAt(variant, "border", role));
+                expect(ref?.against.group).toBe("background");
+                expect(ref?.requirementId).toBe("ui");
+            }
+        }
+    });
+
+    it("alle ROLE_ENTRIES gir enten en gyldig referanse eller eksplisitt null — ingen kaster", () => {
+        for (const entry of ROLE_ENTRIES) {
+            const token = tokenAt(entry.variant, entry.group, entry.role);
+            expect(() => contrastReference(token)).not.toThrow();
+        }
+    });
+});

--- a/portal/src/components/theme-builder/tokens-list/contrastReference.ts
+++ b/portal/src/components/theme-builder/tokens-list/contrastReference.ts
@@ -1,0 +1,73 @@
+import {
+    COLOR_ROLES,
+    type ColorRole,
+    type ColorToken,
+    type ContrastRequirementId,
+    type RoleEntry,
+} from "../tokens";
+
+/**
+ * Den "naturlige" paringen for et token, brukt til å beregne kontrast i listen.
+ *
+ * - `text.on-X` ↔ `background.X` (når det finnes i strukturen)
+ * - `background.X` ↔ `text.on-X` (kun når den eksplisitte paringen finnes)
+ * - øvrige `text.*` og alle `border.*` ↔ `background.page` (den dominante flaten)
+ *
+ * Bakgrunns-tokens uten et tilhørende `text.on-X` returnerer `null`. Surface
+ * tokens har ingen iboende kontrast-rating — vurderingen tas fra forgrunnen
+ * som tegnes på dem (og blir telt der).
+ */
+export function contrastReference(token: ColorToken): {
+    against: RoleEntry;
+    requirementId: ContrastRequirementId;
+} | null {
+    const { variant, group, role } = token;
+
+    if (group === "text" && role.startsWith("on-")) {
+        // `on-X` ↔ `X`. Castet er optimistisk — det er ikke garantert at
+        // X er en gyldig `background.*`-rolle, men oppslagsbruken senere er
+        // tolerant for ukjente nøkler (lookup-en returnerer `undefined`).
+        const bgRole = role.slice("on-".length) as ColorRole;
+        return {
+            against: { variant, group: "background", role: bgRole },
+            requirementId: "text",
+        };
+    }
+
+    if (group === "background") {
+        // Castet er optimistisk på samme måte som over; `includes`-sjekken
+        // håndterer tilfellet hvor `on-X` ikke faktisk er en kjent rolle.
+        const onRole = `on-${role}` as ColorRole;
+        if (COLOR_ROLES.text?.includes(onRole)) {
+            return {
+                against: { variant, group: "text", role: onRole },
+                requirementId: "text",
+            };
+        }
+        return null;
+    }
+
+    if (group === "text" || group === "border") {
+        const surface = dominantSurface();
+        if (!surface) return null;
+        return {
+            against: { variant, group: "background", role: surface },
+            requirementId: group === "text" ? "text" : "ui",
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Den "dominante" flaten å måle øvrige forgrunner mot. Vi foretrekker
+ * `background.page` eksplisitt — det er den naturlige standardflaten —
+ * og faller tilbake til første tilgjengelige bakgrunnsrolle hvis `page`
+ * ikke finnes i strukturen. Dette gjør målingen stabil uavhengig av
+ * rekkefølgen i `color.tokens.json`.
+ */
+function dominantSurface(): ColorRole | undefined {
+    const PAGE = "page" as ColorRole;
+    if (COLOR_ROLES.background?.includes(PAGE)) return PAGE;
+    return COLOR_ROLES.background?.[0];
+}

--- a/portal/src/components/theme-builder/tokens-list/countRatings.test.ts
+++ b/portal/src/components/theme-builder/tokens-list/countRatings.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { ROLE_ENTRIES, THEME_MODES, tokensFromSchema } from "../tokens";
+import { contrastReference } from "./contrastReference";
+import { countRatings } from "./countRatings";
+
+describe("countRatings — JSON-knytning", () => {
+    const tokens = tokensFromSchema();
+
+    it("totalt antall vurderinger = antall tokens med naturlig par × antall theme-modus", () => {
+        const counts = countRatings(tokens);
+        const total = Object.values(counts).reduce((a, b) => a + b, 0);
+
+        const tokensWithReference = ROLE_ENTRIES.filter(
+            (entry) =>
+                contrastReference(
+                    tokens.find(
+                        (t) =>
+                            t.variant === entry.variant &&
+                            t.group === entry.group &&
+                            t.role === entry.role,
+                    ) ?? tokens[0],
+                ) !== null,
+        ).length;
+
+        expect(total).toBe(tokensWithReference * THEME_MODES.length);
+    });
+
+    it("returnerer alle fire kategorier (AAA, AA, A, ✕)", () => {
+        const counts = countRatings(tokens);
+        expect(Object.keys(counts).sort()).toEqual(["A", "AA", "AAA", "✕"]);
+        for (const value of Object.values(counts)) {
+            expect(typeof value).toBe("number");
+            expect(value).toBeGreaterThanOrEqual(0);
+        }
+    });
+});

--- a/portal/src/components/theme-builder/tokens-list/countRatings.ts
+++ b/portal/src/components/theme-builder/tokens-list/countRatings.ts
@@ -1,0 +1,36 @@
+import { type ColorToken, THEME_MODES, tokenKey } from "../tokens";
+import { type ContrastRating, evaluateColorContrast } from "../utils";
+import { contrastReference } from "./contrastReference";
+
+export type RatingCounts = Record<ContrastRating, number>;
+
+const EMPTY_COUNTS: RatingCounts = { AAA: 0, AA: 0, A: 0, "✕": 0 };
+
+/**
+ * Itererer alle tokens og theme-moduser, evaluerer kontrast mot den naturlige
+ * paringen (se {@link contrastReference}), og teller hvor mange som havner i
+ * hver rating-kategori.
+ */
+export function countRatings(tokens: ColorToken[]): RatingCounts {
+    const tokensByKey = new Map(tokens.map((t) => [tokenKey(t), t]));
+    const counts: RatingCounts = { ...EMPTY_COUNTS };
+
+    for (const token of tokens) {
+        const reference = contrastReference(token);
+        if (!reference) continue;
+        const referenceToken = tokensByKey.get(tokenKey(reference.against));
+        if (!referenceToken) continue;
+
+        for (const mode of THEME_MODES) {
+            const evaluation = evaluateColorContrast(
+                token[mode],
+                referenceToken[mode],
+                reference.requirementId,
+            );
+            if (evaluation.kind !== "measured") continue;
+            counts[evaluation.status.rating] += 1;
+        }
+    }
+
+    return counts;
+}

--- a/portal/src/components/theme-builder/tokens-list/tokens-list.module.scss
+++ b/portal/src/components/theme-builder/tokens-list/tokens-list.module.scss
@@ -1,0 +1,85 @@
+@use "@fremtind/jokul/styles/jkl";
+
+.tokensListSwatch {
+    flex-shrink: 0;
+    border: 1px solid var(--jkl-color-border-subdued);
+    border-radius: var(--jkl-border-radius-s);
+    background-color: var(--theme-builder-swatch-color);
+}
+
+.tokensListTextPreview {
+    flex-shrink: 0;
+    display: inline-grid;
+    place-items: center;
+    border-radius: var(--jkl-border-radius-s);
+    background-color: var(--theme-builder-preview-bg);
+    color: var(--theme-builder-preview-color);
+    font-weight: 700;
+}
+
+.tokensListBorderPreview {
+    flex-shrink: 0;
+    border: 0.125rem solid var(--theme-builder-preview-color);
+    border-radius: var(--jkl-border-radius-s);
+    background-color: var(--theme-builder-preview-bg);
+}
+
+.tokensListPreviewSmall {
+    inline-size: 1.75rem;
+    block-size: 1.5rem;
+
+    @include jkl.text-style("text-small");
+}
+
+.tokensListPreviewLarge {
+    inline-size: 100%;
+    min-inline-size: 14rem;
+    block-size: 6rem;
+    border-radius: var(--jkl-border-radius-m);
+
+    @include jkl.text-style("heading-2");
+}
+
+.contrastSummaryList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.contrastSummaryItem {
+    padding-block: var(--jkl-spacing-12);
+    border-block-start: 1px solid var(--jkl-color-border-subdued);
+
+    &:last-child {
+        border-block-end: 1px solid var(--jkl-color-border-subdued);
+    }
+}
+
+.tokensListContrast,
+.tokensListContrastButton {
+    color: var(--jkl-color-text-subdued);
+
+    @include jkl.text-style("text-micro");
+
+    &[data-passes="false"] {
+        color: var(--jkl-color-text-alert);
+    }
+}
+
+.tokensListContrastButton {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 0.2em;
+
+    &:focus-visible {
+        outline: var(--jkl-border-width) solid var(--jkl-color-border-action);
+        outline-offset: 2px;
+        border-radius: var(--jkl-border-radius-s);
+    }
+}

--- a/portal/src/components/theme-builder/tokens.test.ts
+++ b/portal/src/components/theme-builder/tokens.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import schema from "../../../../packages/jokul/src/tokens/color.tokens.json";
+import {
+    COLOR_ROLES,
+    COLOR_VARIANTS,
+    ROLE_ENTRIES,
+    THEME_MODES,
+    tokenKey,
+    tokensFromSchema,
+    tokensToSchema,
+} from "./tokens";
+
+describe("tokens.ts — JSON-knytning", () => {
+    it("COLOR_VARIANTS speiler topp-nivå-nøkler i color.tokens.json (uten meta-nøkkelen `type`)", () => {
+        const expected = Object.keys(schema.color).filter(
+            (key) => key !== "type",
+        );
+        expect(COLOR_VARIANTS).toEqual(expected);
+    });
+
+    it("ROLE_ENTRIES dekker hver (variant, group, role)-trippel i JSON-en — ingen mer, ingen mindre", () => {
+        const expected: { variant: string; group: string; role: string }[] = [];
+        for (const variant of COLOR_VARIANTS) {
+            const groups = (schema.color as Record<string, unknown>)[variant];
+            for (const [group, roles] of Object.entries(
+                groups as Record<string, unknown>,
+            )) {
+                for (const role of Object.keys(roles as object)) {
+                    expected.push({ variant, group, role });
+                }
+            }
+        }
+        expect(ROLE_ENTRIES).toEqual(expected);
+    });
+
+    it("COLOR_ROLES grupperer rollene riktig per gruppe", () => {
+        const expected: Record<string, Set<string>> = {};
+        for (const { group, role } of ROLE_ENTRIES) {
+            expected[group] ??= new Set();
+            expected[group].add(role);
+        }
+        for (const [group, roles] of Object.entries(COLOR_ROLES)) {
+            expect(new Set(roles)).toEqual(expected[group]);
+        }
+        expect(Object.keys(COLOR_ROLES).sort()).toEqual(
+            Object.keys(expected).sort(),
+        );
+    });
+
+    it("THEME_MODES leses fra `value`-objektet på et tilfeldig token i JSON-en", () => {
+        const sample = ROLE_ENTRIES[0];
+        const node = (
+            schema.color as unknown as Record<
+                string,
+                Record<
+                    string,
+                    Record<string, { value: Record<string, string> }>
+                >
+            >
+        )[sample.variant][sample.group][sample.role];
+        expect(THEME_MODES).toEqual(Object.keys(node.value));
+    });
+
+    it("tokenKey gir stabil `variant.group.role`-streng", () => {
+        const t = ROLE_ENTRIES[0];
+        expect(tokenKey(t)).toBe(`${t.variant}.${t.group}.${t.role}`);
+    });
+
+    it("tokensFromSchema gir én ColorToken per ROLE_ENTRY med riktige verdier", () => {
+        const tokens = tokensFromSchema();
+        expect(tokens.length).toBe(ROLE_ENTRIES.length);
+        for (const token of tokens) {
+            const node = (
+                schema.color as unknown as Record<
+                    string,
+                    Record<
+                        string,
+                        Record<string, { value: Record<string, string> }>
+                    >
+                >
+            )[token.variant][token.group][token.role];
+            for (const mode of THEME_MODES) {
+                expect(token[mode]).toBe(node.value[mode]);
+            }
+        }
+    });
+
+    it("tokensToSchema(tokensFromSchema(json)) bevarer color-strukturen — roundtrip", () => {
+        const roundtrip = tokensToSchema(tokensFromSchema());
+        // JSON-en har `type: "colorScheme"` på color-rota — den re-emitteres.
+        expect(roundtrip.color.type).toBe("colorScheme");
+        for (const { variant, group, role } of ROLE_ENTRIES) {
+            const original = (
+                schema.color as unknown as Record<
+                    string,
+                    Record<
+                        string,
+                        Record<string, { value: Record<string, string> }>
+                    >
+                >
+            )[variant][group][role];
+            const round = roundtrip.color[variant][group][role];
+            expect(round.value).toEqual(original.value);
+        }
+    });
+});

--- a/portal/src/components/theme-builder/tokens.ts
+++ b/portal/src/components/theme-builder/tokens.ts
@@ -1,0 +1,166 @@
+/**
+ * Eneste sannhetskilde for theme-builder-strukturen.
+ *
+ * Alt som vises i UI-et — variant-faner, editor-seksjoner og kontrast-sjekker
+ * — utledes herfra fra `color.tokens.json`. Legger du til en variant, gruppe
+ * eller rolle i JSON-en dukker den opp automatisk; ingen andre filer skal
+ * gripe direkte inn i JSON-strukturen.
+ *
+ * # Kontrakter med JSON-strukturen
+ *
+ * Theme-builder forventer at `color.tokens.json` følger disse konvensjonene:
+ *
+ * - **Variant-nivå**: hver variant (f.eks. `neutral`, `accent`) inneholder de
+ *   samme gruppene. Meta-nøkkelen `type` på variantnivå filtreres bort.
+ * - **Gruppenavn**: minst `background`, `text` og `border` — kontrast-logikken
+ *   ({@link contrastReference}) refererer til disse navnene direkte.
+ * - **Rolle-paring**: `text.on-X` antas å være forgrunn for `background.X`
+ *   (f.eks. `text.on-action` på `background.action`).
+ * - **Surface-rolle**: hvis `background.page` finnes brukes den som dominant
+ *   flate for kontrast-måling, ellers første rolle i `background`-gruppa.
+ * - **Theme-modus**: hvert token har et `value`-objekt med (typisk)
+ *   `light`/`dark` — modusene utledes fra et tilfeldig token og brukes
+ *   konsistent overalt via {@link THEME_MODES}.
+ *
+ * Disse konvensjonene er bevisste — de utgjør "API-en" mellom JSON og UI.
+ */
+import schema from "../../../../packages/jokul/src/tokens/color.tokens.json";
+
+type Schema = typeof schema;
+type ColorMap = Schema["color"];
+
+/** En toppnivå-fargevariant (`neutral`, `accent`, `info`, …). */
+export type ColorVariant = Exclude<keyof ColorMap, "type"> & string;
+/** En gruppe innenfor en variant (`background`, `text`, `border`). */
+export type ColorGroup = {
+    [V in ColorVariant]: keyof ColorMap[V];
+}[ColorVariant] &
+    string;
+/** En spesifikk rolle innenfor en gruppe (`page`, `default`, `on-action`, …). */
+export type ColorRole = {
+    [V in ColorVariant]: {
+        [G in keyof ColorMap[V]]: keyof ColorMap[V][G];
+    }[keyof ColorMap[V]];
+}[ColorVariant] &
+    string;
+
+/**
+ * Nøklene i `value`-objektet på hvert token (`light`, `dark`). Utledes fra én
+ * konkret sti i JSON-en — strukturen er ensartet, så alle stier gir samme form.
+ */
+type SampleValue = Schema["color"][Exclude<
+    keyof Schema["color"],
+    "type"
+>] extends infer V
+    ? V[keyof V] extends infer G
+        ? G[keyof G] extends infer N
+            ? N extends { value: infer Val }
+                ? Val
+                : never
+            : never
+        : never
+    : never;
+export type ThemeMode = keyof SampleValue & string;
+export type EditorMode = "visual" | "json";
+export type ContrastRequirementId = "text" | "ui";
+
+/** Flat representasjon av ett token — alt editoren trenger for å vise og redigere det. */
+export type ColorToken = {
+    variant: ColorVariant;
+    group: ColorGroup;
+    role: ColorRole;
+} & Record<ThemeMode, string>;
+
+type ColorTokenNode = { value: Record<ThemeMode, string> };
+export type ColorSchemeJson = {
+    color: { type: "colorScheme" } & {
+        [V in ColorVariant]: {
+            [G in ColorGroup]: Record<string, ColorTokenNode>;
+        };
+    };
+};
+
+/** Identifiserer et token via sin posisjon i strukturen, uten verdier. */
+export type RoleEntry = {
+    variant: ColorVariant;
+    group: ColorGroup;
+    role: ColorRole;
+};
+
+/** Stabil strengnøkkel for en token-referanse — brukes for oppslag og React-keys. */
+export const tokenKey = (t: RoleEntry): string =>
+    `${t.variant}.${t.group}.${t.role}`;
+
+// --- Iterasjon over JSON-strukturen ---
+
+/** Varianter i `color.tokens.json`, med meta-nøkkelen `type` filtrert bort. */
+export const COLOR_VARIANTS = Object.keys(schema.color).filter(
+    (key) => key !== "type",
+) as ColorVariant[];
+
+/** Alle (variant, group, role)-tripler i strukturen, i JSON-rekkefølge. */
+export const ROLE_ENTRIES: RoleEntry[] = COLOR_VARIANTS.flatMap((variant) =>
+    Object.entries(
+        schema.color[variant] as unknown as Record<
+            string,
+            Record<string, unknown>
+        >,
+    ).flatMap(([group, roles]) =>
+        Object.keys(roles).map((role) => ({
+            variant,
+            group: group as ColorGroup,
+            role: role as ColorRole,
+        })),
+    ),
+);
+
+/** Rollene som finnes i hver gruppe, deduplikert på tvers av varianter. */
+export const COLOR_ROLES = ROLE_ENTRIES.reduce(
+    (acc, { group, role }) => {
+        acc[group] ??= [];
+        if (!acc[group].includes(role)) acc[group].push(role);
+        return acc;
+    },
+    {} as Record<ColorGroup, ColorRole[]>,
+);
+
+/** Theme-modusene (`light`, `dark`) lest av `value`-objektet på et tilfeldig token. */
+export const THEME_MODES: ThemeMode[] = (() => {
+    const sample = ROLE_ENTRIES[0];
+    const node = (
+        schema.color as unknown as Record<
+            string,
+            Record<string, Record<string, ColorTokenNode>>
+        >
+    )[sample.variant][sample.group][sample.role];
+    return Object.keys(node.value) as ThemeMode[];
+})();
+
+// --- Toveis konvertering mellom strukturen og redigerbare tokens ---
+
+/** Bygger redigerbare `ColorToken[]` fra JSON-strukturen (default: pakka JSON). */
+export function tokensFromSchema(
+    source: ColorSchemeJson = schema as unknown as ColorSchemeJson,
+): ColorToken[] {
+    return ROLE_ENTRIES.map(({ variant, group, role }) => {
+        const value = source.color[variant]?.[group]?.[role]?.value;
+        const modes = Object.fromEntries(
+            THEME_MODES.map((mode) => [mode, value?.[mode] ?? ""]),
+        ) as Record<ThemeMode, string>;
+        return { variant, group, role, ...modes };
+    });
+}
+
+/** Inversen av {@link tokensFromSchema} — brukes til eksport og JSON-redigering. */
+export function tokensToSchema(tokens: ColorToken[]): ColorSchemeJson {
+    const color = { type: "colorScheme" } as ColorSchemeJson["color"];
+    for (const t of tokens) {
+        color[t.variant] ??= {} as ColorSchemeJson["color"][ColorVariant];
+        color[t.variant][t.group] ??= {};
+        const value = Object.fromEntries(
+            THEME_MODES.map((mode) => [mode, t[mode]]),
+        ) as Record<ThemeMode, string>;
+        color[t.variant][t.group][t.role] = { value };
+    }
+    return { color };
+}

--- a/portal/src/components/theme-builder/utils.test.ts
+++ b/portal/src/components/theme-builder/utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import schema from "../../../../packages/jokul/src/tokens/color.tokens.json";
+import { ROLE_ENTRIES, THEME_MODES, tokensFromSchema } from "./tokens";
+import {
+    isHex,
+    normalizeHex,
+    parseEditorJson,
+    tokensEqual,
+    tokensHaveErrors,
+} from "./utils";
+
+describe("utils.ts — JSON-knytning", () => {
+    it("parseEditorJson aksepterer den ekte color.tokens.json-en", () => {
+        const result = parseEditorJson(JSON.stringify(schema));
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.tokens.length).toBe(ROLE_ENTRIES.length);
+        }
+    });
+
+    it("parseEditorJson rapporterer manglende stier presist", () => {
+        const partial = structuredClone(schema) as unknown as Record<
+            string,
+            Record<string, Record<string, Record<string, unknown>>>
+        >;
+        const variant = ROLE_ENTRIES[0].variant;
+        // Slett én gruppe for å trigge missing-stier
+        delete partial.color[variant][ROLE_ENTRIES[0].group];
+
+        const result = parseEditorJson(JSON.stringify(partial));
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toMatch(/mangler/);
+        }
+    });
+
+    it("parseEditorJson avviser ugyldig JSON", () => {
+        const result = parseEditorJson("{ ikke gyldig");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toMatch(/parses/);
+        }
+    });
+
+    it("parseEditorJson avviser hex-verdier som ikke er #RRGGBB", () => {
+        const broken = structuredClone(schema) as unknown as Record<
+            string,
+            Record<
+                string,
+                Record<
+                    string,
+                    Record<string, { value: Record<string, string> }>
+                >
+            >
+        >;
+        const e = ROLE_ENTRIES[0];
+        broken.color[e.variant][e.group][e.role].value[THEME_MODES[0]] =
+            "ikke-hex";
+
+        const result = parseEditorJson(JSON.stringify(broken));
+        expect(result.ok).toBe(false);
+    });
+
+    it("isHex aksepterer både små og store bokstaver", () => {
+        expect(isHex("#ABCDEF")).toBe(true);
+        expect(isHex("#abcdef")).toBe(true);
+        expect(isHex("#AbCdEf")).toBe(true);
+        expect(isHex("ABCDEF")).toBe(false);
+        expect(isHex("#ABC")).toBe(false);
+        expect(isHex("#GGGGGG")).toBe(false);
+    });
+
+    it("normalizeHex uppercaser og fjerner mellomrom", () => {
+        expect(normalizeHex("  #abcdef ")).toBe("#ABCDEF");
+    });
+
+    it("tokensHaveErrors er false for tokens lest fra JSON-en", () => {
+        expect(tokensHaveErrors(tokensFromSchema())).toBe(false);
+    });
+
+    it("tokensEqual er sann for to identiske roundtrips fra JSON", () => {
+        expect(tokensEqual(tokensFromSchema(), tokensFromSchema())).toBe(true);
+    });
+
+    it("tokensEqual er false når én verdi endres", () => {
+        const a = tokensFromSchema();
+        const b = a.map((t, i) =>
+            i === 0 ? { ...t, [THEME_MODES[0]]: "#000000" } : t,
+        );
+        expect(tokensEqual(a, b)).toBe(false);
+    });
+});

--- a/portal/src/components/theme-builder/utils.ts
+++ b/portal/src/components/theme-builder/utils.ts
@@ -1,0 +1,288 @@
+import { ColorSpace, contrastWCAG21, sRGB } from "colorjs.io/fn";
+import type { CSSProperties } from "react";
+import {
+    COLOR_VARIANTS,
+    type ColorSchemeJson,
+    type ColorToken,
+    type ContrastRequirementId,
+    ROLE_ENTRIES,
+    THEME_MODES,
+    tokenKey,
+    tokensFromSchema,
+} from "./tokens";
+
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const WCAG_TEXT_CONTRAST_AAA = 7;
+const WCAG_TEXT_CONTRAST_AA = 4.5;
+const WCAG_UI_CONTRAST_MINIMUM = 3;
+
+ColorSpace.register(sRGB);
+
+/**
+ * Fire-trinns rating som er felles på tvers av token-grupper, så vi kan vise
+ * en oppsummering øverst i fanen:
+ *
+ * - `AAA` — tekst som passerer WCAG 1.4.6 (≥ 7:1)
+ * - `AA`  — tekst som passerer WCAG 1.4.3 (≥ 4.5:1, < 7:1)
+ * - `A`   — grafisk innhold som passerer WCAG 1.4.11 (≥ 3:1; det laveste
+ *   nivået i WCAG, derav "A")
+ * - `✕`   — feiler det gjeldende kravet
+ */
+export type ContrastRating = "AAA" | "AA" | "A" | "✕";
+
+export type ContrastStatus = {
+    rating: ContrastRating;
+    /** Hvilket kontrastkrav som ble brukt — tekst eller grafisk/ikke-tekst. */
+    scope: "tekst" | "grafisk";
+    /** Laveste forholdstall det *gjeldende* scopet må møte for å passere. */
+    minimum: number;
+};
+
+export type ContrastEvaluation =
+    | { kind: "invalid" }
+    | {
+          kind: "measured";
+          passes: boolean;
+          ratio: number;
+          status: ContrastStatus;
+      };
+
+export const CONTRAST_REQUIREMENTS: Record<
+    ContrastRequirementId,
+    { scope: "tekst" | "grafisk"; minimum: number }
+> = {
+    text: { scope: "tekst", minimum: WCAG_TEXT_CONTRAST_AA },
+    ui: { scope: "grafisk", minimum: WCAG_UI_CONTRAST_MINIMUM },
+};
+
+/** Sann når verdien matcher `#RRGGBB`. Case-insensitiv ved input — `normalizeHex` uppercaser ved lagring. */
+export const isHex = (value: string): boolean => HEX_COLOR_PATTERN.test(value);
+
+/** Stripper mellomrom og gjør om til store bokstaver — stabil form for lagring og sammenligning. */
+export const normalizeHex = (value: string): string =>
+    value.replace(/\s+/g, "").toUpperCase();
+
+/** Inline feilmelding for heks-input, eller `undefined` om verdien er OK. */
+export const hexErrorLabel = (value: string): string | undefined =>
+    isHex(value) ? undefined : "Bruk formatet #RRGGBB";
+
+/** Verdi for native `<input type="color">` — faller tilbake til svart ved ugyldig input. */
+export const colorInputValue = (value: string): string =>
+    isHex(value) ? value : "#000000";
+
+/** WCAG 2.1-kontrastresultat, inkludert utledet status-tag. */
+export function evaluateColorContrast(
+    foreground: string | undefined,
+    background: string | undefined,
+    requirementId: ContrastRequirementId,
+): ContrastEvaluation {
+    if (
+        !foreground ||
+        !background ||
+        !isHex(foreground) ||
+        !isHex(background)
+    ) {
+        return { kind: "invalid" };
+    }
+
+    const ratio = contrastWCAG21(foreground, background);
+    if (ratio === undefined) return { kind: "invalid" };
+
+    const requirement = CONTRAST_REQUIREMENTS[requirementId];
+    return {
+        kind: "measured",
+        passes: ratio >= requirement.minimum,
+        ratio,
+        status: getContrastStatus(ratio, requirementId),
+    };
+}
+
+/**
+ * Parser JSON skrevet inn i editoren og validerer den mot token-strukturen.
+ * Returnerer norske feilmeldinger som editoren kan vise inline.
+ */
+export function parseEditorJson(
+    value: string,
+): { ok: true; tokens: ColorToken[] } | { ok: false; error: string } {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(value);
+    } catch {
+        return {
+            ok: false,
+            error: "JSON-en kan ikke parses. Kontroller komma og klammer.",
+        };
+    }
+
+    const missing = findMissingPaths(parsed);
+    if (missing.length > 0) {
+        const sample = missing.slice(0, 3).join(", ");
+        const suffix =
+            missing.length > 3 ? ` (+${missing.length - 3} til)` : "";
+        return {
+            ok: false,
+            error: `JSON-en mangler ${missing.length} ${missing.length === 1 ? "token" : "tokens"}: ${sample}${suffix}.`,
+        };
+    }
+
+    let tokens: ColorToken[];
+    try {
+        tokens = tokensFromSchema(parsed as ColorSchemeJson);
+    } catch {
+        return {
+            ok: false,
+            error: "JSON-en matcher ikke formatet for color tokens.",
+        };
+    }
+
+    if (tokensHaveErrors(tokens)) {
+        return { ok: false, error: "Alle verdier må bruke formatet #RRGGBB." };
+    }
+    return { ok: true, tokens };
+}
+
+/**
+ * Lister alle (variant.group.role)-stier i strukturen som mangler i den
+ * brukerleverte JSON-en, eller hvis verdiene ikke har `light`/`dark`-felt.
+ */
+function findMissingPaths(source: unknown): string[] {
+    if (typeof source !== "object" || source === null) {
+        return ROLE_ENTRIES.map(
+            (entry) => `${entry.variant}.${entry.group}.${entry.role}`,
+        );
+    }
+    const root = source as { color?: Record<string, unknown> };
+    if (typeof root.color !== "object" || root.color === null) {
+        return ROLE_ENTRIES.map(
+            (entry) => `${entry.variant}.${entry.group}.${entry.role}`,
+        );
+    }
+    const missing: string[] = [];
+    for (const { variant, group, role } of ROLE_ENTRIES) {
+        const path = `${variant}.${group}.${role}`;
+        const variantNode = (root.color as Record<string, unknown>)[variant];
+        if (typeof variantNode !== "object" || variantNode === null) {
+            missing.push(path);
+            continue;
+        }
+        const groupNode = (variantNode as Record<string, unknown>)[group];
+        if (typeof groupNode !== "object" || groupNode === null) {
+            missing.push(path);
+            continue;
+        }
+        const roleNode = (groupNode as Record<string, unknown>)[role];
+        if (typeof roleNode !== "object" || roleNode === null) {
+            missing.push(path);
+            continue;
+        }
+        const value = (roleNode as { value?: unknown }).value;
+        if (typeof value !== "object" || value === null) {
+            missing.push(path);
+            continue;
+        }
+        const valueRecord = value as Record<string, unknown>;
+        if (THEME_MODES.some((mode) => typeof valueRecord[mode] !== "string")) {
+            missing.push(path);
+        }
+    }
+    return missing;
+}
+
+/** Sann hvis noe token har en ugyldig heks-verdi i noen theme-modus. */
+export const tokensHaveErrors = (tokens: ColorToken[]): boolean =>
+    tokens.some((t) => THEME_MODES.some((mode) => !isHex(t[mode])));
+
+/** Strukturlik likhet for to token-lister — brukes for å regne ut "dirty"-status. */
+export const tokensEqual = (a: ColorToken[], b: ColorToken[]): boolean =>
+    a.length === b.length &&
+    a.every((t, i) => {
+        const o = b[i];
+        return (
+            tokenKey(t) === tokenKey(o) &&
+            THEME_MODES.every((mode) => t[mode] === o[mode])
+        );
+    });
+
+/**
+ * Bygger inline CSS-variabler for preview-scopet. Hvert token slippes ut som
+ * en `--jkl-color-<variant>-<group>-<role>`-variabel; den første varianten i
+ * JSON-en aliaseres i tillegg til bart `--jkl-color-<group>-<role>` slik at
+ * uscopete Jøkul-komponenter plukker opp de live-verdiene.
+ *
+ * CSS `light-dark()`-funksjonen tar nøyaktig to argumenter, så vi krever at
+ * `THEME_MODES` har akkurat to entries (`light` og `dark`). Skulle JSON-en
+ * en gang utvides med en tredje mode, vil `assertTwoModes` kaste — det er et
+ * tydelig signal om at preview-mekanismen må tenkes på nytt.
+ */
+export function buildPreviewStyle(tokens: ColorToken[]): CSSProperties {
+    const [lightMode, darkMode] = assertTwoModes();
+    const baseVariant = COLOR_VARIANTS[0];
+    const style: Record<string, string> = {};
+    for (const t of tokens) {
+        const value = `light-dark(${t[lightMode]}, ${t[darkMode]})`;
+        style[`--jkl-color-${t.variant}-${t.group}-${t.role}`] = value;
+        if (t.variant === baseVariant) {
+            style[`--jkl-color-${t.group}-${t.role}`] = value;
+        }
+    }
+    return style as CSSProperties;
+}
+
+function assertTwoModes(): readonly [string, string] {
+    if (THEME_MODES.length !== 2) {
+        throw new Error(
+            `Theme builder forventer akkurat 2 theme-modes (light + dark) for å støtte CSS light-dark(). Fant ${THEME_MODES.length}: ${THEME_MODES.join(", ")}.`,
+        );
+    }
+    return [THEME_MODES[0], THEME_MODES[1]];
+}
+
+/**
+ * Mapper et kontrastforhold til en {@link ContrastRating} innenfor det
+ * gjeldende scopet.
+ *
+ * - **Tekst** (tekst-tokens): WCAG 1.4.3 krever ≥ 4.5:1 (`AA`); 1.4.6 krever
+ *   ≥ 7:1 (`AAA`).
+ * - **Grafisk innhold** (border, ikoner, dekorasjon): WCAG 1.4.11 krever
+ *   ≥ 3:1 — vises som `A` for å markere det som det laveste passerende
+ *   nivået, slik at oppsummeringen øverst skiller det fra tekst-AA.
+ */
+function getContrastStatus(
+    ratio: number,
+    requirementId: ContrastRequirementId,
+): ContrastStatus {
+    const requirement = CONTRAST_REQUIREMENTS[requirementId];
+    if (requirementId === "text") {
+        if (ratio >= WCAG_TEXT_CONTRAST_AAA) {
+            return {
+                rating: "AAA",
+                scope: "tekst",
+                minimum: WCAG_TEXT_CONTRAST_AAA,
+            };
+        }
+        if (ratio >= WCAG_TEXT_CONTRAST_AA) {
+            return {
+                rating: "AA",
+                scope: "tekst",
+                minimum: WCAG_TEXT_CONTRAST_AA,
+            };
+        }
+        return {
+            rating: "✕",
+            scope: requirement.scope,
+            minimum: requirement.minimum,
+        };
+    }
+    if (ratio >= WCAG_UI_CONTRAST_MINIMUM) {
+        return {
+            rating: "A",
+            scope: "grafisk",
+            minimum: WCAG_UI_CONTRAST_MINIMUM,
+        };
+    }
+    return {
+        rating: "✕",
+        scope: requirement.scope,
+        minimum: requirement.minimum,
+    };
+}

--- a/portal/tsconfig.json
+++ b/portal/tsconfig.json
@@ -31,6 +31,9 @@
       ],
       "@storybook-config/*": [
         "../.storybook/*"
+      ],
+      "@jokul-stories/*": [
+        "../packages/jokul/stories/*"
       ]
     },
     "target": "ES2022"

--- a/portal/vite.test.config.mjs
+++ b/portal/vite.test.config.mjs
@@ -1,0 +1,19 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Vitest-config for portalens enhetstester. Theme-builder importerer JSON
+// og Storybook-stories utenfor `portal/`, så vi må eksplisitt løse `.js`/
+// `.jsx`-imports til `.ts`/`.tsx` (samme som `next.config.mjs` gjør).
+export default defineConfig({
+    plugins: [react()],
+    resolve: {
+        extensionAlias: {
+            ".js": [".js", ".ts", ".tsx"],
+            ".jsx": [".jsx", ".tsx"],
+        },
+    },
+    test: {
+        environment: "jsdom",
+        include: ["src/**/*.test.?(c|m)ts?(x)"],
+    },
+});


### PR DESCRIPTION
## Hva er gjort

- lagt til en første versjon av /theme-builder i portalen
- lagt inn redigering av fargetokens, både visuelt og i rå JSON
- lagt til en forhåndsvisning med Jøkul-komponenter så det er lettere å se hvordan temaet faktisk ser ut
- lagt til eksport via kopi og nedlasting
- tatt med oppdateringer av tokennavn og justert tokenreferanser i komponentstiler der det trengs

## Hvorfor
Tanken her er bare å få på plass et første utkast som gjør det mulig å utforske og bygge brand-spesifikke temaer direkte i portalen, med utgangspunkt i [color.tokens.json](https://github.com/fremtind/jokul/blob/release/next/packages/jokul/src/tokens/color.tokens.json)

## Påvirkning

- ny intern side for theme builder i portalen
- ingen endring i publisert API for `@fremtind/jokul`