### PR TITLE
docs(jokul): legg til migrasjonsguide for 5.0

### DIFF
--- a/packages/jokul/MIGRATION.md
+++ b/packages/jokul/MIGRATION.md
@@ -1,5 +1,153 @@
 # Migrasjonsguide
 
+## Jøkul 5.0
+
+Jøkul 5.0 rydder opp i token-strukturen, fontoppsettet og importstiene. De fleste endringene i importstier kan gjøres automatisk med codemoden:
+
+```bash
+pnpm exec jokul codemod --dry-run
+pnpm exec jokul codemod
+```
+
+Codemoden håndterer trygge erstatninger automatisk, og varsler ved tvetydige stilimports for beta-komponenter som krever manuell vurdering.
+
+### Nye importstier for stilark og Sass-hjelpere
+
+| Funksjon | Gammel import | Ny import |
+|---|---|---|
+| Grunnstiler | `@fremtind/jokul/styles/core` | `@fremtind/jokul/styles/base.scss` |
+| Stilark for ALLE komponenter | `@fremtind/jokul/styles` | `@fremtind/jokul/styles/components.scss` |
+| Sass-hjelpere | `@fremtind/jokul/styles/core/jkl` | `@fremtind/jokul/styles/jkl` |
+| Webfonts (SCSS) | `@fremtind/jokul/styles/fonts/webfonts` | `@fremtind/jokul/styles/theme/fonts` |
+| Webfonts (CSS) | `@fremtind/jokul/styles/fonts/webfonts.css` | `@fremtind/jokul/styles/theme/fonts.css` |
+| Tailwind v3 preset | `@fremtind/jokul/tailwind` | `@fremtind/jokul/tailwind` _(uendret)_ |
+| Tailwind v4 theme | `@fremtind/jokul/tailwind/v4` | `@fremtind/jokul/styles/tailwind` |
+
+Stilene som tidligere lå i `styles/fonts/webfonts` er nå inkludert i `styles/base.scss`, så hvis du bruker grunnstilene trenger du ikke importere font-stilene separat.
+
+### Beta-komponenter har egne stilark
+
+Stilarkene for beta-komponentene var tidligere bakt sammen med sine ikke-Beta varianter. De er nå eksportert for seg.
+
+| Komponent | Gammel import | Ny import |
+|---|---|---|
+| Description List | `@fremtind/jokul/styles/components/description-list` | `@fremtind/jokul/styles/components/beta/description-list.scss` |
+| Nav Link | `@fremtind/jokul/styles/components/nav-link` | `@fremtind/jokul/styles/components/beta/nav-link.scss` |
+| Select | `@fremtind/jokul/styles/components/select` | `@fremtind/jokul/styles/components/beta/select.scss` |
+
+Beta-komponentene er flyttet fra `components-beta/` til `components/beta/` internt i pakken. Eksportstiene fra `@fremtind/jokul` til React-komponentene er uendret.
+
+### `core`-konseptet er fjernet
+
+Typer som tidligere ble eksportert fra `@fremtind/jokul/core` ligger nå i `@fremtind/jokul/utilities`:
+
+```diff
+- import type { WithChildren, DataTestAutoId } from "@fremtind/jokul/core";
++ import type { WithChildren, DataTestAutoId } from "@fremtind/jokul/utilities";
+```
+
+### Fremtind Grotesk er erstattet med Inter
+
+Den innebygde fonten er byttet ut. Hvis du har egne stilarkbruk eller serveroppsett som kopierer/refererer til `FremtindGrotesk-*.woff2` må du bytte til `InterVariable.woff2` (og `InterVariable-Italic.woff2` for kursiv).
+
+### Brand-spesifikke fonter via `data-brand`
+
+Fontvalg kan nå styres med `data-brand` på samme måte som brand-farger. Hver brand (`fremtind`, `dnb`, `eika`, `sparebank1`) har egne `@font-face`-definisjoner og setter `--jkl-font-family-regular`, `--jkl-font-family-display` og `--jkl-font-family-mono`.
+
+```html
+<section data-brand="dnb">
+    <!-- Komponentene her bruker DNB Sans -->
+</section>
+```
+
+For å ta i bruk brand-fonter må du i tillegg:
+
+1. Importere brand-stilarkene fra `@fremtind/jokul/styles/theme/brands/<brand>` (de er allerede inkludert i `base.scss`).
+2. Sørge for at fontfilene er tilgjengelige på `/fonts/brands/<brand>/`. Filene ligger i `node_modules/@fremtind/jokul/src/fonts/brands/<brand>/`.
+
+### Brand-navnet `jokul` er omdøpt til `fremtind`
+
+Standardbrandet refereres nå til som `fremtind` overalt. Hvis du har satt `data-brand="jokul"` eksplisitt må dette oppdateres:
+
+```diff
+- <section data-brand="jokul">
++ <section data-brand="fremtind">
+```
+
+Tilsvarende endring gjelder mappestrukturen for brand-stilark og token-filer (kun relevant hvis du har egne integrasjoner mot disse):
+
+```diff
+- @use "@fremtind/jokul/styles/theme/brands/jokul";
++ @use "@fremtind/jokul/styles/theme/brands/fremtind";
+```
+
+### Font-familien `Jokul Material Symbols` er omdøpt til `Jokul Icons`
+
+Hvis du har egne stilark som refererer til ikonfonten direkte må navnet oppdateres:
+
+```diff
+- font-family: "Jokul Material Symbols", "Jokul Material Symbols Fallback", sans-serif;
++ font-family: "Jokul Icons", "Jokul Icons Fallback", sans-serif;
+```
+
+```diff
+- @include jkl.use-font-family("Jokul Material Symbols");
++ @include jkl.use-font-family("Jokul Icons");
+```
+
+### Nye semantiske tekststil-variabler
+
+Tekststilene eksporteres nå også som CSS custom properties via `font`-shorthand:
+
+```css
+.min-tittel {
+    font: var(--jkl-text-style-heading-1);
+}
+```
+
+Du kan fortsatt bruke Sass-mixin om du foretrekker det:
+
+```scss
+.min-tittel {
+    @include jkl.text-style("heading-1");
+}
+```
+
+Tilgjengelige stiler: `title`, `title-small`, `heading-1`–`heading-5`, `paragraph-large`, `paragraph-medium`, `paragraph-small`, `text-large`, `text-medium`, `text-small`, `text-micro`.
+
+### Nye `Text`- og `Title`-komponenter
+
+For å forenkle migrasjon er det lagt til to nye typografikomponenter under `@fremtind/jokul/typography`:
+
+- `Title`: polymorf med `as` begrenset til `h1`–`h6`, `label` og `legend`. `size` på `xs`, `s`, `m`, `l`, `xl` (default `l`).
+- `Text`: polymorf med `as` begrenset til typografisk relevante elementer (`p`, `span`, `label`, `legend`, `small`, `strong`, `em`, `code`, `kbd`, `samp`, `var`). `size` på `xs`, `s`, `m`, `l` (default `m`), pluss `bold`, `short` og `srOnly`.
+
+`as` og `size` er bevisst frakoblet — semantikk styres via `as`, visuell størrelse via `size`. `code`/`kbd`/`samp`/`var` får automatisk monospace.
+
+Det er også lagt til hjelpeklasser `.jkl-heading-xs` til `.jkl-heading-xl` fra `components/typography` som ekvivalenter til `<Title size="…">` brukt på vilkårlige elementer.
+
+### Alle gamle fargevariabler er fjernet
+
+Det er ikke lenger mulig å hente ut fargevariabler som `granitt`, `varde` og tilsvarende, verken som Sass- eller CSS-variabler. Bruk de [semantiske fargevariablene](https://jokul-portal.intern.app.prodaws.fremtind.no/fundamenter/farger).
+
+### Mixins for custom dark/light-farger er fjernet
+
+Mixins for å definere egne fargevariabler for mørk og lys modus er fjernet sammen med de gamle fargene:
+
+```diff
+- @include jkl.light-mode-variables {
+-     --min-farge: jkl.$color-granitt;
+- }
+- @include jkl.dark-mode-variables {
+-     --min-farge: jkl.$color-snohvit;
+- }
+-
+.min-klasse {
+-     color: var(--min-farge);
++     color: var(--jkl-color-text-default);
+}
+```
+
 ## Jøkul 4.0
 
 ### Density-modusene er fjernet til fordel for size-moduser


### PR DESCRIPTION
## Summary

Legger til en ny seksjon i [packages/jokul/MIGRATION.md](packages/jokul/MIGRATION.md) som dokumenterer alle endringene konsumenter må gjøre når de går fra Jøkul 4 til 5. Innholdet er hentet fra changeset-filene under `.changeset/` og PR-er som har landet på `release/next`.

Punkter som dekkes:

- Nye importstier for stilark og Sass-hjelpere (tabell) + henvisning til `jokul codemod`
- Beta-komponenter har egne stilark
- `core`-konseptet er fjernet (typer ligger nå i `utilities`)
- Fremtind Grotesk er erstattet med Inter
- Brand-spesifikke fonter via `data-brand`
- Brand-navnet `jokul` er omdøpt til `fremtind` (fra #5983)
- Font-familien `Jokul Material Symbols` er omdøpt til `Jokul Icons` (fra #5983)
- Nye semantiske tekststil-variabler
- Nye `Text`- og `Title`-komponenter
- Alle gamle fargevariabler er fjernet
- Mixins for custom dark/light-farger er fjernet

## Test plan

- [ ] Les gjennom guiden og verifiser at alle endringer som er innført på `release/next` er dekket
- [ ] Sjekk at importstier i tabellen stemmer med codemoden i [packages/jokul/codemods/import-paths.mjs](packages/jokul/codemods/import-paths.mjs)