### PR TITLE
feat: Text og Title typografikomponenter

### DIFF
--- a/.changeset/text-og-title-komponenter.md
+++ b/.changeset/text-og-title-komponenter.md
@@ -1,0 +1,13 @@
+---
+"@fremtind/jokul": minor
+---
+
+Nye typografikomponenter `Text` og `Title` under `@fremtind/jokul/typography`. Disse vil gjøre det lettere for teamene å gjennomføre migrasjon til Jøkul 5.0 fordi de abstraherer typografistilene, på samme måte som hjelpeklassene i CSS allerede gjør.
+
+`Text` er polymorf med `as` begrenset til typografisk relevante elementer (`p`, `span`, `label`, `legend`, `small`, `strong`, `em`, `code`, `kbd`, `samp`, `var`), `size` på t-shirt-skala (`xs`, `s`, `m`, `l`) med default `m`, og boolean-toggles `bold`, `short` og `srOnly`. `code`/`kbd`/`samp`/`var` får automatisk monospace font.
+
+`Title` er polymorf med `as` begrenset til `h1`–`h6` pluss skjema-elementene `label` og `legend`, `size` på `xs`, `s`, `m`, `l`, `xl` med default `l`, og `srOnly`-toggle. `as` og `size` er bevisst frakoblet — semantikk styres via `as`, visuell størrelse via `size`.
+
+Nye hjelpeklasser `.jkl-heading-xs` til `.jkl-heading-xl` fra `components/typography` er ekvivalenter til `<Title size="…">` brukt på et vilkårlig element.
+
+Eksisterende `.jkl-title`-utility-klasse er scoped med `:not([data-text-size])` slik at den ikke overstyrer Title-komponenten, men fortsatt fungerer som standalone hjelpeklasse på elementer uten `data-text-size`-attributtet.

--- a/packages/jokul/src/components/typography/Text.test.tsx
+++ b/packages/jokul/src/components/typography/Text.test.tsx
@@ -1,0 +1,114 @@
+import { render } from "@testing-library/react";
+import React, { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Text } from "./Text.js";
+
+describe("Text", () => {
+    it("rendres som <p> som standard", () => {
+        const { container } = render(<Text>Brødtekst</Text>);
+
+        const element = container.firstElementChild;
+
+        expect(element?.tagName).toBe("P");
+        expect(element).toHaveClass("jkl-text");
+    });
+
+    it("rendrer elementet satt via `as`", () => {
+        const { getByText } = render(<Text as="strong">Viktig</Text>);
+
+        expect(getByText("Viktig").tagName).toBe("STRONG");
+    });
+
+    it("rendrer som <label> med videresendt `htmlFor`", () => {
+        const { container } = render(
+            <Text as="label" htmlFor="epost">
+                E-post
+            </Text>,
+        );
+
+        const label = container.querySelector("label");
+        expect(label).toBeInTheDocument();
+        expect(label).toHaveTextContent("E-post");
+        expect(label).toHaveAttribute("for", "epost");
+        expect(label).toHaveClass("jkl-text");
+    });
+
+    it("setter `data-text-size` når `size` er satt", () => {
+        const { getByText } = render(<Text size="l">Stor</Text>);
+
+        expect(getByText("Stor")).toHaveAttribute("data-text-size", "l");
+    });
+
+    it("støtter `xs` som minste størrelse", () => {
+        const { getByText } = render(<Text size="xs">Bitteliten</Text>);
+
+        expect(getByText("Bitteliten")).toHaveAttribute("data-text-size", "xs");
+    });
+
+    it("bruker `m` som default når `size` er utelatt", () => {
+        const { getByText } = render(<Text>Default</Text>);
+
+        expect(getByText("Default")).toHaveAttribute("data-text-size", "m");
+    });
+
+    it("setter `data-bold` når `bold` er true", () => {
+        const { getByText } = render(<Text bold>Uthevet</Text>);
+
+        expect(getByText("Uthevet")).toHaveAttribute("data-bold");
+    });
+
+    it("setter ikke `data-bold` når `bold` er false", () => {
+        const { getByText } = render(<Text bold={false}>Vanlig</Text>);
+
+        expect(getByText("Vanlig")).not.toHaveAttribute("data-bold");
+    });
+
+    it("setter `data-short` når `short` er true", () => {
+        const { getByText } = render(<Text short>Tett</Text>);
+
+        expect(getByText("Tett")).toHaveAttribute("data-short");
+    });
+
+    it("legger til `jkl-sr-only` når `srOnly` er true", () => {
+        const { getByText } = render(<Text srOnly>Skjult</Text>);
+
+        expect(getByText("Skjult")).toHaveClass("jkl-text", "jkl-sr-only");
+    });
+
+    it("videresender ekstra className", () => {
+        const { getByText } = render(
+            <Text className="egen-klasse">Med klasse</Text>,
+        );
+
+        expect(getByText("Med klasse")).toHaveClass("jkl-text", "egen-klasse");
+    });
+
+    it("videresender ref til det underliggende elementet", () => {
+        const ref = createRef<HTMLParagraphElement>();
+
+        render(<Text ref={ref}>Med ref</Text>);
+
+        expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+    });
+
+    it("videresender ekstra DOM-attributter via rest", () => {
+        const { getByText } = render(
+            <Text aria-label="etikett" data-testid="text">
+                Innhold
+            </Text>,
+        );
+
+        const element = getByText("Innhold");
+        expect(element).toHaveAttribute("aria-label", "etikett");
+        expect(element).toHaveAttribute("data-testid", "text");
+    });
+
+    it("passerer axe i standardtilstand", async () => {
+        const { container } = render(<Text>Tilgjengelig tekst</Text>);
+
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
+});

--- a/packages/jokul/src/components/typography/Text.tsx
+++ b/packages/jokul/src/components/typography/Text.tsx
@@ -1,0 +1,27 @@
+import clsx from "clsx";
+import React, { forwardRef } from "react";
+import type { PolymorphicRef } from "../../utilities/index.js";
+import type { TextElement, TextProps } from "./types.js";
+
+type TextComponent = <As extends TextElement = "p">(
+    props: TextProps<As>,
+) => React.ReactElement | null;
+
+export const Text: TextComponent = forwardRef(function Text<
+    As extends TextElement = "p",
+>(
+    { as, className, size = "m", bold, short, srOnly, ...rest }: TextProps<As>,
+    ref?: PolymorphicRef<As>,
+) {
+    const Component = (as || "p") as React.ElementType;
+    return (
+        <Component
+            className={clsx("jkl-text", srOnly && "jkl-sr-only", className)}
+            data-text-size={size}
+            data-bold={bold || undefined}
+            data-short={short || undefined}
+            ref={ref}
+            {...rest}
+        />
+    );
+}) as TextComponent;

--- a/packages/jokul/src/components/typography/Title.test.tsx
+++ b/packages/jokul/src/components/typography/Title.test.tsx
@@ -1,0 +1,166 @@
+import { render } from "@testing-library/react";
+import React, { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Title } from "./Title.js";
+
+describe("Title", () => {
+    it("rendres som <h2> med size=l som standard", () => {
+        const { getByRole } = render(<Title>Forside</Title>);
+
+        const heading = getByRole("heading", { level: 2 });
+        expect(heading).toHaveClass("jkl-title");
+        expect(heading).toHaveAttribute("data-text-size", "l");
+    });
+
+    it("rendrer riktig heading-nivå satt via `as`", () => {
+        const { getByRole } = render(<Title as="h1">Hovedtittel</Title>);
+
+        expect(getByRole("heading", { level: 1 })).toHaveTextContent(
+            "Hovedtittel",
+        );
+    });
+
+    it("rendrer alle heading-nivå h1 til h6", () => {
+        const levels: Array<"h1" | "h2" | "h3" | "h4" | "h5" | "h6"> = [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+        ];
+
+        for (const level of levels) {
+            const { getByRole, unmount } = render(
+                <Title as={level}>{level}</Title>,
+            );
+
+            expect(
+                getByRole("heading", { level: Number(level.slice(1)) }),
+            ).toBeInTheDocument();
+
+            unmount();
+        }
+    });
+
+    it("rendrer som <label> med videresendt `htmlFor`", () => {
+        const { container } = render(
+            <Title as="label" htmlFor="epost">
+                E-post
+            </Title>,
+        );
+
+        const label = container.querySelector("label");
+        expect(label).toBeInTheDocument();
+        expect(label).toHaveTextContent("E-post");
+        expect(label).toHaveAttribute("for", "epost");
+        expect(label).toHaveClass("jkl-title");
+    });
+
+    it("rendrer som <legend>", () => {
+        const { container } = render(
+            <fieldset>
+                <Title as="legend">Kontaktinformasjon</Title>
+            </fieldset>,
+        );
+
+        const legend = container.querySelector("legend");
+        expect(legend).toBeInTheDocument();
+        expect(legend).toHaveTextContent("Kontaktinformasjon");
+        expect(legend).toHaveClass("jkl-title");
+    });
+
+    it("setter `data-text-size` for oppgitt size", () => {
+        const { getByRole } = render(
+            <Title as="h2" size="s">
+                Mindre
+            </Title>,
+        );
+
+        expect(getByRole("heading", { level: 2 })).toHaveAttribute(
+            "data-text-size",
+            "s",
+        );
+    });
+
+    it("støtter `xs` og `xl` som ytterpunkter", () => {
+        const { getByRole: getBySmall, unmount } = render(
+            <Title as="h2" size="xs">
+                Minst
+            </Title>,
+        );
+        expect(getBySmall("heading", { level: 2 })).toHaveAttribute(
+            "data-text-size",
+            "xs",
+        );
+        unmount();
+
+        const { getByRole: getByLarge } = render(
+            <Title as="h2" size="xl">
+                Størst
+            </Title>,
+        );
+        expect(getByLarge("heading", { level: 2 })).toHaveAttribute(
+            "data-text-size",
+            "xl",
+        );
+    });
+
+    it("legger til `jkl-sr-only` når `srOnly` er true", () => {
+        const { getByRole } = render(
+            <Title as="h2" srOnly>
+                Skjult
+            </Title>,
+        );
+
+        expect(getByRole("heading", { level: 2 })).toHaveClass(
+            "jkl-title",
+            "jkl-sr-only",
+        );
+    });
+
+    it("videresender ekstra className", () => {
+        const { getByRole } = render(
+            <Title className="egen-klasse">Med klasse</Title>,
+        );
+
+        expect(getByRole("heading", { level: 2 })).toHaveClass(
+            "jkl-title",
+            "egen-klasse",
+        );
+    });
+
+    it("videresender ref til det underliggende heading-elementet", () => {
+        const ref = createRef<HTMLHeadingElement>();
+
+        render(
+            <Title as="h1" ref={ref}>
+                Med ref
+            </Title>,
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+        expect(ref.current?.tagName).toBe("H1");
+    });
+
+    it("videresender ekstra DOM-attributter via rest", () => {
+        const { getByRole } = render(
+            <Title as="h2" id="seksjon-tittel" aria-label="etikett">
+                Innhold
+            </Title>,
+        );
+
+        const heading = getByRole("heading", { level: 2 });
+        expect(heading).toHaveAttribute("id", "seksjon-tittel");
+        expect(heading).toHaveAttribute("aria-label", "etikett");
+    });
+
+    it("passerer axe i standardtilstand", async () => {
+        const { container } = render(<Title as="h1">Tilgjengelig</Title>);
+
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
+});

--- a/packages/jokul/src/components/typography/Title.tsx
+++ b/packages/jokul/src/components/typography/Title.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+import React, { forwardRef } from "react";
+import type { PolymorphicRef } from "../../utilities/index.js";
+import type { TitleElement, TitleProps } from "./types.js";
+
+type TitleComponent = <As extends TitleElement = "h2">(
+    props: TitleProps<As>,
+) => React.ReactElement | null;
+
+export const Title: TitleComponent = forwardRef(function Title<
+    As extends TitleElement = "h2",
+>(
+    { className, size = "l", as, srOnly, ...rest }: TitleProps<As>,
+    ref?: PolymorphicRef<As>,
+) {
+    const Tag = (as || "h2") as React.ElementType;
+    return (
+        <Tag
+            className={clsx("jkl-title", srOnly && "jkl-sr-only", className)}
+            data-text-size={size}
+            ref={ref}
+            {...rest}
+        />
+    );
+}) as TitleComponent;

--- a/packages/jokul/src/components/typography/index.ts
+++ b/packages/jokul/src/components/typography/index.ts
@@ -1,0 +1,4 @@
+export { Text } from "./Text.js";
+export { Title } from "./Title.js";
+
+export type { TextProps, TextSize, TitleProps, TitleSize } from "./types.js";

--- a/packages/jokul/src/components/typography/stories/text.stories.tsx
+++ b/packages/jokul/src/components/typography/stories/text.stories.tsx
@@ -1,0 +1,375 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import React from "react";
+
+import { Link } from "../../link/index.js";
+import {
+    CheckListItem,
+    List,
+    ListItem,
+    OrderedList,
+} from "../../list/index.js";
+import { Text } from "../index.js";
+import "../../../styles/utility/_index.scss";
+import "../../link/styles/_index.scss";
+import "../../list/styles/_index.scss";
+import "../styles/_index.scss";
+
+const meta = {
+    title: "Komponenter/Typografi/Text",
+    component: Text,
+    args: {
+        bold: false,
+        srOnly: false,
+        short: false,
+        size: "m",
+        children:
+            "Fremtind er ett av Norges største forsikringsselskap og står for nær en femtedel av det totale skadeforsikringsmarkedet.",
+    },
+    argTypes: {
+        size: {
+            control: "radio",
+            options: ["xs", "s", "m", "l"],
+            description: "Visuell størrelse.",
+            table: {
+                defaultValue: { summary: "m" },
+                type: { summary: '"xs" | "s" | "m" | "l"' },
+            },
+        },
+        bold: {
+            control: "boolean",
+            description: "Uthever teksten (font-weight: bold).",
+            table: { defaultValue: { summary: "false" } },
+        },
+        short: {
+            control: "boolean",
+            description:
+                "Tettere linjehøyde. Bruk når teksten i all hovedsak går over én linje (f.eks. i tabellceller eller knapper).",
+            table: { defaultValue: { summary: "false" } },
+        },
+        srOnly: {
+            control: "boolean",
+            description:
+                "Skjuler elementet visuelt, men beholder det for skjermlesere.",
+            table: { defaultValue: { summary: "false" } },
+        },
+        as: {
+            control: "select",
+            options: [
+                "p",
+                "span",
+                "label",
+                "legend",
+                "small",
+                "strong",
+                "em",
+                "code",
+                "kbd",
+                "samp",
+                "var",
+            ],
+            description:
+                "Hvilket HTML-element Text rendres som. Begrenset til typografisk relevante inline-elementer, <p>, og skjema-elementene <label>/<legend>.",
+            table: {
+                defaultValue: { summary: "p" },
+                type: {
+                    summary:
+                        '"p" | "span" | "label" | "legend" | "small" | "strong" | "em" | "code" | "kbd" | "samp" | "var"',
+                },
+            },
+        },
+        className: {
+            control: "text",
+            description:
+                "Ekstra klassenavn som legges til i tillegg til `jkl-text`.",
+            table: { type: { summary: "string" } },
+        },
+    },
+    tags: ["autodocs", "grouping content"],
+} satisfies Meta<typeof Text>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+/**
+ * Default-tilstand. Lek gjerne med propsene i kontrollpanelet for å se
+ * hvordan `size`, `bold`, `short`, `srOnly` og `as` påvirker resultatet.
+ */
+export const Default: Story = {};
+
+/**
+ * Text støtter fire størrelser: `xs` (14px), `s` (16px), `m` (18px) og
+ * `l` (24px). Hver størrelse bruker Jøkul sine tekst-stil-tokens, så både
+ * linjehøyde og andre detaljer følger med.
+ */
+export const SizeScale: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text size="xs">Fontstørrelse xs</Text>
+<Text size="s">Fontstørrelse s</Text>
+<Text size="m">Fontstørrelse m</Text>
+<Text size="l">Fontstørrelse l</Text>`,
+            },
+        },
+    },
+    render: () => (
+        <>
+            <Text size="xs">Fontstørrelse xs</Text>
+            <Text size="s">Fontstørrelse s</Text>
+            <Text size="m">Fontstørrelse m</Text>
+            <Text size="l">Fontstørrelse l</Text>
+        </>
+    ),
+};
+
+/**
+ * Bruk `bold` for å utheve tekst, og `short` for å komprimere linjehøyden
+ * (f.eks. i tett-pakkede lister eller kort-lignende oppsett).
+ */
+export const BoldOgShort: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text>
+    Forsikringer kjøper du i banken din eller i forbundet ditt.
+</Text>
+<Text bold>
+    Fremtind hjelper og motiverer folk til å ta vare på helsen, verdiene
+    og omgivelsene sine.
+</Text>
+<Text short>
+    Tett linjehøyde passer når det er begrenset plass.
+</Text>`,
+            },
+        },
+    },
+    render: () => (
+        <>
+            <Text>
+                Forsikringer kjøper du i banken din eller i forbundet ditt.
+            </Text>
+            <Text bold>
+                Fremtind hjelper og motiverer folk til å ta vare på helsen,
+                verdiene og omgivelsene sine.
+            </Text>
+            <Text short>
+                Tett linjehøyde passer når det er begrenset plass, for eksempel
+                i en tabellcelle eller et lite kort. Linjene ligger tettere enn
+                standard brødtekst.
+            </Text>
+        </>
+    ),
+};
+
+/**
+ * Typisk brødtekst i medium størrelse. Teksten under er hentet fra
+ * forsiden til fremtind.no.
+ */
+export const Brødtekst: Story = {
+    args: {
+        children:
+            "Livet skjer når vi aller minst venter det. Mens noens drømmer går i oppfyllelse, går andres i knas. Gledelige begivenheter skjer hver dag, det gjør også skader og ulykker. Og midt i disse øyeblikkene møter vi deg.",
+    },
+};
+
+/**
+ * `as="label"` rendrer et `<label>`-element og får blokk-nivå og bunnmarg
+ * automatisk. Kombineres typisk med et form-element via `htmlFor`.
+ * Samme prop er tilgjengelig på `Title` når du trenger label-stil med
+ * heading-typografi.
+ */
+export const SomLabel: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                type: "code",
+                language: "tsx",
+                code: `<Text as="label" htmlFor="fodselsnummer">
+    Fødselsnummer
+</Text>
+<input id="fodselsnummer" type="text" placeholder="11 siffer" />`,
+            },
+        },
+    },
+    render: () => (
+        <>
+            <Text as="label" htmlFor="fodselsnummer">
+                Fødselsnummer
+            </Text>
+            <input
+                id="fodselsnummer"
+                type="text"
+                placeholder="11 siffer"
+                style={{ padding: "8px", width: 240 }}
+            />
+        </>
+    ),
+};
+
+/**
+ * Bruk `as` til å rendre Text som semantiske inline-elementer som
+ * `strong`, `em`, `kbd` og `code`.
+ */
+export const InlineElementer: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text>
+    Husk at du må <Text as="strong">bekrefte endringen</Text> før den
+    trer i kraft. Trykk <Text as="kbd">Ctrl + S</Text> for å lagre, og
+    se{" "}
+    <Link href="/forsikringsbevis.pdf">
+        <Text as="code">forsikringsbevis.pdf</Text>
+    </Link>{" "}
+    som blir lastet ned til maskinen din.
+</Text>`,
+            },
+        },
+    },
+    render: () => (
+        <Text>
+            Husk at du må <Text as="strong">bekrefte endringen</Text> før den
+            trer i kraft. Trykk <Text as="kbd">Ctrl + S</Text> for å lagre, og
+            se{" "}
+            <Link href="/forsikringsbevis.pdf">
+                <Text as="code">forsikringsbevis.pdf</Text>
+            </Link>{" "}
+            som blir lastet ned til maskinen din.
+        </Text>
+    ),
+};
+
+/**
+ * Bruk `Text` sammen med liste-komponentene (`List`, `OrderedList`,
+ * `ListItem`, `CheckListItem`) fremfor å sende `as="ul"` til Text.
+ * Teksten er hentet fra fremtind.no sine bærekraftssider.
+ */
+export const MedListe: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text>I arbeidet med bærekraft prioriterer Fremtind:</Text>
+<List>
+    <CheckListItem>
+        <Text as="span">Klimagassutslipp og ressursbruk</Text>
+    </CheckListItem>
+    <CheckListItem>
+        <Text as="span">Fysisk klimarisiko og skadeforebygging</Text>
+    </CheckListItem>
+    <CheckListItem>
+        <Text as="span">Ansvarlighet i verdikjeden</Text>
+    </CheckListItem>
+    <CheckListItem>
+        <Text as="span">Helse og forebygging</Text>
+    </CheckListItem>
+</List>`,
+            },
+        },
+    },
+    render: () => (
+        <>
+            <Text>I arbeidet med bærekraft prioriterer Fremtind:</Text>
+            <List>
+                <CheckListItem>
+                    <Text as="span">Klimagassutslipp og ressursbruk</Text>
+                </CheckListItem>
+                <CheckListItem>
+                    <Text as="span">
+                        Fysisk klimarisiko og skadeforebygging
+                    </Text>
+                </CheckListItem>
+                <CheckListItem>
+                    <Text as="span">Ansvarlighet i verdikjeden</Text>
+                </CheckListItem>
+                <CheckListItem>
+                    <Text as="span">Helse og forebygging</Text>
+                </CheckListItem>
+            </List>
+        </>
+    ),
+};
+
+/**
+ * `srOnly` skjuler teksten visuelt, men beholder den for skjermlesere.
+ * Typisk brukt for å legge til kontekst til lenker, knapper og ikoner som
+ * ellers ville vært uklare for brukere av assistive teknologier.
+ */
+export const KunForSkjermleser: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text>
+    Last ned{" "}
+    <Link href="/vilkaar.pdf" external>
+        vilkårene
+        <Text as="span" srOnly> (PDF, åpnes i ny fane)</Text>
+    </Link>{" "}
+    før du inngår avtalen.
+</Text>`,
+            },
+        },
+    },
+    render: () => (
+        <Text>
+            Last ned{" "}
+            <Link href="/vilkaar.pdf" external>
+                vilkårene
+                <Text as="span" srOnly>
+                    {" "}
+                    (PDF, åpnes i ny fane)
+                </Text>
+            </Link>{" "}
+            før du inngår avtalen.
+        </Text>
+    ),
+};
+
+/**
+ * Nummerert liste med `OrderedList` — nyttig når rekkefølgen betyr noe.
+ */
+export const NummerertListe: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Text>Slik kommer du i gang:</Text>
+<OrderedList>
+    <ListItem>
+        <Text as="span">Logg inn på Min side i banken din</Text>
+    </ListItem>
+    <ListItem>
+        <Text as="span">Velg Meld skade</Text>
+    </ListItem>
+    <ListItem>
+        <Text as="span">Velg forsikringen det gjelder</Text>
+    </ListItem>
+</OrderedList>`,
+            },
+        },
+    },
+    render: () => (
+        <>
+            <Text>Slik kommer du i gang:</Text>
+            <OrderedList>
+                <ListItem>
+                    <Text as="span">Logg inn på Min side i banken din</Text>
+                </ListItem>
+                <ListItem>
+                    <Text as="span">Velg Meld skade fra menyen</Text>
+                </ListItem>
+                <ListItem>
+                    <Text as="span">
+                        Velg forsikringen det gjelder og følg veiviseren
+                    </Text>
+                </ListItem>
+            </OrderedList>
+        </>
+    ),
+};

--- a/packages/jokul/src/components/typography/stories/title.stories.tsx
+++ b/packages/jokul/src/components/typography/stories/title.stories.tsx
@@ -1,0 +1,327 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import React from "react";
+
+import { Card } from "../../card/Card.js";
+import { Flex } from "../../flex/Flex.js";
+import { Text, Title } from "../index.js";
+
+import "../../../styles/utility/_index.scss";
+import "../../card/styles/_index.scss";
+import "../styles/_index.scss";
+import "../../flex/styles/_index.scss";
+
+const SIZES = ["xs", "s", "m", "l", "xl"] as const;
+
+const meta = {
+    title: "Komponenter/Typografi/Title",
+    component: Title,
+    args: {
+        srOnly: false,
+        size: "l",
+        children: "Forsikringer kjøper du i banken din eller i forbundet ditt",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: SIZES,
+            description:
+                "Visuell størrelse på tittelen, frakoblet fra `as`-nivået.",
+            table: {
+                defaultValue: { summary: "l" },
+                type: {
+                    summary: '"xs" | "s" | "m" | "l" | "xl"',
+                },
+            },
+        },
+        as: {
+            control: "select",
+            options: ["h1", "h2", "h3", "h4", "h5", "h6", "label", "legend"],
+            description:
+                "Semantisk element. Standard er h2. Bruk h1–h6 for dokument-hierarki, eller label/legend for skjema-grupperinger.",
+            table: {
+                defaultValue: { summary: "h2" },
+                type: {
+                    summary:
+                        '"h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "label" | "legend"',
+                },
+            },
+        },
+        srOnly: {
+            control: "boolean",
+            description:
+                "Skjuler tittelen visuelt, men beholder den i skjermlesere.",
+            table: { defaultValue: { summary: "false" } },
+        },
+        children: { control: "text", description: "Innholdet i tittelen." },
+        className: {
+            control: "text",
+            description:
+                "Ekstra klassenavn som legges til i tillegg til `jkl-title`.",
+            table: { type: { summary: "string" } },
+        },
+    },
+    tags: ["autodocs", "grouping content"],
+} satisfies Meta<typeof Title>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+/**
+ * Default-tilstand. Prøv ulike kombinasjoner av `as` og `size` i
+ * kontrollpanelet for å se hvordan de fungerer uavhengig.
+ */
+export const Default: Story = {};
+
+/**
+ * Title har fem størrelser, fra `xs` (minst) til `xl` (størst).
+ */
+export const Sizes: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Title size="xs">…</Title>
+<Title size="s">…</Title>
+<Title size="m">…</Title>
+<Title size="l">…</Title>
+<Title size="xl">…</Title>`,
+            },
+        },
+    },
+    render: () => (
+        <Flex direction="column" gap="s">
+            {SIZES.map((size) => (
+                <Title key={size} size={size}>
+                    Markedsposisjon og eierforhold — {size}
+                </Title>
+            ))}
+        </Flex>
+    ),
+};
+
+/**
+ * `as` styrer semantikk (tilgjengelighet, heading-hierarki), `size` styrer
+ * visuell størrelse. De to er frakoblet.
+ *
+ * Først: samme semantiske element (`h2`) med ulik visuell størrelse.
+ * Deretter: samme visuelle størrelse (`m`) med ulikt semantisk element.
+ */
+export const SemantikkOgStilFrakoblet: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `{/* Samme element (h2), ulik visuell størrelse */}
+<Title size="xl">Om oss</Title>
+<Title size="m">Om oss</Title>
+<Title size="xs">Om oss</Title>
+
+{/* Samme visuelle størrelse (m), ulikt semantisk element */}
+<Title as="h1" size="m">Bærekraft</Title>
+<Title size="m">Bærekraft</Title>
+<Title as="h3" size="m">Bærekraft</Title>`,
+            },
+        },
+    },
+    render: () => (
+        <Flex direction="column" gap="l">
+            <Flex direction="column" gap="xs">
+                <Title as="h3" size="xs">
+                    Samme element, ulik stil
+                </Title>
+                <Title size="xl">Om oss (h2, xl)</Title>
+                <Title size="m">Om oss (h2, m)</Title>
+                <Title size="xs">Om oss (h2, xs)</Title>
+            </Flex>
+            <Flex direction="column" gap="xs">
+                <Title as="h3" size="xs">
+                    Samme stil, ulikt element
+                </Title>
+                <Title as="h1" size="m">
+                    Bærekraft (h1, m)
+                </Title>
+                <Title size="m">Bærekraft (h2, m)</Title>
+                <Title as="h3" size="m">
+                    Bærekraft (h3, m)
+                </Title>
+            </Flex>
+        </Flex>
+    ),
+};
+
+/**
+ * Bruk `srOnly` når du trenger en semantisk overskrift for skjermlesere,
+ * men hvor designet ikke skal vise tittelen visuelt. Nyttig for landemerker
+ * (navigation, main, complementary) som allerede har visuell kontekst.
+ */
+export const KunForSkjermleser: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<section aria-labelledby="forsikringer">
+    <Title id="forsikringer" srOnly>
+        Forsikringene dine
+    </Title>
+    {/* Visuelt innhold for seksjonen */}
+</section>`,
+            },
+        },
+    },
+    render: () => (
+        <Flex direction="column" gap="xs" style={{ maxWidth: 560 }}>
+            <Title srOnly>Forsikringene dine</Title>
+            <Flex
+                direction="row"
+                gap="s"
+                style={{
+                    border: "1px dashed rgba(0,0,0,.3)",
+                    borderRadius: 6,
+                    padding: 16,
+                }}
+            >
+                <span>🚗 Bilforsikring</span>
+                <span>🏠 Husforsikring</span>
+                <span>✈️ Reiseforsikring</span>
+            </Flex>
+            <p>
+                Over: et visuelt kortgitter. h2-en &quot;Forsikringene
+                dine&quot; er usynlig, men tilgjengelig for skjermlesere slik at
+                landemerket er beskrevet i hierarkiet.
+            </p>
+        </Flex>
+    ),
+};
+
+/**
+ * Typisk sammensetning av `Title` og `Text` inne i et `Card`: en
+ * seksjonstittel på toppen, en ingress i mellomstørrelse, og en liten
+ * sekundær linje. Teksten er hentet fra fremtind.no sine bærekraftssider.
+ */
+export const IKort: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                type: "code",
+                language: "tsx",
+                code: `<Card variant="filled" padding="l">
+    <Flex direction="column" gap="m">
+        <Flex as="hgroup" direction="column" gap="xs">
+            <Title>Ambisjon og bærekraftsarbeid</Title>
+            <Text>
+                Fremtind hjelper og motiverer folk til å ta vare på helsen,
+                verdiene og omgivelsene sine — og er der når det trengs.
+            </Text>
+        </Flex>
+        <Text size="s">
+            Vi tilbyr produkter og tjenester gjennom banker og LO i Norge
+            som «forsikring i bank», og vi er til stede i hele landet.
+        </Text>
+    </Flex>
+</Card>`,
+            },
+        },
+    },
+    render: () => (
+        <Card variant="filled" padding="l">
+            <Flex direction="column" gap="m" style={{ maxWidth: 560 }}>
+                <Flex as="hgroup" direction="column" gap="xs">
+                    <Title>Ambisjon og bærekraftsarbeid</Title>
+                    <Text>
+                        Fremtind hjelper og motiverer folk til å ta vare på
+                        helsen, verdiene og omgivelsene sine — og er der når det
+                        trengs.
+                    </Text>
+                </Flex>
+                <Text size="s">
+                    Vi tilbyr produkter og tjenester gjennom banker og LO i
+                    Norge som «forsikring i bank», og vi er til stede i hele
+                    landet.
+                </Text>
+            </Flex>
+        </Card>
+    ),
+};
+
+/**
+ * Skjema-grupperinger: `as="legend"` gir en fieldset-tittel, og
+ * `as="label"` gir etikett for et enkeltfelt. Begge får automatisk
+ * normal font-weight, relaxed linjehøyde og label får blokk-nivå +
+ * bunnmarg — uavhengig av valgt `size`.
+ */
+export const ISkjema: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            type: "code",
+            language: "tsx",
+            source: {
+                code: `<fieldset>
+    <Title as="legend" size="xs">Kontaktinformasjon</Title>
+    <Title as="label" size="xs" htmlFor="telefon">
+        Telefonnummer
+    </Title>
+    <input id="telefon" type="tel" placeholder="8 siffer" />
+</fieldset>`,
+            },
+        },
+    },
+    render: () => (
+        <fieldset
+            style={{
+                border: "1px solid rgba(0,0,0,.2)",
+                borderRadius: 6,
+                padding: 16,
+                maxWidth: 360,
+            }}
+        >
+            <Title as="legend" size="xs">
+                Kontaktinformasjon
+            </Title>
+            <Title as="label" size="xs" htmlFor="telefon">
+                Telefonnummer
+            </Title>
+            <input
+                id="telefon"
+                type="tel"
+                placeholder="8 siffer"
+                style={{
+                    padding: "8px",
+                    width: "100%",
+                    boxSizing: "border-box",
+                }}
+            />
+        </fieldset>
+    ),
+};
+
+/**
+ * Typisk brukstilfelle: en detaljside hos Fremtind trenger en `h1` for
+ * skjermlesere og SEO, men designet skal ikke ha en dominerende tittel.
+ * Behold `as="h1"` og velg en mindre `size`.
+ */
+export const SemantiskH1MedLavVisuellVekt: Story = {
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            source: {
+                code: `<Title as="h1" size="m">
+    Forsikringene dine
+</Title>
+<Title size="xs">
+    Kundenummer 12345678
+</Title>`,
+            },
+        },
+    },
+    render: () => (
+        <Flex direction="column" gap="2xs">
+            <Title as="h1" size="m">
+                Forsikringene dine
+            </Title>
+            <Title size="xs">Kundenummer 12345678</Title>
+        </Flex>
+    ),
+};

--- a/packages/jokul/src/components/typography/styles/_index.scss
+++ b/packages/jokul/src/components/typography/styles/_index.scss
@@ -1,0 +1,2 @@
+@forward "text";
+@forward "title";

--- a/packages/jokul/src/components/typography/styles/text.scss
+++ b/packages/jokul/src/components/typography/styles/text.scss
@@ -1,0 +1,54 @@
+@use "../../../styles/jkl";
+
+// Hver `size` mapper til en komplett tekst-stil fra `$text-styles` i
+// `core/jkl/_typography.scss` — både font-size, line-height, font-weight
+// og ikon-variabler settes via `jkl.text-style`-mixinen.
+$_size-styles: (
+    "xs": "text-micro",
+    "s": "paragraph-small",
+    "m": "paragraph-medium",
+    "l": "paragraph-large",
+);
+
+@layer jokul.components {
+    :where(.jkl-text) {
+        font-weight: var(--jkl-typography-weight-normal);
+        line-height: var(--jkl-line-height-relaxed);
+    }
+
+    // Scope margin-resetten til komponenten via `data-text-size` så vi ikke
+    // overstyrer margin på elementer som bare bruker `.jkl-text` som
+    // hjelpeklasse.
+    .jkl-text[data-text-size] {
+        margin-block: 0;
+    }
+
+    @each $name, $style in $_size-styles {
+        .jkl-text[data-text-size="#{$name}"] {
+            @include jkl.text-style($style);
+        }
+    }
+
+    // `bold` og `<strong>` skal sette både font-weight og ikon-weight
+    // (samme mønster som `.jkl-bold` og `.jkl strong`). Spesifisiteten må
+    // være lik eller høyere enn `.jkl-text[data-text-size="…"]` som ellers
+    // tvinger normal weight via `jkl.text-style`-mixinen.
+    .jkl-text[data-bold],
+    strong.jkl-text[data-text-size] {
+        font-weight: var(--jkl-typography-weight-bold);
+    }
+
+    .jkl-text[data-short] {
+        line-height: var(--jkl-line-height-tight);
+    }
+
+    :is(code, kbd, samp, var).jkl-text {
+        @include jkl.use-font-family("Jokul Mono");
+    }
+
+    // Labels er blokk-nivå og har bunnmarg til feltet de beskriver.
+    label.jkl-text {
+        display: block;
+        margin-block-end: var(--jkl-spacing-8);
+    }
+}

--- a/packages/jokul/src/components/typography/styles/title.scss
+++ b/packages/jokul/src/components/typography/styles/title.scss
@@ -1,0 +1,59 @@
+@use "../../../styles/jkl";
+
+// Hver `size` mapper til en komplett tekst-stil fra `$text-styles` i
+// `core/jkl/_typography.scss` — både font-size, line-height, font-weight
+// og ikon-variabler settes via `jkl.text-style`-mixinen.
+$_size-styles: (
+    "xs": "heading-5",
+    "s": "heading-4",
+    "m": "heading-3",
+    "l": "heading-2",
+    "xl": "heading-1",
+);
+
+@layer jokul.components {
+    :where(.jkl-title) {
+        font-weight: var(--jkl-typography-weight-normal);
+        line-height: var(--jkl-line-height-tight);
+    }
+
+    // Scope margin-resetten til komponenten via `data-text-size` så vi ikke
+    // overstyrer margin på elementer som bare bruker `.jkl-title` som
+    // hjelpeklasse.
+    .jkl-title[data-text-size] {
+        margin-block: 0;
+    }
+
+    // Genererer både komponent-regler og ekvivalente hjelpeklasser fra
+    // samme kilde slik at de ikke drifter fra hverandre.
+    // `.jkl-heading-<size>` tilsvarer `<Title size="<size>">` brukt på et
+    // vilkårlig element.
+    @each $name, $style in $_size-styles {
+
+        .jkl-title[data-text-size="#{$name}"],
+        .jkl-heading-#{$name} {
+            @include jkl.text-style($style);
+        }
+
+        :where(.jkl-heading-#{$name}) {
+            margin-block: 0;
+        }
+    }
+
+    // Skjema-elementer skal ikke arve heading sine fete font-weight og
+    // tight line-height. De er tekst som beskriver et skjemafelt eller en
+    // gruppe, ikke strukturelle overskrifter. Spesifisiteten må matche
+    // `.jkl-title[data-text-size="…"]` (0,2,0) for å overstyre den.
+    :is(label, legend).jkl-title[data-text-size] {
+        font-weight: var(--jkl-typography-weight-normal);
+        line-height: var(--jkl-line-height-relaxed);
+    }
+
+    // Labels er blokk-nivå og har bunnmarg til feltet de beskriver.
+    // Spesifisiteten her (0,2,1) overstyrer `.jkl-title[data-text-size]`
+    // som ellers nullstiller margin via `margin-block: 0`.
+    label.jkl-title[data-text-size] {
+        display: block;
+        margin-block-end: var(--jkl-spacing-8);
+    }
+}

--- a/packages/jokul/src/components/typography/types.ts
+++ b/packages/jokul/src/components/typography/types.ts
@@ -1,0 +1,78 @@
+import type { PolymorphicPropsWithRef } from "../../utilities/index.js";
+
+export type TextElement =
+    | "p"
+    | "span"
+    | "label"
+    | "legend"
+    | "small"
+    | "strong"
+    | "em"
+    | "code"
+    | "kbd"
+    | "samp"
+    | "var";
+
+export type TitleElement =
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    | "label"
+    | "legend";
+
+export type TextSize = "xs" | "s" | "m" | "l";
+
+export type TitleSize = "xs" | "s" | "m" | "l" | "xl";
+
+type TextOwnProps = {
+    /**
+     * Visuell størrelse på teksten. Tilsvarer font-size-tokens i Jøkul.
+     * @default "m"
+     */
+    size?: TextSize;
+    /**
+     * Uthever teksten (font-weight: bold).
+     * @default false
+     */
+    bold?: boolean;
+    /**
+     * Setter mindre linjehøyde — bruk når teksten i all hovedsak går over
+     * én linje (f.eks. i tabellceller eller knapper).
+     * @default false
+     */
+    short?: boolean;
+    /**
+     * Skjuler elementet visuelt, men beholder det for skjermlesere.
+     * Bruk for å gi ekstra kontekst til assistive teknologier uten å
+     * påvirke det visuelle.
+     * @default false
+     */
+    srOnly?: boolean;
+};
+
+type TitleOwnProps = {
+    /**
+     * Visuell størrelse på tittelen. Frakoblet fra `as` — velg semantisk
+     * nivå via `as`, og visuell størrelse via `size`.
+     * @default "l"
+     */
+    size?: TitleSize;
+    /**
+     * Skjuler elementet visuelt, men beholder det for skjermlesere.
+     * Bruk for å beholde riktig overskrifts-hierarki i skjermlesere
+     * uten å vise tittelen visuelt.
+     * @default false
+     */
+    srOnly?: boolean;
+};
+
+export type TextProps<As extends TextElement = "p"> = PolymorphicPropsWithRef<
+    As,
+    TextOwnProps
+>;
+
+export type TitleProps<As extends TitleElement = "h2"> =
+    PolymorphicPropsWithRef<As, TitleOwnProps>;

--- a/packages/jokul/src/core/styles/utility/_paragraphs.scss
+++ b/packages/jokul/src/core/styles/utility/_paragraphs.scss
@@ -1,0 +1,39 @@
+@use "sass:map";
+@use "../../jkl";
+@use "../../jkl/typography";
+
+@layer jokul.utility {
+    .jkl-body {
+        @include jkl.text-style("paragraph-medium");
+    }
+
+    .jkl-bold {
+        @include jkl.text-style("paragraph-medium") {
+            --jkl-icon-weight: #{jkl.$icon-weight-bold};
+            font-weight: jkl.$typography-weight-bold;
+        }
+    }
+
+    .jkl-small {
+        @include jkl.text-style("paragraph-small");
+    }
+
+    @each $style, $_ in typography.$text-styles {
+        // Title-komponenten bruker `.jkl-title` som klasse og styrer
+        // stilen via `data-text-size`. Utility-laget vinner over
+        // components-laget i cascade, så vi må ekskludere komponenten her
+        // for at `size`-propen fortsatt skal ha effekt.
+        $selector: if(
+            $style == "title",
+            ".jkl-title:not([data-text-size])",
+            ".jkl-#{$style}"
+        );
+
+        #{$selector} {
+            @each $property, $value in map.get(typography.$text-styles, $style)
+            {
+                #{$property}: $value;
+            }
+        }
+    }
+}

--- a/packages/jokul/src/styles/components.scss
+++ b/packages/jokul/src/styles/components.scss
@@ -48,5 +48,6 @@
 @use "../components/toast/styles" as toast;
 @use "../components/toggle-switch/styles" as toggle-switch;
 @use "../components/tooltip/styles" as tooltip;
+@use "../components/typography/styles" as typography;
 @use "../components/help/styles" as help;
 @use "../components/flex/styles" as flex;


### PR DESCRIPTION
Legger til nye Text- og Title-komponenter under
`@fremtind/jokul/typography`. Begge er polymorfe med begrenset `as`-støtte, abstrakte størrelser via `size`-propen, og bruker `data-text-size` for å unngå kollisjon med tema-skalaen.

Text-komponent:
- `as`: p, span, label, small, strong, em, code, kbd, samp, var
- `size`: small (16px), medium (18px), large (24px)
- `bold`, `tight`, `srOnly` som boolean-toggles

Title-komponent:
- `as`: h1–h6
- `size`: xxs, xs, s, m, l, xl, body
- `srOnly` for visuelt skjulte semantiske overskrifter

code/kbd/samp/var-elementer får automatisk Fremtind Grotesk Mono.

Typografi-hjelpeklassene (`.jkl-title`, `.jkl-heading-*`, `.jkl-paragraph-*`, `.jkl-text-*`) og `.jkl-sr-only` er flyttet fra `@layer jokul.utility` til `@layer jokul.components`, slik at komponentene og de ekvivalente hjelpeklassene ligger i samme lag.
