### PR TITLE
fix(utilities): legg til brand-type for data-brand

### DIFF
--- a/.changeset/add-brand-type.md
+++ b/.changeset/add-brand-type.md
@@ -1,0 +1,12 @@
+---
+"@fremtind/jokul": patch
+---
+
+`Brand` og `BRANDS` er tilgjengelig fra utilities. Bruk `Brand` for å type gyldige `data-brand`-verdier, og `BRANDS` når du trenger listen over støttede brand i kode.
+
+```ts
+import { BRANDS, type Brand } from "@fremtind/jokul/utilities";
+
+const brand: Brand = "fremtind";
+const brandOptions = BRANDS.map((brand) => ({ label: brand, value: brand }));
+```

--- a/packages/jokul/src/tokens/style-dictionary/build.ts
+++ b/packages/jokul/src/tokens/style-dictionary/build.ts
@@ -1,5 +1,6 @@
 import StyleDictionary from "style-dictionary";
-import { BRAND_NAMES, createBrandConfig, jokulTokens } from "./config.js";
+import { BRANDS } from "../../utilities/types.js";
+import { createBrandConfig, jokulTokens } from "./config.js";
 import "./register.js";
 
 async function build() {
@@ -9,7 +10,7 @@ async function build() {
     const dictionary = new StyleDictionary(jokulTokens);
     await dictionary.buildAllPlatforms();
 
-    for (const brand of BRAND_NAMES) {
+    for (const brand of BRANDS) {
         console.log(`⚙️ Building separate color output for brand "${brand}"`);
         const brandDictionary = new StyleDictionary(createBrandConfig(brand));
         await brandDictionary.buildPlatform("css");

--- a/packages/jokul/src/tokens/style-dictionary/config.ts
+++ b/packages/jokul/src/tokens/style-dictionary/config.ts
@@ -1,10 +1,8 @@
 import { existsSync } from "node:fs";
 import type { Config } from "style-dictionary/types";
+import type { Brand } from "../../utilities/types.js";
 
 export const PREFIX = "jkl";
-export const BRAND_NAMES = ["fremtind", "dnb", "eika", "sparebank1"] as const;
-
-export type BrandName = (typeof BRAND_NAMES)[number];
 
 export const jokulTokens: Config = {
     log: {
@@ -80,7 +78,7 @@ export const jokulTokens: Config = {
  * Lager en separat CSS-config per brand for å bygge en egen SCSS-fil med et
  * komplett, brand-spesifikt fargesett basert på base tokens og brand tokens.
  */
-export function createBrandConfig(brand: BrandName): Config {
+export function createBrandConfig(brand: Brand): Config {
     const brandSources = [
         `src/tokens/brands/color.${brand}.tokens.json`,
         `src/tokens/brands/typography.${brand}.tokens.json`,

--- a/packages/jokul/src/utilities/types.ts
+++ b/packages/jokul/src/utilities/types.ts
@@ -11,6 +11,10 @@ export type ColorScheme = "light" | "dark";
 
 export type Size = "small" | "medium" | "large";
 
+export const BRANDS = ["fremtind", "dnb", "eika", "sparebank1"] as const;
+
+export type Brand = (typeof BRANDS)[number];
+
 export type Easing = keyof typeof tokens.motion.easing;
 export type Timing = keyof typeof tokens.motion.timing;
 


### PR DESCRIPTION
- La til `Brand` som offentlig TypeScript-type for gyldige `data-brand`-verdier
- La til `BRANDS` som offentlig verdiliste, slik at samme verdier kan brukes både i typer og runtime-kode
- Oppdaterte token-builden til å bruke `BRANDS` i stedet for en egen intern brand-liste


`Brand` og `BRANDS` ligger foreløpig i `utilities`, sammen med andre typer som `ColorScheme` og `Size`. Hvis vi etter hvert får mer TS-API relatert til tema/brand (noe jeg tror er sannsynlig), kan det være aktuelt å samle dette i en egen entrypoint, for eksempel `@fremtind/jokul/theme`. Dropper å gjøre noe med det nå, men det kan være verdt å vurdere senere.


Closes: #6059 