### PR TITLE
Lar expander eie bold tittel i open state

### DIFF
--- a/.changeset/quiet-wolves-shop.md
+++ b/.changeset/quiet-wolves-shop.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Lar Expander styre bold tittel i open state.

--- a/packages/jokul/src/components/expander/styles/expandable.scss
+++ b/packages/jokul/src/components/expander/styles/expandable.scss
@@ -116,9 +116,13 @@
             text-align: right;
         }
 
-        &--open {
+        &.jkl-expander--open {
             .jkl-expander__label {
                 @include jkl.no-grow-bold;
+            }
+
+            .jkl-expander__label * {
+                font-weight: inherit;
             }
 
             .jkl-expander__chevron {


### PR DESCRIPTION
## 💬 Endringer

Flytter ansvaret for `bold` tittel i open state inn i `Expander`, så det ikke må løses lokalt i hver enkelt bruk, samtidig som det fortsatt er mulig å overstyre ved behov.
