### PR TITLE
Vis avkryssede komponenter i kontrasteksempel

### DIFF
--- a/packages/jokul/stories/temabygger/Temabygger.kontrast.stories.tsx
+++ b/packages/jokul/stories/temabygger/Temabygger.kontrast.stories.tsx
@@ -16,13 +16,13 @@ export const Kontrast: Story = {
     render: () => (
         <Flex alignItems="center">
             <Button variant="primary">Knapp</Button>
-            <Checkbox name="kjekkboks" value="kjekkboks">
+            <Checkbox name="kjekkboks" value="kjekkboks" defaultChecked>
                 Kjekkboks
             </Checkbox>
-            <RadioButton name="radio" value="radio">
+            <RadioButton name="radio" value="radio" defaultChecked>
                 Radio
             </RadioButton>
-            <ToggleSwitch />
+            <ToggleSwitch aria-label="Bryter" aria-pressed />
         </Flex>
     ),
 };


### PR DESCRIPTION
## 💬 Endringer

Viser avkryssede komponenter i kontrasteksemplet i Temabyggeren

## 🩹 Løser følgende issues

Closes #6275 
