### PR TITLE
refactor: unngå å generere unødvendige spacing-variabler

### DIFF
--- a/packages/jokul/src/styles/theme/_dynamic-spacing.scss
+++ b/packages/jokul/src/styles/theme/_dynamic-spacing.scss
@@ -20,24 +20,29 @@
     :root {
         @each $spacing-combination in spacing.$combinations {
             $_step: list.nth($spacing-combination, 1);
+            $_value: map.get(jkl.$tokens, "spacing", $_step);
 
-            --#{get-class-name($spacing-combination)}: #{map.get(
-                jkl.$tokens,
-                "spacing",
-                $_step
-            )};
+            @if not $_value {
+                @error "Forsøker å lage en dynamisk spacing-variabel med en avstand som ikke finnes (#{$_step})!"
+            }
+
+            // Vi trenger ikke redefinere de vanlige spacing-variablene (de som bare har én verdi)
+            @if list.length($spacing-combination) != 1 {
+                --#{get-class-name($spacing-combination)}: #{$_value};
+            }
         }
 
         @include screens.from-medium-device {
             @each $spacing-combination in spacing.$combinations {
                 @if list.length($spacing-combination) > 1 {
                     $_step: list.nth($spacing-combination, 2);
+                    $_value: map.get(jkl.$tokens, "spacing", $_step);
 
-                    --#{get-class-name($spacing-combination)}: #{map.get(
-                        jkl.$tokens,
-                        "spacing",
-                        $_step
-                    )};
+                    @if not $_value {
+                        @error "Forsøker å lage en dynamisk spacing-variabel med en avstand som ikke finnes (#{$_step})!"
+                    }
+
+                    --#{get-class-name($spacing-combination)}: #{$_value};
                 }
             }
         }
@@ -46,12 +51,13 @@
             @each $spacing-combination in spacing.$combinations {
                 @if list.length($spacing-combination) > 2 {
                     $_step: list.nth($spacing-combination, 3);
+                    $_value: map.get(jkl.$tokens, "spacing", $_step);
 
-                    --#{get-class-name($spacing-combination)}: #{map.get(
-                        jkl.$tokens,
-                        "spacing",
-                        $_step
-                    )};
+                    @if not $_value {
+                        @error "Forsøker å lage en dynamisk spacing-variabel med en avstand som ikke finnes (#{$_step})!"
+                    }
+
+                    --#{get-class-name($spacing-combination)}: #{$_value};
                 }
             }
         }


### PR DESCRIPTION
Bare en liten videreføring av fiksen som kom i #6012, så la ikke til noe changeset her. Tilfører ingen praktisk endring for sluttbruker.

## 💬 Endringer

I genereringen av dynamiske spacing-variabler ble det også generert ut rene overskrivinger av base-variablene (f.eks. `--jkl-spacing-16: var(--jkl-spacing-16);`). Nå genereres det kun alias-variabler for spacingene som faktisk endres basert på brekkpunkt (f.eks. `--jkl-spacing-16-16-24`).

Det vil nå også kastes feil under bygging av stilark dersom en dynamsisk spacing-variabel peker på et steg som ikke finnes i den grunnlegende spacingskalaen.