### PR TITLE
docs(changeset): Description har nå fått egen id i InputGroup, slik a…

### DIFF
--- a/.changeset/witty-dots-study.md
+++ b/.changeset/witty-dots-study.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Description har nå fått egen id i InputGroup, slik at denne leses opp av skjermlesere på lik linje som support-labels.

--- a/packages/jokul/src/components/input-group/InputGroup.tsx
+++ b/packages/jokul/src/components/input-group/InputGroup.tsx
@@ -25,6 +25,7 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
 
         const uid = useId(id || "jkl-input", { generateSuffix: !id });
         const supportId = useId("jkl-support-label");
+        const descriptionId = useId("jkl-description");
 
         const hasTooltip = !!tooltip;
 
@@ -35,7 +36,13 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
               ? "help"
               : undefined;
 
-        const describedBy = supportText ? supportId : undefined;
+        const describedBy =
+            [
+                description ? descriptionId : undefined,
+                supportText ? supportId : undefined,
+            ]
+                .filter(Boolean)
+                .join(" ") || undefined;
 
         const inputProps: InputProps = {
             "aria-describedby": describedBy,
@@ -87,7 +94,12 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
                     )}
                 </Label>
                 {description && (
-                    <p className="jkl-input-group-description">{description}</p>
+                    <p
+                        id={descriptionId}
+                        className="jkl-input-group-description"
+                    >
+                        {description}
+                    </p>
                 )}
                 {renderInput()}
                 <SupportLabel


### PR DESCRIPTION
…t denne leses opp av skjermlesere på lik linje som support-labels.

## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6327 
