### PR TITLE
Bytt fra mettet til nøytral fargemetadata i palettgeneratoren

### DIFF
--- a/.changeset/silent-rivers-shift.md
+++ b/.changeset/silent-rivers-shift.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Bytter temabyggerens palettgenerator til nøytral fargemetadata, slik at nye paletter får færre kontrastfeil etter valg av basefarge.

--- a/portal/src/app/(frontend)/temabygger/generator/generate.ts
+++ b/portal/src/app/(frontend)/temabygger/generator/generate.ts
@@ -1,7 +1,7 @@
-import { color as colorMetadataDark } from "@fremtind/jokul/tokens/metadata/color.metadata.saturated.dark.json" with {
+import { color as colorMetadataDark } from "@fremtind/jokul/tokens/metadata/color.metadata.dark.json" with {
     type: "json",
 };
-import { color as colorMetadataLight } from "@fremtind/jokul/tokens/metadata/color.metadata.saturated.light.json" with {
+import { color as colorMetadataLight } from "@fremtind/jokul/tokens/metadata/color.metadata.light.json" with {
     type: "json",
 };
 


### PR DESCRIPTION
## 💬 Endringer

Bytter palettgeneratoren i temabyggeren fra mettet til nøytral fargemetadata.

Med mettet metadata fikk vi fort flere kontrastfeil rett etter at en basefarge var valgt. Den nøytrale metadataen ligger nærmere default-paletten vi allerede har, og gir et bedre utgangspunkt for demoen på fredag
