### PR TITLE
Jøkul v4: Match bredde på Select-meny uten anchor-size()

### DIFF
--- a/.changeset/plain-rivers-turn.md
+++ b/.changeset/plain-rivers-turn.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Matcher bredden på Select-menyen mot triggeren med Floating UI sin size-middleware i stedet for CSS Anchor Positioning.

--- a/packages/jokul/src/components/popover/Popover.tsx
+++ b/packages/jokul/src/components/popover/Popover.tsx
@@ -7,6 +7,7 @@ import {
     flip,
     offset,
     shift,
+    size,
     useClick,
     useDismiss,
     useFloating,
@@ -30,6 +31,7 @@ const usePopover = ({
     offset: _offset = 4,
     positionReference,
     onPlacementChange,
+    matchReferenceWidth = false,
     hoverOptions,
     focusOptions,
     clickOptions,
@@ -50,6 +52,15 @@ const usePopover = ({
             offset(_offset),
             flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
             shift({ padding: 12 }),
+            ...(matchReferenceWidth
+                ? [
+                      size({
+                          apply({ rects, elements }) {
+                              elements.floating.style.width = `${rects.reference.width}px`;
+                          },
+                      }),
+                  ]
+                : []),
         ],
         whileElementsMounted: autoUpdate,
     });

--- a/packages/jokul/src/components/popover/types.ts
+++ b/packages/jokul/src/components/popover/types.ts
@@ -77,6 +77,16 @@ export interface PopoverOptions {
      */
     onPlacementChange?: (placement: Placement) => void;
     /**
+     * Setter bredden på popoveren lik bredden på referanse-elementet.
+     * Referanse-elementet er vanligvis `Popover.Trigger`, men kan overstyres
+     * med `positionReference`.
+     *
+     * @see https://floating-ui.com/docs/size#match-reference-width
+     *
+     * @default false
+     */
+    matchReferenceWidth?: boolean;
+    /**
      * Options for hover-interaksjoner.
      *
      * @see https://floating-ui.com/docs/usehover

--- a/packages/jokul/src/components/select/Select.tsx
+++ b/packages/jokul/src/components/select/Select.tsx
@@ -60,9 +60,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         const labelId = `${listId}_label`;
         const buttonId = `${listId}_button`;
         const searchInputId = `${listId}_search-input`;
-        // Unik anchor-name som CSS anchor positioning bruker for å la
-        // dropdown-listen matche bredden til triggeren.
-        const anchorName = `--${listId.replace(/[^a-zA-Z0-9-]/g, "-")}-anchor`;
 
         const [dropdownIsShown, setShown] = useState(false);
         const toggleListVisibility = useCallback(() => {
@@ -545,6 +542,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                 offset={0}
                                 modal={false}
                                 onPlacementChange={handlePlacementChange}
+                                matchReferenceWidth
                                 clickOptions={{ enabled: false }}
                                 dismissOptions={{ enabled: false }}
                                 roleOptions={{ enabled: false }}
@@ -555,12 +553,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                         data-popover-placement={
                                             popoverPlacement
                                         }
-                                        style={
-                                            {
-                                                width,
-                                                anchorName,
-                                            } as CSSProperties
-                                        }
+                                        style={{ width }}
                                     >
                                         {isSearchable && (
                                             <input
@@ -655,9 +648,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
                                     initialFocus={-1}
                                     returnFocus={false}
                                     className="jkl-select__popover"
-                                    style={{
-                                        width: `anchor-size(${anchorName} width)`,
-                                    }}
                                 >
                                     <div
                                         id={listId}


### PR DESCRIPTION
## 💬 Endringer
Tar med breddefiksen fra #6220 til `jokul-4.x`.

I Jøkul 4 handler dette bare om å få bort `anchor-size()` fra Select. Menyen får nå bredden fra Floating UI, så den matcher feltet uten å være avhengig av CSS Anchor Positioning.

Flip/høyde-fiksen fra #6220 er ikke med her, siden den feilen bare gjelder Jøkul 5-sporet.