### PR TITLE
task(portal): legg til sidetittel og metadata i frontend-layouten

### DIFF
--- a/portal/src/app/(frontend)/layout.tsx
+++ b/portal/src/app/(frontend)/layout.tsx
@@ -4,9 +4,16 @@ import { TabListener } from "@/components/TabListener";
 import { Footer, Header } from "@/components/layout";
 import { SanityLive } from "@/sanity/lib/live";
 import { CookiesNextProvider } from "cookies-next";
+import type { Metadata } from "next";
 import { VisualEditing } from "next-sanity/visual-editing";
 import { draftMode } from "next/headers";
 import "./global.scss";
+
+export const metadata: Metadata = {
+    title: "Jøkul – Fremtinds designsystem",
+    description:
+        "Jøkul er Fremtinds designsystem for å bygge enkle og helhetlige brukeropplevelser.",
+};
 
 interface Props {
     children: React.ReactNode;


### PR DESCRIPTION
## 💬 Endringer

Legger til metadata i frontend-layouten så siden får en mer beskrivende tittel.

Favicon-filene lå allerede der og funker fint. De vises bare ikke i prod ennå siden den ikke er oppdatert etter at de ble lagt til. De er på plass i test, og dukker opp i prod ved neste release vil jeg tro.

**PS:** Før vi merger ønsker jeg at vi i fellesskap kommer frem til en god
beskrivelse av Jøkul som brukes som meta description.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6237
