### PR TITLE
Flytt innsending til fargesteget i temabyggeren

### DIFF
--- a/.changeset/quiet-avocados-wave.md
+++ b/.changeset/quiet-avocados-wave.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Flytter innsending til fargesteget i temabyggeren, legger til modal for intern deling av forhåndsvisningslenke, og fjerner innsending fra forhåndsvisningssiden.

--- a/portal/src/app/(forhandsvisning)/temabygger/forhandsvisning/_components/ThemePreviewPage.tsx
+++ b/portal/src/app/(forhandsvisning)/temabygger/forhandsvisning/_components/ThemePreviewPage.tsx
@@ -6,17 +6,12 @@ import {
     useThemePreview,
 } from "@/app/(frontend)/temabygger/_context/ThemePreviewContext";
 import { ThemePreview } from "@/app/(frontend)/temabygger/_preview/ThemePreview";
-import { createColorTokenMailHref } from "@/app/(frontend)/temabygger/_shared/colorTokenMailHref";
 import { buildThemePreviewStyle } from "@/app/(frontend)/temabygger/_shared/previewStyle";
-import { Button } from "@fremtind/jokul/button";
 import { Card } from "@fremtind/jokul/card";
 import { Flex } from "@fremtind/jokul/flex";
-import { Message } from "@fremtind/jokul/message";
 import { Text, Title } from "@fremtind/jokul/typography";
 import { useMemo } from "react";
 import styles from "./theme-preview-page.module.scss";
-
-const DEFAULT_THEME_NAME = "<SpareBank 1>";
 
 export function ThemePreviewPage() {
     return (
@@ -41,36 +36,20 @@ export function ThemePreviewPage() {
 
 function PreviewPageAside() {
     const { draft } = useThemeDraft();
-    const themeName = draft.themeName.trim() || DEFAULT_THEME_NAME;
+    const { themeName } = draft;
 
     return (
         <Card as="aside" padding="l">
-            <Flex direction="column" gap="32">
-                <Flex direction="column" gap="24">
-                    <Title as="h1" size="m">
-                        Forhåndsvisning av tema for {themeName}
-                    </Title>
-                    <Text>
-                        Dette er en visning av hvordan merkevaren deres vil
-                        representeres i Fremtinds designsystem, Jøkul.
-                    </Text>
-                    <Message variant="info">
-                        Vi anbefaler at denne forhåndsvisningen deles internt,
-                        slik at uttrykket er forankret og godkjent før det
-                        sendes til Jøkul.
-                    </Message>
-                </Flex>
-                <Button
-                    as="a"
-                    href={createColorTokenMailHref({
-                        themeName,
-                        colorTokens: draft.colorTokens,
-                        includeDarkMode: draft.includeDarkMode,
-                    })}
-                    variant="primary"
-                >
-                    Send til Jøkul
-                </Button>
+            <Flex direction="column" gap="24">
+                <Title as="h1" size="m">
+                    {themeName
+                        ? `Forhåndsvisning av tema for ${themeName}`
+                        : "Forhåndsvisning av tema"}
+                </Title>
+                <Text>
+                    Dette er en visning av hvordan merkevaren deres vil
+                    representeres i Fremtinds designsystem, Jøkul.
+                </Text>
             </Flex>
         </Card>
     );

--- a/portal/src/app/(frontend)/temabygger/_context/themeDraftReducer.ts
+++ b/portal/src/app/(frontend)/temabygger/_context/themeDraftReducer.ts
@@ -50,7 +50,7 @@ export function themeDraftReducer(
 ): ThemeDraft {
     switch (action.type) {
         case "SET_THEME_NAME":
-            return { ...state, themeName: action.themeName };
+            return { ...state, themeName: action.themeName.trim() };
 
         case "SET_INCLUDE_DARK_MODE":
             return { ...state, includeDarkMode: action.includeDarkMode };
@@ -118,7 +118,10 @@ export function themeDraftReducer(
         }
 
         case "SET_DRAFT":
-            return action.draft;
+            return {
+                ...action.draft,
+                themeName: action.draft.themeName.trim(),
+            };
 
         default:
             action satisfies never;

--- a/portal/src/app/(frontend)/temabygger/_shared/colorTokenMailHref.ts
+++ b/portal/src/app/(frontend)/temabygger/_shared/colorTokenMailHref.ts
@@ -13,7 +13,9 @@ export function createColorTokenMailHref({
     colorTokens,
     includeDarkMode,
 }: ColorTokenMailInput): string {
-    const subject = `Fargetokens for ${themeName}`;
+    const subject = themeName
+        ? `Fargetokens for ${themeName}`
+        : "Fargetokens fra temabygger";
     const body = JSON.stringify({
         color: formatColorTokensForMail(colorTokens, includeDarkMode),
     });

--- a/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/AdjustColorsStep.tsx
@@ -6,7 +6,6 @@ import { Flex } from "@fremtind/jokul/flex";
 import { ErrorIcon } from "@fremtind/jokul/icon";
 import { Message } from "@fremtind/jokul/message";
 import { Title } from "@fremtind/jokul/typography";
-import Link from "next/link";
 import { useState } from "react";
 import { ColorTokenField } from "../_components/ColorTokenField";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
@@ -14,12 +13,14 @@ import {
     type FailingContrastCombination,
     getFailingContrasts,
 } from "../_preview/contrastEvaluation";
+import { createColorTokenMailHref } from "../_shared/colorTokenMailHref";
 import { createThemePreviewHref } from "../_shared/themeDraftPayload";
 import {
     COLOR_SCHEMES,
     type ColorRole,
     type ColorScheme,
 } from "../generator/types";
+import { SharePreviewModal } from "./SharePreviewModal";
 import { StepCard } from "./StepCard";
 import {
     type EditableColorTokenGroup,
@@ -30,69 +31,57 @@ type ContrastErrorLabelsByRole = Partial<Record<ColorRole, string>>;
 
 export function AdjustColorsStep() {
     const { draft } = useThemeDraft();
-    const [hasSubmitted, setHasSubmitted] = useState(false);
+    const [hasTriedToSubmit, setHasTriedToSubmit] = useState(false);
 
-    const themeName = draft.themeName.trim() || "distributøren";
-    const colorTokenGroups = getEditableColorTokenGroups(draft.colorTokens);
-    const colorSchemes: readonly ColorScheme[] = draft.includeDarkMode
-        ? COLOR_SCHEMES
-        : ["light"];
-    const failingContrasts = getFailingContrasts(
-        draft.colorTokens,
-        colorSchemes,
+    const { colorTokens, includeDarkMode, themeName } = draft;
+
+    const editableColorTokenGroups = getEditableColorTokenGroups(colorTokens);
+    const contrastErrors = getFailingContrasts(
+        colorTokens,
+        includeDarkMode ? COLOR_SCHEMES : ["light"],
     );
-    const hasContrastErrors = failingContrasts.length > 0;
+    const hasContrastErrors = contrastErrors.length > 0;
+
     const previewHref = createThemePreviewHref(draft);
-
-    const handlePreviewButtonClick = () => {
-        setHasSubmitted(true);
-    };
-
-    const handleShareClick = async () => {
-        setHasSubmitted(true);
-
-        if (hasContrastErrors) {
-            return;
-        }
-
-        try {
-            const shareUrl = new URL(previewHref, window.location.origin);
-
-            await navigator.clipboard.writeText(shareUrl.toString());
-        } catch {}
-    };
+    const submitMailHref = createColorTokenMailHref({
+        themeName,
+        colorTokens,
+        includeDarkMode,
+    });
 
     return (
         <StepCard>
             <Flex direction="column" gap="32">
                 <Title as="h3" size="m">
-                    Tilpass farger for {themeName}
+                    {themeName
+                        ? `Tilpass farger for ${themeName}`
+                        : "Tilpass farger"}
                 </Title>
                 <Flex direction="column" gap="40">
-                    {draft.includeDarkMode ? (
+                    {includeDarkMode ? (
                         <>
                             <ColorModeAccordion
                                 title="Lyst modus"
                                 colorScheme="light"
-                                groups={colorTokenGroups}
-                                failingContrasts={failingContrasts}
+                                groups={editableColorTokenGroups}
+                                failingContrasts={contrastErrors}
                             />
                             <ColorModeAccordion
                                 title="Mørk modus"
                                 colorScheme="dark"
-                                groups={colorTokenGroups}
-                                failingContrasts={failingContrasts}
+                                groups={editableColorTokenGroups}
+                                failingContrasts={contrastErrors}
                             />
                         </>
                     ) : (
                         <ColorModeAccordion
                             colorScheme="light"
-                            groups={colorTokenGroups}
-                            failingContrasts={failingContrasts}
+                            groups={editableColorTokenGroups}
+                            failingContrasts={contrastErrors}
                         />
                     )}
                 </Flex>
-                {hasSubmitted && hasContrastErrors && (
+                {hasTriedToSubmit && hasContrastErrors && (
                     <Message variant="error" title="Kontrastfeil" role="alert">
                         Noen fargekombinasjoner har for lav kontrast. Juster de
                         markerte feltene før du bruker temaet.
@@ -107,22 +96,16 @@ export function AdjustColorsStep() {
                         <Button
                             type="button"
                             variant="primary"
-                            onClick={handlePreviewButtonClick}
+                            onClick={() => setHasTriedToSubmit(true)}
                         >
-                            Forhåndsvis tema
+                            Send til Jøkul
                         </Button>
                     ) : (
-                        <Button as={Link} href={previewHref} variant="primary">
-                            Forhåndsvis tema
+                        <Button as="a" href={submitMailHref} variant="primary">
+                            Send til Jøkul
                         </Button>
                     )}
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={handleShareClick}
-                    >
-                        Del visning
-                    </Button>
+                    <SharePreviewModal previewHref={previewHref} />
                 </Flex>
             </Flex>
         </StepCard>

--- a/portal/src/app/(frontend)/temabygger/_steps/BaseColorStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/BaseColorStep.tsx
@@ -11,13 +11,15 @@ import { StepCard } from "./StepCard";
 
 export function BaseColorStep() {
     const { draft, dispatch } = useThemeDraft();
-    const themeName = draft.themeName.trim() || "distributøren";
+    const { themeName } = draft;
 
     return (
         <StepCard>
             <Flex direction="column" gap="8">
                 <Title as="h3" size="m">
-                    Fyll inn kontrastfargen til {themeName}
+                    {themeName
+                        ? `Fyll inn kontrastfargen til ${themeName}`
+                        : "Fyll inn kontrastfargen"}
                 </Title>
                 <Text>
                     Vi bruker fargen som utgangspunkt til å generere et tema som

--- a/portal/src/app/(frontend)/temabygger/_steps/SharePreviewModal.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/SharePreviewModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Button } from "@fremtind/jokul/button";
+import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { CheckIcon, CopyIcon } from "@fremtind/jokul/icon";
+import {
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContainer,
+    ModalHeader,
+    ModalOverlay,
+    ModalTitle,
+    useModal,
+} from "@fremtind/jokul/modal";
+import { Text } from "@fremtind/jokul/typography";
+import { useEffect, useState } from "react";
+
+type SharePreviewModalProps = {
+    previewHref: string;
+};
+
+export function SharePreviewModal({ previewHref }: SharePreviewModalProps) {
+    const [modalInstance, { title, overlay, container, modal, closeButton }] =
+        useModal({ title: "Del internt" });
+
+    return (
+        <>
+            <Button
+                type="button"
+                variant="ghost"
+                onClick={() => modalInstance?.show()}
+            >
+                Del internt
+            </Button>
+            <ModalContainer {...container}>
+                <ModalOverlay
+                    {...overlay}
+                    onClick={() => modalInstance?.hide()}
+                />
+                <Modal {...modal}>
+                    <ModalHeader>
+                        <ModalTitle {...title}>Del internt</ModalTitle>
+                        <ModalCloseButton {...closeButton} />
+                    </ModalHeader>
+                    <ModalBody>
+                        <Flex direction="column" gap="40">
+                            <Text>
+                                Vi anbefaler at forhåndsvisningen deles internt,
+                                slik at uttrykket er forankret og godkjent før
+                                det sendes til Jøkul.
+                            </Text>
+                            <Flex direction="column" gap="8">
+                                <Card padding="s" outlined>
+                                    <Flex
+                                        justifyContent="space-between"
+                                        alignItems="center"
+                                        gap="16"
+                                        wrap="nowrap"
+                                    >
+                                        <Text
+                                            as="span"
+                                            title={previewHref}
+                                            style={{
+                                                flex: 1,
+                                                overflow: "hidden",
+                                                whiteSpace: "nowrap",
+                                                textOverflow: "ellipsis",
+                                            }}
+                                        >
+                                            {previewHref}
+                                        </Text>
+                                        <CopyLinkButton
+                                            previewHref={previewHref}
+                                        />
+                                    </Flex>
+                                </Card>
+                                <Text size="s" subdued>
+                                    De du deler lenken med kan ikke redigere
+                                    farger eller fonter.
+                                </Text>
+                            </Flex>
+                        </Flex>
+                    </ModalBody>
+                </Modal>
+            </ModalContainer>
+        </>
+    );
+}
+
+function CopyLinkButton({ previewHref }: { previewHref: string }) {
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!copied) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            setCopied(false);
+        }, 2000);
+
+        return () => window.clearTimeout(timeout);
+    }, [copied]);
+
+    const handleClick = async () => {
+        try {
+            const shareUrl = new URL(
+                previewHref,
+                window.location.origin,
+            ).toString();
+
+            await navigator.clipboard.writeText(shareUrl);
+            setCopied(true);
+        } catch {
+            console.error("Kopiering feilet", previewHref);
+        }
+    };
+
+    return (
+        <Button
+            type="button"
+            variant="ghost"
+            icon={copied ? <CheckIcon /> : <CopyIcon />}
+            iconPosition="right"
+            onClick={handleClick}
+        >
+            {copied ? "Kopiert" : "Kopier"}
+        </Button>
+    );
+}


### PR DESCRIPTION
## 💬 Endringer

Flytter `Send til Jøkul` til fargesteget og legger til `Del internt` med modal og kopiering av lenke. Rydder også bort innsending og infoboks fra forhåndsvisningssiden.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6266 
