### PR TITLE
Jøkul v5: Rett Select-meny etter flytting til Popover

### DIFF
--- a/.changeset/brisk-maps-fold.md
+++ b/.changeset/brisk-maps-fold.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Lar Select-menyen gi Popover riktig høyde, slik at Floating UI kan plassere og flippe listen riktig når det ikke er plass under triggeren.

--- a/.changeset/plain-rivers-turn.md
+++ b/.changeset/plain-rivers-turn.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Matcher bredden på Select-menyen mot triggeren med Floating UI sin size-middleware i stedet for CSS Anchor Positioning.

--- a/packages/jokul/src/components/popover/Popover.tsx
+++ b/packages/jokul/src/components/popover/Popover.tsx
@@ -7,6 +7,7 @@ import {
     flip,
     offset,
     shift,
+    size,
     useClick,
     useDismiss,
     useFloating,
@@ -30,6 +31,7 @@ const usePopover = ({
     offset: _offset = 4,
     positionReference,
     onPlacementChange,
+    matchReferenceWidth = false,
     hoverOptions,
     focusOptions,
     clickOptions,
@@ -50,6 +52,15 @@ const usePopover = ({
             offset(_offset),
             flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
             shift({ padding: 12 }),
+            ...(matchReferenceWidth
+                ? [
+                      size({
+                          apply({ rects, elements }) {
+                              elements.floating.style.width = `${rects.reference.width}px`;
+                          },
+                      }),
+                  ]
+                : []),
         ],
         whileElementsMounted: autoUpdate,
     });

--- a/packages/jokul/src/components/popover/types.ts
+++ b/packages/jokul/src/components/popover/types.ts
@@ -77,6 +77,16 @@ export interface PopoverOptions {
      */
     onPlacementChange?: (placement: Placement) => void;
     /**
+     * Setter bredden på popoveren lik bredden på referanse-elementet.
+     * Referanse-elementet er vanligvis `Popover.Trigger`, men kan overstyres
+     * med `positionReference`.
+     *
+     * @see https://floating-ui.com/docs/size#match-reference-width
+     *
+     * @default false
+     */
+    matchReferenceWidth?: boolean;
+    /**
      * Options for hover-interaksjoner.
      *
      * @see https://floating-ui.com/docs/usehover

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -61,9 +61,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         const labelId = `${listId}_label`;
         const buttonId = `${listId}_button`;
         const searchInputId = `${listId}_search-input`;
-        // Unik anchor-name som CSS anchor positioning bruker for å la
-        // dropdown-listen matche bredden til triggeren.
-        const anchorName = `--${listId.replace(/[^a-zA-Z0-9-]/g, "-")}-anchor`;
 
         const [dropdownIsShown, setShown] = useState(false);
         const toggleListVisibility = useCallback(() => {
@@ -547,6 +544,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                 offset={0}
                                 modal={false}
                                 onPlacementChange={handlePlacementChange}
+                                matchReferenceWidth
                                 clickOptions={{ enabled: false }}
                                 dismissOptions={{ enabled: false }}
                                 roleOptions={{ enabled: false }}
@@ -557,12 +555,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                         data-popover-placement={
                                             popoverPlacement
                                         }
-                                        style={
-                                            {
-                                                width,
-                                                anchorName,
-                                            } as CSSProperties
-                                        }
+                                        style={{ width }}
                                     >
                                         {isSearchable && (
                                             <input
@@ -657,9 +650,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                     initialFocus={-1}
                                     returnFocus={false}
                                     className="jkl-select__popover"
-                                    style={{
-                                        width: `anchor-size(${anchorName} width)`,
-                                    }}
                                 >
                                     <div
                                         id={listId}

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -138,7 +138,6 @@
         &__options-menu {
             background-color: var(--jkl-color-background-container);
             border: jkl.rem(2px) solid var(--jkl-color-border-strong);
-            border-top: none;
             border-radius: 0 0 var(--border-radius) var(--border-radius);
             box-sizing: border-box;
             // Strekker seg ut over kantene på trigger-knappen for å dekke
@@ -225,8 +224,6 @@
         &--open {
             .jkl-select__search-input,
             .jkl-select__button {
-                border-bottom-left-radius: 0;
-                border-bottom-right-radius: 0;
                 border-color: var(--jkl-color-border-strong);
                 background-color: var(--jkl-color-background-container);
                 box-shadow: 0 0 0 jkl.rem(1px) var(--jkl-color-border-strong);

--- a/packages/jokul/src/components/select/styles/select.scss
+++ b/packages/jokul/src/components/select/styles/select.scss
@@ -136,12 +136,6 @@
         }
 
         &__options-menu {
-            position: absolute;
-            left: jkl.rem(-1px);
-            right: jkl.rem(-1px);
-            top: 100%;
-            z-index: jkl.$z-index--dropdown;
-
             background-color: var(--jkl-color-background-container);
             border: jkl.rem(2px) solid var(--jkl-color-border-strong);
             border-top: none;


### PR DESCRIPTION
## 💬 Endringer

Flere team har meldt om trøbbel med Select i Safari på mobil.

Fikk reprodusert en lignende feil i WebKit med iPhone-viewport. Når Select sto langt nede på skjermen, åpnet menyen nedover i stedet for å flippe opp og havnet utenfor viewporten.

PR-en rydder opp i tre ting:

- menyen flipper opp når det ikke er plass under feltet
- menyen får samme bredde som Select-feltet uten å bruke `anchor-size()`
- hjørnene på input ser riktige ut når menyen flippes oppover

## Plassering

Endringene knyttet til selve fiksen ligger i commit https://github.com/fremtind/jokul/commit/f32ff4cbad7d0461179061f562a39835be3c23cc

Select-listen lå med `position: absolute` inne i Popover, så Floating UI trodde listen var lavere enn den faktisk var og plasserte den derfor under feltet.

Når feltet sto langt nede på skjermen, åpnet menyen derfor nedover i stedet for å flippe opp.

Nå får Floating UI riktig høyde på menyen, og kan legge den over feltet når det trengs.

## Før / etter

**Før**

<img width="412" height="242" alt="Skjermbilde 2026-06-12 kl  23 55 49" src="https://github.com/user-attachments/assets/9ee10f81-0ca6-4087-b78d-c59596ecff26" />

**Etter**

<img width="370" height="460" alt="Skjermbilde 2026-06-13 kl  09 36 15" src="https://github.com/user-attachments/assets/3510a241-ffce-431c-ae17-7e6da66e3139" />

## Bredde

https://github.com/fremtind/jokul/commit/8b58983fdbfd738390b414b2748eca9323bfa6f9

Menybredden ble tidligere satt med `anchor-size()`.

`anchor-size()` er en del av CSS Anchor Positioning, og det støttes ikke i Safari-versjonene vi ser hos brukerne, blant annet iOS Safari 18.4/18.7 og Safari 17.x.

[CanIUse](https://caniuse.com/css-anchor-positioning) viser også at CSS Anchor Positioning ikke støttes i Safari/iOS Safari før versjon 26:

<img width="1347" height="239" alt="Skjermbilde 2026-06-13 kl  23 28 46" src="https://github.com/user-attachments/assets/dc644c85-b971-4063-a4cf-1d40889e13e7" />

Siden vi allerede bruker Floating UI til å plassere menyen, lar vi Floating UI sette bredden også. Da matcher menyen Select-feltet uten å være avhengig av CSS Anchor Positioning.

Jeg tror også dette rydder opp i modal-caset vi har sett, der listen blir mye bredere enn selve Select-feltet.

<img width="1306" height="352" alt="Skjermbilde 2026-06-13 kl  00 02 43" src="https://github.com/user-attachments/assets/94d4aafc-fa94-4524-a95a-6315dfb1a183" />

## Radius

Oppdaget under debugging at Select-feltet mistet radius på alle hjørnene når menyen åpnet over feltet.

**Før**
<img width="390" height="484" alt="Skjermbilde 2026-06-12 kl  23 55 57" src="https://github.com/user-attachments/assets/c9c0bbfc-4390-4f96-9d91-5cce23e6a36e" />

**Etter**

<img width="258" height="364" alt="Skjermbilde 2026-06-13 kl  23 00 54" src="https://github.com/user-attachments/assets/5d5862af-4d43-405f-b7cd-93e148e6c2f8" />

Årsaken var at radius alltid ble fjernet nederst når menyen var åpen. Hvis menyen åpnet over feltet, ble radius også fjernet øverst.

## Testet

Klarte å reprodusere feilen ved å bruke Playwright i WebKit med iPhone-viewport og ta screenshots underveis.

## 🩹 Løser følgende issues

- Closes #6208
