### PR TITLE
Fjern @ fra genererte fargeklasser i tailwindPreset

### DIFF
--- a/.changeset/flat-tailwind-colors.md
+++ b/.changeset/flat-tailwind-colors.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser Tailwind v3-preseten slik at standard fargetokens ikke genererer klasser med `@-` i navnet.

--- a/packages/jokul/src/tailwind/tailwindPreset.ts
+++ b/packages/jokul/src/tailwind/tailwindPreset.ts
@@ -2,9 +2,21 @@ import type { Config } from "tailwindcss";
 import tokens from "../tokens.js";
 import { jokulTypographyPlugin } from "./plugins/jokulTypographyPlugin.js";
 
+const DEFAULT_COLOR_VARIANT_KEY = "@";
+
+function createTailwindColors() {
+    const { [DEFAULT_COLOR_VARIANT_KEY]: defaultColors, ...semanticColors } =
+        tokens.color;
+
+    return {
+        ...defaultColors,
+        ...semanticColors,
+    };
+}
+
 export const jokulPreset: Partial<Config> = {
     theme: {
-        colors: tokens.color,
+        colors: createTailwindColors(),
         spacing: tokens.spacing,
         fontWeight: tokens.font.weight,
         fontSize: tokens.font.size,


### PR DESCRIPTION
Sørger for at Tailwind v3-preseten ikke genererer fargeklasser med `@-` i navnet.

## PS

Den ryddigste løsningen hadde vært å fjerne `@`-nivået fra `color.tokens.json`. Det krever imidlertid endringer i blant annet temabyggeren, som forventer dagens struktur, og vil føre til en del støy. Har opprettet [issue #6123](https://github.com/fremtind/jokul/issues/6123) for å ta tak i det senere.

Closes #6122 