### PR TITLE
fix(jokul): codemod fjerner overflødige webfonts.css-imports

### DIFF
--- a/.changeset/codemod-remove-webfonts-css.md
+++ b/.changeset/codemod-remove-webfonts-css.md
@@ -6,8 +6,10 @@ Codemoden fjerner nå overflødige `@fremtind/jokul/styles/fonts/webfonts.css`- 
 
 Codemoden gir også en advarsel hvis import-fjerningen skjer i en fil som ikke har en `base.css`/`components.css`-import fra før, slik at man får beskjed om å legge til `base.css` for å beholde fontene.
 
+Codemoden bytter også ut det gamle font-family-navnet `Fremtind Material Symbols` (og `Fremtind Material Symbols Fallback`) med `Jokul Icons` (og `Jokul Icons Fallback`), siden navnet ble omdøpt i Jøkul 5. Konsumenter som har skrevet font-family direkte i sin egen CSS/SCSS hadde ellers fått en stille brutt referanse.
+
 I tillegg flagger codemoden tre vanlige 4 → 5-mønstre som ikke kan auto-erstattes, men som krever manuell migrering:
 
 - Bruk av fjernede Sass-fargevariabler (`jkl.$color-granitt`, `jkl.$color-varde` osv.) — bytt til semantiske CSS-variabler.
 - `@include jkl.light-mode-variables { … }` og `jkl.dark-mode-variables` — disse mixinene er fjernet.
-- `text-style("body")` / `text-style("small")` — bytt til `paragraph-*`- eller `text-*`-varianter.
+- `text-style("body")` / `text-style("small")` — foretrekk `Text`-komponenten fra `@fremtind/jokul/components/typography`. Hvis du må sette stiler direkte, bytt til `paragraph-*`- eller `text-*`-varianter.

--- a/.changeset/codemod-remove-webfonts-css.md
+++ b/.changeset/codemod-remove-webfonts-css.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+Codemoden fjerner nå overflødige `@fremtind/jokul/styles/fonts/webfonts.css`- og `webfonts.min.css`-imports. I Jøkul 5 er `@font-face`-definisjonene flyttet inn i `styles/base.css`, og den frittstående webfonts-CSS-fila finnes ikke lenger i pakken – så uten denne opprydningen ville bygget feile etter migrering for konsumenter som bruker ren CSS.
+
+Codemoden gir også en advarsel hvis import-fjerningen skjer i en fil som ikke har en `base.css`/`components.css`-import fra før, slik at man får beskjed om å legge til `base.css` for å beholde fontene.

--- a/.changeset/codemod-remove-webfonts-css.md
+++ b/.changeset/codemod-remove-webfonts-css.md
@@ -5,3 +5,9 @@
 Codemoden fjerner nå overflødige `@fremtind/jokul/styles/fonts/webfonts.css`- og `webfonts.min.css`-imports. I Jøkul 5 er `@font-face`-definisjonene flyttet inn i `styles/base.css`, og den frittstående webfonts-CSS-fila finnes ikke lenger i pakken – så uten denne opprydningen ville bygget feile etter migrering for konsumenter som bruker ren CSS.
 
 Codemoden gir også en advarsel hvis import-fjerningen skjer i en fil som ikke har en `base.css`/`components.css`-import fra før, slik at man får beskjed om å legge til `base.css` for å beholde fontene.
+
+I tillegg flagger codemoden tre vanlige 4 → 5-mønstre som ikke kan auto-erstattes, men som krever manuell migrering:
+
+- Bruk av fjernede Sass-fargevariabler (`jkl.$color-granitt`, `jkl.$color-varde` osv.) — bytt til semantiske CSS-variabler.
+- `@include jkl.light-mode-variables { … }` og `jkl.dark-mode-variables` — disse mixinene er fjernet.
+- `text-style("body")` / `text-style("small")` — bytt til `paragraph-*`- eller `text-*`-varianter.

--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -33,7 +33,7 @@ jokul codemod src app --dry-run
 jokul codemod src app
 ```
 
-Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt.
+Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt. Den fjerner også `@fremtind/jokul/styles/fonts/webfonts.css`-imports siden `@font-face`-definisjonene nå ligger i `styles/base.css`.
 
 ## React-komponenter
 

--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -33,7 +33,7 @@ jokul codemod src app --dry-run
 jokul codemod src app
 ```
 
-Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt. Den fjerner også `@fremtind/jokul/styles/fonts/webfonts.css`-imports siden `@font-face`-definisjonene nå ligger i `styles/base.css`.
+Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt. Den fjerner også `@fremtind/jokul/styles/fonts/webfonts.css`-imports siden `@font-face`-definisjonene nå ligger i `styles/base.css`, og flagger fjernede Sass-fargevariabler, gamle `light-mode-variables`/`dark-mode-variables`-mixins og utdaterte `text-style`-navn (`"body"`, `"small"`).
 
 ## React-komponenter
 

--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -33,7 +33,7 @@ jokul codemod src app --dry-run
 jokul codemod src app
 ```
 
-Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt. Den fjerner også `@fremtind/jokul/styles/fonts/webfonts.css`-imports siden `@font-face`-definisjonene nå ligger i `styles/base.css`, og flagger fjernede Sass-fargevariabler, gamle `light-mode-variables`/`dark-mode-variables`-mixins og utdaterte `text-style`-navn (`"body"`, `"small"`).
+Codemoden oppdaterer sikre stier automatisk og varsler når den finner tvetydige stilimports for beta-komponenter som må vurderes manuelt. Den fjerner `@fremtind/jokul/styles/fonts/webfonts.css`-imports siden `@font-face`-definisjonene nå ligger i `styles/base.css`, bytter ut det gamle font-family-navnet `Fremtind Material Symbols` med `Jokul Icons`, og flagger fjernede Sass-fargevariabler, gamle `light-mode-variables`/`dark-mode-variables`-mixins og utdaterte `text-style`-navn (`"body"`, `"small"`).
 
 ## React-komponenter
 

--- a/packages/jokul/codemods/__tests__/import-paths.test.mjs
+++ b/packages/jokul/codemods/__tests__/import-paths.test.mjs
@@ -82,3 +82,69 @@ import "@fremtind/jokul/styles/components/nav-link";
     assert.equal(result.changed, false);
     assert.equal(result.warnings.length, 1);
 });
+
+test("removes redundant webfonts.css imports when base or components css is also imported", () => {
+    const source = `import "@fremtind/jokul/styles/styles.css";
+import "@fremtind/jokul/styles/core/core.css";
+import "@fremtind/jokul/styles/fonts/webfonts.css";
+`;
+
+    const result = transformImportPaths(source, "/tmp/main.tsx");
+
+    assert.equal(
+        result.text.includes("@fremtind/jokul/styles/fonts/webfonts.css"),
+        false,
+    );
+    assert.equal(
+        result.text.includes('import "@fremtind/jokul/styles/components.css";'),
+        true,
+    );
+    assert.equal(
+        result.text.includes('import "@fremtind/jokul/styles/base.css";'),
+        true,
+    );
+    assert.deepEqual(result.warnings, []);
+});
+
+test("removes minified webfonts.css imports as well", () => {
+    const source = `import "@fremtind/jokul/styles/core/core.min.css";
+import "@fremtind/jokul/styles/fonts/webfonts.min.css";
+`;
+
+    const result = transformImportPaths(source, "/tmp/main.ts");
+
+    assert.equal(
+        result.text.includes("webfonts"),
+        false,
+    );
+    assert.equal(
+        result.text.includes('import "@fremtind/jokul/styles/base.min.css";'),
+        true,
+    );
+});
+
+test("warns when webfonts.css is removed without a base or components import", () => {
+    const source = `import "@fremtind/jokul/styles/fonts/webfonts.css";
+`;
+
+    const result = transformImportPaths(source, "/tmp/main.tsx");
+
+    assert.equal(result.text.includes("webfonts"), false);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /styles\/base\.css/);
+});
+
+test("removes css @import of webfonts.css", () => {
+    const source = `@import "@fremtind/jokul/styles/components.css";
+@import "@fremtind/jokul/styles/fonts/webfonts.css";
+`;
+
+    const result = transformImportPaths(source, "/tmp/global.css");
+
+    assert.equal(result.text.includes("webfonts"), false);
+    assert.equal(
+        result.text.includes('@import "@fremtind/jokul/styles/components.css";'),
+        true,
+    );
+    assert.deepEqual(result.warnings, []);
+});

--- a/packages/jokul/codemods/__tests__/import-paths.test.mjs
+++ b/packages/jokul/codemods/__tests__/import-paths.test.mjs
@@ -148,3 +148,86 @@ test("removes css @import of webfonts.css", () => {
     );
     assert.deepEqual(result.warnings, []);
 });
+
+test("warns about removed sass color variables", () => {
+    const source = `@use "@fremtind/jokul/styles/jkl";
+
+.banner {
+    background: jkl.$color-granitt;
+    color: jkl.$color-snohvit;
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/banner.scss");
+
+    assert.equal(
+        result.warnings.some((warning) =>
+            /jkl\.\$color-\*/.test(warning),
+        ),
+        true,
+    );
+    // Bare én advarsel per mønster, selv om det er flere forekomster
+    assert.equal(
+        result.warnings.filter((warning) =>
+            /jkl\.\$color-\*/.test(warning),
+        ).length,
+        1,
+    );
+});
+
+test("warns about removed light/dark mode mixins", () => {
+    const source = `@use "@fremtind/jokul/styles/jkl";
+
+@include jkl.light-mode-variables {
+    --min-farge: jkl.$color-granitt;
+}
+@include jkl.dark-mode-variables {
+    --min-farge: jkl.$color-snohvit;
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/theme.scss");
+
+    assert.equal(
+        result.warnings.some((warning) =>
+            /light-mode-variables/.test(warning),
+        ),
+        true,
+    );
+});
+
+test("warns about deprecated text-style names", () => {
+    const source = `@use "@fremtind/jokul/styles/jkl";
+
+.lead {
+    @include jkl.text-style("body");
+}
+
+.fineprint {
+    @include jkl.text-style("small");
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/typography.scss");
+
+    assert.equal(
+        result.warnings.some((warning) =>
+            /paragraph-large\/medium\/small/.test(warning),
+        ),
+        true,
+    );
+});
+
+test("does not warn about valid 5.0 patterns", () => {
+    const source = `@use "@fremtind/jokul/styles/jkl";
+
+.title {
+    @include jkl.text-style("heading-1");
+    color: var(--jkl-color-text-default);
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/title.scss");
+
+    assert.deepEqual(result.warnings, []);
+});

--- a/packages/jokul/codemods/__tests__/import-paths.test.mjs
+++ b/packages/jokul/codemods/__tests__/import-paths.test.mjs
@@ -216,6 +216,46 @@ test("warns about deprecated text-style names", () => {
         ),
         true,
     );
+    assert.equal(
+        result.warnings.some((warning) => /<Text>-komponenten/.test(warning)),
+        true,
+    );
+});
+
+test("renames Fremtind Material Symbols font-family", () => {
+    const source = `.icon {
+    font-family: "Fremtind Material Symbols", "Fremtind Material Symbols Fallback", sans-serif;
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/icons.scss");
+
+    assert.equal(
+        result.text.includes("Fremtind Material Symbols"),
+        false,
+    );
+    assert.equal(
+        result.text.includes(
+            '"Jokul Icons", "Jokul Icons Fallback", sans-serif',
+        ),
+        true,
+    );
+    assert.equal(result.replacements, 2);
+});
+
+test("renames Fremtind Material Symbols inside CSS files too", () => {
+    const source = `.icon {
+    font-family: 'Fremtind Material Symbols';
+}
+`;
+
+    const result = transformImportPaths(source, "/tmp/icons.css");
+
+    assert.equal(
+        result.text.includes("Fremtind Material Symbols"),
+        false,
+    );
+    assert.equal(result.text.includes("'Jokul Icons'"), true);
 });
 
 test("does not warn about valid 5.0 patterns", () => {

--- a/packages/jokul/codemods/import-paths.mjs
+++ b/packages/jokul/codemods/import-paths.mjs
@@ -272,6 +272,46 @@ function removeRedundantWebfontsCssImport(text) {
     return { text: next, count };
 }
 
+/**
+ * Patterns som ikke kan auto-erstattes, men som krever manuell migrering ved
+ * oppgradering fra Jøkul 4 til 5. Hvert mønster gir én advarsel per fil det
+ * matcher i (uavhengig av antall forekomster), med peker til hva man skal
+ * gjøre i stedet.
+ */
+const MANUAL_MIGRATION_WARNINGS = [
+    {
+        // jkl.$color-granitt, jkl.$color-varde, osv. Alle Sass-fargevariabler
+        // ble fjernet i Jøkul 5 til fordel for semantiske CSS-variabler.
+        pattern: /\bjkl\.\$color-[a-z][a-z0-9-]*/i,
+        message:
+            "Fjernede Sass-fargevariabler (jkl.$color-*). I Jøkul 5 er alle gamle fargenavn (granitt, varde, snohvit osv.) fjernet — bruk semantiske CSS-variabler, f.eks. var(--jkl-color-text-default). Se https://jokul-portal.intern.app.prodaws.fremtind.no/fundamenter/farger.",
+    },
+    {
+        // @include jkl.light-mode-variables { ... } / dark-mode-variables { ... }
+        pattern: /@include\s+jkl\.(?:light|dark)-mode-variables\b/,
+        message:
+            "Fjernede mixins for custom light/dark-farger (jkl.light-mode-variables / jkl.dark-mode-variables). I Jøkul 5 må du bruke semantiske CSS-variabler i stedet for å definere egne dark/light-varianter.",
+    },
+    {
+        // @include jkl.text-style("body") / text-style("small")
+        pattern: /\btext-style\(\s*["'](?:body|small)["']\s*\)/,
+        message:
+            'Fjernede tekststiler ("body", "small") i text-style-mixin. Bytt til "paragraph-large/medium/small" eller "text-large/medium/small/micro" — se https://jokul-portal.intern.app.prodaws.fremtind.no/fundamenter/typografi.',
+    },
+];
+
+function collectManualMigrationWarnings(text) {
+    const warnings = [];
+
+    for (const { pattern, message } of MANUAL_MIGRATION_WARNINGS) {
+        if (pattern.test(text)) {
+            warnings.push(`Manuell vurdering: ${message}`);
+        }
+    }
+
+    return warnings;
+}
+
 function reorderConfiguredFontImport(text) {
     const fontImportPattern =
         /^@use\s+["']@fremtind\/jokul\/styles\/theme\/fonts["'][\s\S]*?;\s*/m;
@@ -315,7 +355,10 @@ export function transformImportPaths(text, filePath = "") {
         reordered = reorderedResult.reordered;
     }
 
-    const warnings = [...beta.warnings];
+    const warnings = [
+        ...beta.warnings,
+        ...collectManualMigrationWarnings(text),
+    ];
 
     if (
         webfontsRemoval.count > 0 &&

--- a/packages/jokul/codemods/import-paths.mjs
+++ b/packages/jokul/codemods/import-paths.mjs
@@ -226,6 +226,34 @@ function applyBetaStyleReplacements(text) {
     return { text: next, replacements, warnings };
 }
 
+/**
+ * Font-family-navnet "Fremtind Material Symbols" (og tilhørende fallback) ble
+ * omdøpt til "Jokul Icons" i Jøkul 5. Konsumenter som har skrevet font-family
+ * direkte i sin egen CSS/SCSS får ellers en stille brutt referanse.
+ *
+ * Fallback-navnet erstattes først (lengst først), slik at det ikke blir
+ * delvis overskrevet av kortere mønster.
+ */
+const FONT_FAMILY_REPLACEMENTS = [
+    ["Fremtind Material Symbols Fallback", "Jokul Icons Fallback"],
+    ["Fremtind Material Symbols", "Jokul Icons"],
+];
+
+function applyFontFamilyReplacements(text) {
+    let next = text;
+    let count = 0;
+
+    for (const [from, to] of FONT_FAMILY_REPLACEMENTS) {
+        const pattern = new RegExp(escapeRegExp(from), "g");
+        next = next.replace(pattern, () => {
+            count += 1;
+            return to;
+        });
+    }
+
+    return { text: next, count };
+}
+
 const WEBFONTS_CSS_SPECIFIER =
     "@fremtind/jokul/styles/fonts/webfonts(?:\\.min)?\\.css";
 
@@ -296,7 +324,7 @@ const MANUAL_MIGRATION_WARNINGS = [
         // @include jkl.text-style("body") / text-style("small")
         pattern: /\btext-style\(\s*["'](?:body|small)["']\s*\)/,
         message:
-            'Fjernede tekststiler ("body", "small") i text-style-mixin. Bytt til "paragraph-large/medium/small" eller "text-large/medium/small/micro" — se https://jokul-portal.intern.app.prodaws.fremtind.no/fundamenter/typografi.',
+            'Fjernede tekststiler ("body", "small") i text-style-mixin. Foretrekk å bruke <Text>-komponenten der det er mulig (`import { Text } from "@fremtind/jokul/components/typography"`). Hvis du må sette stiler direkte, bytt til "paragraph-large/medium/small" eller "text-large/medium/small/micro" — se https://jokul-portal.intern.app.prodaws.fremtind.no/fundamenter/typografi.',
     },
 ];
 
@@ -344,7 +372,8 @@ function reorderConfiguredFontImport(text) {
 
 export function transformImportPaths(text, filePath = "") {
     const webfontsRemoval = removeRedundantWebfontsCssImport(text);
-    const direct = applyDirectReplacements(webfontsRemoval.text);
+    const fontFamily = applyFontFamilyReplacements(webfontsRemoval.text);
+    const direct = applyDirectReplacements(fontFamily.text);
     const beta = applyBetaStyleReplacements(direct.text);
     let next = beta.text;
     let reordered = false;
@@ -373,7 +402,10 @@ export function transformImportPaths(text, filePath = "") {
         text: next,
         changed: next !== text,
         replacements:
-            direct.replacements + beta.replacements + webfontsRemoval.count,
+            direct.replacements +
+            beta.replacements +
+            webfontsRemoval.count +
+            fontFamily.count,
         warnings,
         reordered,
     };

--- a/packages/jokul/codemods/import-paths.mjs
+++ b/packages/jokul/codemods/import-paths.mjs
@@ -226,6 +226,52 @@ function applyBetaStyleReplacements(text) {
     return { text: next, replacements, warnings };
 }
 
+const WEBFONTS_CSS_SPECIFIER =
+    "@fremtind/jokul/styles/fonts/webfonts(?:\\.min)?\\.css";
+
+const BASE_OR_COMPONENT_CSS_PATTERN = new RegExp(
+    "@fremtind/jokul/styles/(?:base|components)(?:\\.min)?\\.css",
+);
+
+const WEBFONTS_CSS_REMOVAL_PATTERNS = [
+    // import "@fremtind/jokul/styles/fonts/webfonts.css"; (ESM)
+    new RegExp(
+        `^[ \\t]*import\\s+["']${WEBFONTS_CSS_SPECIFIER}["']\\s*;?[ \\t]*\\r?\\n?`,
+        "gm",
+    ),
+    // require("@fremtind/jokul/styles/fonts/webfonts.css"); (CJS)
+    new RegExp(
+        `^[ \\t]*require\\(\\s*["']${WEBFONTS_CSS_SPECIFIER}["']\\s*\\)\\s*;?[ \\t]*\\r?\\n?`,
+        "gm",
+    ),
+    // @import "@fremtind/jokul/styles/fonts/webfonts.css"; (CSS / SCSS)
+    new RegExp(
+        `^[ \\t]*@import\\s+["']${WEBFONTS_CSS_SPECIFIER}["']\\s*;?[ \\t]*\\r?\\n?`,
+        "gm",
+    ),
+];
+
+/**
+ * I Jøkul 5 er `@font-face`-definisjonene flyttet inn i `styles/base.css`, og den
+ * frittstående `styles/fonts/webfonts.css` finnes ikke lenger i pakken. For
+ * .css-konsumenter betyr det at gamle `webfonts.css`-imports må fjernes – ellers
+ * blir bygget brutt fordi filen er borte. SCSS-konsumenter håndteres av
+ * `DIRECT_REPLACEMENTS` siden de kan ha behov for å overstyre `$webfonts-dir`.
+ */
+function removeRedundantWebfontsCssImport(text) {
+    let next = text;
+    let count = 0;
+
+    for (const pattern of WEBFONTS_CSS_REMOVAL_PATTERNS) {
+        next = next.replace(pattern, () => {
+            count += 1;
+            return "";
+        });
+    }
+
+    return { text: next, count };
+}
+
 function reorderConfiguredFontImport(text) {
     const fontImportPattern =
         /^@use\s+["']@fremtind\/jokul\/styles\/theme\/fonts["'][\s\S]*?;\s*/m;
@@ -257,7 +303,8 @@ function reorderConfiguredFontImport(text) {
 }
 
 export function transformImportPaths(text, filePath = "") {
-    const direct = applyDirectReplacements(text);
+    const webfontsRemoval = removeRedundantWebfontsCssImport(text);
+    const direct = applyDirectReplacements(webfontsRemoval.text);
     const beta = applyBetaStyleReplacements(direct.text);
     let next = beta.text;
     let reordered = false;
@@ -268,11 +315,23 @@ export function transformImportPaths(text, filePath = "") {
         reordered = reorderedResult.reordered;
     }
 
+    const warnings = [...beta.warnings];
+
+    if (
+        webfontsRemoval.count > 0 &&
+        !BASE_OR_COMPONENT_CSS_PATTERN.test(next)
+    ) {
+        warnings.push(
+            "Manuell vurdering: fjernet import av `styles/fonts/webfonts.css`. `@font-face`-definisjonene ligger nå i `@fremtind/jokul/styles/base.css`, så den må importeres for at fontene skal lastes.",
+        );
+    }
+
     return {
         text: next,
         changed: next !== text,
-        replacements: direct.replacements + beta.replacements,
-        warnings: beta.warnings,
+        replacements:
+            direct.replacements + beta.replacements + webfontsRemoval.count,
+        warnings,
         reordered,
     };
 }


### PR DESCRIPTION
## Summary

Tilbakemelding fra en konsument som bruker `.css` (ikke `.scss`) viste at codemoden lot stå igjen `@fremtind/jokul/styles/fonts/webfonts.css`-importer etter migrering. Den filen finnes ikke lenger i Jøkul 5 (fontene ligger nå i `styles/base.css`), så bygget feilet.

Codemoden:
- Fjerner ESM-imports (`import "...webfonts.css"`), CJS (`require("...webfonts.css")`) og CSS-`@import` av både `webfonts.css` og `webfonts.min.css`.
- Varsler hvis fjerningen skjer i en fil som ikke allerede har `base.css`/`base.min.css`/`components.css`/`components.min.css`-import, så man husker å legge til `base.css` for å beholde fontene.
- SCSS-omdøpingen til `theme/fonts` er uendret siden SCSS-konsumenter kan ha behov for å overstyre `\$webfonts-dir`.

## Test plan

- [x] `node --test packages/jokul/codemods/__tests__/import-paths.test.mjs` (9/9 passerer, 4 nye tester)
- [ ] Manuell sanity-test mot et CSS-only oppsett (importerte `styles.css` + `core/core.css` + `fonts/webfonts.css` ender opp med `components.css` + `base.css` uten webfonts-linjen)