### PR TITLE
fix(select,modal,popover): løft flytende innhold i modal

### DIFF
--- a/.changeset/select-modal-layering.md
+++ b/.changeset/select-modal-layering.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Gjør lagdelingen for flytende innhold kontekststyrt, slik at Popover-baserte komponenter som Select automatisk vises over innholdet når de brukes inni Modal.

--- a/packages/jokul/src/components/modal/styles/_layout.scss
+++ b/packages/jokul/src/components/modal/styles/_layout.scss
@@ -9,6 +9,8 @@
     }
 
     .jkl-modal-container {
+        --jkl-floating-z-index: #{jkl.$z-index--floating};
+
         z-index: jkl.$z-index--modal;
         display: flex;
         align-items: center;

--- a/packages/jokul/src/components/modal/styles/modal.scss
+++ b/packages/jokul/src/components/modal/styles/modal.scss
@@ -2,7 +2,6 @@
 @use "../../../styles/jkl";
 
 @layer jokul.components {
-
     .jkl-modal-container,
     .jkl-modal-overlay {
         position: fixed;
@@ -10,6 +9,8 @@
     }
 
     .jkl-modal-container {
+        --jkl-floating-z-index: #{jkl.$z-index--floating};
+
         z-index: jkl.$z-index--modal;
         display: flex;
 

--- a/packages/jokul/src/components/popover/styles/popover.scss
+++ b/packages/jokul/src/components/popover/styles/popover.scss
@@ -8,7 +8,7 @@
         --shadow-color: light-dark(rgb(49 48 48 / 20%), rgb(0 0 0 / 50%));
         /* stylelint-enable declaration-block-no-duplicate-custom-properties */
         padding: var(--popover-padding, 0);
-        z-index: jkl.$z-index--floating;
+        z-index: var(--jkl-floating-z-index, #{jkl.$z-index--floating});
         box-shadow: 0 4px 20px 0 var(--shadow-color);
         background-color: var(--jkl-color-background-container);
         border-radius: var(--jkl-border-radius-s);

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -100,10 +100,8 @@
         }
 
         @include jkl.keyboard-navigation {
-
             &__search-input,
             &__button {
-
                 &:focus-visible,
                 &:has(:focus-visible) {
                     @include jkl.focus-outline;
@@ -111,7 +109,6 @@
             }
 
             &:has(:focus-visible) {
-
                 .jkl-select__button,
                 .jkl-select__search-input {
                     @include jkl.focus-outline;
@@ -232,7 +229,6 @@
         }
 
         &--open {
-
             .jkl-select__search-input,
             .jkl-select__button {
                 border-bottom-left-radius: 0;
@@ -248,7 +244,6 @@
 
             // Lista ligger under (default): flat bunn på input/knapp.
             .jkl-select__outer-wrapper[data-popover-placement="bottom"] {
-
                 .jkl-select__search-input,
                 .jkl-select__button {
                     border-bottom-left-radius: 0;
@@ -258,7 +253,6 @@
 
             // Lista ligger over: flat topp på input/knapp.
             .jkl-select__outer-wrapper[data-popover-placement="top"] {
-
                 .jkl-select__search-input,
                 .jkl-select__button {
                     border-top-left-radius: 0;
@@ -268,7 +262,6 @@
         }
 
         &--invalid {
-
             .jkl-select__search-input,
             .jkl-select__button {
                 background-color: var(--jkl-color-error-background-container);
@@ -320,13 +313,13 @@
     // standard padding/bakgrunn/skygge slik at `.jkl-select__options-menu`
     // selv styrer ramme og bakgrunn — også når Select brukes inne i en
     // Card, ExpandablePanel eller andre containere med overflow-clip.
-    // Select skal følge samme lagdeling som andre dropdown-/menykomponenter
-    // (Combobox, Datepicker, Menu) og ikke arve Popover sitt floating-nivå.
+    // Select skal følge samme lagdeling som andre dropdown-/menykomponenter,
+    // men kan løftes av en portal-kontekst som Modal via `--jkl-floating-z-index`.
     .jkl-popover.jkl-select__popover {
         background: none;
         box-shadow: none;
         border-radius: 0;
-        z-index: jkl.$z-index--dropdown;
+        z-index: var(--jkl-floating-z-index, #{jkl.$z-index--dropdown});
     }
 
     // Mild fade + slide-in når lista mounter i portalen. Animeres på


### PR DESCRIPTION
Fikser at Select-menyen havner bak Modal ved å gjøre z-index for flytende innhold kontekststyrt.