### PR TITLE
Endre hjelpetekster for fargeroller i temabyggeren

### DIFF
--- a/.changeset/crisp-deltas-sing.md
+++ b/.changeset/crisp-deltas-sing.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Oppdaterer hjelpetekstene for fargeroller i temabyggerens redigeringssteg.

--- a/portal/src/app/(frontend)/temabygger/_steps/colorTokenMetadata.ts
+++ b/portal/src/app/(frontend)/temabygger/_steps/colorTokenMetadata.ts
@@ -44,16 +44,15 @@ const COLOR_TOKEN_METADATA: Record<string, ColorTokenMetadata> = {
     },
     "background.container": {
         label: "Container",
-        description:
-            "Standard farge for fylte flater som ligger på sidebakgrunn",
+        description: "Standard overflate",
     },
     "background.container-accent": {
         label: "Container accent",
-        description: "Fremhevet farge med sterkere knytning til merkevaren",
+        description: "Fremhevet overflate",
     },
     "background.contrast": {
         label: "Background contrast",
-        description: "Kontrastfarge med sterk knytning til merkevaren",
+        description: "Kontrastflate",
         groupId: "contrast",
     },
     "text.default": {
@@ -70,20 +69,20 @@ const COLOR_TOKEN_METADATA: Record<string, ColorTokenMetadata> = {
     },
     "text.on-contrast": {
         label: "Text on contrast",
-        description: "Tekst- og ikonfarge på kontrast bakgrunn",
+        description: "Tekst- og ikonfarge på kontrastflate",
         groupId: "contrast",
     },
     "border.default": {
         label: "Border default",
-        description: "Standard",
+        description: "Standard kantlinje",
     },
     "border.subdued": {
         label: "Border subdued",
-        description: "Nedtonet",
+        description: "Nedtonet kantlinje",
     },
     "border.strong": {
         label: "Border strong",
-        description: "Fremhevet",
+        description: "Fremhevet kantlinje",
     },
 };
 


### PR DESCRIPTION
## 💬 Endringer

Oppdaterer hjelpetekstene for fargerollene i temabyggerens redigeringssteg.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6271 
