### PR TITLE
Hindre at ikoner krymper i flex-layout

### DIFF
--- a/.changeset/red-mice-admire.md
+++ b/.changeset/red-mice-admire.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Hindrer at ikoner blir klemt i flex-layout.

--- a/packages/jokul/src/components/icon/styles/_base-styles.scss
+++ b/packages/jokul/src/components/icon/styles/_base-styles.scss
@@ -14,6 +14,7 @@
     font-weight: 400;
     line-height: 1;
     display: inline-block;
+    flex-shrink: 0;
     -webkit-font-smoothing: antialiased;
 
     @include jkl.motion("standard", "energetic");


### PR DESCRIPTION
## 💬 Endringer

Fikser at ikoner blir klemt i flex-layout når teksten brekker over flere linjer.

`flex-shrink: 0` er vanlig praksis for ikoner med fast form og størrelse, så jeg legger derfor regelen inn i basestilen.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6232 
