### PR TITLE
fix(tokens): rett opp manglende bindestrek i CSS-variabelnavn

### DIFF
--- a/.changeset/fix-spacing-token-hyphen.md
+++ b/.changeset/fix-spacing-token-hyphen.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser CSS-variabelnavn for tokens der bindestrek manglet mellom kategori og tall (f.eks. `jkl-spacing20` i stedet for `jkl-spacing-20`). Feilen skyldes at TypeScript-plattformen brukte `name/camel` i stedet for `name/kebab` som navnetransform.

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.test.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.test.ts
@@ -1,0 +1,171 @@
+import { kebabCase } from "change-case";
+import type { TransformedToken } from "style-dictionary/types";
+import { describe, expect, it } from "vitest";
+import cssTailwind4Format from "./css-tailwind4.js";
+
+/**
+ * Simulerer token slik det ser ut etter at name/kebab og value/resolve har kjørt
+ * (Tailwind-plattformen bruker transformGroup: "css" som inkluderer begge).
+ */
+function makeToken(
+    path: string[],
+    value: unknown,
+    original?: unknown,
+): TransformedToken {
+    return {
+        path,
+        name: kebabCase([undefined, ...path].join(" ")),
+        value,
+        original: { value: original ?? value },
+    } as unknown as TransformedToken;
+}
+
+async function runFormat(tokens: TransformedToken[]): Promise<string> {
+    return (cssTailwind4Format.format as Function)({
+        dictionary: { allTokens: tokens },
+        file: { destination: "tailwind.css" },
+        options: {},
+        platform: {},
+    });
+}
+
+describe("css/tailwind4-format", () => {
+    describe("fargevariabler (formatColorVariables)", () => {
+        it("bruker token.name (satt av name/kebab) til å bygge variabelnavnet", async () => {
+            const token = makeToken(
+                ["color", "neutral", "background", "page"],
+                { light: "#F4F2EF", dark: "#1B1917" },
+            );
+            const result = await runFormat([token]);
+            expect(result).toContain(
+                "--color-neutral-background-page: #F4F2EF;",
+            );
+            expect(result).toContain(
+                "--color-neutral-background-page: light-dark(#F4F2EF, #1B1917);",
+            );
+        });
+
+        it("håndterer camelCase path-segmenter korrekt via name/kebab", async () => {
+            // Hypotetisk farge-token med camelCase i stien – skal ikke skje i dag,
+            // men name/kebab sørger for at det ville fungert
+            const token = makeToken(
+                ["color", "accent", "backgroundAction"],
+                { light: "#aaa", dark: "#333" },
+            );
+            const result = await runFormat([token]);
+            expect(result).toContain("--color-accent-background-action:");
+        });
+    });
+
+    describe("spacingvariabler (formatSpacingVariables)", () => {
+        it("genererer riktig variabelnavn for numeriske spacing-tokens", async () => {
+            const tokens = [
+                makeToken(["spacing", "24"], "1.5rem"),
+                makeToken(["spacing", "168"], "10.5rem"),
+            ];
+            const result = await runFormat(tokens);
+            expect(result).toContain("--spacing-24: 1.5rem;");
+            expect(result).toContain("--spacing-168: 10.5rem;");
+        });
+
+        it("genererer riktig variabelnavn for alfanumeriske tokens (2xs, 2xl)", async () => {
+            const tokens = [
+                makeToken(["spacing", "2xs"], "0.25rem"),
+                makeToken(["spacing", "2xl"], "6.5rem"),
+            ];
+            const result = await runFormat(tokens);
+            expect(result).toContain("--spacing-2xs: 0.25rem;");
+            expect(result).toContain("--spacing-2xl: 6.5rem;");
+        });
+
+        it("utelater størrelsesavhengige spacing-tokens (isSizeToken)", async () => {
+            const sizeToken = makeToken(
+                ["spacing", "base"],
+                { small: "5px", medium: "8px", large: "11px" },
+            );
+            const result = await runFormat([sizeToken]);
+            expect(result).not.toContain("--spacing-base");
+        });
+    });
+
+    describe("breakpoint-variabler (formatBreakpointVariables)", () => {
+        it("genererer riktig variabelnavn for breakpoint-tokens", async () => {
+            const tokens = [
+                makeToken(["breakpoint", "medium"], "680px"),
+                makeToken(["breakpoint", "large"], "1200px"),
+            ];
+            const result = await runFormat(tokens);
+            expect(result).toContain("--breakpoint-medium: 680px;");
+            expect(result).toContain("--breakpoint-large: 1200px;");
+        });
+    });
+
+    describe("teksthjelpe-klasser (formatTextUtilities)", () => {
+        const textStyleValue = { fontSize: "1rem", lineHeight: "1.5", fontWeight: "400", fontFamily: "sans-serif" };
+
+        const allTextStyles = [
+            "title",
+            "title-small",
+            "heading-1",
+            "heading-2",
+            "heading-3",
+            "heading-4",
+            "heading-5",
+            "paragraph-large",
+            "paragraph-medium",
+            "paragraph-small",
+            "text-large",
+            "text-medium",
+            "text-small",
+            "text-micro",
+        ];
+
+        it.each(allTextStyles)(
+            'genererer korrekt @utility-blokk for "%s"',
+            async (name) => {
+                const token = makeToken(["textStyle", name], textStyleValue);
+                const result = await runFormat([token]);
+                expect(result).toContain(`@utility ${name} {`);
+                expect(result).toContain(`    font: var(--jkl-text-style-${name});`);
+                expect(result).toContain("}");
+            },
+        );
+
+        it("genererer alle 14 tekststil-utilities i én kjøring", async () => {
+            const tokens = allTextStyles.map((name) =>
+                makeToken(["textStyle", name], textStyleValue),
+            );
+            const result = await runFormat(tokens);
+            for (const name of allTextStyles) {
+                expect(result).toContain(`@utility ${name} {`);
+                expect(result).toContain(`    font: var(--jkl-text-style-${name});`);
+            }
+        });
+
+        it("utelater tokens som ikke er textStyle", async () => {
+            const nonTextToken = makeToken(
+                ["spacing", "16"],
+                "1rem",
+            );
+            const result = await runFormat([nonTextToken]);
+            expect(result).not.toContain("@utility");
+        });
+
+        it("utelater textStyle-tokens uten fontSize (isTextStyleToken-filter)", async () => {
+            const incompleteToken = makeToken(
+                ["textStyle", "custom"],
+                { lineHeight: "1.5" },
+            );
+            const result = await runFormat([incompleteToken]);
+            expect(result).not.toContain("@utility custom");
+        });
+
+        it("genererer riktig blokk-struktur med innrykk og korrekte klammeparenteser", async () => {
+            const token = makeToken(["textStyle", "heading-1"], textStyleValue);
+            const result = await runFormat([token]);
+            expect(result).toContain(
+                "@utility heading-1 {\n    font: var(--jkl-text-style-heading-1);\n}",
+            );
+        });
+    });
+});

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.ts
@@ -1,4 +1,3 @@
-import { kebabCase } from "change-case";
 import type {
     Dictionary,
     File,
@@ -54,7 +53,7 @@ function formatSpacingVariables(
                 token.path.length === 2,
         )
         .map((token) => {
-            const step = kebabCase(token.path[1]);
+            const step = token.path[1];
             return `${indentation}--spacing-${step}: ${token.value};`;
         })
         .join("\n");
@@ -93,7 +92,7 @@ function formatBreakpointVariables(
             (token) => token.path[0] === "breakpoint" && !isSizeToken(token),
         )
         .map((token) => {
-            const step = kebabCase(token.path[1]);
+            const step = token.path[1];
             return `${indentation}--breakpoint-${step}: ${token.value};`;
         })
         .join("\n");
@@ -149,7 +148,7 @@ function formatTextUtilities(tokens: TransformedToken[]): string {
     return tokens
         .filter(isTextStyleToken)
         .map((token) => {
-            const name = kebabCase(token.path[1]);
+            const name = token.path[1];
             return [
                 `@utility ${name} {`,
                 `    font: var(--jkl-text-style-${name});`,

--- a/packages/jokul/src/tokens/style-dictionary/register.test.ts
+++ b/packages/jokul/src/tokens/style-dictionary/register.test.ts
@@ -1,0 +1,153 @@
+import { kebabCase } from "change-case";
+import type { TransformedToken } from "style-dictionary/types";
+import { describe, expect, it } from "vitest";
+import { cssVarReferenceTransform } from "./register.js";
+
+/**
+ * Simulerer det SD sitt `name/kebab`-transform gjør, slik at vi kan teste
+ * hele pipelinen (name/kebab → value/css-var-reference) uten å kjøre SD-bygget.
+ */
+function makeToken(path: string[]): Pick<TransformedToken, "name"> {
+    return { name: kebabCase([undefined, ...path].join(" ")) };
+}
+
+describe("cssVarReferenceTransform", () => {
+    describe("spacing", () => {
+        it("genererer riktig CSS-variabelreferanse for numeriske tokens", () => {
+            expect(cssVarReferenceTransform(makeToken(["spacing", "0"]))).toBe(
+                "var(--jkl-spacing-0)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "24"]))).toBe(
+                "var(--jkl-spacing-24)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "168"]))).toBe(
+                "var(--jkl-spacing-168)",
+            );
+        });
+
+        it("genererer riktig CSS-variabelreferanse for alfanumeriske tokens (2xs, 2xl)", () => {
+            expect(cssVarReferenceTransform(makeToken(["spacing", "2xs"]))).toBe(
+                "var(--jkl-spacing-2xs)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "2xl"]))).toBe(
+                "var(--jkl-spacing-2xl)",
+            );
+        });
+
+        it("genererer riktig CSS-variabelreferanse for semantiske tokens", () => {
+            expect(cssVarReferenceTransform(makeToken(["spacing", "none"]))).toBe(
+                "var(--jkl-spacing-none)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "xs"]))).toBe(
+                "var(--jkl-spacing-xs)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "m"]))).toBe(
+                "var(--jkl-spacing-m)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["spacing", "xl"]))).toBe(
+                "var(--jkl-spacing-xl)",
+            );
+        });
+    });
+
+    describe("farger (color)", () => {
+        it("genererer riktig CSS-variabelreferanse for dypt nøstede fargetokens", () => {
+            expect(
+                cssVarReferenceTransform(
+                    makeToken(["color", "neutral", "background", "page"]),
+                ),
+            ).toBe("var(--jkl-color-neutral-background-page)");
+            expect(
+                cssVarReferenceTransform(
+                    makeToken(["color", "warning", "border", "strong"]),
+                ),
+            ).toBe("var(--jkl-color-warning-border-strong)");
+        });
+    });
+
+    describe("typografi (font)", () => {
+        it("genererer riktig CSS-variabelreferanse for skriftstørrelse", () => {
+            expect(cssVarReferenceTransform(makeToken(["font", "size", "1"]))).toBe(
+                "var(--jkl-font-size-1)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["font", "size", "10"]))).toBe(
+                "var(--jkl-font-size-10)",
+            );
+        });
+
+        it("genererer riktig CSS-variabelreferanse for tekststiler med bindestrek", () => {
+            expect(
+                cssVarReferenceTransform(makeToken(["text", "style", "heading-1"])),
+            ).toBe("var(--jkl-text-style-heading-1)");
+            expect(
+                cssVarReferenceTransform(
+                    makeToken(["text", "style", "paragraph-large"]),
+                ),
+            ).toBe("var(--jkl-text-style-paragraph-large)");
+        });
+    });
+
+    describe("bevegelse (motion)", () => {
+        it("håndterer camelCase-segmenter via name/kebab (ingen egendefinert logikk)", () => {
+            expect(
+                cssVarReferenceTransform(
+                    makeToken(["motion", "easing", "easeInBounceOut"]),
+                ),
+            ).toBe("var(--jkl-motion-easing-ease-in-bounce-out)");
+        });
+
+        it("genererer riktig CSS-variabelreferanse for enkle motion-tokens", () => {
+            expect(
+                cssVarReferenceTransform(makeToken(["motion", "timing", "productive"])),
+            ).toBe("var(--jkl-motion-timing-productive)");
+        });
+    });
+
+    describe("enheter (unit)", () => {
+        it("genererer riktig CSS-variabelreferanse for numeriske enhets-tokens", () => {
+            expect(cssVarReferenceTransform(makeToken(["unit", "10"]))).toBe(
+                "var(--jkl-unit-10)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["unit", "20"]))).toBe(
+                "var(--jkl-unit-20)",
+            );
+        });
+
+        it("genererer riktig CSS-variabelreferanse for desimal-tokens (02, 05)", () => {
+            expect(cssVarReferenceTransform(makeToken(["unit", "02"]))).toBe(
+                "var(--jkl-unit-02)",
+            );
+            expect(cssVarReferenceTransform(makeToken(["unit", "05"]))).toBe(
+                "var(--jkl-unit-05)",
+            );
+        });
+    });
+
+    describe("kant (border)", () => {
+        it("genererer riktig CSS-variabelreferanse for border-tokens", () => {
+            expect(
+                cssVarReferenceTransform(makeToken(["border", "radius", "xs"])),
+            ).toBe("var(--jkl-border-radius-xs)");
+            expect(
+                cssVarReferenceTransform(makeToken(["border", "width", "1"])),
+            ).toBe("var(--jkl-border-width-1)");
+        });
+    });
+
+    describe("regresjonstest: name/kebab må kjøre før value/css-var-reference", () => {
+        it("produserer feil resultat hvis name/camel har kjørt i stedet (dokumenterer bugg i next.8)", () => {
+            // Etter name/camel ville token.name være "spacing24" (uten bindestrek)
+            const mangledToken = { name: "spacing24" };
+            expect(cssVarReferenceTransform(mangledToken)).toBe(
+                "var(--jkl-spacing24)",
+            );
+        });
+
+        it("produserer riktig resultat når name/kebab har kjørt", () => {
+            const correctToken = makeToken(["spacing", "24"]);
+            expect(cssVarReferenceTransform(correctToken)).toBe(
+                "var(--jkl-spacing-24)",
+            );
+        });
+    });
+});

--- a/packages/jokul/src/tokens/style-dictionary/register.ts
+++ b/packages/jokul/src/tokens/style-dictionary/register.ts
@@ -1,5 +1,5 @@
-import { kebabCase } from "change-case";
 import StyleDictionary from "style-dictionary";
+import type { TransformedToken } from "style-dictionary/types";
 
 import cssBrandFontsFormat from "./formats/css-brand-fonts.js";
 import cssColorSchemeBrand from "./formats/css-color-scheme-brand.js";
@@ -28,22 +28,27 @@ StyleDictionary.registerFormat(cssTailwind4Format);
 // Transforms
 
 /**
- * Transformerer token-verdier til CSS-variabelreferanser.
+ * Konverterer en token-verdi til en CSS-variabelreferanse.
  *
- * Konverterer en token med navn "color-background-page"
- * til verdien "var(--jkl-color-background-page)".
+ * Baserer seg på `token.name` som er satt av SD sitt innebygde `name/kebab`-transform,
+ * slik at navngivingslogikken ligger ett sted og vi ikke gjenskaper den her.
  *
- * Håndterer også camelCase i token-navn ved å konvertere dem til kebab-case,
- * slik at "typographyLineHeightTight" blir "var(--jkl-typography-line-height-tight)".
+ * Eksempler (forutsetter at name/kebab har kjørt):
+ * - token.name = "spacing-24"                     → var(--jkl-spacing-24)
+ * - token.name = "spacing-2xs"                    → var(--jkl-spacing-2xs)
+ * - token.name = "motion-easing-ease-in-bounce-out" → var(--jkl-motion-easing-ease-in-bounce-out)
  */
+export function cssVarReferenceTransform(
+    token: Pick<TransformedToken, "name">,
+): string {
+    return `var(--${PREFIX}-${token.name})`;
+}
+
 StyleDictionary.registerTransform({
     name: "value/css-var-reference",
     type: "value",
     transitive: true,
-    transform: (token) => {
-        const varName = kebabCase(token.name);
-        return `var(--${PREFIX}-${varName})`;
-    },
+    transform: cssVarReferenceTransform,
 });
 
 // Filters
@@ -55,12 +60,14 @@ StyleDictionary.registerFilter(isBrandFontValue);
 /**
  * Transform-gruppe for TypeScript-output.
  *
- * Konverterer token-navn til camelCase og token-verdier til CSS-variabelreferanser.
- * Brukes for å generere TypeScript-objekter der verdiene peker til CSS custom properties.
+ * Bruker `name/kebab` (samme som CSS-plattformen) slik at `token.name` alltid
+ * er korrekt kebab-case når `value/css-var-reference` bruker det til å bygge
+ * CSS-variabelreferansen. Den nøstede objektstrukturen i tokens.ts er uavhengig
+ * av token-navn og styres av token-stien.
  */
 StyleDictionary.registerTransformGroup({
     name: "typescript-css-var",
-    transforms: ["name/camel", "value/css-var-reference"],
+    transforms: ["name/kebab", "value/css-var-reference"],
 });
 
 /**


### PR DESCRIPTION
## Summary

- Fikser `jkl-spacing20` → `jkl-spacing-20` (og tilsvarende for alle tokens med tall i navn)
- Rotårsak: `typescript-css-var`-transformgruppen brukte `name/camel` i stedet for `name/kebab`; `camelCase("spacing 24")` = `"spacing24"`, og `kebabCase` klarer ikke å finne ordgrensen mellom bokstaver og tall uten mellomrom
- Fikset ved å bruke `name/kebab` (samme som CSS/SCSS-plattformene) og forenkle `cssVarReferenceTransform` til å lese `token.name` direkte
- Samme forenkling gjort i Tailwind-formatet (`css-tailwind4.ts`)

## Test plan

- [x] 38 tester kjøres automatisk (`register.test.ts`, `css-tailwind4.test.ts`) — dekker alle token-grupper (spacing, farge, typografi, motion, enhet, border) og alle 14 `@utility`-tekststilklasser
- [x] Regresjonstest dokumenterer buggen eksplisitt: viser at `{ name: "spacing24" }` (etter `name/camel`) gir feil, mens `makeToken(["spacing", "24"])` (etter `name/kebab`) gir riktig

🤖 Generated with [Claude Code](https://claude.com/claude-code)