### PR TITLE
fix(formatters): behold markørposisjon ved redigering av formatterte tall

### DIFF
--- a/.changeset/fix-register-with-number-caret.md
+++ b/.changeset/fix-register-with-number-caret.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fiks markørplassering i `registerWithNumber` når brukeren redigerer formatterte tall.

--- a/packages/jokul/src/components/text-input/stories/TextInput.stories.tsx
+++ b/packages/jokul/src/components/text-input/stories/TextInput.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React from "react";
+import { useForm } from "react-hook-form";
+import { registerWithMasks } from "../../../utilities/index.js";
 import { Flex } from "../../flex/index.js";
 import { IconButton } from "../../icon-button/index.js";
 import { CloseIcon } from "../../icon/index.js";
@@ -65,6 +67,47 @@ export const UnitAlign: Story = {
         placeholder: "0",
         unit: "kvm",
     },
+};
+
+type NumberMaskForm = {
+    amount: string;
+};
+
+const NumberMaskExample = (
+    args: React.ComponentProps<typeof TextInputComponent>,
+) => {
+    const form = useForm<NumberMaskForm>({
+        defaultValues: {
+            amount: "1 200",
+        },
+    });
+    const { registerWithNumber } = registerWithMasks(form);
+
+    return (
+        <TextInputComponent
+            {...args}
+            {...registerWithNumber("amount")}
+            label="Beløp"
+            maxLength={10}
+            placeholder="0"
+            unit="kr"
+        />
+    );
+};
+
+export const Tallmaskering: Story = {
+    name: "Tallmaskering",
+    parameters: {
+        docs: {
+            description: {
+                story: "Eksempel på TextInput brukt sammen med registerWithMasks().registerWithNumber for formattering av tall.",
+            },
+        },
+    },
+    args: {
+        placeholder: "0",
+    },
+    render: (args) => <NumberMaskExample {...args} />,
 };
 
 /**

--- a/packages/jokul/src/utilities/formatters/util/registerWithMask.test.tsx
+++ b/packages/jokul/src/utilities/formatters/util/registerWithMask.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import UserEventModule from "@testing-library/user-event";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { registerWithMasks } from "./registerWithMask.js";
+
+// https://github.com/testing-library/user-event/issues/1146
+// @ts-ignore typecheck liker ikke at default muligens ikke finnes
+const userEvent = UserEventModule.default ?? UserEventModule;
+
+type SkjemaMedTallmaske = {
+    belop: string;
+};
+
+type TallmaskeInputProps = {
+    defaultValue?: string;
+};
+
+const TallmaskeInput = ({ defaultValue = "1 200" }: TallmaskeInputProps) => {
+    const form = useForm<SkjemaMedTallmaske>({
+        defaultValues: {
+            belop: defaultValue,
+        },
+    });
+    const { registerWithNumber } = registerWithMasks(form);
+
+    return <input aria-label="Beløp" {...registerWithNumber("belop")} />;
+};
+
+describe("registerWithMasks", () => {
+    it("beholder markøren på slutten når et tall formateres mens brukeren skriver", async () => {
+        render(<TallmaskeInput defaultValue="" />);
+
+        const input = screen.getByLabelText("Beløp") as HTMLInputElement;
+        input.focus();
+
+        await userEvent.type(input, "1000", { skipClick: true });
+
+        expect(input).toHaveValue("1\u00A0000");
+        expect(input.selectionStart).toBe(5);
+        expect(input.selectionEnd).toBe(5);
+    });
+
+    it("beholder markørposisjonen når brukeren sletter og skriver inni et formatert tall", async () => {
+        render(<TallmaskeInput />);
+
+        const input = screen.getByLabelText("Beløp") as HTMLInputElement;
+        input.focus();
+        input.setSelectionRange(4, 4);
+
+        await userEvent.type(input, "{backspace}5", { skipClick: true });
+
+        expect(input).toHaveValue("1\u00A0250");
+        expect(input.selectionStart).toBe(4);
+        expect(input.selectionEnd).toBe(4);
+    });
+
+    it("flytter markøren forbi tusenskillet når brukeren sletter et formattert mellomrom", async () => {
+        render(<TallmaskeInput defaultValue="1 000" />);
+
+        const input = screen.getByLabelText("Beløp") as HTMLInputElement;
+        input.focus();
+        input.setSelectionRange(2, 2);
+
+        await userEvent.type(input, "{backspace}", { skipClick: true });
+
+        expect(input).toHaveValue("1\u00A0000");
+        expect(input.selectionStart).toBe(1);
+        expect(input.selectionEnd).toBe(1);
+    });
+
+    it("beholder gyldig markørposisjon når første siffer slettes foran et tusenskille", async () => {
+        render(<TallmaskeInput defaultValue="1 200" />);
+
+        const input = screen.getByLabelText("Beløp") as HTMLInputElement;
+        input.focus();
+        input.setSelectionRange(1, 1);
+
+        await userEvent.type(input, "{backspace}", { skipClick: true });
+
+        expect(input).toHaveValue("200");
+        expect(input.selectionStart).toBe(0);
+        expect(input.selectionEnd).toBe(0);
+    });
+});

--- a/packages/jokul/src/utilities/formatters/util/registerWithMask.ts
+++ b/packages/jokul/src/utilities/formatters/util/registerWithMask.ts
@@ -26,6 +26,9 @@ const formatters = {
 };
 export type Formatter = keyof typeof formatters;
 
+const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max);
+
 export type RegisterWithMaskOptions<T extends FieldValues> = Omit<
     RegisterOptions<T>,
     "setValueAs"
@@ -40,6 +43,7 @@ const registerWithMask =
     ) => {
         let onKeyDownCaretPosition = 0;
         let onKeyDownKeyPressed = "";
+        let deletedCharactersOnKeyDown = "";
 
         const setValueAs = (value: string) => value.replace(/\s/g, "");
         const onChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -54,12 +58,12 @@ const registerWithMask =
                 onChangeCaretPosition = event.target.selectionStart;
             }
 
-            form.setValue(
-                name,
-                formatters[formatter](event.target.value, {
-                    partial: true,
-                }) as PathValue<T, Path<T>>,
-            );
+            const formattedValue = formatters[formatter](event.target.value, {
+                partial: true,
+            });
+            const formattedLength = formattedValue.toString().length;
+
+            form.setValue(name, formattedValue as PathValue<T, Path<T>>);
 
             let newPosition: number | null = null;
 
@@ -67,22 +71,32 @@ const registerWithMask =
                 // handle removing content
                 // calculate how much to move the caret, this also accounts for removing sections of text
                 const delta = onKeyDownCaretPosition - onChangeCaretPosition;
+                const formattedLengthChange =
+                    deletedCharactersOnKeyDown.trim() === ""
+                        ? 0
+                        : formattedLength - inputLength;
 
                 // calculate new caret position (- because we move backwards)
-                newPosition = onKeyDownCaretPosition - delta;
-            } else if (onChangeCaretPosition < event.target.value.length) {
+                newPosition =
+                    onKeyDownCaretPosition - delta + formattedLengthChange;
+            } else if (
+                onChangeCaretPosition < event.target.value.length ||
+                inputLength !== formattedLength
+            ) {
                 // handle adding content from inside the string
                 // calculate how much to move the caret forwards
-                const delta = event.target.value.length - inputLength;
+                const delta = formattedLength - inputLength;
 
                 // calculate new caret position (+ because we move forwards)
                 newPosition = onChangeCaretPosition + delta;
             }
 
             if (newPosition !== null) {
+                const clampedPosition = clamp(newPosition, 0, formattedLength);
+
                 event.target.setSelectionRange(
-                    newPosition,
-                    newPosition,
+                    clampedPosition,
+                    clampedPosition,
                     undefined,
                 );
             }
@@ -99,9 +113,26 @@ const registerWithMask =
 
         // save the caret position before the change occured
         const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
-            if ((event.target as HTMLInputElement).selectionStart !== null) {
-                onKeyDownCaretPosition = (event.target as HTMLInputElement)
-                    .selectionStart as number;
+            deletedCharactersOnKeyDown = "";
+
+            const input = event.target as HTMLInputElement;
+            const { selectionStart, selectionEnd, value } = input;
+
+            if (selectionStart !== null) {
+                onKeyDownCaretPosition = selectionStart;
+
+                if (selectionEnd !== null && selectionEnd > selectionStart) {
+                    deletedCharactersOnKeyDown = value.slice(
+                        selectionStart,
+                        selectionEnd,
+                    );
+                } else if (event.key === "Backspace") {
+                    deletedCharactersOnKeyDown =
+                        value[onKeyDownCaretPosition - 1] ?? "";
+                } else if (event.key === "Delete") {
+                    deletedCharactersOnKeyDown =
+                        value[onKeyDownCaretPosition] ?? "";
+                }
             }
             onKeyDownKeyPressed = event.key;
         };


### PR DESCRIPTION
Fikser markørposisjonen i `registerWithNumber` når man redigerer formatterte tall.

Problemet var at koden ikke tok høyde for at formatteringen kan legge til eller fjerne mellomrom.

Nå tas lengden på den formatterte verdien med i beregningen, så markøren blir stående der man forventer.
