### PR TITLE
La symbolet skalere med tekststørrelse i RadioButton og Checkbox

### DIFF
--- a/.changeset/dirty-lemons-follow.md
+++ b/.changeset/dirty-lemons-follow.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Lar symbolet skalere med tekststørrelse i `RadioButton` og `Checkbox`. Det respekterer nå tekststil/-størrelse satt på hele `RadioButton`- eller `Checkbox`-komponenten.

--- a/packages/jokul/src/components/checkbox/styles/checkbox.scss
+++ b/packages/jokul/src/components/checkbox/styles/checkbox.scss
@@ -40,8 +40,6 @@
             @include jkl.motion;
             transition-property: color;
 
-            @include jkl.text-style("text-medium");
-
             &::before {
                 content: "check_box_outline_blank";
                 margin-inline-end: 0.25em;

--- a/packages/jokul/src/components/radio-button/styles/radio-button.scss
+++ b/packages/jokul/src/components/radio-button/styles/radio-button.scss
@@ -8,6 +8,7 @@
         display: flex;
         position: relative;
 
+        @include jkl.text-style("text-medium");
         @include jkl.reset-outline;
 
         &__input {
@@ -35,7 +36,6 @@
             @include jkl.motion;
             transition-property: color;
 
-            @include jkl.text-style("text-medium");
 
             &::before {
                 content: "radio_button_unchecked";
@@ -47,6 +47,7 @@
 
         &__input:focus-visible + &__label::before {
             border-radius: var(--jkl-border-radius-full);
+
             @include jkl.focus-outline;
         }
 


### PR DESCRIPTION
## 💬 Endringer

Lar symbolet skalere med tekststørrelse i `RadioButton` og `Checkbox`. Det respekterer nå tekststil/-størrelse satt på hele `RadioButton`- eller `Checkbox`-komponenten.

## 🩹 Løser følgende issues

Closes #6113
