### PR TITLE
fix(textarea): tell defaultValue fra react-hook-form i TextArea

### DIFF
--- a/.changeset/quiet-lemons-count.md
+++ b/.changeset/quiet-lemons-count.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser at TextArea-counteren viste 0 når feltet fikk startverdi fra react-hook-form defaultValues.

--- a/packages/jokul/src/components/text-area/BaseTextArea.tsx
+++ b/packages/jokul/src/components/text-area/BaseTextArea.tsx
@@ -2,11 +2,12 @@ import React, {
     type ChangeEvent,
     type FocusEvent,
     forwardRef,
-    type RefObject,
     useEffect,
+    useMemo,
     useRef,
     useState,
 } from "react";
+import { mergeRefs } from "../../utilities/mergeRefs.js";
 import { getCounterValue } from "./counter.js";
 import type { BaseTextAreaProps } from "./types.js";
 
@@ -31,12 +32,12 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
         const strategy = counter?.strategy ?? "characters";
         const isControlled = typeof value !== "undefined";
 
-        const [uncontrolledValue, setUncontrolledValue] =
-            useState(defaultValue);
+        const [uncontrolledValue, setUncontrolledValue] = useState(
+            defaultValue ?? "",
+        );
         const [textAreaFocused, setTextAreaFocused] = useState(false);
         const internalRef = useRef<HTMLTextAreaElement>(null);
-        const textAreaRef =
-            (ref as RefObject<HTMLTextAreaElement>) || internalRef;
+        const textAreaRef = useMemo(() => mergeRefs(internalRef, ref), [ref]);
 
         // Hvis feltet styres utenfra bruker vi `value`, ellers holder vi styr på verdien selv.
         const textAreaValue = isControlled ? value : uncontrolledValue;
@@ -48,9 +49,18 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
         const isOverLimit = Boolean(counter && counterCurrent > counterTotal);
         const invalid = Boolean(ariaInvalid || isOverLimit);
 
+        useEffect(() => {
+            if (!isControlled && internalRef.current) {
+                const value = internalRef.current.value;
+                setUncontrolledValue((currentValue) =>
+                    currentValue === value ? currentValue : value,
+                );
+            }
+        }, [isControlled]);
+
         // biome-ignore lint/correctness/useExhaustiveDependencies: counterCurrent trengs for å lytte på tekstendringer i textarea for auto-expand funksjonalitet
         useEffect(() => {
-            const textAreaElement = textAreaRef.current;
+            const textAreaElement = internalRef.current;
             if (textAreaElement) {
                 if (!autoExpand) {
                     textAreaElement.style.height = "";
@@ -64,13 +74,7 @@ export const BaseTextArea = forwardRef<HTMLTextAreaElement, BaseTextAreaProps>(
                     textAreaElement.style.height = "";
                 }
             }
-        }, [
-            autoExpand,
-            textAreaRef,
-            textAreaValue,
-            textAreaFocused,
-            counterCurrent,
-        ]);
+        }, [autoExpand, textAreaValue, textAreaFocused, counterCurrent]);
 
         function handleOnFocus(e: FocusEvent<HTMLTextAreaElement>) {
             setTextAreaFocused(true);

--- a/packages/jokul/src/components/text-area/TextArea.test.tsx
+++ b/packages/jokul/src/components/text-area/TextArea.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 import { axe } from "vitest-axe";
 import { TextArea } from "./TextArea.js";
@@ -117,6 +118,31 @@ describe("TextArea", () => {
         );
 
         expect(screen.getByText(/6\s*\/\s*10/)).toBeInTheDocument();
+    });
+
+    it("shows the initial character count when react-hook-form sets the textarea value from defaultValues", async () => {
+        type FormValues = {
+            message: string;
+        };
+
+        function WrappedTextArea(props: { defaultValues: FormValues }) {
+            const { register } = useForm<FormValues>({
+                defaultValues: props.defaultValues,
+            });
+
+            return (
+                <TextArea
+                    label="testing"
+                    counter={{ maxLength: 10 }}
+                    {...register("message")}
+                />
+            );
+        }
+
+        render(<WrappedTextArea defaultValues={{ message: "default" }} />);
+
+        expect(screen.getByRole("textbox")).toHaveValue("default");
+        expect(await screen.findByText(/7\s*\/\s*10/)).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
Fikser en feil i `TextArea` der telleren kunne vise `0` selv om tekstområdet allerede hadde innhold.

## Hva er endret?

- `TextArea` beholder nå sin interne ref selv om en ekstern ref sendes inn.
- Komponenten leser "defaultValue" fra selve `<textarea>`-elementet etter at det er rendret.
- Tomme `textarea` starter med intern verdi `""`, som matcher default-verdien i browsere.