### PR TITLE
Bruk text-accent for Link-komponenten

### DIFF
--- a/.changeset/amber-pages-rest.md
+++ b/.changeset/amber-pages-rest.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Oppdaterer lenketeksten i komponentvisningen i temabyggeren.

--- a/.changeset/silver-links-drift.md
+++ b/.changeset/silver-links-drift.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Oppdaterer Link til å bruke text-accent som standard fargerolle.

--- a/packages/jokul/src/components/link/styles/link.scss
+++ b/packages/jokul/src/components/link/styles/link.scss
@@ -3,9 +3,9 @@
 
 @layer jokul.components {
     .jkl-link {
-        --link-color: var(--jkl-color-text-default);
+        --link-color: var(--jkl-color-text-accent);
 
-        color: inherit;
+        color: var(--link-color);
         outline: none;
         text-decoration: none;
 
@@ -64,7 +64,6 @@
         padding: 0;
         margin: 0;
         background: none;
-        line-height: inherit;
         font: inherit;
         text-align: inherit;
     }

--- a/packages/jokul/stories/temabygger/Temabygger.komponenter.stories.tsx
+++ b/packages/jokul/stories/temabygger/Temabygger.komponenter.stories.tsx
@@ -70,7 +70,7 @@ export const KomponentOversikt: Story = {
                         </Text>
                     </Flex>
                     <Flex>
-                        <Link>Accent</Link>
+                        <Link>Link</Link>
                     </Flex>
 
                     <Flex direction="column" gap="16">
@@ -158,7 +158,7 @@ export const KomponentOversikt: Story = {
                         </Text>
                     </Flex>
                     <Flex>
-                        <Link>Accent</Link>
+                        <Link>Link</Link>
                     </Flex>
 
                     <Flex direction="column" gap="16">


### PR DESCRIPTION
## 💬 Endringer

Bruker `text-accent` som standard fargerolle for `Link`, og oppdaterer komponentvisningen i temabyggeren så lenken vises som `Link`.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6270 
