### PR TITLE
fix(select): rendre nedtrekksliste via Popover

### DIFF
--- a/.changeset/select-popover-portal.md
+++ b/.changeset/select-popover-portal.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Select-menyen rendres nå i en portal via `Popover`-komponenten. Det fikser at hele listen ikke ble synlig når `Select` ble brukt inne i containere med `overflow: hidden|clip|auto` (f.eks. `Card` eller `ExpandablePanel`), og at lista i tillegg flippes over til toppen dersom det ikke er plass under triggeren. Bredden til lista matcher triggeren via CSS `anchor-size()`, og `Popover` har fått en ny `onPlacementChange`-callback som lar Select bytte hvilken side av lista og knappen som er flat når lista flippes opp.

--- a/packages/jokul/src/components/popover/Popover.tsx
+++ b/packages/jokul/src/components/popover/Popover.tsx
@@ -73,9 +73,15 @@ const usePopover = ({
         }
     }, [positionReference, data.refs]);
 
-    React.useEffect(() => {
+    // useLayoutEffect (i stedet for useEffect) sikrer at konsumenter får
+    // riktig placement før paint — ellers ville første frame bruke default
+    // placement og deretter snappe over til den faktiske, noe som gir et
+    // synlig "glitch" på styling som er placement-avhengig (f.eks. flat side
+    // / border-radius på Select-listboxen ved flip).
+    React.useLayoutEffect(() => {
+        if (!open) return;
         onPlacementChange?.(data.placement);
-    }, [data.placement, onPlacementChange]);
+    }, [open, data.placement, onPlacementChange]);
 
     return React.useMemo(
         () => ({

--- a/packages/jokul/src/components/popover/Popover.tsx
+++ b/packages/jokul/src/components/popover/Popover.tsx
@@ -29,6 +29,7 @@ const usePopover = ({
     modal = true,
     offset: _offset = 4,
     positionReference,
+    onPlacementChange,
     hoverOptions,
     focusOptions,
     clickOptions,
@@ -71,6 +72,10 @@ const usePopover = ({
             data.refs.setPositionReference(positionReference?.current);
         }
     }, [positionReference, data.refs]);
+
+    React.useEffect(() => {
+        onPlacementChange?.(data.placement);
+    }, [data.placement, onPlacementChange]);
 
     return React.useMemo(
         () => ({
@@ -216,8 +221,15 @@ const PopoverContent = React.forwardRef<
     },
     propRef,
 ) {
-    const { context, modal, refs, open, floatingStyles, getFloatingProps } =
-        usePopoverContext();
+    const {
+        context,
+        modal,
+        refs,
+        open,
+        floatingStyles,
+        getFloatingProps,
+        isPositioned,
+    } = usePopoverContext();
     const ref = useMergeRefs([refs.setFloating, propRef]);
 
     const referenceElement = refs.reference.current as ReferenceElement;
@@ -256,6 +268,14 @@ const PopoverContent = React.forwardRef<
                             ...style,
                             ...floatingStyles,
                             "--popover-padding": `var(--jkl-spacing-${padding})`,
+                            // Skjul popoveren inntil floating-ui har regnet
+                            // ut første posisjon — ellers blinker den
+                            // kort i (0,0) før den hopper på plass.
+                            // Bare for ikke-modale popovere; modale bruker
+                            // umiddelbar fokus-trap som forutsetter at
+                            // innholdet er fokuserbart fra første render.
+                            visibility:
+                                modal || isPositioned ? "visible" : "hidden",
                         } as React.CSSProperties
                     }
                     {...getFloatingProps(props)}

--- a/packages/jokul/src/components/popover/types.ts
+++ b/packages/jokul/src/components/popover/types.ts
@@ -1,4 +1,5 @@
 import type {
+    Placement,
     ReferenceType,
     UseFloatingOptions,
     useClick,
@@ -68,6 +69,13 @@ export interface PopoverOptions {
      * @default Popover.Trigger
      */
     positionReference?: React.RefObject<ReferenceType>;
+    /**
+     * Trigges når popoverens faktiske plassering endrer seg, f.eks. når
+     * `flip`-middlewaren snur popoveren over triggeren fordi det ikke er
+     * plass under. Kan brukes til å justere styling avhengig av om
+     * popoveren ligger over eller under referansen.
+     */
+    onPlacementChange?: (placement: Placement) => void;
     /**
      * Options for hover-interaksjoner.
      *

--- a/packages/jokul/src/components/select/Select.test.tsx
+++ b/packages/jokul/src/components/select/Select.test.tsx
@@ -28,14 +28,18 @@ function setup(jsx: JSX.Element, renderOptions?: RenderOptions) {
 }
 
 describe("Select", () => {
-    it("should render correct amount of options", () => {
-        const { getAllByTestId } = setup(
+    it("should render correct amount of options", async () => {
+        const { getAllByTestId, getByTestId } = setup(
             <Select
                 name="snoop"
                 items={["drop", "it", "like", "its", "hot"]}
                 label="Snoop"
             />,
         );
+
+        await act(async () => {
+            await userEvent.click(getByTestId("jkl-select__button"));
+        });
 
         const options = getAllByTestId("jkl-select__option");
 
@@ -554,6 +558,128 @@ describe("Select", () => {
         await waitFor(() => {
             expect(getByTestId("jkl-select__button")).toHaveTextContent("B");
             expect(getByTestId("jkl-native-select")).toHaveValue("B");
+        });
+    });
+
+    // Regresjonstester for #4583 og #5976
+    it("should render the listbox outside the input-group root (portal)", async () => {
+        const screen = setup(
+            <Select
+                name="snoop"
+                items={["drop", "it", "like", "its", "hot"]}
+                label="Snoop"
+            />,
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId("jkl-select__button"));
+        });
+
+        const inputGroup = screen.getByTestId("jkl-select");
+        const listbox = screen.getByRole("listbox");
+        expect(inputGroup.contains(listbox)).toBe(false);
+    });
+
+    it("should render options even when wrapped in an overflow-clipped ancestor (#4583, #5976)", async () => {
+        const screen = setup(
+            <div
+                data-testid="overflow-wrapper"
+                style={{ overflow: "hidden", height: 50 }}
+            >
+                <Select
+                    name="snoop"
+                    items={["drop", "it", "like", "its", "hot"]}
+                    label="Snoop"
+                />
+            </div>,
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId("jkl-select__button"));
+        });
+
+        const wrapper = screen.getByTestId("overflow-wrapper");
+        const listbox = screen.getByRole("listbox");
+        // Lista skal rendres utenfor den klippede containeren — det er
+        // selve regresjonen vi tester for. Bare å sjekke at den finnes
+        // under `body` er ikke nok, fordi det også var sant før portal-
+        // endringen.
+        expect(wrapper.contains(listbox)).toBe(false);
+        // Ikke-modale popovere skjules med `visibility: hidden` til
+        // floating-ui har posisjonert dem (`isPositioned`). Vent
+        // eksplisitt for å unngå flakiness når posisjoneringen
+        // fullføres etter klikk-`act`.
+        await waitFor(() => {
+            expect(
+                screen.getByRole("option", { name: "drop" }),
+            ).toBeVisible();
+        });
+    });
+
+    it("should set data-popover-placement on both trigger and listbox", async () => {
+        const screen = setup(
+            <Select
+                name="snoop"
+                items={["drop", "it", "like", "its", "hot"]}
+                label="Snoop"
+            />,
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId("jkl-select__button"));
+        });
+
+        const listbox = screen.getByRole("listbox");
+        const outerWrapper = screen
+            .getByTestId("jkl-select__button")
+            .closest(".jkl-select__outer-wrapper");
+        // Default i jsdom (uten layout) skal være "bottom" siden flip ikke
+        // har grunnlag for å snu.
+        expect(listbox).toHaveAttribute("data-popover-placement", "bottom");
+        expect(outerWrapper).toHaveAttribute(
+            "data-popover-placement",
+            "bottom",
+        );
+    });
+
+    it("should focus the currently selected option when the dropdown opens", async () => {
+        const screen = setup(
+            <Select
+                name="phone"
+                items={["Apple", "Samsung", "Google"]}
+                label="Telefon"
+                value="Samsung"
+            />,
+        );
+
+        const button = screen.getByTestId("jkl-select__button");
+
+        // Åpne, lukk via Escape, og åpne igjen — fokuset skal lande på
+        // valgt option begge ganger (regresjonstest for callback-refen som
+        // håndterer at listen mountes via portal).
+        await act(async () => {
+            await userEvent.click(button);
+        });
+        await waitFor(() => {
+            expect(
+                screen.getByRole("option", { name: "Samsung" }),
+            ).toHaveFocus();
+        });
+
+        await act(async () => {
+            await userEvent.keyboard("{Escape}");
+        });
+        await waitFor(() => {
+            expect(button).toHaveFocus();
+        });
+
+        await act(async () => {
+            await userEvent.click(button);
+        });
+        await waitFor(() => {
+            expect(
+                screen.getByRole("option", { name: "Samsung" }),
+            ).toHaveFocus();
         });
     });
 });

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -5,20 +5,19 @@ import React, {
     forwardRef,
     type KeyboardEvent,
     type MouseEvent,
-    type RefObject,
     useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
 } from "react";
-import { useAnimatedHeight } from "../../hooks/useAnimatedHeight/useAnimatedHeight.js";
 import { useId } from "../../hooks/useId/useId.js";
 import { useListNavigation } from "../../hooks/useListNavigation/useListNavigation.js";
 import { usePreviousValue } from "../../hooks/usePreviousValue/usePreviousValue.js";
 import { type ValuePair, getValuePair } from "../../utilities/valuePair.js";
 import { ArrowVerticalAnimated } from "../icon/icons/animated/ArrowVerticalAnimated.js";
 import { InputGroup } from "../input-group/InputGroup.js";
+import Popover from "../popover/Popover.js";
 import type { PopupTipProps } from "../tooltip/types.js";
 import { focusSelected, toLower } from "./select-utils.js";
 import type { SelectProps } from "./types.js";
@@ -61,10 +60,23 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         const labelId = `${listId}_label`;
         const buttonId = `${listId}_button`;
         const searchInputId = `${listId}_search-input`;
+        // Unik anchor-name som CSS anchor positioning bruker for å la
+        // dropdown-listen matche bredden til triggeren.
+        const anchorName = `--${listId.replace(/[^a-zA-Z0-9-]/g, "-")}-anchor`;
 
         const [dropdownIsShown, setShown] = useState(false);
         const toggleListVisibility = useCallback(() => {
             setShown((previousValue) => !previousValue);
+        }, []);
+
+        // Lagrer faktisk placement etter at floating-ui har kjørt `flip`,
+        // slik at vi kan bytte hvilken side av lista og knappen som er
+        // flat når lista snus over triggeren.
+        const [popoverPlacement, setPopoverPlacement] = useState<
+            "top" | "bottom"
+        >("bottom");
+        const handlePlacementChange = useCallback((p: string) => {
+            setPopoverPlacement(p.startsWith("top") ? "top" : "bottom");
         }, []);
 
         /// Søk
@@ -195,35 +207,61 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         const searchFieldRef = useRef<HTMLInputElement>(null);
         const buttonRef = useRef<HTMLButtonElement>(null);
 
-        const handleFocusPlacement = useCallback(
-            (isOpen: boolean, ref: RefObject<HTMLElement | null>) => {
-                if (isOpen && !isSearchable) {
-                    const listElement = ref.current;
-                    if (listElement) {
-                        focusSelected(listElement, selectedValue);
-                    }
-                } else if (isOpen) {
-                    if (searchFieldRef.current) {
-                        searchFieldRef.current.focus();
-                    }
-                } else {
-                    if (focusInsideRef.current && buttonRef.current) {
-                        buttonRef.current.focus();
-                    }
-                }
-            },
-            [isSearchable, selectedValue],
-        );
+        const dropdownRef = useRef<HTMLDivElement | null>(null);
+        // Lagrer listbox-elementet i state slik at downstream-hooks
+        // (f.eks. `useListNavigation`) kan re-feste listeneren idet
+        // `FloatingPortal` mounter listen.
+        const [listboxEl, setListboxEl] = useState<HTMLDivElement | null>(null);
 
-        const [dropdownRef] = useAnimatedHeight<HTMLDivElement>(
-            dropdownIsShown,
-            {
-                onFirstVisible: handleFocusPlacement,
-                onTransitionEnd: handleFocusPlacement,
-            },
-        );
+        // Listen rendres i en `FloatingPortal` som monteres via en
+        // `useLayoutEffect` + `setState` i floating-ui. Refen er derfor
+        // ikke tilgjengelig før i en senere render. Vi bruker en
+        // callback-ref for å plassere fokus på valgt option idet listen
+        // faktisk er i DOM-en. Refen holdes stabil (tom dependency-list)
+        // slik at en endring i `selectedValue`/`isSearchable` ikke får
+        // React til å avmontere/remontere refen og dermed flytte fokus
+        // mens menyen er åpen — vi leser siste verdier via refs.
+        const isSearchableRef = useRef(isSearchable);
+        const selectedValueRef = useRef(selectedValue);
+        useEffect(() => {
+            isSearchableRef.current = isSearchable;
+            selectedValueRef.current = selectedValue;
+        });
 
-        useListNavigation({ ref: dropdownRef });
+        const setDropdownRef = useCallback((node: HTMLDivElement | null) => {
+            dropdownRef.current = node;
+            setListboxEl(node);
+            if (node && !isSearchableRef.current) {
+                // Popover skjules med `visibility: hidden` til
+                // floating-ui har regnet ut første posisjon. Defer
+                // fokus til etter neste paint, slik at vi ikke flytter
+                // fokus til et usynlig element (kan gi manglende
+                // fokusindikator i enkelte nettlesere).
+                requestAnimationFrame(() => {
+                    if (dropdownRef.current === node) {
+                        focusSelected(node, selectedValueRef.current);
+                    }
+                });
+            }
+        }, []);
+
+        // Søkbart felt og knappen som får fokus ved lukking lever i hoved-
+        // DOM-en, så for de tilfellene holder en useEffect.
+        const wasShown = usePreviousValue(dropdownIsShown);
+        useEffect(() => {
+            if (dropdownIsShown === wasShown) return;
+            if (dropdownIsShown && isSearchable) {
+                searchFieldRef.current?.focus();
+            } else if (
+                !dropdownIsShown &&
+                focusInsideRef.current &&
+                buttonRef.current
+            ) {
+                buttonRef.current.focus();
+            }
+        }, [dropdownIsShown, wasShown, isSearchable]);
+
+        useListNavigation({ element: listboxEl });
 
         const close = useCallback(() => {
             if (isSearchable) {
@@ -245,11 +283,15 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         const handleBlur = useCallback(
             (e: FocusEvent<HTMLButtonElement | HTMLInputElement>) => {
                 const componentRootElement = componentRootElementRef.current;
+                const dropdownElement = dropdownRef.current;
                 // There are known issues in Firefox when using "relatedTarget" in onBlur events:
                 // https://github.com/facebook/react/issues/2011
                 // This might be fixed in react 17. Se issue above.
+                // Dropdown rendres i en portal, så vi må sjekke begge trærne
+                // for å avgjøre om fokus blir værende inne i komponenten.
                 const nextFocusIsInsideComponent =
-                    componentRootElement?.contains(e.relatedTarget as Node);
+                    componentRootElement?.contains(e.relatedTarget as Node) ||
+                    dropdownElement?.contains(e.relatedTarget as Node);
                 if (!nextFocusIsInsideComponent) {
                     close();
                 }
@@ -281,28 +323,33 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         // Handle focus and blur of hidden select element
         useEffect(() => {
             const select = selectRef.current;
-            const searchField = searchFieldRef.current;
-            const button = buttonRef.current;
-            const componentRootElement = componentRootElementRef.current;
+            if (!select) return;
 
-            select?.addEventListener("focus", () => {
-                showSearchInputField ? searchField?.focus() : button?.focus();
-            });
-            select?.addEventListener("blur", function (this, ev) {
-                componentRootElement?.contains(ev.relatedTarget as Node) &&
+            const onSelectFocus = () => {
+                if (showSearchInputField) {
+                    searchFieldRef.current?.focus();
+                } else {
+                    buttonRef.current?.focus();
+                }
+            };
+            const onSelectBlur = (ev: globalThis.FocusEvent) => {
+                // Les refs ved hvert kall slik at vi alltid sjekker mot
+                // siste listbox-element — den portalerte listen kan ha
+                // mountet etter at denne effekten ble satt opp.
+                const target = ev.relatedTarget as Node | null;
+                const insideComponent =
+                    componentRootElementRef.current?.contains(target);
+                const insideDropdown = dropdownRef.current?.contains(target);
+                if (insideComponent || insideDropdown) {
                     ev.preventDefault();
-            });
+                }
+            };
 
+            select.addEventListener("focus", onSelectFocus);
+            select.addEventListener("blur", onSelectBlur);
             return () => {
-                select?.removeEventListener("focus", () => {
-                    showSearchInputField
-                        ? searchField?.focus()
-                        : button?.focus();
-                });
-                select?.removeEventListener("blur", function (this, ev) {
-                    componentRootElement?.contains(ev.relatedTarget as Node) &&
-                        ev.preventDefault();
-                });
+                select.removeEventListener("focus", onSelectFocus);
+                select.removeEventListener("blur", onSelectBlur);
             };
         }, [showSearchInputField]);
 
@@ -363,7 +410,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                     e.stopPropagation();
                 }
             },
-            [dropdownRef, selectedValue, isSearchable, dropdownIsShown],
+            [selectedValue, isSearchable, dropdownIsShown],
         );
 
         // onKeyDown so this Tab listener isn't triggered by tabbing from search field to option
@@ -396,7 +443,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                     }
                 }
             },
-            [dropdownRef],
+            [],
         );
 
         // Add support for closing the dropdown with Escape like native select. Unfortunately, Escape does not trigger the button onKeyDown.
@@ -470,12 +517,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                     }
                     {...rest}
                     id={isSearchable ? searchInputId : buttonId}
-                    style={
-                        {
-                            "--jkl-select-max-shown-options": maxShownOptions,
-                            ...style,
-                        } as CSSProperties
-                    }
+                    style={style}
                     label={label}
                     labelProps={{
                         id: labelId,
@@ -488,140 +530,205 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                     render={({
                         "aria-invalid": ariaInvalid,
                         ...inputProps
-                    }) => (
-                        <div
-                            className="jkl-select__outer-wrapper"
-                            style={{ width }}
-                        >
-                            {isSearchable && (
-                                <input
-                                    {...inputProps}
-                                    aria-invalid={ariaInvalid}
-                                    id={searchInputId}
-                                    hidden={!showSearchInputField}
-                                    ref={searchFieldRef}
-                                    placeholder="Søk"
-                                    value={searchValue}
-                                    onChange={(e) =>
-                                        setSearchValue(e.target.value)
-                                    }
-                                    data-testid="jkl-select__search-input"
-                                    className="jkl-select__search-input"
-                                    aria-autocomplete="list"
-                                    aria-activedescendant={
-                                        hasSelectedValue
-                                            ? `${listId}__${toLower(
-                                                  selectedValue,
-                                              )}`
-                                            : undefined
-                                    }
-                                    aria-controls={listId}
-                                    aria-expanded={dropdownIsShown}
-                                    role="combobox"
-                                    onKeyDown={handleSearchOnKeyDown}
-                                    onBlur={handleBlur}
-                                    onFocus={handleFocus}
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                    }}
-                                />
-                            )}
-                            {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
-                            <button
-                                // Nei dette er ikke i henhold til speccen, men VoiceOver leser den likevel og det er oppførselen vi ønsker
-                                aria-invalid={ariaInvalid}
-                                {...inputProps}
-                                id={buttonId}
-                                ref={buttonRef}
-                                hidden={showSearchInputField}
-                                type="button"
-                                name={`${name}-btn`}
-                                className={clsx("jkl-select__button", {
-                                    "jkl-select__button--active-value":
-                                        !!selectedValue,
-                                })}
-                                data-testid="jkl-select__button"
-                                aria-label={`${
-                                    selectedValueLabel || "Velg"
-                                },${label}`}
-                                aria-expanded={dropdownIsShown}
-                                aria-controls={listId}
-                                onBlur={handleBlur}
-                                onFocus={handleFocus}
-                                onKeyDown={handleOnKeyDown}
-                                onClick={toggleListVisibility}
-                                onMouseDown={(e) => {
-                                    // Workaround for en Safari-bug hvor e.relatedTarget er null i onBlur
-                                    // https://twitter.com/MilesSorce/status/1278762360669265925
-                                    e.preventDefault();
-                                    buttonRef.current?.focus();
-                                }}
+                    }) => {
+                        // Lista vises kun når dropdown er åpnet *og* det
+                        // finnes minst ett synlig valg. `aria-expanded` på
+                        // trigger og combobox må følge samme boolean for
+                        // ikke å lyve om popoverens tilstand.
+                        const isPopoverOpen =
+                            dropdownIsShown &&
+                            visibleItems.some((item) => item.visible);
+                        return (
+                            <Popover
+                                open={isPopoverOpen}
+                                placement="bottom-start"
+                                offset={0}
+                                modal={false}
+                                onPlacementChange={handlePlacementChange}
+                                clickOptions={{ enabled: false }}
+                                dismissOptions={{ enabled: false }}
+                                roleOptions={{ enabled: false }}
                             >
-                                {selectedValueLabel}
-                            </button>
-                            <div
-                                id={listId}
-                                ref={dropdownRef}
-                                // biome-ignore lint/a11y/useSemanticElements: Vi reimplementerer select
-                                role="listbox"
-                                className="jkl-select__options-menu"
-                                hidden={
-                                    !dropdownIsShown ||
-                                    visibleItems.every((item) => !item.visible)
-                                }
-                                aria-labelledby={labelId}
-                                tabIndex={-1}
-                                data-focus="controlled" // lar oss styre markering av valg vha focus
-                            >
-                                {visibleItems.map((item, i) =>
-                                    // Det er viktig at vi _fjerner_ elementer som ikke er synlige fra DOMen for at tastaturnavigasjon skal fungere.
-                                    // For eksempel, hvis vi har elementene Apple, Samsung og LG i den rekkefølgen og søker etter "l"
-                                    // vil Samsung ikke synes. Om vi bare setter hidden-attributtet på Samsung vil ArrowDown fra Apple ikke fungere.
-                                    // Dette lar seg ikke gjenskape i en enhetstest med JSDOM + user-events, og Cypress lukker Select
-                                    // ved første {downArrow} ¯\_(ツ)_/¯. Så please test scenariet over manuelt om dette skaper trøbbel for deg.
-                                    item.visible ? (
+                                <Popover.Trigger asChild>
+                                    <div
+                                        className="jkl-select__outer-wrapper"
+                                        data-popover-placement={
+                                            popoverPlacement
+                                        }
+                                        style={
+                                            {
+                                                width,
+                                                anchorName,
+                                            } as CSSProperties
+                                        }
+                                    >
+                                        {isSearchable && (
+                                            <input
+                                                {...inputProps}
+                                                aria-invalid={ariaInvalid}
+                                                id={searchInputId}
+                                                hidden={!showSearchInputField}
+                                                ref={searchFieldRef}
+                                                placeholder="Søk"
+                                                value={searchValue}
+                                                onChange={(e) =>
+                                                    setSearchValue(
+                                                        e.target.value,
+                                                    )
+                                                }
+                                                data-testid="jkl-select__search-input"
+                                                className="jkl-select__search-input"
+                                                aria-autocomplete="list"
+                                                aria-activedescendant={
+                                                    isPopoverOpen &&
+                                                    hasSelectedValue
+                                                        ? `${listId}__${toLower(
+                                                              selectedValue,
+                                                          )}`
+                                                        : undefined
+                                                }
+                                                aria-controls={
+                                                    isPopoverOpen
+                                                        ? listId
+                                                        : undefined
+                                                }
+                                                aria-expanded={isPopoverOpen}
+                                                role="combobox"
+                                                onKeyDown={
+                                                    handleSearchOnKeyDown
+                                                }
+                                                onBlur={handleBlur}
+                                                onFocus={handleFocus}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                }}
+                                            />
+                                        )}
+                                        {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
                                         <button
-                                            key={`${listId}-${item.value}`}
-                                            hidden={!item.visible}
+                                            // Nei dette er ikke i henhold til speccen, men VoiceOver leser den likevel og det er oppførselen vi ønsker
+                                            aria-invalid={ariaInvalid}
+                                            {...inputProps}
+                                            id={buttonId}
+                                            ref={buttonRef}
+                                            hidden={showSearchInputField}
                                             type="button"
-                                            id={`${listId}__${toLower(
-                                                item.value,
-                                            )}`}
-                                            className="jkl-select__option"
-                                            data-testid="jkl-select__option"
-                                            aria-selected={
-                                                item.value === selectedValue
+                                            name={`${name}-btn`}
+                                            className={clsx(
+                                                "jkl-select__button",
+                                                {
+                                                    "jkl-select__button--active-value":
+                                                        !!selectedValue,
+                                                },
+                                            )}
+                                            data-testid="jkl-select__button"
+                                            aria-label={`${
+                                                selectedValueLabel || "Velg"
+                                            },${label}`}
+                                            aria-expanded={isPopoverOpen}
+                                            aria-controls={
+                                                isPopoverOpen
+                                                    ? listId
+                                                    : undefined
                                             }
-                                            // biome-ignore lint/a11y/useSemanticElements: Vi reimplementerer select
-                                            role="option"
-                                            value={item.value}
-                                            data-testautoid={`jkl-select__option-${i}`}
                                             onBlur={handleBlur}
                                             onFocus={handleFocus}
-                                            onKeyDown={handleOptionOnKeyDown}
-                                            onClick={(e) => {
+                                            onKeyDown={handleOnKeyDown}
+                                            onClick={toggleListVisibility}
+                                            onMouseDown={(e) => {
+                                                // Workaround for en Safari-bug hvor e.relatedTarget er null i onBlur
+                                                // https://twitter.com/MilesSorce/status/1278762360669265925
                                                 e.preventDefault();
-                                                selectOption(item);
+                                                buttonRef.current?.focus();
                                             }}
-                                            onMouseOver={handleMouseOver}
                                         >
-                                            {item.label}
-                                            {item.description ? (
-                                                <span className="jkl-select__option-description">
-                                                    {item.description}
-                                                </span>
-                                            ) : null}
+                                            {selectedValueLabel}
                                         </button>
-                                    ) : null,
-                                )}
-                            </div>
-                            <ArrowVerticalAnimated
-                                variant="medium"
-                                pointingDown={!dropdownIsShown}
-                                className="jkl-select__arrow"
-                            />
-                        </div>
-                    )}
+                                        <ArrowVerticalAnimated
+                                            variant="medium"
+                                            pointingDown={!isPopoverOpen}
+                                            className="jkl-select__arrow"
+                                        />
+                                    </div>
+                                </Popover.Trigger>
+                                <Popover.Content
+                                    initialFocus={-1}
+                                    returnFocus={false}
+                                    className="jkl-select__popover"
+                                    style={{
+                                        width: `anchor-size(${anchorName} width)`,
+                                    }}
+                                >
+                                    <div
+                                        id={listId}
+                                        ref={setDropdownRef}
+                                        // biome-ignore lint/a11y/useSemanticElements: Vi reimplementerer select
+                                        role="listbox"
+                                        className="jkl-select__options-menu"
+                                        data-popover-placement={
+                                            popoverPlacement
+                                        }
+                                        aria-labelledby={labelId}
+                                        tabIndex={-1}
+                                        data-focus="controlled" // lar oss styre markering av valg vha focus
+                                        style={
+                                            {
+                                                "--jkl-select-max-shown-options":
+                                                    maxShownOptions,
+                                            } as CSSProperties
+                                        }
+                                    >
+                                        {visibleItems.map((item, i) =>
+                                            // Det er viktig at vi _fjerner_ elementer som ikke er synlige fra DOMen for at tastaturnavigasjon skal fungere.
+                                            // For eksempel, hvis vi har elementene Apple, Samsung og LG i den rekkefølgen og søker etter "l"
+                                            // vil Samsung ikke synes. Om vi bare setter hidden-attributtet på Samsung vil ArrowDown fra Apple ikke fungere.
+                                            // Dette lar seg ikke gjenskape i en enhetstest med JSDOM + user-events, og Cypress lukker Select
+                                            // ved første {downArrow} ¯\_(ツ)_/¯. Så please test scenariet over manuelt om dette skaper trøbbel for deg.
+                                            item.visible ? (
+                                                <button
+                                                    key={`${listId}-${item.value}`}
+                                                    hidden={!item.visible}
+                                                    type="button"
+                                                    id={`${listId}__${toLower(
+                                                        item.value,
+                                                    )}`}
+                                                    className="jkl-select__option"
+                                                    data-testid="jkl-select__option"
+                                                    aria-selected={
+                                                        item.value ===
+                                                        selectedValue
+                                                    }
+                                                    // biome-ignore lint/a11y/useSemanticElements: Vi reimplementerer select
+                                                    role="option"
+                                                    value={item.value}
+                                                    data-testautoid={`jkl-select__option-${i}`}
+                                                    onBlur={handleBlur}
+                                                    onFocus={handleFocus}
+                                                    onKeyDown={
+                                                        handleOptionOnKeyDown
+                                                    }
+                                                    onClick={(e) => {
+                                                        e.preventDefault();
+                                                        selectOption(item);
+                                                    }}
+                                                    onMouseOver={
+                                                        handleMouseOver
+                                                    }
+                                                >
+                                                    {item.label}
+                                                    {item.description ? (
+                                                        <span className="jkl-select__option-description">
+                                                            {item.description}
+                                                        </span>
+                                                    ) : null}
+                                                </button>
+                                            ) : null,
+                                        )}
+                                    </div>
+                                </Popover.Content>
+                            </Popover>
+                        );
+                    }}
                 />
             </>
         );

--- a/packages/jokul/src/components/select/stories/select.stories.tsx
+++ b/packages/jokul/src/components/select/stories/select.stories.tsx
@@ -1,9 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React from "react";
+import { Card } from "../../card/Card.js";
+import { ExpandablePanel } from "../../expander/ExpandablePanel.js";
+import { ExpandablePanelContent } from "../../expander/ExpandablePanelContent.js";
+import { Expander } from "../../expander/Expander.js";
 import { Flex } from "../../flex/index.js";
 import { PopupTip } from "../../tooltip/PopupTip.js";
 import { Select } from "../Select.js";
 import "../styles/_index.scss";
+import "../../card/styles/_index.scss";
+import "../../expander/styles/_index.scss";
 
 const meta: Meta = {
     title: "Komponenter/Select",
@@ -113,4 +119,87 @@ export const SelectMedTooltip: Story = {
             />
         ),
     },
+};
+
+/**
+ * Demonstrerer at nedtrekkslisten ikke lenger klippes av en `Card` med
+ * begrenset høyde (issue #5976).
+ */
+export const SelectIKort: Story = {
+    name: "I et Card",
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Tidligere ble lista klippet fordi `Card` har " +
+                    "`overflow: clip`. Lista rendres nå i en portal og " +
+                    "vises uavhengig av forelderens overflow.",
+            },
+        },
+    },
+    render: (args) => (
+        <Card padding="m" style={{ width: "20rem" }}>
+            <Select {...args} />
+        </Card>
+    ),
+};
+
+/**
+ * Demonstrerer at nedtrekkslisten ikke lenger klippes av en
+ * `ExpandablePanel` (issue #4583).
+ */
+export const SelectIExpandablePanel: Story = {
+    name: "I en ExpandablePanel",
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Tidligere ble lista klippet av panelets `overflow: " +
+                    "hidden` når innholdet i panelet var lavt. Etter " +
+                    "endringen rendres lista i en portal og vises som forventet.",
+            },
+        },
+    },
+    render: (args) => (
+        <div style={{ width: "30rem" }}>
+            <ExpandablePanel>
+                <Expander>Velg telefonmerke</Expander>
+                <ExpandablePanelContent>
+                    <Select {...args} />
+                </ExpandablePanelContent>
+            </ExpandablePanel>
+        </div>
+    ),
+};
+
+/**
+ * Demonstrerer auto-flip: når Select er nederst i viewporten, åpner lista
+ * seg over knappen i stedet for under, slik at hele lista alltid er synlig
+ * (issue #3775).
+ */
+export const SelectNederstPaSiden: Story = {
+    name: "Nederst på siden (flipper opp)",
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    "Floating-ui-middlewaren `flip` snur listen over " +
+                    "knappen når det ikke er plass under. Scroll Select " +
+                    "ned mot bunnen av viewporten for å se effekten.",
+            },
+        },
+    },
+    render: (args) => (
+        <div style={{ height: "120dvh" }}>
+            <div
+                style={{
+                    position: "absolute",
+                    bottom: "1rem",
+                    left: "1rem",
+                }}
+            >
+                <Select {...args} />
+            </div>
+        </div>
+    ),
 };

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -313,10 +313,13 @@
     // standard padding/bakgrunn/skygge slik at `.jkl-select__options-menu`
     // selv styrer ramme og bakgrunn — også når Select brukes inne i en
     // Card, ExpandablePanel eller andre containere med overflow-clip.
+    // Select skal følge samme lagdeling som andre dropdown-/menykomponenter
+    // (Combobox, Datepicker, Menu) og ikke arve Popover sitt floating-nivå.
     .jkl-popover.jkl-select__popover {
         background: none;
         box-shadow: none;
         border-radius: 0;
+        z-index: jkl.$z-index--dropdown;
     }
 
     // Mild fade + slide-in når lista mounter i portalen. Animeres på

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -141,17 +141,18 @@
         }
 
         &__options-menu {
-            position: absolute;
-            left: jkl.rem(-1px);
-            right: jkl.rem(-1px);
-            top: 100%;
-            z-index: jkl.$z-index--dropdown;
-
             background-color: var(--jkl-color-background-container-high);
             border: jkl.rem(2px) solid var(--jkl-color-border-input-focus);
-            border-top: none;
-            border-radius: 0 0 var(--border-radius) var(--border-radius);
             box-sizing: border-box;
+            // Strekker seg ut over kantene på trigger-knappen for å dekke
+            // den 1px brede borderen, slik at listen visuelt henger sammen
+            // med inputfeltet.
+            margin-inline: jkl.rem(-1px);
+            width: calc(100% + #{jkl.rem(2px)});
+            // Definerer egne tokens her fordi listen rendres i en portal og
+            // ikke arver kaskaderte custom properties fra `.jkl-select`.
+            --min-option-height: min(var(--jkl-unit-60), 3rem);
+            --option-padding: var(--jkl-unit-05) 0.75em;
 
             overflow-y: auto;
             // Sett makshøyde på listen til høyden av (maxShownOptions + 0.5) ganger høyden på ett enlinjes valg
@@ -160,9 +161,23 @@
                     var(--min-option-height)
             );
 
-            transition-property: height;
+            // Standard: lista ligger under triggeren — flat topp, runde
+            // bunnhjørner, ingen border på toppen som ville duplisert
+            // knappens border.
+            &[data-popover-placement="bottom"] {
+                border-top: none;
+                border-radius: 0 0 var(--jkl-border-radius-s)
+                    var(--jkl-border-radius-s);
+            }
 
-            @include jkl.motion;
+            // Når `flip` snur lista over knappen byttes flat side og runde
+            // hjørner, slik at lista og knappen fortsatt henger sammen
+            // visuelt.
+            &[data-popover-placement="top"] {
+                border-bottom: none;
+                border-radius: var(--jkl-border-radius-s)
+                    var(--jkl-border-radius-s) 0 0;
+            }
         }
 
         &__option-wrapper {
@@ -218,8 +233,6 @@
         &--open {
             .jkl-select__search-input,
             .jkl-select__button {
-                border-bottom-left-radius: 0;
-                border-bottom-right-radius: 0;
                 border-color: var(--jkl-color-border-input-focus);
                 background-color: var(--jkl-color-background-container-high);
                 box-shadow: 0 0 0 jkl.rem(1px)
@@ -227,6 +240,24 @@
 
                 &:hover ~ .jkl-select__arrow {
                     transform: translateY(calc(-50% + #{jkl.rem(-3px)}));
+                }
+            }
+
+            // Lista ligger under (default): flat bunn på input/knapp.
+            .jkl-select__outer-wrapper[data-popover-placement="bottom"] {
+                .jkl-select__search-input,
+                .jkl-select__button {
+                    border-bottom-left-radius: 0;
+                    border-bottom-right-radius: 0;
+                }
+            }
+
+            // Lista ligger over: flat topp på input/knapp.
+            .jkl-select__outer-wrapper[data-popover-placement="top"] {
+                .jkl-select__search-input,
+                .jkl-select__button {
+                    border-top-left-radius: 0;
+                    border-top-right-radius: 0;
                 }
             }
         }
@@ -256,21 +287,85 @@
                     border-color: Highlight;
                 }
             }
+        }
+    }
 
-            & .jkl-select__option {
-                color: CanvasText;
+    // Options rendres i portal og er ikke descendants av `.jkl-select`,
+    // så forced-colors-reglene må stå på topp-nivå for å treffe dem.
+    @include jkl.forced-colors-mode {
+        .jkl-select__option {
+            color: CanvasText;
 
-                border-top: 1px solid Canvas;
-                border-bottom: 1px solid Canvas;
+            border-top: 1px solid Canvas;
+            border-bottom: 1px solid Canvas;
 
-                &:hover,
-                &:focus {
-                    border-top: 1px solid SelectedItem;
-                    border-bottom: 1px solid SelectedItem;
+            &:hover,
+            &:focus {
+                border-top: 1px solid SelectedItem;
+                border-bottom: 1px solid SelectedItem;
 
-                    @include jkl.no-grow-bold;
-                }
+                @include jkl.no-grow-bold;
             }
         }
+    }
+
+    // Listen rendres i en portal via `Popover`. Vi nøytraliserer Popover sin
+    // standard padding/bakgrunn/skygge slik at `.jkl-select__options-menu`
+    // selv styrer ramme og bakgrunn — også når Select brukes inne i en
+    // Card, ExpandablePanel eller andre containere med overflow-clip.
+    .jkl-popover.jkl-select__popover {
+        background: none;
+        box-shadow: none;
+        border-radius: 0;
+    }
+
+    // Mild fade + slide-in når lista mounter i portalen. Animeres på
+    // selve listbox-en — ikke på popover-wrapperen — fordi wrapperen
+    // bærer floating-ui sin posisjonerings-`transform`. Hadde vi animert
+    // wrapperen ville `translateY` overstyrt floating-ui's transform i
+    // animasjonsvinduet, og lista ville blinket i (0,0).
+    @media (prefers-reduced-motion: no-preference) {
+        .jkl-select__options-menu {
+            animation: jkl-select-options-menu-in
+                var(--jkl-motion-timing-snappy)
+                var(--jkl-motion-easing-standard);
+
+            // Når lista flippes opp animerer vi fra motsatt retning slik
+            // at bevegelsen alltid kommer fra triggeren.
+            &[data-popover-placement="top"] {
+                animation-name: jkl-select-options-menu-in-from-top;
+            }
+        }
+    }
+
+    @keyframes jkl-select-options-menu-in {
+        from {
+            opacity: 0;
+            transform: translateY(jkl.rem(-4px));
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    @keyframes jkl-select-options-menu-in-from-top {
+        from {
+            opacity: 0;
+            transform: translateY(jkl.rem(4px));
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    // Options rendres i en portal og er ikke lenger descendants av
+    // `.jkl-select`, så regelen `.jkl-select & *:focus-visible { outline:
+    // none }` treffer dem ikke. Vi gjenoppretter fokus-visualiseringen
+    // (background-color via &:focus) ved å eksplisitt fjerne den native
+    // outlinen på options i portalen.
+    .jkl-select__option:focus-visible {
+        outline: none;
     }
 }

--- a/packages/jokul/src/hooks/useListNavigation/useListNavigation.ts
+++ b/packages/jokul/src/hooks/useListNavigation/useListNavigation.ts
@@ -1,6 +1,6 @@
-import { type RefObject, useEffect } from "react";
+import { type RefObject, useLayoutEffect } from "react";
 
-type Timer = number | undefined;
+type TimerHandle = { id: number | undefined };
 type KeyBuffer = { keys: string } | undefined;
 type Direction = "prev" | "next" | "first" | "last";
 interface MoveDetails {
@@ -11,7 +11,7 @@ interface MoveDetails {
 interface ListDetails {
     list: HTMLElement;
     search: KeyBuffer;
-    searchResetTimer: Timer;
+    searchResetTimer: TimerHandle;
 }
 interface SearchDetails extends ListDetails {
     key: string;
@@ -19,34 +19,55 @@ interface SearchDetails extends ListDetails {
 interface EventDetails extends ListDetails {
     event: KeyboardEvent;
 }
-type UseListNavigationProps<T> = {
-    /** Ref til et element med rollen `listbox` */
-    ref: RefObject<T | null>;
-};
+/**
+ * Enten `ref` eller `element` må gis. `ref` brukes når listen alltid
+ * er i DOM-en; `element` foretrekkes når elementet mountes/unmountes
+ * dynamisk (f.eks. portalert via floating-ui), slik at listeneren
+ * re-festes når elementet faktisk er tilgjengelig.
+ */
+type UseListNavigationProps<T> =
+    | {
+          ref: RefObject<T | null>;
+          element?: never;
+      }
+    | {
+          ref?: never;
+          element: T | null;
+      };
 
 export function useListNavigation<T extends HTMLElement>({
     ref,
+    element,
 }: UseListNavigationProps<T>): void {
-    useEffect(() => {
-        let searchResetTimer: Timer;
+    // Bruker `useLayoutEffect` slik at keydown-listeneren er på plass før
+    // browseren maler neste frame. Det er viktig for konsumenter som
+    // flytter fokus inn i lista i en `requestAnimationFrame`-callback
+    // (som Select), ellers kan første tastetrykk gå tapt.
+    useLayoutEffect(() => {
+        // `ref?.current` leses inne i effekten — refen er fylt i commit-
+        // fasen, og var `null` i render-tid for callere som passerer
+        // `ref` (som Combobox).
+        const list = element ?? ref?.current ?? null;
+        if (!list) return;
+
+        // `TimerHandle` er et muterbart objekt slik at `resetWhenIdle`
+        // kan oppdatere `id` på samme referanse — `setTimeout`-handlen må
+        // være delt på tvers av tastetrykk for at `clearTimeout` skal
+        // kunne avbryte forrige timeout.
+        const searchResetTimer: TimerHandle = { id: undefined };
         const search: KeyBuffer = { keys: "" }; // keypress buffer is an object to preserve state
-        const list = ref.current;
         const handler = (event: KeyboardEvent) => {
-            if (list) {
-                handleListKeyNav({ list, event, search, searchResetTimer });
-            }
+            handleListKeyNav({ list, event, search, searchResetTimer });
         };
 
-        if (list) {
-            list.addEventListener("keydown", handler);
-        }
-
+        list.addEventListener("keydown", handler);
         return () => {
-            if (list) {
-                list.removeEventListener("keydown", handler);
+            list.removeEventListener("keydown", handler);
+            if (searchResetTimer.id !== undefined) {
+                clearTimeout(searchResetTimer.id);
             }
         };
-    }, [ref]);
+    }, [element, ref]);
 }
 
 function handleMoveTo(
@@ -179,19 +200,15 @@ function findItem({
     return null;
 }
 
-function resetWhenIdle(search: KeyBuffer, timer: Timer) {
-    if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
+function resetWhenIdle(search: KeyBuffer, timer: TimerHandle) {
+    if (timer.id !== undefined) {
+        clearTimeout(timer.id);
+        timer.id = undefined;
     }
-    timer = setTimeout(
-        () => {
-            // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
-            search ? (search.keys = "") : (search = { keys: "" });
-            timer = undefined;
-        },
-        500,
-        search,
-        timer,
-    );
+    timer.id = window.setTimeout(() => {
+        if (search) {
+            search.keys = "";
+        }
+        timer.id = undefined;
+    }, 500);
 }


### PR DESCRIPTION
Select-lista rendres nå i en portal via `Popover`, slik at hele lista blir synlig når Select brukes inne i containere med `overflow: hidden|clip|auto` (f.eks. `Card` eller `ExpandablePanel`). Lista flippes over triggeren hvis det ikke er plass under, og bredden matches mot triggeren via CSS `anchor-size()`.

Closes #4583
Closes #5976
Closes #3775