### PR TITLE
Kontrastkort til temabyggeren

### DIFF
--- a/.changeset/strong-wombats-try.md
+++ b/.changeset/strong-wombats-try.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Legger til komponent for å vise kontraster mellom fargeroller i temabyggeren

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,13 +423,13 @@ importers:
         version: link:../packages/jokul
       '@mdx-js/loader':
         specifier: ^3.1.0
-        version: 3.1.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0))
+        version: 3.1.1(webpack@5.104.1(esbuild@0.27.0))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@18.3.1)(react@18.3.1)
       '@next/mdx':
         specifier: ^16.2.6
-        version: 16.2.6(@mdx-js/loader@3.1.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)))(@mdx-js/react@3.1.1(@types/react@18.3.1)(react@18.3.1))
+        version: 16.2.6(@mdx-js/loader@3.1.1(webpack@5.104.1(esbuild@0.27.0)))(@mdx-js/react@3.1.1(@types/react@18.3.1)(react@18.3.1))
       '@portabletext/react':
         specifier: ^5.0.0
         version: 5.0.0(react@18.3.1)
@@ -7070,9 +7070,6 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
-
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -14650,12 +14647,12 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mdx-js/loader@3.1.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0))':
+  '@mdx-js/loader@3.1.1(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)
+      webpack: 5.104.1(esbuild@0.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14831,11 +14828,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)))(@mdx-js/react@3.1.1(@types/react@18.3.1)(react@18.3.1))':
+  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1(webpack@5.104.1(esbuild@0.27.0)))(@mdx-js/react@3.1.1(@types/react@18.3.1)(react@18.3.1))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      '@mdx-js/loader': 3.1.1(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0))
+      '@mdx-js/loader': 3.1.1(webpack@5.104.1(esbuild@0.27.0))
       '@mdx-js/react': 3.1.1(@types/react@18.3.1)(react@18.3.1)
 
   '@next/swc-darwin-arm64@16.2.6':
@@ -19220,7 +19217,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -19243,7 +19240,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -19258,14 +19255,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19280,7 +19277,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20065,10 +20062,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-
-  get-tsconfig@4.13.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -24711,15 +24704,14 @@ snapshots:
       '@swc/core': 1.15.2(@swc/helpers@0.5.17)
       esbuild: 0.25.12
 
-  terser-webpack-plugin@5.5.0(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)):
+  terser-webpack-plugin@5.5.0(esbuild@0.27.0)(webpack@5.104.1(esbuild@0.27.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.1
-      webpack: 5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)
+      webpack: 5.104.1(esbuild@0.27.0)
     optionalDependencies:
-      '@swc/core': 1.15.2(@swc/helpers@0.5.17)
       esbuild: 0.27.0
     optional: true
 
@@ -24932,7 +24924,7 @@ snapshots:
   tsx@4.20.6:
     dependencies:
       esbuild: 0.25.12
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -25505,7 +25497,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0):
+  webpack@5.104.1(esbuild@0.27.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -25529,7 +25521,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.5.0(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0)(webpack@5.104.1(@swc/core@1.15.2(@swc/helpers@0.5.17))(esbuild@0.27.0))
+      terser-webpack-plugin: 5.5.0(esbuild@0.27.0)(webpack@5.104.1(esbuild@0.27.0))
       watchpack: 2.5.0
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/portal/src/app/(frontend)/temabygger/_components/ColorCombinationCard.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ColorCombinationCard.tsx
@@ -1,0 +1,102 @@
+import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { Text } from "@fremtind/jokul/typography";
+import type { CSSProperties } from "react";
+import type { ColorRole } from "../generator/types";
+
+import styles from "./color-combination.module.scss";
+
+type ContrastType = "text" | "border" | "container";
+
+type ColorCombinationCardProps = {
+    type?: ContrastType;
+    foregroundRole: ColorRole;
+    backgroundRole: ColorRole;
+    actualContrast: number;
+    expectedContrast: number;
+};
+
+export const ColorCombinationCard = ({
+    type = "text",
+    backgroundRole,
+    foregroundRole,
+    actualContrast,
+    expectedContrast,
+}: ColorCombinationCardProps): JSX.Element => (
+    <Card
+        as={Flex}
+        padding="s"
+        direction="column"
+        gap="8"
+        style={{ flexBasis: "30ch" }}
+    >
+        <Card
+            outlined={backgroundRole === "background.container"}
+            as={Flex}
+            alignItems="center"
+            justifyContent="center"
+            style={{
+                backgroundColor: `var(--jkl-color-${backgroundRole.replaceAll(".", "-")})`,
+                aspectRatio: "2",
+            }}
+        >
+            <ColorCombinationExample type={type} colorRole={foregroundRole} />
+        </Card>
+        <Text size="s" bold>
+            {foregroundRole}
+        </Text>
+        {actualContrast < expectedContrast && (
+            <Text size="s">
+                <Text as="span" bold className={styles.contrastError}>
+                    {actualContrast}:1
+                </Text>
+                <Text as="span">
+                    Krever {expectedContrast}:1 mot{" "}
+                    {backgroundRole.split(".")[1]}
+                </Text>
+            </Text>
+        )}
+    </Card>
+);
+
+const ColorCombinationExample = ({
+    type,
+    colorRole,
+}: { type: ContrastType; colorRole: ColorRole }) => {
+    const colorStyle: CSSProperties = {
+        color: `var(--jkl-color-${colorRole.replaceAll(".", "-")})`,
+    };
+
+    switch (type) {
+        case "text":
+            return (
+                <Text size="l" style={colorStyle}>
+                    Abc
+                </Text>
+            );
+        case "border":
+            return (
+                <div
+                    style={{
+                        width: "74px",
+                        height: "74px",
+                        borderRadius: "var(--jkl-border-radius-s)",
+                        border: "1px solid currentColor",
+                        ...colorStyle,
+                    }}
+                />
+            );
+        case "container":
+            return (
+                <div
+                    style={{
+                        width: "74px",
+                        height: "74px",
+                        borderRadius: "var(--jkl-border-radius-s)",
+                        backgroundColor: "currentColor",
+                        ...colorStyle,
+                    }}
+                />
+            );
+    }
+};

--- a/portal/src/app/(frontend)/temabygger/_components/color-combination.module.scss
+++ b/portal/src/app/(frontend)/temabygger/_components/color-combination.module.scss
@@ -1,0 +1,16 @@
+@use "@fremtind/jokul/styles/components/icon/base-styles" as icon;
+
+.contrastError {
+    color: var(--jkl-color-error-background-contrast);
+    margin-inline-end: var(--jkl-spacing-8);
+
+    &::before {
+        --jkl-icon-fill: 1;
+
+        content: "cancel" / "";
+        padding-inline-end: var(--jkl-spacing-4);
+        vertical-align: middle;
+
+        @include icon.base-styles;
+    }
+}


### PR DESCRIPTION
## 💬 Endringer

Legger til komponent for å vise kontraster mellom fargeroller i temabyggeren

<img width="1023" height="483" alt="Skjermbilde 2026-06-19 kl  12 24 00" src="https://github.com/user-attachments/assets/f5a2b172-c6ad-4450-8155-27c1d389607e" />

## 🩹 Løser følgende issues

Closes #6229 
