### PR TITLE
Legg til mixpanel

### DIFF
--- a/.changeset/cool-meals-bow.md
+++ b/.changeset/cool-meals-bow.md
@@ -1,0 +1,11 @@
+---
+"portal": minor
+---
+
+Legger til sporing med Mixpanel
+
+- Sporer sidevisninger automatisk
+- Legger til generisk `track`-funksjon som kan brukes i portalen
+- Skrur av persistence i Mixpanel, slik at det ikke blir brukt cookies i
+  forbindelse med sporingen.
+- Sender trafikk til Mixpanel via vår egen server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.12.0
+      mixpanel-browser:
+        specifier: ^2.79.0
+        version: 2.79.0
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0)
@@ -2840,6 +2843,27 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==}
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==}
+    peerDependencies:
+      '@mixpanel/rrweb': ^2.0.0-alpha.18
+      '@mixpanel/rrweb-utils': ^2.0.0-alpha.18
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==}
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -4223,6 +4247,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -4289,6 +4316,9 @@ packages:
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/json-logic-js@2.0.5':
+    resolution: {integrity: sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4731,6 +4761,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   '@xstate/react@6.0.0':
     resolution: {integrity: sha512-xXlLpFJxqLhhmecAXclBECgk+B4zYSrDTl8hTfPZBogkn82OHKbm9zJxox3Z/YXoOhAQhKFTRLMYGdlbhc6T9A==}
     peerDependencies:
@@ -5139,6 +5172,10 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -7940,6 +7977,9 @@ packages:
   json-lexer@1.2.0:
     resolution: {integrity: sha512-7otpx5UPFeSELoF8nkZPHCfywg86wOsJV0WNOaysuO7mfWj1QFp2vlqESRRCeJKBXr+tqDgHh4HgqUFKTLcifQ==}
 
+  json-logic-js@2.0.5:
+    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
+
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
@@ -8554,6 +8594,13 @@ packages:
   mississippi@4.0.0:
     resolution: {integrity: sha512-7PujJ3Te6GGg9lG1nfw5jYCPV6/BsoAT0nCQwb6w+ROuromXYxI6jc/CQSlD82Z/OUMSBX1SoaqhTE+vXiLQzQ==}
     engines: {node: '>=4.0.0'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mixpanel-browser@2.79.0:
+    resolution: {integrity: sha512-+XRUJfplXy6bwW85ZOEIABlxZyfAVgyBPfMO0QiWr6wkRbvpWbS4xCPTR6iEl5ATPN8+ae+Nv4vusANjrk0DEA==}
+    engines: {node: '>=20 <26'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -14746,6 +14793,34 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.4':
+    dependencies:
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.4
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4(@mixpanel/rrweb-utils@2.0.0-alpha.18.4)(@mixpanel/rrweb@2.0.0-alpha.18.4)':
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.4':
+    dependencies:
+      postcss: 8.5.14
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.4': {}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.4': {}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.4':
+    dependencies:
+      '@mixpanel/rrdom': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-types': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
@@ -16563,6 +16638,8 @@ snapshots:
     dependencies:
       '@types/node': 24.10.9
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -16641,6 +16718,8 @@ snapshots:
       pretty-format: 30.2.0
 
   '@types/js-yaml@4.0.9': {}
+
+  '@types/json-logic-js@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -17197,6 +17276,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xstate/fsm@1.6.5': {}
+
   '@xstate/react@6.0.0(@types/react@18.3.1)(react@18.3.1)(xstate@5.24.0)':
     dependencies:
       react: 18.3.1
@@ -17626,6 +17707,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -21090,6 +21173,8 @@ snapshots:
 
   json-lexer@1.2.0: {}
 
+  json-logic-js@2.0.5: {}
+
   json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -21891,6 +21976,16 @@ snapshots:
       pumpify: 1.5.1
       stream-each: 1.2.3
       through2: 3.0.2
+
+  mitt@3.0.1: {}
+
+  mixpanel-browser@2.79.0:
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-plugin-console-record': 2.0.0-alpha.18.4(@mixpanel/rrweb-utils@2.0.0-alpha.18.4)(@mixpanel/rrweb@2.0.0-alpha.18.4)
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+      '@types/json-logic-js': 2.0.5
+      json-logic-js: 2.0.5
 
   mkdirp-classic@0.5.3: {}
 

--- a/portal/.env.example
+++ b/portal/.env.example
@@ -2,4 +2,5 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=<project_id>
 NEXT_PUBLIC_SANITY_DATASET=<dataset>
 SANITY_API_READ_TOKEN=<api_read_token>
 SANITY_REVALIDATE_SECRET=<sanity_revalidate_secret>
+NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN=<mixpanel_project_token>
 NEXT_PUBLIC_STORYBOOK_BASE_URL="http://localhost:6007"

--- a/portal/next.config.mjs
+++ b/portal/next.config.mjs
@@ -5,6 +5,15 @@ const nextConfig = {
     // Your Next.js config here
     pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 
+    async rewrites() {
+        return [
+            {
+                source: "/mp/:path*",
+                destination: "https://api-eu.mixpanel.com/:path*",
+            },
+        ];
+    },
+
     async redirects() {
         return [
             {

--- a/portal/package.json
+++ b/portal/package.json
@@ -34,6 +34,7 @@
         "cross-env": "^10.1.0",
         "dompurify": "^3.4.0",
         "graphql": "^16.8.1",
+        "mixpanel-browser": "^2.79.0",
         "next": "16.2.6",
         "next-sanity": "^11.6.12",
         "react": "^18.3.1",

--- a/portal/src/app/(frontend)/layout.tsx
+++ b/portal/src/app/(frontend)/layout.tsx
@@ -1,4 +1,5 @@
 import { DisableDraftMode } from "@/components/DisableDraftMode";
+import { MixpanelProvider } from "@/components/MixpanelProvider";
 import { TabListener } from "@/components/TabListener";
 import { Footer, Header } from "@/components/layout";
 import { SanityLive } from "@/sanity/lib/live";
@@ -17,11 +18,13 @@ export default async function PortalLayout({ children }: Props) {
             <body>
                 <TabListener />
                 <CookiesNextProvider>
-                    <div className="jkl-portal-layout">
-                        <Header />
-                        <main>{children}</main>
-                        <Footer />
-                    </div>
+                    <MixpanelProvider>
+                        <div className="jkl-portal-layout">
+                            <Header />
+                            <main>{children}</main>
+                            <Footer />
+                        </div>
+                    </MixpanelProvider>
                 </CookiesNextProvider>
                 <SanityLive />
                 {(await draftMode()).isEnabled && (

--- a/portal/src/components/MixpanelProvider.tsx
+++ b/portal/src/components/MixpanelProvider.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { initMixpanel } from "@/utils/tracking/mixpanel";
+import { type ReactNode, useEffect } from "react";
+
+type ProviderProps = { children?: ReactNode };
+export function MixpanelProvider({ children }: ProviderProps) {
+    useEffect(() => {
+        initMixpanel();
+    }, []);
+
+    return <>{children}</>;
+}

--- a/portal/src/utils/tracking/mixpanel.ts
+++ b/portal/src/utils/tracking/mixpanel.ts
@@ -1,0 +1,23 @@
+import type { EventName } from "@/utils/tracking/types";
+import mixpanel, { type Dict } from "mixpanel-browser";
+
+const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN;
+const IS_ENABLED = typeof window !== "undefined" && !!MIXPANEL_TOKEN;
+
+export function initMixpanel() {
+    if (IS_ENABLED) {
+        mixpanel.init(MIXPANEL_TOKEN, {
+            api_host: "/mp",
+            debug: process.env.NODE_ENV === "development",
+            track_pageview: "url-with-path-and-query-string",
+            disable_persistence: true,
+        });
+        mixpanel.register({ environment: process.env.NODE_ENV || "unknown" });
+    }
+}
+
+export const trackEvent = (eventName: EventName, props?: Dict) => {
+    if (IS_ENABLED) {
+        mixpanel.track(eventName, props);
+    }
+};

--- a/portal/src/utils/tracking/types.ts
+++ b/portal/src/utils/tracking/types.ts
@@ -1,0 +1,1 @@
+export type EventName = "Klikk";


### PR DESCRIPTION
## 💬 Endringer

Legger til sporing med Mixpanel

- Sporer sidevisninger automatisk
- Legger til generisk `track`-funksjon som kan brukes i portalen
- Skrur av persistence i Mixpanel, slik at det ikke blir brukt cookies i
  forbindelse med sporingen.
- Sender trafikk til Mixpanel via vår egen server

**Må gjøres**:

- [x] Sjekk at det er åpnet for trafikk til Mixpanel fra containeren i
  Shifter
- [ ] Legg til riktig Mixpanel-token som `NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN`
  i oppsettet til containerene i Shifter

## 🩹 Løser følgende issues

Closes #6053 
