### PR TITLE
fix(dropdowns): samkjør valgstørrelser i nedtrekksliste

### DIFF
--- a/.changeset/good-maps-go.md
+++ b/.changeset/good-maps-go.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Rett opp størrelse og spacing på valg i Autosuggest, Combobox og Select slik at nedtrekkslistene fremstår likt på tvers av størrelser.

--- a/packages/jokul/src/components/autosuggest/BaseAutosuggest.tsx
+++ b/packages/jokul/src/components/autosuggest/BaseAutosuggest.tsx
@@ -37,7 +37,7 @@ function BaseAutosuggest<T>({
     leadText,
     errorLabel,
     helpLabel,
-    variant = "small",
+    variant,
     noHitsMessage,
     maxNumberOfHits,
     placeholder,
@@ -84,6 +84,7 @@ function BaseAutosuggest<T>({
                         {...getRootProps()}
                         label={label}
                         className={clsx("jkl-autosuggest", className)}
+                        data-size={variant}
                         labelProps={{
                             variant,
                             ...labelProps,

--- a/packages/jokul/src/components/autosuggest/styles/autosuggest.scss
+++ b/packages/jokul/src/components/autosuggest/styles/autosuggest.scss
@@ -7,8 +7,8 @@
         --jkl-autosuggest-controller-button-width: auto;
         --jkl-autosuggest-controller-button-padding: 0 var(--jkl-unit-15);
         --jkl-autosuggest-controller-button-icon-size: #{jkl.rem(20px)};
-        --jkl-autosuggest-option-padding: var(--jkl-unit-10) 0.75em;
-        --jkl-autosuggest-option-height: #{jkl.rem(48px)};
+        --jkl-autosuggest-option-padding: var(--jkl-unit-10);
+        --jkl-autosuggest-option-height: min(var(--jkl-unit-60), #{jkl.rem(48px)});
 
         display: flex;
         flex-direction: column;
@@ -54,6 +54,7 @@
             color: unset;
             display: flex; // avoids wrapping long names "under" the focus arrow
             align-items: center;
+            box-sizing: border-box;
             border: 0; // removes native styling
             background-color: transparent;
             min-height: var(--jkl-autosuggest-option-height);
@@ -69,7 +70,7 @@
             &--active,
             &:hover {
                 color: var(--jkl-color-text-default);
-                background-color: color-mix(in srgb, currentColor 10%, transparent);
+                background-color: var(--jkl-color-background-container-accent);
             }
         }
     }

--- a/packages/jokul/src/components/combobox/styles/combobox.scss
+++ b/packages/jokul/src/components/combobox/styles/combobox.scss
@@ -13,8 +13,8 @@
         --jkl-combobox-chips-gap: var(--jkl-unit-05);
         --jkl-combobox-search-input-padding: var(--jkl-combobox-button-padding);
         --jkl-combobox-native-padding: 0 var(--jkl-unit-50) 0 var(--jkl-unit-10);
-        --jkl-combobox-option-padding: var(--jkl-unit-10) var(--jkl-unit-15);
-        --jkl-combobox-option-line-height: 2rem;
+        --jkl-combobox-option-padding: var(--jkl-unit-10);
+        --jkl-combobox-option-height: min(var(--jkl-unit-60), #{jkl.rem(48px)});
         --jkl-combobox-search-input-height: #{jkl.rem(28px)};
 
         @include jkl.small-device {
@@ -107,10 +107,10 @@
             background-color: transparent;
             transition-property: color, background-color;
             cursor: pointer;
+            min-height: var(--jkl-combobox-option-height);
             padding: var(--jkl-combobox-option-padding);
             width: 100%;
             text-align: left;
-            line-height: var(--jkl-combobox-option-line-height);
 
             &:focus,
             &:hover {

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -8,11 +8,11 @@
         --jkl-select-arrow-right: var(--jkl-unit-05);
         --border-width: #{jkl.rem(1px)};
         --border-radius: var(--jkl-border-radius-s);
-        --min-option-height: min(var(--jkl-unit-60), 3rem);
+        --min-option-height: min(var(--jkl-unit-60), #{jkl.rem(48px)});
 
         /* Vi må trekke fra bredden til rammen for å få riktig høyde */
         --button-padding: calc(var(--jkl-unit-15) - var(--border-width)) calc(0.75em - var(--border-width));
-        --option-padding: var(--jkl-unit-05) 0.75em;
+        --option-padding: var(--jkl-unit-10);
 
         display: block;
         position: relative;


### PR DESCRIPTION
Fikser at valg i Autosuggest og Combobox var høyere enn i Select.

## Endret

- Autosuggest låser ikke lenger størrelsen til `small`
- Autosuggest, Combobox og Select bruker samme token-baserte høyde for valg
- Autosuggest bruker `border-box` på valg, slik at padding ikke gjør dem høyere enn Select
- Combobox bruker line-height fra tekststilen i stedet for egen override

Closes: #6023 
