### PR TITLE
fix(temabygger): styr åpne ExpandablePanel med kontrollert state

### DIFF
--- a/.changeset/fuzzy-lamps-wave.md
+++ b/.changeset/fuzzy-lamps-wave.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Styrer åpent ExpandablePanel i temabyggeren med kontrollert state.

--- a/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
@@ -6,6 +6,7 @@ import { Flex } from "@fremtind/jokul/flex";
 import { Message } from "@fremtind/jokul/message";
 import { Text, Title } from "@fremtind/jokul/typography";
 import Link from "next/link";
+import { useState } from "react";
 import { ColorTokenField } from "../_components/ColorTokenField";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import type { ColorScheme } from "../generator/types";
@@ -99,17 +100,23 @@ function ColorSchemeSection({
 }
 
 function ColorSchemeEditor({
-    colorScheme,
     groups,
     defaultOpenGroup,
+    colorScheme,
 }: ColorSchemeEditorProps) {
+    const [openGroupId, setOpenGroupId] = useState<string | null>(
+        defaultOpenGroup ?? null,
+    );
+
     return (
         <Accordion outlined>
             {groups.map((group) => (
                 <ExpandablePanel
                     key={group.id}
-                    name={colorScheme}
-                    defaultOpen={group.id === defaultOpenGroup}
+                    open={openGroupId === group.id}
+                    onOpenChange={(open) =>
+                        setOpenGroupId(open ? group.id : null)
+                    }
                 >
                     <ExpandablePanel.Header>
                         {group.title}


### PR DESCRIPTION
## 💬 Endringer

Velger å styre `open`-state utenfra foreløpig og ikke bruke `name`-propen. Det fører til at `ExpandablePanel` stopper standardoppførselen på `summary` og styrer `open`-state selv, så når `name` brukes begynner browseren og React å dra i hver sin retning. Ser at det blant annet fører til bugs i temabyggeren hvor paneler plutselig ikke vil åpne seg.

Tror vi burde ta en egen runde på `ExpandablePanel` etter hvert. Uheldig at native `details`-oppførsel ikke fungerer når vi faktisk rendrer et `details`-element.