### PR TITLE
Fikser feil i text- og title-komponentene

### DIFF
--- a/.changeset/shiny-carpets-ring.md
+++ b/.changeset/shiny-carpets-ring.md
@@ -1,0 +1,6 @@
+---
+"@fremtind/jokul": patch
+---
+
+- Fikser en feil der `Text`-komponenten ikke ble bold
+- Fikser en feil der `Title`-komponenten ikke fikk riktig tekststørrelse

--- a/packages/jokul/src/components/typography/Title.test.tsx
+++ b/packages/jokul/src/components/typography/Title.test.tsx
@@ -9,7 +9,6 @@ describe("Title", () => {
         const { getByRole } = render(<Title>Forside</Title>);
 
         const heading = getByRole("heading", { level: 2 });
-        expect(heading).toHaveClass("jkl-title");
         expect(heading).toHaveAttribute("data-text-size", "l");
     });
 
@@ -55,7 +54,6 @@ describe("Title", () => {
         expect(label).toBeInTheDocument();
         expect(label).toHaveTextContent("E-post");
         expect(label).toHaveAttribute("for", "epost");
-        expect(label).toHaveClass("jkl-title");
     });
 
     it("rendrer som <legend>", () => {
@@ -68,7 +66,6 @@ describe("Title", () => {
         const legend = container.querySelector("legend");
         expect(legend).toBeInTheDocument();
         expect(legend).toHaveTextContent("Kontaktinformasjon");
-        expect(legend).toHaveClass("jkl-title");
     });
 
     it("setter `data-text-size` for oppgitt size", () => {
@@ -114,10 +111,7 @@ describe("Title", () => {
             </Title>,
         );
 
-        expect(getByRole("heading", { level: 2 })).toHaveClass(
-            "jkl-title",
-            "jkl-sr-only",
-        );
+        expect(getByRole("heading", { level: 2 })).toHaveClass("jkl-sr-only");
     });
 
     it("videresender ekstra className", () => {
@@ -125,10 +119,7 @@ describe("Title", () => {
             <Title className="egen-klasse">Med klasse</Title>,
         );
 
-        expect(getByRole("heading", { level: 2 })).toHaveClass(
-            "jkl-title",
-            "egen-klasse",
-        );
+        expect(getByRole("heading", { level: 2 })).toHaveClass("egen-klasse");
     });
 
     it("videresender ref til det underliggende heading-elementet", () => {

--- a/packages/jokul/src/components/typography/Title.tsx
+++ b/packages/jokul/src/components/typography/Title.tsx
@@ -16,7 +16,7 @@ export const Title: TitleComponent = forwardRef(function Title<
     const Tag = (as || "h2") as React.ElementType;
     return (
         <Tag
-            className={clsx("jkl-title", srOnly && "jkl-sr-only", className)}
+            className={clsx(srOnly && "jkl-sr-only", className)}
             data-text-size={size}
             ref={ref}
             {...rest}

--- a/packages/jokul/src/components/typography/styles/text.scss
+++ b/packages/jokul/src/components/typography/styles/text.scss
@@ -12,7 +12,7 @@ $_size-styles: (
 
 @layer jokul.components {
     :where(.jkl-text) {
-        font-weight: var(--jkl-typography-weight-normal);
+        font-weight: var(--jkl-font-weight-normal);
         line-height: var(--jkl-line-height-relaxed);
     }
 
@@ -35,7 +35,7 @@ $_size-styles: (
     // tvinger normal weight via `jkl.text-style`-mixinen.
     .jkl-text[data-bold],
     strong.jkl-text[data-text-size] {
-        font-weight: var(--jkl-typography-weight-bold);
+        font-weight: var(--jkl-font-weight-bold);
     }
 
     .jkl-text[data-short] {

--- a/packages/jokul/src/components/typography/styles/title.scss
+++ b/packages/jokul/src/components/typography/styles/title.scss
@@ -12,47 +12,24 @@ $_size-styles: (
 );
 
 @layer jokul.components {
-    :where(.jkl-title) {
-        font-weight: var(--jkl-typography-weight-normal);
-        line-height: var(--jkl-line-height-tight);
-    }
-
-    // Scope margin-resetten til komponenten via `data-text-size` så vi ikke
-    // overstyrer margin på elementer som bare bruker `.jkl-title` som
-    // hjelpeklasse.
-    .jkl-title[data-text-size] {
-        margin-block: 0;
-    }
-
-    // Genererer både komponent-regler og ekvivalente hjelpeklasser fra
-    // samme kilde slik at de ikke drifter fra hverandre.
-    // `.jkl-heading-<size>` tilsvarer `<Title size="<size>">` brukt på et
-    // vilkårlig element.
     @each $name, $style in $_size-styles {
-
-        .jkl-title[data-text-size="#{$name}"],
-        .jkl-heading-#{$name} {
-            @include jkl.text-style($style);
-        }
-
-        :where(.jkl-heading-#{$name}) {
+        :is(h1, h2, h3, h4, h5, h6, label, legend)[data-text-size="#{$name}"] {
             margin-block: 0;
+
+            @include jkl.text-style($style);
         }
     }
 
     // Skjema-elementer skal ikke arve heading sine fete font-weight og
     // tight line-height. De er tekst som beskriver et skjemafelt eller en
-    // gruppe, ikke strukturelle overskrifter. Spesifisiteten må matche
-    // `.jkl-title[data-text-size="…"]` (0,2,0) for å overstyre den.
-    :is(label, legend).jkl-title[data-text-size] {
-        font-weight: var(--jkl-typography-weight-normal);
+    // gruppe, ikke strukturelle overskrifter.
+    :is(label, legend)[data-text-size] {
+        font-weight: var(--jkl-font-weight-normal);
         line-height: var(--jkl-line-height-relaxed);
     }
 
     // Labels er blokk-nivå og har bunnmarg til feltet de beskriver.
-    // Spesifisiteten her (0,2,1) overstyrer `.jkl-title[data-text-size]`
-    // som ellers nullstiller margin via `margin-block: 0`.
-    label.jkl-title[data-text-size] {
+    :is(label)[data-text-size] {
         display: block;
         margin-block-end: var(--jkl-spacing-8);
     }


### PR DESCRIPTION
## 💬 Endringer

- Fikser en feil der `Text`-komponenten ikke ble bold
- Fikser en feil der `Title`-komponenten ikke fikk riktig tekststørrelse

Se rotårsak og argumentasjon for fiks i #6086

## 🩹 Løser følgende issues

Closes #6085
Closes #6086
