### PR TITLE
portal(temabygger): gjør mørk modus valgfritt

### DIFF
--- a/.changeset/quiet-maps-shine.md
+++ b/.changeset/quiet-maps-shine.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Gjør mørk modus valgfritt i temabyggeren.

--- a/portal/src/app/(frontend)/temabygger/_components/ThemeBuilder.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ThemeBuilder.tsx
@@ -17,19 +17,24 @@ type ThemeBuilderProps = {
 };
 
 export function ThemeBuilder({ children }: ThemeBuilderProps) {
-    const { color } = useThemeDraft();
+    const { color, settings } = useThemeDraft();
     const [previewColorScheme, setPreviewColorScheme] =
         useState<ColorScheme>("light");
+    const activePreviewColorScheme = settings.includeDarkMode
+        ? previewColorScheme
+        : "light";
 
     return (
         <ThemeBuilderLayout>
             <ThemeBuilderLayout.Form>{children}</ThemeBuilderLayout.Form>
             <ThemeBuilderLayout.Preview
-                colorScheme={previewColorScheme}
+                colorScheme={activePreviewColorScheme}
+                includeDarkMode={settings.includeDarkMode}
                 tokens={color.tokens}
             >
                 <ThemePreview
-                    colorScheme={previewColorScheme}
+                    colorScheme={activePreviewColorScheme}
+                    includeDarkMode={settings.includeDarkMode}
                     onColorSchemeChange={setPreviewColorScheme}
                 />
             </ThemeBuilderLayout.Preview>

--- a/portal/src/app/(frontend)/temabygger/_components/ThemeBuilderLayout.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ThemeBuilderLayout.tsx
@@ -19,6 +19,7 @@ type ThemeBuilderLayoutSlotProps = {
 
 type ThemeBuilderLayoutPreviewProps = ThemeBuilderLayoutSlotProps & {
     colorScheme: ColorScheme;
+    includeDarkMode: boolean;
     tokens: ColorTokens;
 };
 
@@ -41,6 +42,7 @@ const ThemeBuilderLayoutRoot = ({ children }: ThemeBuilderLayoutProps) => (
 const ThemeBuilderLayoutPreview = ({
     children,
     colorScheme,
+    includeDarkMode,
     tokens,
 }: ThemeBuilderLayoutPreviewProps) => {
     const { typography } = useThemeDraft();
@@ -48,13 +50,18 @@ const ThemeBuilderLayoutPreview = ({
         const regularFont = getFontOption(typography.regularFont);
         const displayFont = getFontOption(typography.displayFont);
         return {
-            ...buildColorStyle(tokens),
+            ...buildColorStyle(tokens, includeDarkMode),
             "--jkl-font-family-regular": regularFont.font.family.regular,
             "--jkl-font-family-display": displayFont.font.family.display,
             "--jkl-font-weight-normal": regularFont.font.weight.normal,
             "--jkl-font-weight-bold": regularFont.font.weight.bold,
         } as CSSProperties;
-    }, [tokens, typography.regularFont, typography.displayFont]);
+    }, [
+        tokens,
+        includeDarkMode,
+        typography.regularFont,
+        typography.displayFont,
+    ]);
 
     return (
         <Card
@@ -90,12 +97,16 @@ export const ThemeBuilderLayout = Object.assign(ThemeBuilderLayoutRoot, {
     Form: ThemeBuilderLayoutForm,
 });
 
-function buildColorStyle(tokens: ColorTokens): Record<string, string> {
+function buildColorStyle(
+    tokens: ColorTokens,
+    includeDarkMode: boolean,
+): Record<string, string> {
     const style: Record<string, string> = {};
     for (const [group, roles] of Object.entries(tokens)) {
         for (const [role, token] of Object.entries(roles)) {
-            style[`--jkl-color-${group}-${role}`] =
-                `light-dark(${token.light}, ${token.dark})`;
+            style[`--jkl-color-${group}-${role}`] = includeDarkMode
+                ? `light-dark(${token.light}, ${token.dark})`
+                : token.light;
         }
     }
     return style;

--- a/portal/src/app/(frontend)/temabygger/_context/ThemeDraftContext.tsx
+++ b/portal/src/app/(frontend)/temabygger/_context/ThemeDraftContext.tsx
@@ -108,9 +108,15 @@ type ThemeIdentityDraft = {
     setThemeName: (name: string) => void;
 };
 
+type ThemeSettingsDraft = {
+    includeDarkMode: boolean;
+    setIncludeDarkMode: (includeDarkMode: boolean) => void;
+};
+
 type ThemeDraftContextValue = {
     color: ThemeColorDraft;
     identity: ThemeIdentityDraft;
+    settings: ThemeSettingsDraft;
     typography: ThemeTypographyDraft;
 };
 
@@ -130,6 +136,7 @@ export function ThemeDraftProvider({ children }: ThemeDraftProviderProps) {
         DEFAULT_FONT_OPTION_ID,
     );
     const [themeName, setThemeName] = useState("");
+    const [includeDarkMode, setIncludeDarkMode] = useState(true);
 
     const updateToken = useCallback(
         (
@@ -214,6 +221,10 @@ export function ThemeDraftProvider({ children }: ThemeDraftProviderProps) {
                 themeName,
                 setThemeName,
             },
+            settings: {
+                includeDarkMode,
+                setIncludeDarkMode,
+            },
             typography: {
                 regularFont,
                 displayFont,
@@ -230,6 +241,7 @@ export function ThemeDraftProvider({ children }: ThemeDraftProviderProps) {
         regularFont,
         displayFont,
         themeName,
+        includeDarkMode,
     ]);
 
     return (

--- a/portal/src/app/(frontend)/temabygger/_preview/ContrastView.tsx
+++ b/portal/src/app/(frontend)/temabygger/_preview/ContrastView.tsx
@@ -30,21 +30,29 @@ import {
 import styles from "./contrast-view.module.scss";
 
 type ContrastViewProps = {
+    includeDarkMode: boolean;
     tokens: ColorTokens;
 };
 
-export function ContrastView({ tokens }: ContrastViewProps) {
-    const counts = useMemo(() => countRatings(tokens), [tokens]);
+const LIGHT_COLOR_SCHEMES = ["light"] as const satisfies readonly ColorScheme[];
+
+export function ContrastView({ includeDarkMode, tokens }: ContrastViewProps) {
+    const colorSchemes = includeDarkMode ? COLOR_SCHEMES : LIGHT_COLOR_SCHEMES;
+    const counts = useMemo(
+        () => countRatings(tokens, colorSchemes),
+        [colorSchemes, tokens],
+    );
 
     return (
         <Flex direction="column" gap="2xl">
             <ContrastSummary counts={counts} />
-            <TokenTable tokens={tokens} />
+            <TokenTable colorSchemes={colorSchemes} tokens={tokens} />
         </Flex>
     );
 }
 
 type TokenTableProps = {
+    colorSchemes: readonly ColorScheme[];
     tokens: ColorTokens;
 };
 
@@ -54,7 +62,7 @@ type TokenTableItem = {
     token: ColorToken;
 };
 
-function TokenTable({ tokens }: TokenTableProps) {
+function TokenTable({ colorSchemes, tokens }: TokenTableProps) {
     const tokenList = useMemo(() => getTokenTableItems(tokens), [tokens]);
 
     return (
@@ -69,7 +77,7 @@ function TokenTable({ tokens }: TokenTableProps) {
                 <TableRow>
                     <TableHeader scope="col">group</TableHeader>
                     <TableHeader scope="col">role</TableHeader>
-                    {COLOR_SCHEMES.map((scheme) => (
+                    {colorSchemes.map((scheme) => (
                         <TableHeader key={scheme} scope="col">
                             {scheme}
                         </TableHeader>
@@ -93,7 +101,7 @@ function TokenTable({ tokens }: TokenTableProps) {
                             <TableCell data-th="role">
                                 <code>{role}</code>
                             </TableCell>
-                            {COLOR_SCHEMES.map((scheme) => (
+                            {colorSchemes.map((scheme) => (
                                 <TableCell key={scheme} data-th={scheme}>
                                     <TokenSwatch
                                         group={group}

--- a/portal/src/app/(frontend)/temabygger/_preview/ThemePreview.tsx
+++ b/portal/src/app/(frontend)/temabygger/_preview/ThemePreview.tsx
@@ -32,11 +32,13 @@ const COLOR_SCHEME_ICONS: Record<ColorScheme, string> = {
 
 type ThemePreviewProps = {
     colorScheme: ColorScheme;
+    includeDarkMode: boolean;
     onColorSchemeChange: (colorScheme: ColorScheme) => void;
 };
 
 export function ThemePreview({
     colorScheme,
+    includeDarkMode,
     onColorSchemeChange,
 }: ThemePreviewProps) {
     const { color } = useThemeDraft();
@@ -68,20 +70,25 @@ export function ThemePreview({
                         </SegmentedControlButton>
                     ))}
                 </SegmentedControl>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    icon={<Icon>{COLOR_SCHEME_ICONS[colorScheme]}</Icon>}
-                    onClick={() => onColorSchemeChange(nextColorScheme)}
-                    aria-label={`Bytt til ${COLOR_SCHEME_LABELS[nextColorScheme].toLowerCase()}`}
-                >
-                    {COLOR_SCHEME_LABELS[colorScheme]}
-                </Button>
+                {includeDarkMode && (
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        icon={<Icon>{COLOR_SCHEME_ICONS[colorScheme]}</Icon>}
+                        onClick={() => onColorSchemeChange(nextColorScheme)}
+                        aria-label={`Bytt til ${COLOR_SCHEME_LABELS[nextColorScheme].toLowerCase()}`}
+                    >
+                        {COLOR_SCHEME_LABELS[colorScheme]}
+                    </Button>
+                )}
             </Flex>
             {activeTab === "overview" ? (
                 <ExampleView />
             ) : (
-                <ContrastView tokens={color.tokens} />
+                <ContrastView
+                    includeDarkMode={includeDarkMode}
+                    tokens={color.tokens}
+                />
             )}
         </Flex>
     );

--- a/portal/src/app/(frontend)/temabygger/_preview/contrastEvaluation.ts
+++ b/portal/src/app/(frontend)/temabygger/_preview/contrastEvaluation.ts
@@ -2,6 +2,7 @@ import { ColorSpace, contrastWCAG21, sRGB } from "colorjs.io/fn";
 import { COLOR_SCHEMES } from "../_components/ThemeBuilder";
 import type { ColorToken, ColorTokens } from "../_context/ThemeDraftContext";
 import { isHex } from "../_lib/hexColor";
+import type { ColorScheme } from "../generator/types";
 
 const WCAG_TEXT_CONTRAST_AAA = 7;
 const WCAG_TEXT_CONTRAST_AA = 4.5;
@@ -57,7 +58,10 @@ type ContrastReference = {
 
 const EMPTY_COUNTS: RatingCounts = { AAA: 0, AA: 0, A: 0, "✕": 0 };
 
-export function countRatings(tokens: ColorTokens): RatingCounts {
+export function countRatings(
+    tokens: ColorTokens,
+    colorSchemes: readonly ColorScheme[] = COLOR_SCHEMES,
+): RatingCounts {
     const counts: RatingCounts = { ...EMPTY_COUNTS };
 
     for (const [group, roles] of Object.entries(tokens) as Array<
@@ -71,7 +75,7 @@ export function countRatings(tokens: ColorTokens): RatingCounts {
                 tokens[reference.againstGroup]?.[reference.againstRole];
             if (!referenceToken) continue;
 
-            for (const scheme of COLOR_SCHEMES) {
+            for (const scheme of colorSchemes) {
                 const evaluation = evaluateColorContrast(
                     token[scheme],
                     referenceToken[scheme],

--- a/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
@@ -21,7 +21,7 @@ type ColorSchemeEditorProps = {
 };
 
 export function AdjustColorsStep() {
-    const { color, identity } = useThemeDraft();
+    const { color, identity, settings } = useThemeDraft();
     const colorTokenGroups = getEditableColorTokenGroups(color.tokens);
     const themeName = identity.themeName.trim() || "distributøren";
 
@@ -31,17 +31,27 @@ export function AdjustColorsStep() {
                 Tilpass farger for {themeName}
             </Title>
             <Flex direction="column" gap="40">
-                <ColorSchemeSection
-                    title="Lyst modus"
-                    colorScheme="light"
-                    groups={colorTokenGroups}
-                    defaultOpenGroup="background"
-                />
-                <ColorSchemeSection
-                    title="Mørk modus"
-                    colorScheme="dark"
-                    groups={colorTokenGroups}
-                />
+                {settings.includeDarkMode ? (
+                    <>
+                        <ColorSchemeSection
+                            title="Lyst modus"
+                            colorScheme="light"
+                            groups={colorTokenGroups}
+                            defaultOpenGroup="background"
+                        />
+                        <ColorSchemeSection
+                            title="Mørk modus"
+                            colorScheme="dark"
+                            groups={colorTokenGroups}
+                        />
+                    </>
+                ) : (
+                    <ColorSchemeSection
+                        colorScheme="light"
+                        groups={colorTokenGroups}
+                        defaultOpenGroup="background"
+                    />
+                )}
             </Flex>
             <Message variant="warning" title="Informasjon">
                 Her kommer relevant informasjon.
@@ -59,7 +69,7 @@ export function AdjustColorsStep() {
 }
 
 type ColorSchemeSectionProps = ColorSchemeEditorProps & {
-    title: string;
+    title?: string;
 };
 
 function ColorSchemeSection({
@@ -70,7 +80,7 @@ function ColorSchemeSection({
 }: ColorSchemeSectionProps) {
     return (
         <Flex direction="column" gap="16">
-            <Text bold>{title}</Text>
+            {title && <Text bold>{title}</Text>}
             <ColorSchemeEditor
                 colorScheme={colorScheme}
                 groups={groups}

--- a/portal/src/app/(frontend)/temabygger/_steps/BaseColorStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/BaseColorStep.tsx
@@ -5,7 +5,6 @@ import { Checkbox } from "@fremtind/jokul/checkbox";
 import { Flex } from "@fremtind/jokul/flex";
 import { Text, Title } from "@fremtind/jokul/typography";
 import Link from "next/link";
-import { useState } from "react";
 import { ColorTokenField } from "../_components/ColorTokenField";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import { StepCard } from "./StepCard";
@@ -15,8 +14,7 @@ type BaseColorStepProps = {
 };
 
 export function BaseColorStep({ nextStepPath }: BaseColorStepProps) {
-    const { color, identity } = useThemeDraft();
-    const [includeDarkMode, setIncludeDarkMode] = useState(true);
+    const { color, identity, settings } = useThemeDraft();
     const contrastToken = color.tokens.background.contrast;
     const themeName = identity.themeName.trim() || "distributøren";
 
@@ -44,8 +42,10 @@ export function BaseColorStep({ nextStepPath }: BaseColorStepProps) {
             <Checkbox
                 name="includeDarkMode"
                 value="includeDarkMode"
-                checked={includeDarkMode}
-                onChange={(event) => setIncludeDarkMode(event.target.checked)}
+                checked={settings.includeDarkMode}
+                onChange={(event) =>
+                    settings.setIncludeDarkMode(event.target.checked)
+                }
             >
                 Lag tema for mørk modus, også
             </Checkbox>


### PR DESCRIPTION
## 💬 Endringer

Koblet valget for mørk modus til temabyggeren, så det faktisk styrer hva som vises.

Det finnes en egen oppgave for å rydde opp i kontrasttabellen senere: #6205. Endringen her er bare tatt med for at tabellen ikke skal vise mørk modus når brukeren har valgt det bort.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6201 
