### PR TITLE
Fiks styling for klikkbare card som rendres som button

### DIFF
--- a/.changeset/friendly-buses-share.md
+++ b/.changeset/friendly-buses-share.md
@@ -1,0 +1,4 @@
+"@fremtind/jokul": patch
+---
+
+Fikser `Card` rendret som `button`, så det ikke arver nettleserens knappestiler. Klikkbare kort får også riktig border i default og hover.

--- a/packages/jokul/src/components/card/styles/card.scss
+++ b/packages/jokul/src/components/card/styles/card.scss
@@ -22,6 +22,16 @@
         text-decoration: none;
         color: var(--jkl-color-text-default);
 
+        // Lar Card rendres som button uten å arve native knappestiler.
+        &:where(button) {
+            appearance: none;
+            border: 0;
+            margin: 0;
+            background: none;
+            font: inherit;
+            text-align: inherit;
+        }
+
         &::after {
             content: "";
             position: absolute;
@@ -62,6 +72,7 @@
         }
 
         &[data-clickable="true"] {
+            --border-color: var(--jkl-color-border-subdued);
             cursor: pointer;
 
             &:hover {


### PR DESCRIPTION
## 💬 Endringer

Fiks default- og hover-stil for klikkbare `Card` rendret som `button`

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6268 
