### PR TITLE
fix: Setter display font til det samme som regular font, men lar bruk…

### DIFF
--- a/portal/src/app/(frontend)/temabygger/_context/themeDraftReducer.ts
+++ b/portal/src/app/(frontend)/temabygger/_context/themeDraftReducer.ts
@@ -1,5 +1,5 @@
 import {
-    DEFAULT_FONT_OPTION_ID,
+    DEFAULT_REGULAR_FONT_OPTION_ID,
     type FontOptionId,
 } from "../_shared/fontOptions";
 import { isHex, normalizeHex } from "../_shared/utils";
@@ -14,8 +14,9 @@ import type { ThemeDraft } from "./types";
 
 export const INITIAL_STATE = {
     colorTokens: INITIAL_COLOR_TOKENS,
-    regularFont: DEFAULT_FONT_OPTION_ID,
-    displayFont: DEFAULT_FONT_OPTION_ID,
+    regularFont: DEFAULT_REGULAR_FONT_OPTION_ID,
+    displayFont: DEFAULT_REGULAR_FONT_OPTION_ID,
+    hasCustomDisplayFont: false,
     themeName: "",
     includeDarkMode: true,
 } as const satisfies ThemeDraft;
@@ -56,10 +57,20 @@ export function themeDraftReducer(
             return { ...state, includeDarkMode: action.includeDarkMode };
 
         case "SET_REGULAR_FONT":
-            return { ...state, regularFont: action.font };
+            return {
+                ...state,
+                regularFont: action.font,
+                displayFont: state.hasCustomDisplayFont
+                    ? state.displayFont
+                    : action.font,
+            };
 
         case "SET_DISPLAY_FONT":
-            return { ...state, displayFont: action.font };
+            return {
+                ...state,
+                displayFont: action.font,
+                hasCustomDisplayFont: true,
+            };
 
         case "SET_COLOR_TOKENS":
             return { ...state, colorTokens: action.tokens };

--- a/portal/src/app/(frontend)/temabygger/_context/types.ts
+++ b/portal/src/app/(frontend)/temabygger/_context/types.ts
@@ -7,6 +7,7 @@ export type ThemeDraft = {
     colorTokens: EditableLightDarkPalette;
     regularFont: FontOptionId;
     displayFont: FontOptionId;
+    hasCustomDisplayFont: boolean;
     themeName: string;
     includeDarkMode: boolean;
 };

--- a/portal/src/app/(frontend)/temabygger/_shared/fontOptions.ts
+++ b/portal/src/app/(frontend)/temabygger/_shared/fontOptions.ts
@@ -1,66 +1,93 @@
 export const FONT_OPTIONS = {
     "inter-variable": {
         label: "Inter Variable",
-        font: {
-            family: {
-                regular:
-                    "'Jokul', 'Adjusted Arial Fallback', arial, sans-serif",
-                display:
-                    "'Jokul Display', 'Adjusted Arial Display Fallback', arial, sans-serif",
-            },
-            weight: {
-                normal: "380",
-                bold: "530",
-            },
+        family: "'Jokul', 'Adjusted Arial Fallback', arial, sans-serif",
+        weight: {
+            normal: "380",
+            bold: "530",
+        },
+    },
+    "inter-variable-display": {
+        label: "Inter Variable Display",
+        family: "'Jokul Display', 'Adjusted Arial Display Fallback', arial, sans-serif",
+        weight: {
+            normal: "380",
+            bold: "530",
         },
     },
     sparebank1: {
         label: "SpareBank 1",
-        font: {
-            family: {
-                regular: "'SpareBank 1', sans-serif",
-                display: "'SpareBank 1 Display', sans-serif",
-            },
-            weight: {
-                normal: "400",
-                bold: "600",
-            },
+        family: "'SpareBank 1', sans-serif",
+        weight: {
+            normal: "400",
+            bold: "600",
+        },
+    },
+    "sparebank1-display": {
+        label: "SpareBank 1 Display",
+        family: "'SpareBank 1 Display', sans-serif",
+        weight: {
+            normal: "400",
+            bold: "600",
         },
     },
     "dnb-sans": {
         label: "DNB Sans",
-        font: {
-            family: {
-                regular: "'DNB Sans', sans-serif",
-                display: "'DNB Sans', sans-serif",
-            },
-            weight: {
-                normal: "400",
-                bold: "500",
-            },
+        family: "'DNB Sans', sans-serif",
+        weight: {
+            normal: "400",
+            bold: "500",
         },
     },
     "open-sans": {
         label: "Open Sans",
-        font: {
-            family: {
-                regular: "'Open Sans', sans-serif",
-                display: "'Open Sans', sans-serif",
-            },
-            weight: {
-                normal: "400",
-                bold: "600",
-            },
+        family: "'Open Sans', sans-serif",
+        weight: {
+            normal: "400",
+            bold: "600",
         },
     },
 } as const;
 
+export const REGULAR_FONT_SELECT_OPTIONS = [
+    {
+        label: FONT_OPTIONS["inter-variable"].label,
+        value: "inter-variable",
+    },
+    {
+        label: FONT_OPTIONS.sparebank1.label,
+        value: "sparebank1",
+    },
+    {
+        label: FONT_OPTIONS["dnb-sans"].label,
+        value: "dnb-sans",
+    },
+    {
+        label: FONT_OPTIONS["open-sans"].label,
+        value: "open-sans",
+    },
+] satisfies Array<{
+    label: string;
+    value: FontOptionId;
+}>;
+
 export type FontOptionId = keyof typeof FONT_OPTIONS;
 export type FontOption = (typeof FONT_OPTIONS)[FontOptionId];
 
-export const DEFAULT_FONT_OPTION_ID = "inter-variable" satisfies FontOptionId;
+export const DEFAULT_REGULAR_FONT_OPTION_ID =
+    "inter-variable" satisfies FontOptionId;
+
+export const DEFAULT_DISPLAY_FONT_OPTION_ID =
+    "inter-variable-display" satisfies FontOptionId;
 
 export const FONT_SELECT_OPTIONS = Object.entries(FONT_OPTIONS).map(
+    ([id, option]) => ({
+        label: option.label,
+        value: id as FontOptionId,
+    }),
+);
+
+export const DISPLAY_FONT_SELECT_OPTIONS = Object.entries(FONT_OPTIONS).map(
     ([id, option]) => ({
         label: option.label,
         value: id as FontOptionId,

--- a/portal/src/app/(frontend)/temabygger/_shared/previewStyle.ts
+++ b/portal/src/app/(frontend)/temabygger/_shared/previewStyle.ts
@@ -20,10 +20,10 @@ export function buildThemePreviewStyle({
 
     return {
         ...buildColorStyle(tokens, includeDarkMode),
-        "--jkl-font-family-regular": regularFontOption.font.family.regular,
-        "--jkl-font-family-display": displayFontOption.font.family.display,
-        "--jkl-font-weight-normal": regularFontOption.font.weight.normal,
-        "--jkl-font-weight-bold": regularFontOption.font.weight.bold,
+        "--jkl-font-family-regular": regularFontOption.family,
+        "--jkl-font-family-display": displayFontOption.family,
+        "--jkl-font-weight-normal": regularFontOption.weight.normal,
+        "--jkl-font-weight-bold": regularFontOption.weight.bold,
     } as CSSProperties;
 }
 

--- a/portal/src/app/(frontend)/temabygger/_steps/IdentityStep.tsx
+++ b/portal/src/app/(frontend)/temabygger/_steps/IdentityStep.tsx
@@ -7,7 +7,11 @@ import { TextInput } from "@fremtind/jokul/text-input";
 import { Title } from "@fremtind/jokul/typography";
 import Link from "next/link";
 import { useThemeDraft } from "../_context/ThemeDraftContext";
-import { FONT_SELECT_OPTIONS, type FontOptionId } from "../_shared/fontOptions";
+import {
+    DISPLAY_FONT_SELECT_OPTIONS,
+    type FontOptionId,
+    REGULAR_FONT_SELECT_OPTIONS,
+} from "../_shared/fontOptions";
 import { StepCard } from "./StepCard";
 
 export function IdentityStep() {
@@ -35,7 +39,7 @@ export function IdentityStep() {
                 <Select
                     name="regularFont"
                     label="Velg font"
-                    items={FONT_SELECT_OPTIONS}
+                    items={REGULAR_FONT_SELECT_OPTIONS}
                     width="100%"
                     value={draft.regularFont}
                     onChange={(event) =>
@@ -49,7 +53,7 @@ export function IdentityStep() {
                     name="displayFont"
                     label="Velg display font"
                     description="Brukes til store overskrifter"
-                    items={FONT_SELECT_OPTIONS}
+                    items={DISPLAY_FONT_SELECT_OPTIONS}
                     width="100%"
                     value={draft.displayFont}
                     onChange={(event) =>


### PR DESCRIPTION

## 💬 Endringer

Skrev om logikken bak hvordan fonter velges i de to selectene: 

- Gjort det mulig å velge regularfont og displayfont uavhengig av hverandre.
- Dersom brukeren manuelt velger en displayfont, beholdes dette valget selv om regularfont endres senere.
- Introdusert en egen state (hasCustomDisplayFont) for å holde oversikt over om displayfont er tilpasset av brukeren.
- Flyttet logikken for synkronisering av fonter til reduceren, slik at komponentene kun trenger å dispatch-e handlinger av brukeren.
- Utvidet fontvalgene slik at displayfont-selecten kan vise både regular- og displayvarianter av fonter der dette finnes.
## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #NNNN
