### PR TITLE
fix(tokens): behold breakpoint som råverdi i tokens.ts

### DIFF
--- a/.changeset/fix-use-screen-breakpoints.md
+++ b/.changeset/fix-use-screen-breakpoints.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fiks `useScreen` slik at hooken bruker konkrete breakpoint-verdier i media queries.

--- a/packages/jokul/src/tokens/style-dictionary/register.test.ts
+++ b/packages/jokul/src/tokens/style-dictionary/register.test.ts
@@ -20,24 +20,24 @@ describe("cssVarReferenceTransform", () => {
             expect(cssVarReferenceTransform(makeToken(["spacing", "24"]))).toBe(
                 "var(--jkl-spacing-24)",
             );
-            expect(cssVarReferenceTransform(makeToken(["spacing", "168"]))).toBe(
-                "var(--jkl-spacing-168)",
-            );
+            expect(
+                cssVarReferenceTransform(makeToken(["spacing", "168"])),
+            ).toBe("var(--jkl-spacing-168)");
         });
 
         it("genererer riktig CSS-variabelreferanse for alfanumeriske tokens (2xs, 2xl)", () => {
-            expect(cssVarReferenceTransform(makeToken(["spacing", "2xs"]))).toBe(
-                "var(--jkl-spacing-2xs)",
-            );
-            expect(cssVarReferenceTransform(makeToken(["spacing", "2xl"]))).toBe(
-                "var(--jkl-spacing-2xl)",
-            );
+            expect(
+                cssVarReferenceTransform(makeToken(["spacing", "2xs"])),
+            ).toBe("var(--jkl-spacing-2xs)");
+            expect(
+                cssVarReferenceTransform(makeToken(["spacing", "2xl"])),
+            ).toBe("var(--jkl-spacing-2xl)");
         });
 
         it("genererer riktig CSS-variabelreferanse for semantiske tokens", () => {
-            expect(cssVarReferenceTransform(makeToken(["spacing", "none"]))).toBe(
-                "var(--jkl-spacing-none)",
-            );
+            expect(
+                cssVarReferenceTransform(makeToken(["spacing", "none"])),
+            ).toBe("var(--jkl-spacing-none)");
             expect(cssVarReferenceTransform(makeToken(["spacing", "xs"]))).toBe(
                 "var(--jkl-spacing-xs)",
             );
@@ -47,6 +47,18 @@ describe("cssVarReferenceTransform", () => {
             expect(cssVarReferenceTransform(makeToken(["spacing", "xl"]))).toBe(
                 "var(--jkl-spacing-xl)",
             );
+        });
+    });
+
+    describe("breakpoint", () => {
+        it("beholder breakpoint-tokens som rå verdier", () => {
+            expect(
+                cssVarReferenceTransform({
+                    name: "breakpoint-medium",
+                    path: ["breakpoint", "medium"],
+                    value: "680px",
+                }),
+            ).toBe("680px");
         });
     });
 
@@ -67,17 +79,19 @@ describe("cssVarReferenceTransform", () => {
 
     describe("typografi (font)", () => {
         it("genererer riktig CSS-variabelreferanse for skriftstørrelse", () => {
-            expect(cssVarReferenceTransform(makeToken(["font", "size", "1"]))).toBe(
-                "var(--jkl-font-size-1)",
-            );
-            expect(cssVarReferenceTransform(makeToken(["font", "size", "10"]))).toBe(
-                "var(--jkl-font-size-10)",
-            );
+            expect(
+                cssVarReferenceTransform(makeToken(["font", "size", "1"])),
+            ).toBe("var(--jkl-font-size-1)");
+            expect(
+                cssVarReferenceTransform(makeToken(["font", "size", "10"])),
+            ).toBe("var(--jkl-font-size-10)");
         });
 
         it("genererer riktig CSS-variabelreferanse for tekststiler med bindestrek", () => {
             expect(
-                cssVarReferenceTransform(makeToken(["text", "style", "heading-1"])),
+                cssVarReferenceTransform(
+                    makeToken(["text", "style", "heading-1"]),
+                ),
             ).toBe("var(--jkl-text-style-heading-1)");
             expect(
                 cssVarReferenceTransform(
@@ -98,7 +112,9 @@ describe("cssVarReferenceTransform", () => {
 
         it("genererer riktig CSS-variabelreferanse for enkle motion-tokens", () => {
             expect(
-                cssVarReferenceTransform(makeToken(["motion", "timing", "productive"])),
+                cssVarReferenceTransform(
+                    makeToken(["motion", "timing", "productive"]),
+                ),
             ).toBe("var(--jkl-motion-timing-productive)");
         });
     });

--- a/packages/jokul/src/tokens/style-dictionary/register.ts
+++ b/packages/jokul/src/tokens/style-dictionary/register.ts
@@ -33,14 +33,23 @@ StyleDictionary.registerFormat(cssTailwind4Format);
  * Baserer seg på `token.name` som er satt av SD sitt innebygde `name/kebab`-transform,
  * slik at navngivingslogikken ligger ett sted og vi ikke gjenskaper den her.
  *
+ * Breakpoint-tokens beholdes som rå verdier fordi de brukes i media queries og
+ * Tailwind-screens, hvor CSS custom properties ikke er gyldige.
+ *
  * Eksempler (forutsetter at name/kebab har kjørt):
- * - token.name = "spacing-24"                     → var(--jkl-spacing-24)
- * - token.name = "spacing-2xs"                    → var(--jkl-spacing-2xs)
- * - token.name = "motion-easing-ease-in-bounce-out" → var(--jkl-motion-easing-ease-in-bounce-out)
+ * - token.path = ["breakpoint", "medium"], token.value = "680px" → 680px
+ * - token.name = "spacing-24"                                   → var(--jkl-spacing-24)
+ * - token.name = "spacing-2xs"                                  → var(--jkl-spacing-2xs)
+ * - token.name = "motion-easing-ease-in-bounce-out"             → var(--jkl-motion-easing-ease-in-bounce-out)
  */
 export function cssVarReferenceTransform(
-    token: Pick<TransformedToken, "name">,
+    token: Pick<TransformedToken, "name"> &
+        Partial<Pick<TransformedToken, "path" | "value">>,
 ): string {
+    if (token.path?.[0] === "breakpoint") {
+        return String(token.value);
+    }
+
     return `var(--${PREFIX}-${token.name})`;
 }
 


### PR DESCRIPTION
I [`bc8094bc69`](https://github.com/fremtind/jokul/commit/bc8094bc6926ee8f16e10d1e9176d95481ed0293) ble `useScreen` flyttet over til ny `tokens.ts`. Der blir tokenverdier gjort om til CSS-variabler, og da endte også breakpoints opp som `var(--jkl-breakpoint-*)`.

Det funker dårlig når hooken skal bygge media queries i JS.

Endringen lar `breakpoint` være rå verdier i `tokens.ts`, f.eks. `680px`, mens resten av token-oppsettet står som før.

Closes #6038