### PR TITLE
Småfiks i noen av ikonene

### DIFF
--- a/.changeset/spicy-numbers-pick.md
+++ b/.changeset/spicy-numbers-pick.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Bruker ikon direkte fra Material Symbols for `GreenCheckIcon` og `RedCrossIcon`, og merker `bold`-propen som deprecated (den har ikke hatt effekt siden Jøkul 5.0). Overskriver `filled`-propen for ikoner som alltid skal være fylt.

--- a/packages/jokul/src/components/icon/Icon.tsx
+++ b/packages/jokul/src/components/icon/Icon.tsx
@@ -4,33 +4,12 @@ import type {
     PolymorphicPropsWithRef,
     PolymorphicRef,
 } from "../../utilities/polymorphism/polymorphism.js";
-import type { IconVariant } from "./types.js";
+import type { IconProps } from "./types.js";
 
-type IconComponentProps<
-    ElementType extends "span" | "div",
-> = PolymorphicPropsWithRef<
-    ElementType,
-    {
-        "data-testid"?: string;
-        /**
-         * Størrelsesvarianten til ikonet. `"small"` er 16px med 20px bounding box, og `"medium"` er 20px med 24px bounding box.
-         * `"inherit"` setter størrelsen til ikonet (ikke bounding box) lik skriftstørrelsen (1em).
-         */
-        variant?: IconVariant;
-        /**
-         * Angir om ikonet skal vises i fet versjon
-         * @default false
-         */
-        bold?: boolean;
-        filled?: boolean;
-        className?: string;
-        style?: React.CSSProperties;
-    }
->;
+type IconComponentProps<ElementType extends "span" | "div"> =
+    PolymorphicPropsWithRef<ElementType, IconProps>;
 
-export type IconComponent = (<
-    ElementType extends "span" | "div" = "span",
->(
+export type IconComponent = (<ElementType extends "span" | "div" = "span">(
     props: IconComponentProps<ElementType>,
 ) => React.ReactElement | null) & { displayName?: string };
 

--- a/packages/jokul/src/components/icon/icons/ErrorIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/ErrorIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
 export const ErrorIcon: IconComponent = (props: IconProps) => (
-    <Icon bold filled {...props}>
+    <Icon {...props} filled>
         {"\ue82a"}
     </Icon>
 );

--- a/packages/jokul/src/components/icon/icons/GreenCheckIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/GreenCheckIcon.tsx
@@ -3,9 +3,12 @@ import React from "react";
 import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
-export const GreenCheckIcon: IconComponent = (props: IconProps) => (
-    <Icon {...props} className={clsx("jkl-icon-green-check", props.className)}>
-        {"\ue5ca"}
+export const GreenCheckIcon: IconComponent = ({
+    className,
+    ...props
+}: IconProps) => (
+    <Icon {...props} filled className={clsx("jkl-icon-green-check", className)}>
+        {"\uf0be"}
     </Icon>
 );
 GreenCheckIcon.displayName = "GreenCheckIcon";

--- a/packages/jokul/src/components/icon/icons/InfoIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/InfoIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
 export const InfoIcon: IconComponent = (props: IconProps) => (
-    <Icon bold filled {...props}>
+    <Icon {...props} filled>
         {"\ue88e"}
     </Icon>
 );

--- a/packages/jokul/src/components/icon/icons/RedCrossIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/RedCrossIcon.tsx
@@ -3,9 +3,12 @@ import React from "react";
 import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
-export const RedCrossIcon: IconComponent = (props: IconProps) => (
-    <Icon {...props} className={clsx("jkl-icon-red-cross", props.className)}>
-        {"\ue5cd"}
+export const RedCrossIcon: IconComponent = ({
+    className,
+    ...props
+}: IconProps) => (
+    <Icon {...props} filled className={clsx("jkl-icon-red-cross", className)}>
+        {"\ue5c9"}
     </Icon>
 );
 RedCrossIcon.displayName = "RedCrossIcon";

--- a/packages/jokul/src/components/icon/icons/SuccessIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/SuccessIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
 export const SuccessIcon: IconComponent = (props: IconProps) => (
-    <Icon bold filled {...props}>
+    <Icon {...props} filled>
         {"\uf0be"}
     </Icon>
 );

--- a/packages/jokul/src/components/icon/icons/WarningIcon.tsx
+++ b/packages/jokul/src/components/icon/icons/WarningIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, type IconComponent } from "../Icon.js";
 import type { IconProps } from "../types.js";
 
 export const WarningIcon: IconComponent = (props: IconProps) => (
-    <Icon bold filled {...props}>
+    <Icon {...props} filled>
         {"\uf083"}
     </Icon>
 );

--- a/packages/jokul/src/components/icon/styles/icon.scss
+++ b/packages/jokul/src/components/icon/styles/icon.scss
@@ -17,31 +17,12 @@
         }
     }
 
-    .jkl-icon-red-cross,
-    .jkl-icon-green-check {
-        width: 1.3em;
-        height: 1.3em;
-        box-sizing: border-box;
-        border-radius: 999px;
-        display: inline-grid;
-        place-items: center;
-        font-size: 1em;
-
-        @include jkl.forced-colors-mode {
-            background-color: Canvas;
-            color: CanvasText;
-            border: 1px solid CanvasText;
-        }
-    }
-
     .jkl-icon-red-cross {
-        background-color: var(--jkl-color-error-background-contrast);
-        color: var(--jkl-color-error-text-on-contrast);
+        color: var(--jkl-color-error-background-contrast);
     }
 
     .jkl-icon-green-check {
-        background-color: var(--jkl-color-success-background-contrast);
-        color: var(--jkl-color-success-text-on-contrast);
+        color: var(--jkl-color-success-background-contrast);
     }
 
     .jkl-animated-horizontal-arrows,

--- a/packages/jokul/src/components/icon/types.ts
+++ b/packages/jokul/src/components/icon/types.ts
@@ -1,7 +1,6 @@
 export type IconVariant = "inherit" | "small" | "medium";
 
 export interface IconProps {
-    as?: "div" | "span";
     "data-testid"?: string;
     /**
      * @deprecated Størrelsen settes nå automatisk etter fontstørrelse.
@@ -11,7 +10,7 @@ export interface IconProps {
      */
     variant?: IconVariant;
     /**
-     * Angir om ikonet skal vises i fet versjon
+     * @deprecated Fra Jøkul 5.0 har ikonene alltid samme vekt, og bold har ingen effekt
      * @default false
      */
     bold?: boolean;


### PR DESCRIPTION
## 💬 Endringer

- Bruker ikon direkte fra Material Symbols for `GreenCheckIcon` og `RedCrossIcon`
- Merker `bold`-propen som deprecated (den har ikke hatt effekt siden Jøkul 5.0).
- Overskriver `filled`-propen for ikoner som alltid skal være fylt.

## 🩹 Løser følgende issues

Closes #6259 (Sannsynligvis. Vi har ikke reprodusert feilen, men den skal ikke kunne oppstå med disse endringene)
