### PR TITLE
fix(expandable-panel): fjern iOS klikkindikator fra ExpandablePanel

### DIFF
--- a/.changeset/fix-expandable-panel-ios-tap-highlight.md
+++ b/.changeset/fix-expandable-panel-ios-tap-highlight.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fjerner iOS sin klikkindikator fra ExpandablePanel.

--- a/packages/jokul/src/components/expander/styles/expandable.scss
+++ b/packages/jokul/src/components/expander/styles/expandable.scss
@@ -105,6 +105,7 @@
         text-align: left;
         cursor: pointer;
         color: var(--jkl-color);
+        -webkit-tap-highlight-color: transparent;
 
         display: flex;
         gap: jkl.rem(8px);


### PR DESCRIPTION
Fjerner tap highlight på `ExpandablePanel`, så man slipper blinket som dukker opp når panelet trykkes på iOS.

Closes: #5822 