### PR TITLE
fix: fjern feilaktig verdi for fontstørrelse fra komponentsidene

### DIFF
--- a/.changeset/wet-hounds-turn.md
+++ b/.changeset/wet-hounds-turn.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Fjerner fluid typografi for tittelen på komponentsiden. `clamp()`-funksjonen mangler en verdi for å fungere som den skal, og det er også eneste sted i løsningen vi brukte fluid typografi.

--- a/portal/src/app/(frontend)/komponenter/[slug]/components/componentHeader.module.scss
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/componentHeader.module.scss
@@ -29,10 +29,6 @@
 
     .name {
         @include jkl.text-style("title") {
-            font-size: clamp(
-                var(--jkl-typography-font-size-36),
-                1.8673rem + 1.6327vw
-            );
             line-height: var(--jkl-spacing-40);
         }
     }


### PR DESCRIPTION
## 💬 Endringer

Fjerner fluid typografi for tittelen på komponentsiden. `clamp()`-funksjonen mangler en verdi for å fungere som den skal, og det er også eneste sted i løsningen vi brukte fluid typografi.
