### PR TITLE
Skjul ikonene til RadioButton og Checkbox fra skjermlesere

### DIFF
--- a/.changeset/late-yaks-cover.md
+++ b/.changeset/late-yaks-cover.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Sørger for at ikke navnet på ikonene til `RadioButton` og `Checkbox` leses opp av skjermlesere.

--- a/packages/jokul/src/components/checkbox/styles/checkbox.scss
+++ b/packages/jokul/src/components/checkbox/styles/checkbox.scss
@@ -44,7 +44,7 @@
 
             &::before {
                 color: var(--icon-color);
-                content: "check_box_outline_blank";
+                content: "check_box_outline_blank" / "";
                 margin-inline-end: 0.25em;
 
                 @include icon.base-styles;
@@ -62,13 +62,13 @@
         }
 
         &__input:checked + &__label::before {
-            content: "check_box";
+            content: "check_box" / "";
 
             --jkl-icon-fill: 1;
         }
 
         &__input:indeterminate:not(:checked) + &__label::before {
-            content: "indeterminate_check_box";
+            content: "indeterminate_check_box" / "";
 
             --jkl-icon-fill: 1;
         }

--- a/packages/jokul/src/components/radio-button/styles/radio-button.scss
+++ b/packages/jokul/src/components/radio-button/styles/radio-button.scss
@@ -42,7 +42,7 @@
 
             &::before {
                 color: var(--icon-color);
-                content: "radio_button_unchecked";
+                content: "radio_button_unchecked" / "";
                 margin-inline-end: 0.25em;
 
                 @include icon.base-styles;
@@ -62,7 +62,7 @@
         }
 
         &__input:checked + &__label::before {
-            content: "radio_button_checked";
+            content: "radio_button_checked" / "";
         }
 
         &__input[aria-invalid="true"] + &__label::before {


### PR DESCRIPTION
## 💬 Endringer

Sørger for at ikke navnet på ikonene til `RadioButton` og `Checkbox` leses opp av skjermlesere.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
Closes #6273 
