### PR TITLE
Legger til spesifikk eksportsti for Sass-hjelpefunksjoner

### DIFF
--- a/.changeset/fluffy-laws-type.md
+++ b/.changeset/fluffy-laws-type.md
@@ -1,0 +1,7 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legger til spesifikk eksportsti for Sass-hjelpefunksjoner
+
+Det virker som noen byggverktøy sliter med wildcard-eksportstier for Sass-filer, og derfor ikke klarer å laste inn f.eks. `@fremtind/jokul/styles/jkl`. Vi legger til denne filen som en spesifikk eksportsti.

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -23,6 +23,7 @@
     },
     "exports": {
         "./package.json": "./package.json",
+        "./styles/jkl": "./styles/jkl/_index.scss",
         "./styles/*": "./styles/*",
         "./tailwind": {
             "import": {


### PR DESCRIPTION
## 💬 Endringer


Det virker som noen byggverktøy sliter med wildcard-eksportstier for Sass-filer, og derfor ikke klarer å laste inn f.eks. `@fremtind/jokul/styles/jkl`. Vi legger til denne filen som en spesifikk eksportsti.
