### PR TITLE
refactor(portal): samle ColorScheme-definisjon i temabyggeren

### DIFF
--- a/.changeset/curly-rivers-spark.md
+++ b/.changeset/curly-rivers-spark.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Samler definisjonen av fargetemaer i temabyggeren, slik at `ColorScheme` og `COLOR_SCHEMES` har samme kilde.

--- a/portal/src/app/(forhandsvisning)/temabygger/forhandsvisning/_components/ThemePreviewPage.tsx
+++ b/portal/src/app/(forhandsvisning)/temabygger/forhandsvisning/_components/ThemePreviewPage.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type { ColorScheme } from "@/app/(frontend)/temabygger/_components/ThemeBuilder";
 import { useThemeDraft } from "@/app/(frontend)/temabygger/_context/ThemeDraftContext";
 import { ThemePreview } from "@/app/(frontend)/temabygger/_preview/ThemePreview";
 import { createColorTokenMailHref } from "@/app/(frontend)/temabygger/_shared/colorTokenMailHref";
 import { buildThemePreviewStyle } from "@/app/(frontend)/temabygger/_shared/previewStyle";
+import type { ColorScheme } from "@/app/(frontend)/temabygger/generator/types";
 import { Button } from "@fremtind/jokul/button";
 import { Card } from "@fremtind/jokul/card";
 import { Flex } from "@fremtind/jokul/flex";

--- a/portal/src/app/(frontend)/temabygger/_components/ColorTokenField.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ColorTokenField.tsx
@@ -2,9 +2,9 @@
 
 import { Flex } from "@fremtind/jokul/flex";
 import { TextInput } from "@fremtind/jokul/text-input";
-import type { ColorScheme } from "../_components/ThemeBuilder";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import { hexErrorLabel } from "../_shared/utils";
+import type { ColorScheme } from "../generator/types";
 import { ColorPicker } from "./ColorPicker/ColorPicker";
 
 type ColorTokenFieldProps = {

--- a/portal/src/app/(frontend)/temabygger/_components/ThemeBuilder.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ThemeBuilder.tsx
@@ -3,14 +3,8 @@
 import { type ReactNode, useState } from "react";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import { ThemePreview } from "../_preview/ThemePreview";
+import type { ColorScheme } from "../generator/types";
 import { ThemeBuilderLayout } from "./ThemeBuilderLayout";
-
-export type ColorScheme = "light" | "dark";
-
-export const COLOR_SCHEMES = [
-    "light",
-    "dark",
-] as const satisfies readonly ColorScheme[];
 
 type ThemeBuilderProps = {
     children: ReactNode;

--- a/portal/src/app/(frontend)/temabygger/_components/ThemeBuilderLayout.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ThemeBuilderLayout.tsx
@@ -6,8 +6,7 @@ import { Text, Title } from "@fremtind/jokul/typography";
 import { type ReactNode, useMemo } from "react";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import { buildThemePreviewStyle } from "../_shared/previewStyle";
-import type { EditableLightDarkPalette } from "../generator/types";
-import type { ColorScheme } from "./ThemeBuilder";
+import type { ColorScheme, EditableLightDarkPalette } from "../generator/types";
 
 type ThemeBuilderLayoutProps = {
     children: ReactNode;

--- a/portal/src/app/(frontend)/temabygger/_preview/ContrastView.tsx
+++ b/portal/src/app/(frontend)/temabygger/_preview/ContrastView.tsx
@@ -16,9 +16,12 @@ import {
 import { Tag } from "@fremtind/jokul/tag";
 import { Text, Title } from "@fremtind/jokul/typography";
 import { type CSSProperties, useMemo, useState } from "react";
-import { COLOR_SCHEMES, type ColorScheme } from "../_components/ThemeBuilder";
 import type { ThemeDraftColorTokenValue } from "../_context/types";
-import type { EditableLightDarkPalette } from "../generator/types";
+import {
+    COLOR_SCHEMES,
+    type ColorScheme,
+    type EditableLightDarkPalette,
+} from "../generator/types";
 import {
     type ContrastEvaluation,
     type ContrastRating,

--- a/portal/src/app/(frontend)/temabygger/_preview/ThemePreview.tsx
+++ b/portal/src/app/(frontend)/temabygger/_preview/ThemePreview.tsx
@@ -8,8 +8,8 @@ import {
     SegmentedControlButton,
 } from "@fremtind/jokul/segmented-control";
 import { useState } from "react";
-import type { ColorScheme } from "../_components/ThemeBuilder";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
+import type { ColorScheme } from "../generator/types";
 import { ContrastView } from "./ContrastView";
 import { ExampleView } from "./ExampleView";
 

--- a/portal/src/app/(frontend)/temabygger/_preview/contrastEvaluation.ts
+++ b/portal/src/app/(frontend)/temabygger/_preview/contrastEvaluation.ts
@@ -1,8 +1,11 @@
 import { ColorSpace, contrastWCAG21, sRGB } from "colorjs.io/fn";
-import { COLOR_SCHEMES } from "../_components/ThemeBuilder";
 import type { ThemeDraftColorTokenValue } from "../_context/types";
 import { isHex } from "../_shared/utils";
-import type { ColorScheme, EditableLightDarkPalette } from "../generator/types";
+import {
+    COLOR_SCHEMES,
+    type ColorScheme,
+    type EditableLightDarkPalette,
+} from "../generator/types";
 
 const WCAG_TEXT_CONTRAST_AAA = 7;
 const WCAG_TEXT_CONTRAST_AA = 4.5;

--- a/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
@@ -7,8 +7,8 @@ import { Message } from "@fremtind/jokul/message";
 import { Text, Title } from "@fremtind/jokul/typography";
 import Link from "next/link";
 import { ColorTokenField } from "../_components/ColorTokenField";
-import type { ColorScheme } from "../_components/ThemeBuilder";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
+import type { ColorScheme } from "../generator/types";
 import { StepCard } from "./StepCard";
 import {
     type EditableColorTokenGroup,

--- a/portal/src/app/(frontend)/temabygger/generator/types.ts
+++ b/portal/src/app/(frontend)/temabygger/generator/types.ts
@@ -5,8 +5,10 @@ import { color as colorMetadata } from "@fremtind/jokul/tokens/metadata/color.me
 /** En hex-fargestreng som starter med `#`, typisk på formen `#rrggbb` eller `#rrggbbaa`. */
 export type HexColor = `#${string}`;
 
+export const COLOR_SCHEMES = ["light", "dark"] as const;
+
 /** Lys eller mørkt fargetema. */
-export type ColorScheme = "light" | "dark";
+export type ColorScheme = (typeof COLOR_SCHEMES)[number];
 
 /**
  * En streng på formen `"gruppe.rolle"` som identifiserer én bestemt fargetokens


### PR DESCRIPTION
## 💬 Endringer

`COLOR_SCHEMES` er flyttet til fargetypene i generatoren, og `ColorScheme` utledes nå derfra. Da har temabyggeren én kilde for gyldige fargetemaer.

Man kan argumentere for at `ColorScheme`-typene hører hjemme et annet sted, men med planene for mappe- og filstrukturen kan dette være riktig plass inntil videre?

