### PR TITLE
fix(modal): legg til manglende stil for transparent overlay

### DIFF
--- a/.changeset/fix-transparent-modal-overlay.md
+++ b/.changeset/fix-transparent-modal-overlay.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+La til manglende stil for Modal-overlay når `transparent`-propen brukes.

--- a/packages/jokul/src/components/modal/Modal.test.tsx
+++ b/packages/jokul/src/components/modal/Modal.test.tsx
@@ -163,4 +163,12 @@ describe("Modal", () => {
         );
         expect(modalContainer).toHaveClass("jkl-modal-container--slide-in");
     });
+
+    it("should apply transparent overlay class", () => {
+        const { container } = setup(<ModalOverlay transparent />);
+
+        expect(container.firstChild).toHaveClass(
+            "jkl-modal-overlay--transparent",
+        );
+    });
 });

--- a/packages/jokul/src/components/modal/styles/_overlay.scss
+++ b/packages/jokul/src/components/modal/styles/_overlay.scss
@@ -5,6 +5,10 @@
         background-color: rgb(27 25 23 / 80%);
         opacity: 0;
 
+        &--transparent {
+            background-color: transparent;
+        }
+
         @include jkl.motion("entrance", "expressive", opacity);
     }
 


### PR DESCRIPTION
Lagt til manglende CSS for `ModalOverlay` når `transparent`-propen brukes.

Closes: #6057 