### PR TITLE
Sett data-properties på riktig nivå i InputPanel

### DIFF
--- a/.changeset/crisp-doors-boil.md
+++ b/.changeset/crisp-doors-boil.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legger til et interface som eksponerer typer for moduser brukt i Jøkul (brand, størrelse og mørk/lys modus) så de enkelt kan brukes som props i komponenter.

--- a/.changeset/huge-geese-spend.md
+++ b/.changeset/huge-geese-spend.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der moduser som `data-size` ble satt på uventet sted i komponenter som bruker InputPanel. `data-size` og `data-theme` vil nå gjelde _hele_ komponenten i `RadioPanel` og `CheckboxPanel`, ikke bare selve inputfeltet.

--- a/packages/jokul/src/components/checkbox-panel/CheckboxPanel.tsx
+++ b/packages/jokul/src/components/checkbox-panel/CheckboxPanel.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { InputPanel } from "../input-panel/InputPanel.js";
 import type { CheckboxPanelProps } from "./types.js";
 
-export const CheckboxPanel = (props: CheckboxPanelProps) => (
-    <InputPanel {...props} type="checkbox" />
+export const CheckboxPanel = forwardRef<HTMLInputElement, CheckboxPanelProps>(
+    function CheckboxPanel(props, ref) {
+        return <InputPanel {...props} ref={ref} type="checkbox" />;
+    },
 );

--- a/packages/jokul/src/components/input-panel/InputPanel.tsx
+++ b/packages/jokul/src/components/input-panel/InputPanel.tsx
@@ -16,6 +16,8 @@ export const InputPanel = forwardRef(function BasePanel(
         children,
         extraLabel,
         alwaysOpen = false,
+        "data-size": dataSize,
+        "data-theme": dataTheme,
         ...rest
     }: InputPanelProps,
     ref: ForwardedRef<HTMLInputElement>,
@@ -23,12 +25,18 @@ export const InputPanel = forwardRef(function BasePanel(
     return (
         <div
             className={clsx("jkl-input-panel", `jkl-${type}-panel`, className)}
-            ref={ref}
             data-always-open={alwaysOpen}
+            data-size={dataSize}
+            data-theme={dataTheme}
         >
             <div className="jkl-input-panel__header">
                 {type === "checkbox" && (
-                    <Checkbox value={value?.toString()} name={name} {...rest}>
+                    <Checkbox
+                        value={value?.toString()}
+                        name={name}
+                        ref={ref}
+                        {...rest}
+                    >
                         {label}
                     </Checkbox>
                 )}
@@ -36,6 +44,7 @@ export const InputPanel = forwardRef(function BasePanel(
                     <RadioButton
                         value={value?.toString()}
                         name={name}
+                        ref={ref}
                         {...rest}
                     >
                         {label}

--- a/packages/jokul/src/components/input-panel/types.ts
+++ b/packages/jokul/src/components/input-panel/types.ts
@@ -1,26 +1,28 @@
 import type { InputHTMLAttributes, ReactNode } from "react";
+import type { JokulModes } from "../../utilities/types.js";
 
 export type InputPanelProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
     "children"
-> & {
-    label: string;
-    type: "radio" | "checkbox";
-    /**
-     * Viser pris til høyre i panelet
-     */
-    amount?: string;
-    description?: ReactNode;
-    /**
-     * @deprecated fjernet for å gi brukeren den fulle konteksten rundt valget hele tiden.
-     */
-    alwaysOpen?: boolean;
-    /**
-     * @deprecated bruk {@link amount} for tilsvarende funksjonalitet.
-     */
-    extraLabel?: string;
-    /**
-     * @deprecated bruk {@link description} for tilsvarende funksjonalitet.
-     */
-    children?: ReactNode;
-};
+> &
+    JokulModes & {
+        label: string;
+        type: "radio" | "checkbox";
+        /**
+         * Viser pris til høyre i panelet
+         */
+        amount?: string;
+        description?: ReactNode;
+        /**
+         * @deprecated fjernet for å gi brukeren den fulle konteksten rundt valget hele tiden.
+         */
+        alwaysOpen?: boolean;
+        /**
+         * @deprecated bruk {@link amount} for tilsvarende funksjonalitet.
+         */
+        extraLabel?: string;
+        /**
+         * @deprecated bruk {@link description} for tilsvarende funksjonalitet.
+         */
+        children?: ReactNode;
+    };

--- a/packages/jokul/src/components/radio-panel/RadioPanel.tsx
+++ b/packages/jokul/src/components/radio-panel/RadioPanel.tsx
@@ -1,10 +1,9 @@
-import React, { type ForwardedRef, forwardRef } from "react";
+import React, { forwardRef } from "react";
 import { InputPanel } from "../input-panel/InputPanel.js";
 import type { RadioPanelProps } from "./types.js";
 
-export const RadioPanel = forwardRef(function RadioPanel(
-    { ...rest }: RadioPanelProps,
-    ref: ForwardedRef<HTMLInputElement>,
-) {
-    return <InputPanel {...rest} type="radio" ref={ref} />;
-});
+export const RadioPanel = forwardRef<HTMLInputElement, RadioPanelProps>(
+    function RadioPanel(props, ref) {
+        return <InputPanel {...props} type="radio" ref={ref} />;
+    },
+);

--- a/packages/jokul/src/utilities/types.ts
+++ b/packages/jokul/src/utilities/types.ts
@@ -7,13 +7,21 @@ export interface DataTestAutoId {
     "data-testautoid"?: string;
 }
 
+export const BRANDS = [] as const;
+export type Brand = (typeof BRANDS)[number];
+export type Size = "small" | "medium" | "large";
 export type ColorScheme = "light" | "dark";
 
-export type Size = "small" | "medium" | "large";
-
-export const BRANDS = [] as const;
-
-export type Brand = (typeof BRANDS)[number];
+/**
+ * Eksplisitte typer for modusene som brukes i Jøkul, slik at de kan brukes aktivt i komponentene
+ * @example type Props = { myProp: string } & JokulModes;
+ * @example interface Props extends JokulModes { myProp: string };
+ */
+export interface JokulModes {
+    "data-brand"?: Brand;
+    "data-size"?: Size;
+    "data-theme"?: ColorScheme;
+}
 
 export type Easing = keyof typeof tokens.motion.easing;
 export type Timing = keyof typeof tokens.motion.timing;


### PR DESCRIPTION
## 💬 Endringer

- Legger til et interface som eksponerer typer for moduser brukt i Jøkul (brand, størrelse og mørk/lys modus) så de enkelt kan brukes som props i komponenter.
- Fikser en feil der moduser som `data-size` ble satt på uventet sted i komponenter som bruker InputPanel. `data-size` og `data-theme` vil nå gjelde _hele_ komponenten i `RadioPanel` og `CheckboxPanel`, ikke bare selve inputfeltet.

## 🩹 Løser følgende issues

Closes #6072 
