### PR TITLE
Gjør hele headeren i input-panel klikkbar

### DIFF
--- a/.changeset/tiny-otters-smile.md
+++ b/.changeset/tiny-otters-smile.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Gjør hele headeren i `RadioPanel` og `CheckboxPanel` klikkbar.

--- a/packages/jokul/src/components/input-panel/styles/input-panel.scss
+++ b/packages/jokul/src/components/input-panel/styles/input-panel.scss
@@ -37,6 +37,24 @@
                 inline-size: 100%;
             }
 
+            label::after {
+                content: "";
+                position: absolute;
+                inset: 0;
+            }
+
+            label,
+            .jkl-radio-button,
+            .jkl-checkbox {
+                position: unset;
+            }
+
+            input[type="checkbox"],
+            input[type="radio"] {
+                inset-block-start: var(--jkl-unit-20);
+                inset-inline-start: var(--padding-inline);
+            }
+
             &__amount {
                 display: flex;
                 height: 100%;


### PR DESCRIPTION
## 💬 Endringer

Hele headeren i panelene er nå klikkbar og ikke bare selve radio-/checkbox-labelen.

Dette løser problemet nå, men på sikt burde dette kanskje løses ved at panelvarianten eier riktig input/label-struktur selv, i stedet for at vi justerer klikkflaten rundt Checkbox eller Radio-komponentene?

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6168 
