### PR TITLE
fix: center subdued text title

### DIFF
--- a/.changeset/neat-tigers-swim.md
+++ b/.changeset/neat-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": minor
+---
+
+Legger til `center` og `subdued` props på `Text` komponenten, og `center` prop på `Title` komponenten for å forenkle vanlige tekststyler uten custom CSS.

--- a/packages/jokul/src/components/typography/Text.test.tsx
+++ b/packages/jokul/src/components/typography/Text.test.tsx
@@ -76,6 +76,30 @@ describe("Text", () => {
         expect(getByText("Skjult")).toHaveClass("jkl-text", "jkl-sr-only");
     });
 
+    it("setter `data-center` når `center` er true", () => {
+        const { getByText } = render(<Text center>Sentrert</Text>);
+
+        expect(getByText("Sentrert")).toHaveAttribute("data-center");
+    });
+
+    it("setter ikke `data-center` når `center` er false", () => {
+        const { getByText } = render(<Text center={false}>Venstrestilt</Text>);
+
+        expect(getByText("Venstrestilt")).not.toHaveAttribute("data-center");
+    });
+
+    it("setter `data-subdued` når `subdued` er true", () => {
+        const { getByText } = render(<Text subdued>Dempet</Text>);
+
+        expect(getByText("Dempet")).toHaveAttribute("data-subdued");
+    });
+
+    it("setter ikke `data-subdued` når `subdued` er false", () => {
+        const { getByText } = render(<Text subdued={false}>Normal</Text>);
+
+        expect(getByText("Normal")).not.toHaveAttribute("data-subdued");
+    });
+
     it("videresender ekstra className", () => {
         const { getByText } = render(
             <Text className="egen-klasse">Med klasse</Text>,

--- a/packages/jokul/src/components/typography/Text.tsx
+++ b/packages/jokul/src/components/typography/Text.tsx
@@ -10,7 +10,17 @@ type TextComponent = <As extends TextElement = "p">(
 export const Text: TextComponent = forwardRef(function Text<
     As extends TextElement = "p",
 >(
-    { as, className, size = "m", bold, short, srOnly, ...rest }: TextProps<As>,
+    {
+        as,
+        className,
+        size = "m",
+        bold,
+        short,
+        srOnly,
+        center,
+        subdued,
+        ...rest
+    }: TextProps<As>,
     ref?: PolymorphicRef<As>,
 ) {
     const Component = (as || "p") as React.ElementType;
@@ -20,6 +30,8 @@ export const Text: TextComponent = forwardRef(function Text<
             data-text-size={size}
             data-bold={bold || undefined}
             data-short={short || undefined}
+            data-center={center || undefined}
+            data-subdued={subdued || undefined}
             ref={ref}
             {...rest}
         />

--- a/packages/jokul/src/components/typography/Title.test.tsx
+++ b/packages/jokul/src/components/typography/Title.test.tsx
@@ -114,6 +114,30 @@ describe("Title", () => {
         expect(getByRole("heading", { level: 2 })).toHaveClass("jkl-sr-only");
     });
 
+    it("setter `data-center` når `center` er true", () => {
+        const { getByRole } = render(
+            <Title as="h2" center>
+                Sentrert
+            </Title>,
+        );
+
+        expect(getByRole("heading", { level: 2 })).toHaveAttribute(
+            "data-center",
+        );
+    });
+
+    it("setter ikke `data-center` når `center` er false", () => {
+        const { getByRole } = render(
+            <Title as="h2" center={false}>
+                Venstrestilt
+            </Title>,
+        );
+
+        expect(getByRole("heading", { level: 2 })).not.toHaveAttribute(
+            "data-center",
+        );
+    });
+
     it("videresender ekstra className", () => {
         const { getByRole } = render(
             <Title className="egen-klasse">Med klasse</Title>,

--- a/packages/jokul/src/components/typography/Title.tsx
+++ b/packages/jokul/src/components/typography/Title.tsx
@@ -10,7 +10,7 @@ type TitleComponent = <As extends TitleElement = "h2">(
 export const Title: TitleComponent = forwardRef(function Title<
     As extends TitleElement = "h2",
 >(
-    { className, size = "l", as, srOnly, ...rest }: TitleProps<As>,
+    { className, size = "l", as, srOnly, center, ...rest }: TitleProps<As>,
     ref?: PolymorphicRef<As>,
 ) {
     const Tag = (as || "h2") as React.ElementType;
@@ -18,6 +18,7 @@ export const Title: TitleComponent = forwardRef(function Title<
         <Tag
             className={clsx(srOnly && "jkl-sr-only", className)}
             data-text-size={size}
+            data-center={center || undefined}
             ref={ref}
             {...rest}
         />

--- a/packages/jokul/src/components/typography/styles/text.scss
+++ b/packages/jokul/src/components/typography/styles/text.scss
@@ -42,6 +42,14 @@ $_size-styles: (
         line-height: var(--jkl-line-height-tight);
     }
 
+    .jkl-text[data-center] {
+        text-align: center;
+    }
+
+    .jkl-text[data-subdued] {
+        color: var(--jkl-color-text-subdued);
+    }
+
     :is(code, kbd, samp, var).jkl-text {
         @include jkl.use-font-family("Jokul Mono");
     }

--- a/packages/jokul/src/components/typography/styles/title.scss
+++ b/packages/jokul/src/components/typography/styles/title.scss
@@ -33,4 +33,8 @@ $_size-styles: (
         display: block;
         margin-block-end: var(--jkl-spacing-8);
     }
+
+    :is(h1, h2, h3, h4, h5, h6, label, legend)[data-text-size][data-center] {
+        text-align: center;
+    }
 }

--- a/packages/jokul/src/components/typography/types.ts
+++ b/packages/jokul/src/components/typography/types.ts
@@ -51,6 +51,18 @@ type TextOwnProps = {
      * @default false
      */
     srOnly?: boolean;
+    /**
+     * Sentrerer teksten horisontalt (text-align: center).
+     * Bruk når sentrering ikke arves fra containeren, f.eks. inne i en Flex
+     * med alignItems: center.
+     * @default false
+     */
+    center?: boolean;
+    /**
+     * Bruker dempet tekstfarge (--jkl-color-text-subdued).
+     * @default false
+     */
+    subdued?: boolean;
 };
 
 type TitleOwnProps = {
@@ -67,6 +79,11 @@ type TitleOwnProps = {
      * @default false
      */
     srOnly?: boolean;
+    /**
+     * Sentrerer teksten horisontalt (text-align: center).
+     * @default false
+     */
+    center?: boolean;
 };
 
 export type TextProps<As extends TextElement = "p"> = PolymorphicPropsWithRef<

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
         "verbatimModuleSyntax": true,
         "esModuleInterop": true,
         "baseUrl": "./",
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "types": ["@testing-library/jest-dom"],
     },
     "exclude": ["**/node_modules", "**/.*", "**/build", "**/dist"],
     "include": ["./packages/**/*"]


### PR DESCRIPTION
## 💬 Endringer

Legger til center og subdued props på Text og Title komponentene for å forenkle vanlige tekststyler uten custom CSS. Oppdatert også `tsconfig.json` med `@testing-library/jest-dom` og `vitest/globals` typer for å fikse TypeScript-feil i test-filer.

## 🩹 Løser følgende issues
-   Closes #6156 
