### PR TITLE
fix(expandablepanel): tillat name-prop på ExpandablePanel

### DIFF
--- a/.changeset/brave-details-dance.md
+++ b/.changeset/brave-details-dance.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Retter typene til ExpandablePanel slik at de matcher default-elementet `details`. Det gjør at `name` kan brukes direkte på komponenten for native accordion-oppførsel.

--- a/packages/jokul/src/components/expander/types.ts
+++ b/packages/jokul/src/components/expander/types.ts
@@ -21,7 +21,7 @@ export type ExpandablePanelProps<ElementType extends React.ElementType> =
 export type ExpandablePanelComponent = {
     Content: ExpandablePanelContentComponent;
     Header: ExpanderComponent;
-} & (<ElementType extends React.ElementType = "div">(
+} & (<ElementType extends React.ElementType = "details">(
     props: ExpandablePanelProps<ElementType>,
 ) => React.ReactElement | null);
 


### PR DESCRIPTION
## 💬 Endringer

Fikser typene til `ExpandablePanel` så de matcher det komponenten faktisk gjør: default er `details`, ikke `div`.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6244 
