### PR TITLE
fix(portal): åpne gitHub-lenker i ny fane

### DIFF
--- a/.changeset/github-lenker-ny-fane.md
+++ b/.changeset/github-lenker-ny-fane.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Sørger for at GitHub-lenkene nederst på komponentsidene åpnes i ny fane.

--- a/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentEmptyState.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentEmptyState.tsx
@@ -2,7 +2,7 @@
 
 import { Flex } from "@fremtind/jokul/flex";
 import { Link } from "@fremtind/jokul/link";
-import { InfoMessage } from "@fremtind/jokul/message";
+import { Message } from "@fremtind/jokul/message";
 
 type ComponentEmptyStateProps = {
     name: string;
@@ -10,21 +10,25 @@ type ComponentEmptyStateProps = {
 
 export const ComponentEmptyState = ({ name }: ComponentEmptyStateProps) => {
     return (
-        <InfoMessage title={`${name} mangler fortsatt innhold`}>
+        <Message title={`${name} mangler fortsatt innhold`}>
             <Flex as="footer" gap="m" wrap="wrap">
                 <Link
                     external
                     href={`https://github.com/fremtind/jokul/issues/new?&template=dokumentasjon.yml&title=%5BBidra+med+innhold%5D%3A+${name}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     Bidra med innhold
                 </Link>
                 <Link
                     external
                     href={`https://github.com/fremtind/jokul/issues/new?&template=innspill-komponent.yml&title=%5BInnspill+til+komponent%5D%3A+${name}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     Innspill til <span lang="en">{name}</span>
                 </Link>
             </Flex>
-        </InfoMessage>
+        </Message>
     );
 };

--- a/portal/src/components/PageFooter.tsx
+++ b/portal/src/components/PageFooter.tsx
@@ -2,7 +2,6 @@
 
 import { Flex } from "@fremtind/jokul/flex";
 import { Link } from "@fremtind/jokul/link";
-import { getURL } from "next/dist/shared/lib/utils";
 import styles from "../app/(frontend)/komponenter/[slug]/component.module.scss";
 
 type ComponentFooterProps = {
@@ -16,6 +15,8 @@ export const PageFooter = ({ name }: ComponentFooterProps) => {
                 <Link
                     external
                     href="https://github.com/fremtind/jokul/issues/new?&template=dokumentasjon.yml&title=%5BInnspill+til+innhold%5D%3A"
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     Innspill til innholdet
                 </Link>
@@ -28,12 +29,16 @@ export const PageFooter = ({ name }: ComponentFooterProps) => {
             <Link
                 external
                 href={`https://github.com/fremtind/jokul/issues/new?&template=dokumentasjon.yml&title=%5BBidra+med+innhold%5D%3A+${name}`}
+                target="_blank"
+                rel="noopener noreferrer"
             >
                 Bidra med innhold
             </Link>
             <Link
                 external
                 href={`https://github.com/fremtind/jokul/issues/new?&template=innspill-komponent.yml&title=%5BInnspill+til+komponent%5D%3A+${name}`}
+                target="_blank"
+                rel="noopener noreferrer"
             >
                 Innspill til <span lang="en">{name}</span>
             </Link>


### PR DESCRIPTION
GitHub-lenkene nederst på komponentsidene åpnes nå i ny fane.

Closes: #6040 
