### PR TITLE
fix: bruk semantiske fargetokens i komponentstiler

### DIFF
--- a/packages/jokul/codemods/__tests__/import-paths.test.mjs
+++ b/packages/jokul/codemods/__tests__/import-paths.test.mjs
@@ -337,7 +337,7 @@ test("returns changed: false for an already-migrated file", () => {
 
 test("does not rename token that is a prefix of a longer token", () => {
     // --jkl-color-text-inverted should not match inside --jkl-color-text-inverted-extra
-    const source = `.x { color: var(--jkl-color-text-inverted-extra); }`;
+    const source = ".x { color: var(--jkl-color-text-inverted-extra); }";
 
     const result = transformImportPaths(source, "/tmp/x.css");
 
@@ -346,7 +346,7 @@ test("does not rename token that is a prefix of a longer token", () => {
 });
 
 test("does not rename --jkl-color-background-container (base token, not a v4 token)", () => {
-    const source = `.x { background: var(--jkl-color-background-container); }`;
+    const source = ".x { background: var(--jkl-color-background-container); }";
 
     const result = transformImportPaths(source, "/tmp/x.css");
 
@@ -372,7 +372,7 @@ test("renames container-high but leaves sibling container-low and base container
 });
 
 test("does not rename alert-info token that has a longer suffix", () => {
-    const source = `.x { background: var(--jkl-color-background-alert-info-extra); }`;
+    const source = ".x { background: var(--jkl-color-background-alert-info-extra); }";
 
     const result = transformImportPaths(source, "/tmp/x.css");
 

--- a/packages/jokul/src/components/checkbox/styles/checkbox.scss
+++ b/packages/jokul/src/components/checkbox/styles/checkbox.scss
@@ -5,7 +5,7 @@
 
 @layer jokul.components {
     .jkl-checkbox {
-        --text-color: var(--jkl-color-text-default);
+        --text-color: var(--jkl-color-background-contrast);
         --background-color: transparent;
 
         @include jkl.text-style("text-medium");

--- a/packages/jokul/src/components/combobox/styles/combobox.scss
+++ b/packages/jokul/src/components/combobox/styles/combobox.scss
@@ -114,7 +114,7 @@
 
             &:focus,
             &:hover {
-                background-color: color-mix(in srgb, currentColor 10%, transparent);
+                background-color: var(--jkl-color-background-container-accent)
             }
 
             &-description {

--- a/packages/jokul/src/components/expander/styles/expandable.scss
+++ b/packages/jokul/src/components/expander/styles/expandable.scss
@@ -84,7 +84,7 @@
 
                 @media (hover: hover) {
                     &:hover {
-                        background-color: color-mix(in srgb, currentColor 15%, transparent);
+                        background-color: var(--jkl-color-background-container-accent);
                     }
                 }
             }

--- a/packages/jokul/src/components/link-list/styles/link-list.scss
+++ b/packages/jokul/src/components/link-list/styles/link-list.scss
@@ -50,7 +50,7 @@
                 }
 
                 &:is(:hover, :focus-visible) {
-                    background-color: color-mix(in srgb, var(--text-color) 15%);
+                    background-color: var(--jkl-color-background-container-accent);
 
                     &::after {
                         translate: 4px 0;

--- a/packages/jokul/src/components/menu/styles/_menu-item.scss
+++ b/packages/jokul/src/components/menu/styles/_menu-item.scss
@@ -53,7 +53,7 @@
 
         &:hover,
         &:focus-visible {
-            --background-color: color-mix(in srgb, currentColor 18%, transparent);
+            --background-color: var(--jkl-color-background-container-accent);
         }
     }
 }

--- a/packages/jokul/src/components/message/styles/message.scss
+++ b/packages/jokul/src/components/message/styles/message.scss
@@ -15,17 +15,16 @@ $_message-width--compact: jkl.rem(440px);
         --jkl-message-dismiss-button-size: var(--jkl-unit-50);
         --jkl-message-gap: var(--jkl-unit-20);
         --jkl-message-padding: var(--jkl-unit-25) var(--jkl-unit-15);
+        --icon-color: var(--jkl-color-background-contrast);
         --background-color: var(--jkl-color-background-container);
         --text-color: var(--jkl-color-text-default);
-        --border-color: var(--jkl-color-border-subdued);
 
         width: 100%;
         max-width: $_message-width;
         padding: var(--jkl-message-padding);
         background-color: var(--background-color);
         color: var(--text-color);
-        border: 1px solid var(--border-color);
-        border-radius: jkl.rem(4px);
+        border-radius: var(--jkl-border-radius-s);
         box-sizing: border-box;
 
         display: grid;
@@ -42,6 +41,7 @@ $_message-width--compact: jkl.rem(440px);
         &__icon {
             grid-area: icon;
             margin-right: var(--jkl-message-gap);
+            color: var(--icon-color);
 
             @include jkl.forced-colors-svg-fallback($stroke: CanvasText);
         }
@@ -116,25 +116,25 @@ $_message-width--compact: jkl.rem(440px);
         &--info {
             --background-color: var(--jkl-color-info-background-container);
             --text-color: var(--jkl-color-info-text-default);
-            --border-color: var(--jkl-color-info-border-subdued);
+            --icon-color: var(--jkl-color-info-background-contrast);
         }
 
         &--warning {
             --background-color: var(--jkl-color-warning-background-container);
             --text-color: var(--jkl-color-warning-text-default);
-            --border-color: var(--jkl-color-warning-border-subdued);
+            --icon-color: var(--jkl-color-warning-background-contrast);
         }
 
         &--error {
             --background-color: var(--jkl-color-error-background-container);
             --text-color: var(--jkl-color-error-text-default);
-            --border-color: var(--jkl-color-error-border-subdued);
+            --icon-color: var(--jkl-color-error-background-contrast);
         }
 
         &--success {
             --background-color: var(--jkl-color-success-background-container);
             --text-color: var(--jkl-color-success-text-default);
-            --border-color: var(--jkl-color-success-border-subdued);
+            --icon-color: var(--jkl-color-success-background-contrast);
         }
 
         &--dismissed {

--- a/packages/jokul/src/components/radio-button/styles/radio-button.scss
+++ b/packages/jokul/src/components/radio-button/styles/radio-button.scss
@@ -5,10 +5,6 @@
 
 @layer jokul.components {
     .jkl-radio-button {
-        /* stylelint-disable declaration-block-no-duplicate-custom-properties -- fallback for browsers without light-dark() support */
-        --jkl-radio-button-error-color: #ab2e43;
-        --jkl-radio-button-error-color: light-dark(#ab2e43, #d79ba5);
-        /* stylelint-enable declaration-block-no-duplicate-custom-properties */
         display: flex;
         position: relative;
 
@@ -66,7 +62,7 @@
         }
 
         &__input[aria-invalid="true"] + &__label::before {
-            color: var(--jkl-color-error-text-default);
+            color: var(--jkl-color-error-background-contrast);
         }
 
         & + &,

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -186,9 +186,7 @@
             &:focus,
             :not([data-focus="controlled"]) > &:hover {
                 color: var(--jkl-color-text-default);
-                background-color: color-mix(in srgb,
-                        currentColor 10%,
-                        transparent);
+                background-color: var(--jkl-color-background-container-accent);
             }
 
             &-description {

--- a/packages/jokul/src/components/system-message/styles/system-message.scss
+++ b/packages/jokul/src/components/system-message/styles/system-message.scss
@@ -8,161 +8,154 @@ $_dismiss-animation-duration: jkl.timing("lazy");
 @layer jokul.components {
     .jkl-system-message {
         --jkl-system-message-icon-height: var(--jkl-unit-30);
-        --jkl-system-message-icon-padding: #{jkl.rem(3px)} 0 0 0;
         --jkl-system-message-content-padding: var(--jkl-unit-30);
         --jkl-system-message-dismiss-button-size: var(--jkl-unit-40);
-        --jkl-system-message-dismiss-button-margin: -#{jkl.rem(
- 6.5px)
-    }
+        --jkl-system-message-dismiss-button-margin: -#{jkl.rem(6.5px)} -#{jkl.rem(18px)} -#{jkl.rem(6.5px)} auto;
+        --jkl-system-message-message-margin: 0 var(--jkl-unit-20);
+        --icon-color: var(--jkl-color-background-contrast);
+        --background-color: var(--jkl-color-background-container);
+        --text-color: var(--jkl-color-text-default);
 
-    -#{jkl.rem(18px)} -#{jkl.rem(6.5px)} auto;
-    --jkl-system-message-message-margin: 0 var(--jkl-unit-20);
-    --background-color: var(--jkl-color-background-container);
-    --text-color: var(--jkl-color-text-default);
-    --border-color: var(--jkl-color-border-subdued);
-
-    width: 100%;
-    background-color: var(--background-color);
-    color: var(--text-color);
-    border: 1px solid var(--border-color);
-    transition-behavior: allow-discrete;
-    box-sizing: border-box;
-
-    &__content {
-        box-sizing: border-box;
-        padding: var(--jkl-system-message-content-padding);
-        display: grid;
-        grid-template-columns: min-content 1fr min-content;
-        align-items: flex-start;
         width: 100%;
-        margin: 0 auto;
-    }
+        background-color: var(--background-color);
+        color: var(--text-color);
+        transition-behavior: allow-discrete;
+        box-sizing: border-box;
 
-    &__icon {
-        height: var(--jkl-system-message-icon-height);
-        margin: var(--jkl-system-message-icon-padding);
-        flex-shrink: 0;
-
-        @include jkl.forced-colors-svg-fallback($stroke: CanvasText);
-    }
-
-    &__message {
-        @include jkl.text-style("text-medium");
-        margin: var(--jkl-system-message-message-margin);
-    }
-
-    &__dismiss-button {
-        background-color: transparent;
-        padding: 0;
-        cursor: pointer;
-        display: grid;
-        place-content: center;
-        position: relative;
-        flex-shrink: 0;
-        margin-top: jkl.rem(3px); // visual alignment with text
-        color: inherit;
-
-        // Sørg for å ha en stor nok touch target.
-        &::after {
-            content: "";
-            position: absolute;
-            display: block;
-            width: var(--jkl-system-message-dismiss-button-size);
-            height: var(--jkl-system-message-dismiss-button-size);
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
+        &__content {
+            box-sizing: border-box;
+            padding: var(--jkl-system-message-content-padding);
+            display: grid;
+            grid-template-columns: min-content 1fr min-content;
+            align-items: flex-start;
+            width: 100%;
+            margin: 0 auto;
         }
 
-        @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
+        &__icon {
+            height: var(--jkl-system-message-icon-height);
+            color: var(--icon-color);
+            flex-shrink: 0;
 
-        @include jkl.forced-colors-mode {
-            background-color: ButtonFace;
+            @include jkl.forced-colors-svg-fallback($stroke: CanvasText);
         }
 
-        @include jkl.reset-outline;
+        &__message {
+            @include jkl.text-style("text-medium");
+            margin: var(--jkl-system-message-message-margin);
+        }
 
-        &:hover {
-            color: var(--jkl-color-text-subdued);
+        &__dismiss-button {
+            background-color: transparent;
+            padding: 0;
+            cursor: pointer;
+            display: grid;
+            place-content: center;
+            position: relative;
+            flex-shrink: 0;
+            color: inherit;
+
+            // Sørg for å ha en stor nok touch target.
+            &::after {
+                content: "";
+                position: absolute;
+                display: block;
+                width: var(--jkl-system-message-dismiss-button-size);
+                height: var(--jkl-system-message-dismiss-button-size);
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+            }
 
             @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
-        }
-
-        &:focus-visible {
-            @include jkl.focus-outline;
 
             @include jkl.forced-colors-mode {
-                outline: 2px solid ButtonText;
-                outline-offset: 2px;
+                background-color: ButtonFace;
+            }
+
+            @include jkl.reset-outline;
+
+            &:hover {
+                color: var(--jkl-color-text-subdued);
+
+                @include jkl.forced-colors-svg-fallback($stroke: ButtonText);
+            }
+
+            &:focus-visible {
+                @include jkl.focus-outline;
+
+                @include jkl.forced-colors-mode {
+                    outline: 2px solid ButtonText;
+                    outline-offset: 2px;
+                }
+            }
+        }
+
+        &__message,
+        &__message:last-child {
+            margin-bottom: 0;
+        }
+
+        &--dismissed {
+            animation: $_dismiss-animation-name jkl.timing("lazy") forwards;
+            transition: block jkl.timing("lazy") jkl.timing("lazy");
+        }
+
+        &--info {
+            --background-color: var(--jkl-color-info-background-container);
+            --text-color: var(--jkl-color-info-text-default);
+            --icon-color: var(--jkl-color-info-background-contrast);
+        }
+
+        &--warning {
+            --background-color: var(--jkl-color-warning-background-container);
+            --text-color: var(--jkl-color-warning-text-default);
+            --icon-color: var(--jkl-color-warning-background-contrast);
+        }
+
+        &--error {
+            --background-color: var(--jkl-color-error-background-container);
+            --text-color: var(--jkl-color-error-text-default);
+            --icon-color: var(--jkl-color-error-background-contrast);
+        }
+
+        &--success {
+            --background-color: var(--jkl-color-success-background-container);
+            --text-color: var(--jkl-color-success-text-default);
+            --icon-color: var(--jkl-color-success-background-contrast);
+        }
+
+        @include jkl.forced-colors-mode {
+            border: 2px solid CanvasText;
+
+            &--info {
+                border-style: dotted;
+            }
+
+            &--warning {
+                border-style: dashed;
+            }
+
+            &--error {
+                border-style: double;
+                border-width: 4px;
             }
         }
     }
 
-    &__message,
-    &__message:last-child {
-        margin-bottom: 0;
-    }
-
-    &--dismissed {
-        animation: $_dismiss-animation-name jkl.timing("lazy") forwards;
-        transition: block jkl.timing("lazy") jkl.timing("lazy");
-    }
-
-    &--info {
-        --background-color: var(--jkl-color-info-background-container);
-        --text-color: var(--jkl-color-info-text-default);
-        --border-color: var(--jkl-color-info-border-subdued);
-    }
-
-    &--warning {
-        --background-color: var(--jkl-color-warning-background-container);
-        --text-color: var(--jkl-color-warning-text-default);
-        --border-color: var(--jkl-color-warning-border-subdued);
-    }
-
-    &--error {
-        --background-color: var(--jkl-color-error-background-container);
-        --text-color: var(--jkl-color-error-text-default);
-        --border-color: var(--jkl-color-error-border-subdued);
-    }
-
-    &--success {
-        --background-color: var(--jkl-color-success-background-container);
-        --text-color: var(--jkl-color-success-text-default);
-        --border-color: var(--jkl-color-success-border-subdued);
-    }
-
-    @include jkl.forced-colors-mode {
-        border: 2px solid CanvasText;
-
-        &--info {
-            border-style: dotted;
+    @keyframes #{$_dismiss-animation-name} {
+        from {
+            opacity: 1;
+            transform: translateY(0);
+            filter: saturate(1);
+            display: block;
         }
 
-        &--warning {
-            border-style: dashed;
-        }
-
-        &--error {
-            border-style: double;
-            border-width: 4px;
+        to {
+            opacity: 0;
+            transform: translateY(-10%);
+            filter: saturate(0.7);
+            display: none;
         }
     }
-}
-
-@keyframes #{$_dismiss-animation-name} {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-        filter: saturate(1);
-        display: block;
-    }
-
-    to {
-        opacity: 0;
-        transform: translateY(-10%);
-        filter: saturate(0.7);
-        display: none;
-    }
-}
 }

--- a/packages/jokul/src/components/tag/styles/tag.scss
+++ b/packages/jokul/src/components/tag/styles/tag.scss
@@ -23,25 +23,25 @@
     gap: var(--gap);
 
     &--info {
-        --background-color: var(--jkl-color-info-background-container);
+        --background-color: var(--jkl-color-info-background-container-accent);
         --text-color: var(--jkl-color-info-text-default);
         --border-color: var(--jkl-color-info-border-subdued);
     }
 
     &--warning {
-        --background-color: var(--jkl-color-warning-background-container);
+        --background-color: var(--jkl-color-warning-background-container-accent);
         --text-color: var(--jkl-color-warning-text-default);
         --border-color: var(--jkl-color-warning-border-subdued);
     }
 
     &--error {
-        --background-color: var(--jkl-color-error-background-container);
+        --background-color: var(--jkl-color-error-background-container-accent);
         --text-color: var(--jkl-color-error-text-default);
         --border-color: var(--jkl-color-error-border-subdued);
     }
 
     &--success {
-        --background-color: var(--jkl-color-success-background-container);
+        --background-color: var(--jkl-color-success-background-container-accent);
         --text-color: var(--jkl-color-success-text-default);
         --border-color: var(--jkl-color-success-border-subdued);
     }


### PR DESCRIPTION
## Oppsummering

Oppdaterer flere komponentstiler til å bruke semantiske fargetokens for statusflater, hoverflater og kontrastfarger.
