### PR TITLE
fix(select): legg til testautoid på listbox

### DIFF
--- a/.changeset/select-listbox-testid.md
+++ b/.changeset/select-listbox-testid.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Legg til `data-testautoid` på Select-listboxen for enklere og mer stabil testautomatisering.

--- a/packages/jokul/src/components/select/Select.test.tsx
+++ b/packages/jokul/src/components/select/Select.test.tsx
@@ -580,6 +580,53 @@ describe("Select", () => {
         expect(inputGroup.contains(listbox)).toBe(false);
     });
 
+    it("should expose a stable test id for the portaled listbox", async () => {
+        const screen = setup(
+            <Select
+                name="snoop"
+                items={["drop", "it", "like", "its", "hot"]}
+                label="Snoop"
+            />,
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId("jkl-select__button"));
+        });
+
+        const listbox = screen.getByTestId("jkl-select__listbox");
+        expect(listbox).toHaveAttribute("role", "listbox");
+        expect(listbox).toHaveAttribute(
+            "data-testautoid",
+            "jkl-select__listbox",
+        );
+    });
+
+    it("should derive listbox testautoid from the root testautoid", async () => {
+        const screen = setup(
+            <Select
+                name="snoop"
+                items={["drop", "it", "like", "its", "hot"]}
+                label="Snoop"
+                data-testautoid="phone-brand-select"
+            />,
+        );
+
+        const inputGroup = screen.getByTestId("jkl-select");
+        expect(inputGroup).toHaveAttribute(
+            "data-testautoid",
+            "phone-brand-select",
+        );
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId("jkl-select__button"));
+        });
+
+        expect(screen.getByTestId("jkl-select__listbox")).toHaveAttribute(
+            "data-testautoid",
+            "phone-brand-select__listbox",
+        );
+    });
+
     it("should render options even when wrapped in an overflow-clipped ancestor (#4583, #5976)", async () => {
         const screen = setup(
             <div
@@ -610,9 +657,7 @@ describe("Select", () => {
         // eksplisitt for å unngå flakiness når posisjoneringen
         // fullføres etter klikk-`act`.
         await waitFor(() => {
-            expect(
-                screen.getByRole("option", { name: "drop" }),
-            ).toBeVisible();
+            expect(screen.getByRole("option", { name: "drop" })).toBeVisible();
         });
     });
 

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -53,6 +53,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             maxShownOptions = 5,
             style,
             tooltip,
+            "data-testautoid": dataTestAutoId,
             ...rest
         } = props;
 
@@ -498,6 +499,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                         "jkl-select--no-value": !hasSelectedValue,
                         "jkl-select--invalid": !!errorLabel || invalid,
                     })}
+                    data-testautoid={dataTestAutoId}
                     tooltip={
                         tooltip && React.isValidElement<PopupTipProps>(tooltip)
                             ? React.cloneElement(tooltip, {
@@ -670,6 +672,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                         }
                                         aria-labelledby={labelId}
                                         tabIndex={-1}
+                                        data-testid="jkl-select__listbox"
+                                        data-testautoid={
+                                            dataTestAutoId
+                                                ? `${dataTestAutoId}__listbox`
+                                                : "jkl-select__listbox"
+                                        }
                                         data-focus="controlled" // lar oss styre markering av valg vha focus
                                         style={
                                             {


### PR DESCRIPTION
Select rendrer nå listen med valg i en portal via Popover. Det betyr at options ikke lenger ligger som children av Select-komponenten i DOM-en, noe som fører til at eksisterende TestComplete-tester feiler.

Denne endringen legger til `data-testautoid` på listboxen, slik at testautomatisering enklere kan finne både listen og tilhørende options.
