### PR TITLE
feat(portal): release notes som egen dokumenttype

### DIFF
--- a/portal/src/app/(frontend)/release-notes/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/release-notes/[slug]/page.tsx
@@ -1,0 +1,66 @@
+import { PageFooter } from "@/components/PageFooter";
+import { PortableText } from "@/components/portable-text/PortableText";
+import { sanityFetch } from "@/sanity/lib/live";
+import { releaseNoteBySlugQuery } from "@/sanity/queries/releaseNotes";
+
+import { ArticleHeader } from "@/components/article/header";
+import { logger } from "logger";
+import type { Metadata } from "next";
+
+type Props = {
+    params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const slug = (await params).slug;
+
+    const { data: note } = await sanityFetch({
+        query: releaseNoteBySlugQuery,
+        params: { slug },
+        requestTag: "release-note",
+        tags: [`jokul_release_notes:${slug}`],
+    });
+
+    return {
+        title: note?.version ? `Jøkul ${note.version}` : "Release notes",
+    };
+}
+
+export default async function ReleaseNotePage({ params }: Props) {
+    const { slug } = await params;
+
+    const initialTime = performance.now();
+    const { data: note } = await sanityFetch({
+        query: releaseNoteBySlugQuery,
+        params: { slug },
+        requestTag: "release-note",
+        tags: [`jokul_release_notes:${slug}`],
+    });
+
+    if (!note) {
+        logger.warn("Release note not found", { slug });
+        return null;
+    }
+
+    logger.info("Fetched release note", {
+        slug,
+        time: `${Math.round(performance.now() - initialTime)}ms`,
+    });
+
+    return (
+        <article className={"prose"}>
+            <ArticleHeader
+                title={note.version ? `Jøkul ${note.version}` : ""}
+                description={note.short_description ?? undefined}
+                date={
+                    note.releaseDate
+                        ? { published: new Date(note.releaseDate) }
+                        : undefined
+                }
+                backLink={{ href: "/release-notes", label: "Release notes" }}
+            />
+            {note.article ? <PortableText blocks={note.article} /> : null}
+            <PageFooter />
+        </article>
+    );
+}

--- a/portal/src/app/(frontend)/release-notes/page.tsx
+++ b/portal/src/app/(frontend)/release-notes/page.tsx
@@ -1,0 +1,39 @@
+import { OverviewCard } from "@/components/overview/card";
+import { OverviewGrid } from "@/components/overview/grid";
+import { OverviewHeader } from "@/components/overview/header";
+import { sanityFetch } from "@/sanity/lib/live";
+import { releaseNotesQuery } from "@/sanity/queries/releaseNotes";
+import { logger } from "logger";
+
+export default async function ReleaseNotesPage() {
+    logger.info("Rendering release notes overview page");
+
+    const { data: notes } = await sanityFetch({
+        query: releaseNotesQuery,
+        requestTag: "release-notes",
+        tags: ["jokul_release_notes"],
+    });
+
+    if (!notes) {
+        logger.warn("No release notes found");
+        return null;
+    }
+
+    return (
+        <>
+            <OverviewHeader title="Release notes" />
+            <OverviewGrid>
+                {notes
+                    .filter((note) => note.slug)
+                    .map((note) => (
+                        <OverviewCard
+                            key={note._id}
+                            title={note.version || note.slug || ""}
+                            description={note.short_description || ""}
+                            link={`/release-notes/${note.slug}`}
+                        />
+                    ))}
+            </OverviewGrid>
+        </>
+    );
+}

--- a/portal/src/components/portable-text/PortableText.tsx
+++ b/portal/src/components/portable-text/PortableText.tsx
@@ -47,6 +47,7 @@ const jokulBlockTypes = {
     }: {
         value: SanityImageObject & { alt?: string };
     }) {
+        if (!value?.asset) return null;
         return (
             <img
                 src={getSanityImageUrlBuilder(value).width(1200).url()}

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -419,6 +419,32 @@
                                                   }
                                                 },
                                                 "dereferencesTo": "jokul_blog_post"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "attributes": {
+                                                  "_ref": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "string",
+                                                      "value": "reference"
+                                                    }
+                                                  },
+                                                  "_weak": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "optional": true
+                                                  }
+                                                },
+                                                "dereferencesTo": "jokul_release_notes"
                                               }
                                             ]
                                           },
@@ -3023,6 +3049,451 @@
           "of": {
             "type": "string"
           }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "jokul_release_notes",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "jokul_release_notes"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "version": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      },
+      "releaseDate": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "short_description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "article": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "union",
+            "of": [
+              {
+                "type": "object",
+                "attributes": {
+                  "children": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "object",
+                        "attributes": {
+                          "marks": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "string"
+                              }
+                            },
+                            "optional": true
+                          },
+                          "text": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "span"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "optional": true
+                  },
+                  "style": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": [
+                        {
+                          "type": "string",
+                          "value": "normal"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h1"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h2"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h3"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h4"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h5"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h6"
+                        },
+                        {
+                          "type": "string",
+                          "value": "blockquote"
+                        }
+                      ]
+                    },
+                    "optional": true
+                  },
+                  "listItem": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": [
+                        {
+                          "type": "string",
+                          "value": "bullet"
+                        },
+                        {
+                          "type": "string",
+                          "value": "number"
+                        }
+                      ]
+                    },
+                    "optional": true
+                  },
+                  "markDefs": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "object",
+                        "attributes": {
+                          "href": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "link"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "optional": true
+                  },
+                  "level": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "block"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_linkCard"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "sanity.imageAsset"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_code"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_codeBlock"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_examples"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_storybook"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_table"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_qa"
+                }
+              }
+            ]
+          }
+        },
+        "optional": true
+      },
+      "migrationUrl": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "figmaUrl": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
         },
         "optional": true
       }

--- a/portal/src/sanity/queries/releaseNotes.ts
+++ b/portal/src/sanity/queries/releaseNotes.ts
@@ -1,0 +1,42 @@
+import { defineQuery } from "next-sanity";
+
+export const releaseNotesQuery = defineQuery(
+    `*[_type == "jokul_release_notes"]{
+        _id,
+        version,
+        "slug": slug.current,
+        short_description,
+        releaseDate,
+    } | order(releaseDate desc)`,
+);
+
+export const releaseNoteBySlugQuery = defineQuery(
+    `*[_type == "jokul_release_notes" && slug.current == $slug][0] {
+        version,
+        releaseDate,
+        short_description,
+        migrationUrl,
+        figmaUrl,
+        article[]{
+            ...,
+            _type == "jokul_code" => {
+                ...,
+                title,
+                code,
+                "language": code.language,
+            },
+            _type == "jokul_examples" => {
+                ...,
+                title,
+                examples[]->{
+                    name,
+                    id,
+                    description,
+                    height,
+                    inert,
+                    code
+                },
+            },
+        },
+    }`,
+);

--- a/portal/src/sanity/queries/siteData.ts
+++ b/portal/src/sanity/queries/siteData.ts
@@ -17,9 +17,10 @@ export const siteDataQuery = defineQuery(
                     text,
                     "url": select(
     url[0]._type == "internalLink" => select(
-      url[0].internalReference->_type == "jokul_component" => "komponenter/" + url[0].internalReference->slug.current,
-      url[0].internalReference->_type == "jokul_fundamentals" => "fundamenter/" + url[0].internalReference->slug.current,
-      url[0].internalReference->_type == "jokul_blog_post" => "blog/" + url[0].internalReference->slug.current,
+      url[0].internalReference->_type == "jokul_component" => "/komponenter/" + url[0].internalReference->slug.current,
+      url[0].internalReference->_type == "jokul_fundamentals" => "/fundamenter/" + url[0].internalReference->slug.current,
+      url[0].internalReference->_type == "jokul_blog_post" => "/blog/" + url[0].internalReference->slug.current,
+      url[0].internalReference->_type == "jokul_release_notes" => "/release-notes/" + url[0].internalReference->slug.current,
       "/" + url[0].internalReference->slug.current
     ),
     url[0]._type == "externalLink" => url[0].url

--- a/portal/src/sanity/schemas/documents/releaseNotes.ts
+++ b/portal/src/sanity/schemas/documents/releaseNotes.ts
@@ -1,0 +1,89 @@
+import { RocketIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+export const releaseNotes = defineType({
+    name: "jokul_release_notes",
+    title: "Release notes",
+    type: "document",
+    icon: RocketIcon,
+    groups: [
+        { name: "generelt", title: "Generelt", default: true },
+        { name: "innhold", title: "Innhold" },
+        { name: "ressurser", title: "Ressurser" },
+    ],
+    fields: [
+        defineField({
+            name: "version",
+            title: "Versjon",
+            description: "Versjonsnummer, f.eks. 5.0.0",
+            type: "string",
+            group: "generelt",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "slug",
+            title: "Slug",
+            type: "slug",
+            group: "generelt",
+            options: {
+                source: "version",
+                slugify: (input) =>
+                    input.trim().toLowerCase().replace(/\./g, "-"),
+            },
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "releaseDate",
+            title: "Utgivelsesdato",
+            type: "date",
+            group: "generelt",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "short_description",
+            title: "Kort beskrivelse",
+            type: "text",
+            rows: 2,
+            group: "generelt",
+        }),
+        defineField({
+            name: "article",
+            title: "Artikkel",
+            type: "array",
+            group: "innhold",
+            of: [
+                { type: "block" },
+                { type: "jokul_linkCard" },
+                { type: "image" },
+                { type: "jokul_code" },
+                { type: "jokul_codeBlock" },
+                { type: "jokul_examples" },
+                { type: "jokul_storybook" },
+                { type: "jokul_table" },
+                { type: "jokul_qa" },
+            ],
+        }),
+        defineField({
+            name: "migrationUrl",
+            title: "Migrasjonsguide (GitHub)",
+            type: "url",
+            group: "ressurser",
+            initialValue:
+                "https://github.com/fremtind/jokul/blob/main/packages/jokul/MIGRATION.md",
+        }),
+        defineField({
+            name: "figmaUrl",
+            title: "Endringer i Figma",
+            type: "url",
+            group: "ressurser",
+            initialValue:
+                "https://www.figma.com/design/jd7QGZJIQ5ZU6AhAq31yuv/J%C3%B8kul-4.1?node-id=31238-4543",
+        }),
+    ],
+    preview: {
+        select: {
+            title: "version",
+            subtitle: "releaseDate",
+        },
+    },
+});

--- a/portal/src/sanity/schemas/documents/siteData.ts
+++ b/portal/src/sanity/schemas/documents/siteData.ts
@@ -82,12 +82,19 @@ export const siteData = defineType({
                                                                         {
                                                                             type: "jokul_blog_post",
                                                                         },
+                                                                        {
+                                                                            type: "jokul_release_notes",
+                                                                        },
                                                                     ],
                                                                 },
                                                             ],
                                                             preview: {
                                                                 select: {
                                                                     title: "internalReference.name",
+                                                                    version: "internalReference.version",
+                                                                },
+                                                                prepare({ title, version }) {
+                                                                    return { title: title ?? version };
                                                                 },
                                                             },
                                                         },

--- a/portal/src/sanity/schemas/index.ts
+++ b/portal/src/sanity/schemas/index.ts
@@ -8,6 +8,7 @@ import { doAndDont } from "./doAndDont";
 import { blogPost } from "./documents/blogPost";
 import { component } from "./documents/component";
 import { fundamentals } from "./documents/fundamentals";
+import { releaseNotes } from "./documents/releaseNotes";
 import { siteData } from "./documents/siteData";
 import { story } from "./documents/story";
 import { examples } from "./examples";
@@ -21,6 +22,7 @@ import { table } from "./table";
 export const schemaTypes = [
     component,
     blogPost,
+    releaseNotes,
     temaside,
     componentProps,
     code,

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -86,6 +86,11 @@ export type Jokul_siteData = {
             _type: "reference";
             _weak?: boolean;
             [internalGroqTypeReferenceTo]?: "jokul_blog_post";
+          } | {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "jokul_release_notes";
           };
           _type: "internalLink";
           _key: string;
@@ -471,6 +476,64 @@ export type Jokul_temaside = {
   keywords?: Array<string>;
 };
 
+export type Jokul_release_notes = {
+  _id: string;
+  _type: "jokul_release_notes";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  version?: string;
+  slug?: Slug;
+  releaseDate?: string;
+  short_description?: string;
+  article?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  } | {
+    _key: string;
+  } & Jokul_linkCard | {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+    _key: string;
+  } | {
+    _key: string;
+  } & Jokul_code | {
+    _key: string;
+  } & Jokul_codeBlock | {
+    _key: string;
+  } & Jokul_examples | {
+    _key: string;
+  } & Jokul_storybook | {
+    _key: string;
+  } & Jokul_table | {
+    _key: string;
+  } & Jokul_qa>;
+  migrationUrl?: string;
+  figmaUrl?: string;
+};
+
 export type Jokul_blog_post = {
   _id: string;
   _type: "jokul_blog_post";
@@ -784,7 +847,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_blog_post | Table | Jokul_component | Code | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_fundamentals | Slug | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_code | Jokul_componentProps | Jokul_temaside | Jokul_release_notes | Jokul_blog_post | Table | Jokul_component | Code | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -1631,6 +1694,131 @@ export type FundamentalsBySlugQueryResult = {
   }> | null;
 } | null;
 
+// Source: ./src/sanity/queries/releaseNotes.ts
+// Variable: releaseNotesQuery
+// Query: *[_type == "jokul_release_notes"]{        _id,        version,        "slug": slug.current,        short_description,        releaseDate,    } | order(releaseDate desc)
+export type ReleaseNotesQueryResult = Array<{
+  _id: string;
+  version: string | null;
+  slug: string | null;
+  short_description: string | null;
+  releaseDate: string | null;
+}>;
+// Variable: releaseNoteBySlugQuery
+// Query: *[_type == "jokul_release_notes" && slug.current == $slug][0] {        version,        releaseDate,        short_description,        migrationUrl,        figmaUrl,        article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                "language": code.language,            },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                    name,                    id,                    description,                    height,                    inert,                    code                },            },        },    }
+export type ReleaseNoteBySlugQueryResult = {
+  version: string | null;
+  releaseDate: string | null;
+  short_description: string | null;
+  migrationUrl: string | null;
+  figmaUrl: string | null;
+  article: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    listItem?: "bullet" | "number";
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  } | {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+    _key: string;
+  } | {
+    _key: string;
+    _type: "jokul_code";
+    title: string | null;
+    code: Code | null;
+    language: string | null;
+  } | {
+    _key: string;
+    _type: "jokul_codeBlock";
+    language?: string;
+    code?: string;
+  } | {
+    _key: string;
+    _type: "jokul_examples";
+    title: string | null;
+    examples: Array<{
+      name: string | null;
+      id: string | null;
+      description: string | null;
+      height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
+      inert: boolean | null;
+      code: Code | null;
+    }> | null;
+    layout?: "carousel" | "gallery" | "list";
+  } | {
+    _key: string;
+    _type: "jokul_linkCard";
+    external_links?: Array<{
+      title?: string;
+      description?: string;
+      url?: string;
+      _type: "link";
+      _key: string;
+    }>;
+  } | {
+    _key: string;
+    _type: "jokul_qa";
+    title?: string;
+    faq?: Array<{
+      question?: string;
+      answer?: Array<{
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+        listItem?: "bullet" | "number";
+        markDefs?: Array<{
+          href?: string;
+          _type: "link";
+          _key: string;
+        }>;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }>;
+      _type: "faqitem";
+      _key: string;
+    }>;
+  } | {
+    _key: string;
+    _type: "jokul_storybook";
+    story?: Jokul_storybookStory;
+    code?: Jokul_codeBlock;
+    height?: number;
+  } | {
+    _key: string;
+    _type: "jokul_table";
+    caption?: string;
+    table?: Table;
+    show_caption?: boolean;
+    sticky_header?: boolean;
+    copy_button?: boolean;
+  }> | null;
+} | null;
+
 // Source: ./src/sanity/queries/search.ts
 // Variable: searchQuery
 // Query: *[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post"] && defined(slug.current) && (        name match "*" + $searchString + "*" ||        short_description match "*" + $searchString + "*" ||        (_type == "jokul_component" && keywords[] match "*" + $searchString + "*")    )] | {        _id,        name,        slug,        short_description,        "image": select(            _type == "jokul_component" => image.asset->url,            null        ),        "type": select(            _type == "jokul_component" => "Komponent",            _type == "jokul_fundamentals" => "Fundament",            _type == "jokul_blog_post" => "Blogg"        ),        "href": select(            _type == "jokul_component" => "/komponenter/" + slug.current,            _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,            _type == "jokul_blog_post" => "/blog/" + slug.current        )    }
@@ -1662,7 +1850,7 @@ export type SearchQueryResult = Array<{
 
 // Source: ./src/sanity/queries/siteData.ts
 // Variable: siteDataQuery
-// Query: *[_type == "jokul_siteData"]{        ...,        "seo": {            "title": coalesce(seo.title, title, ""),            "description": coalesce(seo.description,  ""),            "image": seo.image,            "noIndex": seo.noIndex == true          },        footer {            text,            linkGroups[]{                title,                linkList[]{                    text,                    "url": select(    url[0]._type == "internalLink" => select(      url[0].internalReference->_type == "jokul_component" => "komponenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_fundamentals" => "fundamenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_blog_post" => "blog/" + url[0].internalReference->slug.current,      "/" + url[0].internalReference->slug.current    ),    url[0]._type == "externalLink" => url[0].url  )                }            }        },        "date": _createdAt,    } | order(_createdAt desc)[0]
+// Query: *[_type == "jokul_siteData"]{        ...,        "seo": {            "title": coalesce(seo.title, title, ""),            "description": coalesce(seo.description,  ""),            "image": seo.image,            "noIndex": seo.noIndex == true          },        footer {            text,            linkGroups[]{                title,                linkList[]{                    text,                    "url": select(    url[0]._type == "internalLink" => select(      url[0].internalReference->_type == "jokul_component" => "/komponenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_fundamentals" => "/fundamenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_blog_post" => "/blog/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_release_notes" => "/release-notes/" + url[0].internalReference->slug.current,      "/" + url[0].internalReference->slug.current    ),    url[0]._type == "externalLink" => url[0].url  )                }            }        },        "date": _createdAt,    } | order(_createdAt desc)[0]
 export type SiteDataQueryResult = {
   _id: string;
   _type: "jokul_siteData";
@@ -1718,8 +1906,10 @@ declare module "@sanity/client" {
     "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  name,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
     "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        image,\n        imageDark,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": FundamentalsQueryResult;
     "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n            },\n        },\n    }": FundamentalsBySlugQueryResult;
+    "*[_type == \"jokul_release_notes\"]{\n        _id,\n        version,\n        \"slug\": slug.current,\n        short_description,\n        releaseDate,\n    } | order(releaseDate desc)": ReleaseNotesQueryResult;
+    "*[_type == \"jokul_release_notes\" && slug.current == $slug][0] {\n        version,\n        releaseDate,\n        short_description,\n        migrationUrl,\n        figmaUrl,\n        article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                \"language\": code.language,\n            },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                    name,\n                    id,\n                    description,\n                    height,\n                    inert,\n                    code\n                },\n            },\n        },\n    }": ReleaseNoteBySlugQueryResult;
     "*[_type in [\"jokul_component\", \"jokul_fundamentals\", \"jokul_blog_post\"] && defined(slug.current) && (\n        name match \"*\" + $searchString + \"*\" ||\n        short_description match \"*\" + $searchString + \"*\" ||\n        (_type == \"jokul_component\" && keywords[] match \"*\" + $searchString + \"*\")\n    )] | {\n        _id,\n        name,\n        slug,\n        short_description,\n        \"image\": select(\n            _type == \"jokul_component\" => image.asset->url,\n            null\n        ),\n        \"type\": select(\n            _type == \"jokul_component\" => \"Komponent\",\n            _type == \"jokul_fundamentals\" => \"Fundament\",\n            _type == \"jokul_blog_post\" => \"Blogg\"\n        ),\n        \"href\": select(\n            _type == \"jokul_component\" => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\" => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_blog_post\" => \"/blog/\" + slug.current\n        )\n    }": SearchQueryResult;
-    "*[_type == \"jokul_siteData\"]{\n        ...,\n        \"seo\": {\n            \"title\": coalesce(seo.title, title, \"\"),\n            \"description\": coalesce(seo.description,  \"\"),\n            \"image\": seo.image,\n            \"noIndex\": seo.noIndex == true\n          },\n        footer {\n            text,\n            linkGroups[]{\n                title,\n                linkList[]{\n                    text,\n                    \"url\": select(\n    url[0]._type == \"internalLink\" => select(\n      url[0].internalReference->_type == \"jokul_component\" => \"komponenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_fundamentals\" => \"fundamenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_blog_post\" => \"blog/\" + url[0].internalReference->slug.current,\n      \"/\" + url[0].internalReference->slug.current\n    ),\n    url[0]._type == \"externalLink\" => url[0].url\n  )\n                }\n            }\n        },\n        \"date\": _createdAt,\n    } | order(_createdAt desc)[0]": SiteDataQueryResult;
+    "*[_type == \"jokul_siteData\"]{\n        ...,\n        \"seo\": {\n            \"title\": coalesce(seo.title, title, \"\"),\n            \"description\": coalesce(seo.description,  \"\"),\n            \"image\": seo.image,\n            \"noIndex\": seo.noIndex == true\n          },\n        footer {\n            text,\n            linkGroups[]{\n                title,\n                linkList[]{\n                    text,\n                    \"url\": select(\n    url[0]._type == \"internalLink\" => select(\n      url[0].internalReference->_type == \"jokul_component\" => \"/komponenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_fundamentals\" => \"/fundamenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_blog_post\" => \"/blog/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_release_notes\" => \"/release-notes/\" + url[0].internalReference->slug.current,\n      \"/\" + url[0].internalReference->slug.current\n    ),\n    url[0]._type == \"externalLink\" => url[0].url\n  )\n                }\n            }\n        },\n        \"date\": _createdAt,\n    } | order(_createdAt desc)[0]": SiteDataQueryResult;
     "*[_type == \"jokul_example\"]{\n    title,\n    id,\n    description,\n    height,\n    inert,\n} | order(name)": ExamplesQueryResult;
   }
 }


### PR DESCRIPTION
Legger til `jokul_release_notes` som dedikert Sanity-dokumenttype i stedet for å bruke bloggkategorier.

## Endringer

- Ny dokumenttype `jokul_release_notes` med feltgrupper (Generelt, Innhold, Ressurser)
- Ressurslenker til migrasjonsguide og Figma med forhåndsutfylte standardverdier
- Ruter på `/release-notes` (oversikt) og `/release-notes/[versjon]` (detaljside)
- Footer-støtte for interne lenker til release notes via `siteDataQuery`
- Migrasjonsskript (`portal/scripts/migrate-release-notes.mjs`) for å flytte eksisterende blogginnlegg med kategori "Release notes"

## Etter merge

- Legg til lenke i footeren via Sanity Studio (`jokul_siteData`-dokumentet)
- Kjør migrasjonsskriptet med `--dry-run` og verifiser output før kjøring