### PR TITLE
Fiks plassering av colorpicker ved feilmelding i temabyggeren

### DIFF
--- a/.changeset/green-melons-jam.md
+++ b/.changeset/green-melons-jam.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Holder colorpickeren i temabyggeren på linje med tekstfeltet også når feltet viser feilmelding.

--- a/portal/src/app/(frontend)/temabygger/_components/ColorPicker/ColorPicker.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ColorPicker/ColorPicker.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import type { CSSProperties } from "react";
 import { isHex } from "../../_shared/utils";
 import styles from "./color-picker.module.scss";
@@ -6,19 +7,21 @@ const FALLBACK_COLOR = "#000000";
 
 type ColorPickerProps = {
     "aria-label": string;
+    className?: string;
     value: string;
     onChange: (value: string) => void;
 };
 
 export function ColorPicker({
     "aria-label": ariaLabel,
+    className,
     value,
     onChange,
 }: ColorPickerProps) {
     const pickerValue = isHex(value) ? value : FALLBACK_COLOR;
 
     return (
-        <label className={styles.colorPicker}>
+        <label className={clsx(styles.colorPicker, className)}>
             <span
                 className={styles.swatch}
                 style={

--- a/portal/src/app/(frontend)/temabygger/_components/ColorPicker/color-picker.module.scss
+++ b/portal/src/app/(frontend)/temabygger/_components/ColorPicker/color-picker.module.scss
@@ -1,27 +1,13 @@
 .colorPicker {
-    --color-picker-padding: var(--jkl-unit-02);
+    --color-picker-padding: var(--jkl-unit-10);
 
     position: relative;
-    flex: 0 0 auto;
-    display: inline-flex;
-    width: var(--jkl-unit-60);
-    height: var(--jkl-unit-60);
     padding: var(--color-picker-padding);
     cursor: pointer;
-    background-color: var(--jkl-color-background-container);
     border-radius: var(--jkl-border-radius-s);
-    box-shadow:
-        inset 0 0 0 1px var(--jkl-color-border-default),
-        0 0 0 1px transparent;
 }
 
-.colorPicker:hover {
-    box-shadow:
-        inset 0 0 0 1px var(--jkl-color-border-strong),
-        0 0 0 1px var(--jkl-color-border-strong);
-}
-
-.colorPicker:focus-within {
+.colorPicker:has(input:focus-visible) {
     outline: 3px solid var(--jkl-color-border-strong);
     outline-offset: var(--jkl-unit-05);
 }
@@ -29,10 +15,7 @@
 .swatch {
     width: 100%;
     height: 100%;
-    border-radius: calc(
-        var(--jkl-border-radius-s) - var(--color-picker-padding)
-    );
+    border-radius: var(--jkl-border-radius-xs);
     background-color: var(--theme-builder-color-picker-value);
+    box-shadow: inset 0 0 0 1px var(--jkl-color-border-default);
 }
-
-

--- a/portal/src/app/(frontend)/temabygger/_components/ColorTokenField.tsx
+++ b/portal/src/app/(frontend)/temabygger/_components/ColorTokenField.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Flex } from "@fremtind/jokul/flex";
 import { TextInput } from "@fremtind/jokul/text-input";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
 import { hexErrorLabel } from "../_shared/utils";
@@ -48,24 +47,24 @@ export function ColorTokenField({
             }));
 
     return (
-        <Flex alignItems="end" gap="8" fill>
-            <TextInput
-                label={label}
-                description={description}
-                name={id}
-                value={value}
-                maxLength={7}
-                spellCheck={false}
-                autoComplete="off"
-                errorLabel={hexErrorLabel(value) ?? contrastErrorLabel}
-                width="100%"
-                onChange={(event) => handleValueChange(event.target.value)}
-            />
-            <ColorPicker
-                aria-label={`${accessibleLabel} fargevelger`}
-                value={value}
-                onChange={handleValueChange}
-            />
-        </Flex>
+        <TextInput
+            label={label}
+            description={description}
+            name={id}
+            value={value}
+            maxLength={7}
+            spellCheck={false}
+            autoComplete="off"
+            errorLabel={hexErrorLabel(value) ?? contrastErrorLabel}
+            width="100%"
+            actionButton={
+                <ColorPicker
+                    aria-label={`${accessibleLabel} fargevelger`}
+                    value={value}
+                    onChange={handleValueChange}
+                />
+            }
+            onChange={(event) => handleValueChange(event.target.value)}
+        />
     );
 }


### PR DESCRIPTION
## 💬 Endringer

Colorpickeren holdt ikke plasseringen sin når feltet har kontrastfeil. Flytter den inn i `TextInput`-actionButton proppen, så den holder seg på linje med feltet.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6296 
