### PR TITLE
fix(portal): bruk redigerbar fargepalett-type i createColorTokenMailHref

### DIFF
--- a/.changeset/fuzzy-clouds-juggle.md
+++ b/.changeset/fuzzy-clouds-juggle.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Bruker `EditableLightDarkPalette` som fargetoken-type i temabyggeren.

--- a/portal/src/app/(frontend)/temabygger/_shared/colorTokenMailHref.ts
+++ b/portal/src/app/(frontend)/temabygger/_shared/colorTokenMailHref.ts
@@ -1,10 +1,10 @@
-import type { ThemeDraftColorTokensState } from "../_context/types";
+import type { EditableLightDarkPalette } from "../generator/types";
 
 const COLOR_TOKEN_MAIL_RECIPIENT = "fremtind.designsystem@fremtind.no";
 
 type ColorTokenMailInput = {
     themeName: string;
-    colorTokens: ThemeDraftColorTokensState;
+    colorTokens: EditableLightDarkPalette;
     includeDarkMode: boolean;
 };
 
@@ -24,7 +24,7 @@ export function createColorTokenMailHref({
 }
 
 function formatColorTokensForMail(
-    colorTokens: ThemeDraftColorTokensState,
+    colorTokens: EditableLightDarkPalette,
     includeDarkMode: boolean,
 ) {
     if (includeDarkMode) {

--- a/portal/src/app/(frontend)/temabygger/_steps/colorTokenMetadata.ts
+++ b/portal/src/app/(frontend)/temabygger/_steps/colorTokenMetadata.ts
@@ -1,7 +1,5 @@
-import type {
-    ThemeDraftColorTokenValue,
-    ThemeDraftColorTokensState,
-} from "../_context/types";
+import type { ThemeDraftColorTokenValue } from "../_context/types";
+import type { EditableLightDarkPalette } from "../generator/types";
 
 export type EditableColorToken = {
     group: string;
@@ -89,7 +87,7 @@ const COLOR_TOKEN_METADATA: Record<string, ColorTokenMetadata> = {
 };
 
 export function getEditableColorTokenGroups(
-    colorTokens: ThemeDraftColorTokensState,
+    colorTokens: EditableLightDarkPalette,
 ): EditableColorTokenGroup[] {
     const groups = new Map<string, EditableColorToken[]>();
 


### PR DESCRIPTION
## 💬 Endringer

Oppdaterer typen som brukes i `createColorTokenMailHref` til `EditableLightDarkPalette`.

Fikser opp i typefeilen som gjør at `jokul-deploy-portal`-workflowen kræsjer.
