### PR TITLE
fix(system-message): rett ikonfarge i dark mode

### DIFF
--- a/.changeset/bright-indigo-bridge.md
+++ b/.changeset/bright-indigo-bridge.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser fargen på ikonene i SystemMessage i dark mode.

--- a/packages/jokul/src/components/system-message/SystemMessage.tsx
+++ b/packages/jokul/src/components/system-message/SystemMessage.tsx
@@ -40,7 +40,6 @@ function systemFactory(
                 <div
                     className="jkl-system-message__content"
                     data-testid="system-message-content"
-                    data-theme="light"
                     style={{
                         maxWidth: maxContentWidth,
                         paddingLeft,
@@ -52,7 +51,6 @@ function systemFactory(
                     </span>
                     {dismissAction?.handleDismiss && (
                         <DismissButton
-                            data-theme="light"
                             aria-controls={systemId}
                             className="jkl-system-message__dismiss-button"
                             label={dismissAction.buttonTitle || "Lukk"}
@@ -99,7 +97,6 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
             <div
                 className="jkl-system-message__content"
                 data-testid="system-message-content"
-                data-theme="light"
                 style={{
                     maxWidth: maxContentWidth,
                     paddingLeft,
@@ -109,7 +106,6 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
                 <span className="jkl-system-message__message">{children}</span>
                 {dismissAction?.handleDismiss && (
                     <DismissButton
-                        data-theme="light"
                         aria-controls={systemId}
                         className="jkl-system-message__dismiss-button"
                         label={dismissAction.buttonTitle || "Lukk"}


### PR DESCRIPTION
## 💬 Endringer

Fikser feil farge på ikonene i `SystemMessage` i dark mode ved å la innhold og lukkeknapp arve aktivt tema

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6090
