### PR TITLE
feat: legger til mønster som en sidetype i Sanity.

### DIFF
--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -196,6 +196,36 @@ export default async function Page({ params }: Props) {
                                 </>
                             ) : null}
 
+                            {component.related_patterns &&
+                            component.related_patterns.length > 0 ? (
+                                <>
+                                    <h2>Brukes i mønstre</h2>
+                                    <OverviewGridWithPreferences
+                                        initialPreferences={userPreferences}
+                                    >
+                                        {component.related_patterns.map(
+                                            (pattern) => (
+                                                <OverviewCardWithPreferences
+                                                    key={pattern.slug}
+                                                    title={pattern.name || ""}
+                                                    description={
+                                                        pattern.short_description ||
+                                                        ""
+                                                    }
+                                                    image={{
+                                                        light: pattern.image,
+                                                    }}
+                                                    link={`/monster/${pattern.slug}`}
+                                                    initialPreferences={
+                                                        userPreferences
+                                                    }
+                                                />
+                                            ),
+                                        )}
+                                    </OverviewGridWithPreferences>
+                                </>
+                            ) : null}
+
                             <PageFooter name={component.name} />
                         </>
                     ) : (

--- a/portal/src/app/(frontend)/monster/MonsterFilter.tsx
+++ b/portal/src/app/(frontend)/monster/MonsterFilter.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Select } from "@fremtind/jokul/select";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type MonsterFilterProps = {
+    options: { label: string; value: string }[];
+    selected: string;
+};
+
+export function MonsterFilter({ options, selected }: MonsterFilterProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    return (
+        <Select
+            name="komponent"
+            label="Filtrer på komponent"
+            searchable
+            width="20rem"
+            value={selected}
+            items={[{ label: "Alle komponenter", value: "" }, ...options]}
+            onChange={(event) => {
+                const params = new URLSearchParams(searchParams.toString());
+                const value = event.target.value;
+                if (value) {
+                    params.set("komponent", value);
+                } else {
+                    params.delete("komponent");
+                }
+                router.push(`${pathname}?${params.toString()}`);
+            }}
+        />
+    );
+}

--- a/portal/src/app/(frontend)/monster/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/monster/[slug]/page.tsx
@@ -1,0 +1,117 @@
+import { PageFooter } from "@/components/PageFooter";
+import { ArticleHeader } from "@/components/article/header";
+import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
+import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
+import { PortableText } from "@/components/portable-text/PortableText";
+import { getSanityImageUrl } from "@/sanity/lib/image";
+import { sanityFetch } from "@/sanity/lib/live";
+import { monsterBySlugQuery } from "@/sanity/queries/monster";
+import { parseUserPreferences } from "@/utils/user-preferences";
+import { getCookie } from "cookies-next";
+import { logger } from "logger";
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+
+type Props = {
+    params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const slug = (await params).slug;
+
+    const { data: monster } = await sanityFetch({
+        query: monsterBySlugQuery,
+        params: { slug },
+        requestTag: "monster",
+        tags: [`jokul_monster:${slug}`],
+    });
+
+    const ogImage = getSanityImageUrl(monster?.image);
+
+    return {
+        title: monster?.name || "Mønster",
+        description: monster?.short_description || undefined,
+        openGraph: {
+            title: monster?.name || "Mønster",
+            description: monster?.short_description || undefined,
+            images: ogImage ? [{ url: ogImage }] : undefined,
+        },
+    };
+}
+
+export default async function MonsterPage({ params }: Props) {
+    const { slug } = await params;
+
+    const { data: monster } = await sanityFetch({
+        query: monsterBySlugQuery,
+        params: { slug },
+        requestTag: "monster",
+        tags: [`jokul_monster:${slug}`],
+    });
+
+    if (!monster) {
+        logger.warn("Mønster not found", { slug });
+        return null;
+    }
+
+    const userPreferences = parseUserPreferences(
+        await getCookie("userPreferences", { cookies }),
+    );
+
+    return (
+        <article className="prose">
+            <ArticleHeader
+                title={monster.name || ""}
+                description={monster.short_description}
+                date={{ updated: new Date(monster._updatedAt) }}
+                backLink={{ href: "/monster", label: "Mønster" }}
+            />
+            {monster.article ? <PortableText blocks={monster.article} /> : null}
+            {monster.related_components &&
+            monster.related_components.length > 0 ? (
+                <>
+                    <h2>Relevante komponenter</h2>
+                    <OverviewGridWithPreferences
+                        initialPreferences={userPreferences}
+                    >
+                        {monster.related_components.map((component) => (
+                            <OverviewCardWithPreferences
+                                key={component.slug}
+                                title={component.name || ""}
+                                description={component.short_description || ""}
+                                image={{
+                                    light: component.image,
+                                    dark: component.imageDark,
+                                }}
+                                link={`/komponenter/${component.slug}`}
+                                initialPreferences={userPreferences}
+                            />
+                        ))}
+                    </OverviewGridWithPreferences>
+                </>
+            ) : null}
+
+            {monster.related_patterns && monster.related_patterns.length > 0 ? (
+                <>
+                    <h2>Relaterte mønstre</h2>
+                    <OverviewGridWithPreferences
+                        initialPreferences={userPreferences}
+                    >
+                        {monster.related_patterns.map((pattern) => (
+                            <OverviewCardWithPreferences
+                                key={pattern.slug}
+                                title={pattern.name || ""}
+                                description={pattern.short_description || ""}
+                                image={{ light: pattern.image }}
+                                link={`/monster/${pattern.slug}`}
+                                initialPreferences={userPreferences}
+                            />
+                        ))}
+                    </OverviewGridWithPreferences>
+                </>
+            ) : null}
+
+            <PageFooter />
+        </article>
+    );
+}

--- a/portal/src/app/(frontend)/monster/page.tsx
+++ b/portal/src/app/(frontend)/monster/page.tsx
@@ -1,0 +1,82 @@
+import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
+import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
+import { OverviewHeader } from "@/components/overview/header";
+import { sanityFetch } from "@/sanity/lib/live";
+import { monstreQuery } from "@/sanity/queries/monster";
+import { parseUserPreferences } from "@/utils/user-preferences";
+import { getCookie } from "cookies-next";
+import { logger } from "logger";
+import { cookies } from "next/headers";
+import { MonsterFilter } from "./MonsterFilter";
+
+export default async function MonstrePage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | undefined }>;
+}) {
+    logger.info("Rendering mønster overview page");
+
+    let { data: monstre } = await sanityFetch({
+        query: monstreQuery,
+        requestTag: "monster-overview",
+        tags: ["jokul_monster"],
+    });
+
+    if (!monstre) {
+        logger.warn("No mønstre found");
+        return (
+            <>
+                <OverviewHeader title="Mønster" />
+                <p>Fant ingen mønstre :(</p>
+            </>
+        );
+    }
+
+    const userPreferences = parseUserPreferences(
+        await getCookie("userPreferences", { cookies }),
+    );
+
+    const { komponent } = await searchParams;
+
+    const componentOptions = Array.from(
+        monstre
+            .flatMap((m) => m.related_components || [])
+            .reduce((map, c) => {
+                if (c?.slug) map.set(c.slug, c.name ?? c.slug);
+                return map;
+            }, new Map<string, string>())
+            .entries(),
+    )
+        .map(([value, label]) => ({ value, label }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+    if (komponent) {
+        logger.info(`Filtering mønstre by component: ${komponent}`);
+        monstre = monstre.filter((m) =>
+            (m.related_components || []).some((c) => c?.slug === komponent),
+        );
+    }
+
+    return (
+        <>
+            <OverviewHeader title="Mønster" showToolbar>
+                <MonsterFilter
+                    options={componentOptions}
+                    selected={komponent ?? ""}
+                />
+            </OverviewHeader>
+            <OverviewGridWithPreferences initialPreferences={userPreferences}>
+                {monstre.map((monster) => (
+                    <OverviewCardWithPreferences
+                        key={monster.slug}
+                        title={monster.name || ""}
+                        description={monster.short_description || ""}
+                        image={{ light: monster.image }}
+                        link={`/monster/${monster.slug}`}
+                        initialPreferences={userPreferences}
+                    />
+                ))}
+            </OverviewGridWithPreferences>
+        </>
+    );
+}

--- a/portal/src/components/layout/header/navigation/menu/data.ts
+++ b/portal/src/components/layout/header/navigation/menu/data.ts
@@ -1,1 +1,5 @@
-export const navigationLinks = ["komponenter", "fundamenter"];
+export const navigationLinks = [
+    { href: "/fundamenter", label: "Fundamenter" },
+    { href: "/komponenter", label: "Komponenter" },
+    { href: "/monster", label: "Mønster" },
+];

--- a/portal/src/components/layout/header/navigation/menu/hamburger/HamburgerMenu.tsx
+++ b/portal/src/components/layout/header/navigation/menu/hamburger/HamburgerMenu.tsx
@@ -30,9 +30,9 @@ export const HamburgerMenu = () => {
                 className={styles.hamburger}
                 onClick={() => setOpen(!open)}
             >
-                {navigationLinks.map((link) => (
-                    <HamburgerMenuItem key={link} href={`/${link}`}>
-                        {link.charAt(0).toUpperCase() + link.slice(1)}
+                {navigationLinks.map(({ href, label }) => (
+                    <HamburgerMenuItem key={href} href={href}>
+                        {label}
                     </HamburgerMenuItem>
                 ))}
             </Popover.Content>

--- a/portal/src/components/layout/header/navigation/menu/list/List.tsx
+++ b/portal/src/components/layout/header/navigation/menu/list/List.tsx
@@ -18,9 +18,9 @@ export const NavigationList = () => {
             style={{ listStyleType: "none", padding: 0, margin: 0 }}
             className={styles.list}
         >
-            {navigationLinks.map((link) => (
-                <Button as={Link} href={`/${link}`} variant="ghost" key={link}>
-                    {link.charAt(0).toUpperCase() + link.slice(1)}
+            {navigationLinks.map(({ href, label }) => (
+                <Button as={Link} href={href} variant="ghost" key={href}>
+                    {label}
                 </Button>
             ))}
         </Flex>

--- a/portal/src/components/layout/header/navigation/search/Results.tsx
+++ b/portal/src/components/layout/header/navigation/search/Results.tsx
@@ -17,7 +17,7 @@ type SearchResult = {
     slug: { current?: string } | null;
     short_description: string | null;
     image: string | null;
-    type: "Komponent" | "Fundament" | "Blogg";
+    type: "Komponent" | "Fundament" | "Blogg" | "Mønster";
     href: string;
 };
 
@@ -44,7 +44,8 @@ const getRankScore = (result: SearchResult, query: string) => {
     }
 
     const blogPenalty = result.type === "Blogg" ? 10_000 : 0;
-    return best + blogPenalty;
+    const monsterPenalty = result.type === "Mønster" ? 5_000 : 0;
+    return best + blogPenalty + monsterPenalty;
 };
 
 const escapeRegExp = (value: string) =>

--- a/portal/src/components/portable-text/link/InternalLink.tsx
+++ b/portal/src/components/portable-text/link/InternalLink.tsx
@@ -19,7 +19,8 @@ type InternalLinkArticle = {
         | "jokul_blog_post"
         | "jokul_fundamentals"
         | "jokul_release_notes"
-        | "jokul_temaside";
+        | "jokul_temaside"
+        | "jokul_monster";
     name: string | null;
     short_description: string | null;
     slug: string | null;
@@ -38,6 +39,7 @@ const ARTICLE_TYPE_TO_PATH: Record<InternalLinkArticle["_type"], string> = {
     jokul_fundamentals: "/fundamenter",
     jokul_release_notes: "/release-notes",
     jokul_temaside: "/tema",
+    jokul_monster: "/monster",
 };
 
 export const InternalLink = ({ value, children }: LinkProps) => {

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -146,6 +146,32 @@
                   }
                 },
                 "dereferencesTo": "jokul_temaside"
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "jokul_monster"
               }
             ]
           },
@@ -600,6 +626,32 @@
                                                   }
                                                 },
                                                 "dereferencesTo": "jokul_release_notes"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "attributes": {
+                                                  "_ref": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "_type": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "string",
+                                                      "value": "reference"
+                                                    }
+                                                  },
+                                                  "_weak": {
+                                                    "type": "objectAttribute",
+                                                    "value": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "optional": true
+                                                  }
+                                                },
+                                                "dereferencesTo": "jokul_monster"
                                               }
                                             ]
                                           },
@@ -640,6 +692,10 @@
                                               {
                                                 "type": "string",
                                                 "value": "fundamenter"
+                                              },
+                                              {
+                                                "type": "string",
+                                                "value": "monster"
                                               },
                                               {
                                                 "type": "string",
@@ -2431,6 +2487,32 @@
                                         }
                                       },
                                       "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
                                     }
                                   ]
                                 },
@@ -3173,6 +3255,32 @@
                                         }
                                       },
                                       "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
                                     }
                                   ]
                                 },
@@ -4168,6 +4276,32 @@
                                         }
                                       },
                                       "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
                                     }
                                   ]
                                 },
@@ -4781,6 +4915,32 @@
                                         }
                                       },
                                       "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
                                     }
                                   ]
                                 },
@@ -5401,6 +5561,32 @@
                                         }
                                       },
                                       "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
                                     }
                                   ]
                                 },
@@ -5782,6 +5968,780 @@
           "type": "array",
           "of": {
             "type": "string"
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "jokul_monster",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "jokul_monster"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      },
+      "short_description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "image": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "article": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "union",
+            "of": [
+              {
+                "type": "object",
+                "attributes": {
+                  "children": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "object",
+                        "attributes": {
+                          "marks": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "string"
+                              }
+                            },
+                            "optional": true
+                          },
+                          "text": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "span"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "optional": true
+                  },
+                  "style": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": [
+                        {
+                          "type": "string",
+                          "value": "normal"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h1"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h2"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h3"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h4"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h5"
+                        },
+                        {
+                          "type": "string",
+                          "value": "h6"
+                        },
+                        {
+                          "type": "string",
+                          "value": "blockquote"
+                        }
+                      ]
+                    },
+                    "optional": true
+                  },
+                  "listItem": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "union",
+                      "of": [
+                        {
+                          "type": "string",
+                          "value": "bullet"
+                        },
+                        {
+                          "type": "string",
+                          "value": "number"
+                        },
+                        {
+                          "type": "string",
+                          "value": "check"
+                        },
+                        {
+                          "type": "string",
+                          "value": "cross"
+                        }
+                      ]
+                    },
+                    "optional": true
+                  },
+                  "markDefs": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "href": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                },
+                                "optional": true
+                              },
+                              "blank": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "boolean"
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "link"
+                                }
+                              }
+                            },
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "article": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "union",
+                                  "of": [
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_component"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_blog_post"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_fundamentals"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_release_notes"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_temaside"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_ref": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "_type": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string",
+                                            "value": "reference"
+                                          }
+                                        },
+                                        "_weak": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "boolean"
+                                          },
+                                          "optional": true
+                                        }
+                                      },
+                                      "dereferencesTo": "jokul_monster"
+                                    }
+                                  ]
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "jokul_internal_link"
+                                }
+                              }
+                            },
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "optional": true
+                  },
+                  "level": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "number"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "block"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "sanity.imageAsset"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_code"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_examples"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_doAndDont"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_messageBox"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_table"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_qa"
+                }
+              }
+            ]
+          }
+        },
+        "optional": true
+      },
+      "related_components": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "jokul_component",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "related_patterns": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "jokul_monster",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         },
         "optional": true

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -136,5 +136,11 @@ export const componentBySlugQuery =
                 related_components,
                 categories
             }
-        }
+        },
+        "related_patterns": *[_type == "jokul_monster" && references(^._id)]{
+            name,
+            "slug": slug.current,
+            short_description,
+            image
+        } | order(name)
     }`);

--- a/portal/src/sanity/queries/monster.ts
+++ b/portal/src/sanity/queries/monster.ts
@@ -1,0 +1,79 @@
+import { defineQuery } from "next-sanity";
+
+export const monstreQuery = defineQuery(`*[_type == "jokul_monster"]{
+    name,
+    "slug": slug.current,
+    short_description,
+    image,
+    related_components[]->{
+        name,
+        "slug": slug.current
+    }
+} | order(name)`);
+
+export const monsterBySlugQuery = defineQuery(
+    `*[_type == "jokul_monster" && slug.current == $slug][0]{
+        ...,
+        "slug": slug.current,
+        related_components[]->{
+            name,
+            short_description,
+            "slug": slug.current,
+            image,
+            imageDark
+        },
+        "related_patterns": *[
+            _type == "jokul_monster"
+            && _id != ^._id
+            && (_id in ^.related_patterns[]._ref || references(^._id))
+        ]{
+            name,
+            short_description,
+            "slug": slug.current,
+            image
+        } | order(name),
+        article[]{
+            ...,
+            _type == "jokul_code" => {
+                ...,
+                title,
+                code,
+                language
+            },
+            _type == "jokul_examples" => {
+                ...,
+                title,
+                examples[]->{
+                    name,
+                    id,
+                    description,
+                    height,
+                    inert,
+                    code
+                }
+            },
+            markDefs[] {
+                ...,
+                _type == "jokul_internal_link" => {
+                    article->{
+                        _type,
+                        "name": coalesce(name, tema, version),
+                        short_description,
+                        "slug": slug.current,
+                        image,
+                        imageDark
+                    }
+                },
+                _type == "componentPageLink" => {
+                    component->{
+                        name,
+                        short_description,
+                        "slug": slug.current,
+                        image,
+                        imageDark
+                    }
+                }
+            }
+        }
+    }`,
+);

--- a/portal/src/sanity/queries/search.ts
+++ b/portal/src/sanity/queries/search.ts
@@ -1,7 +1,7 @@
 import { defineQuery } from "next-sanity";
 
 export const searchQuery = defineQuery(
-    `*[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post"] && defined(slug.current) && (
+    `*[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post", "jokul_monster"] && defined(slug.current) && (
         name match "*" + $searchString + "*" ||
         short_description match "*" + $searchString + "*" ||
         slug.current match "*" + $searchString + "*" ||
@@ -10,7 +10,10 @@ export const searchQuery = defineQuery(
             documentation_article[].children[].text match "*" + $searchString + "*" ||
             considerations[].title match "*" + $searchString + "*" ||
             considerations[].description match "*" + $searchString + "*"
-        ))
+        )) ||
+        (_type == "jokul_monster" &&
+            article[].children[].text match "*" + $searchString + "*"
+        )
     )] | {
         _id,
         name,
@@ -18,17 +21,20 @@ export const searchQuery = defineQuery(
         short_description,
         "image": select(
             _type == "jokul_component" => image.asset->url,
+            _type == "jokul_monster" => image.asset->url,
             null
         ),
         "type": select(
             _type == "jokul_component" => "Komponent",
             _type == "jokul_fundamentals" => "Fundament",
-            _type == "jokul_blog_post" => "Blogg"
+            _type == "jokul_blog_post" => "Blogg",
+            _type == "jokul_monster" => "Mønster"
         ),
         "href": select(
             _type == "jokul_component" => "/komponenter/" + slug.current,
             _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,
-            _type == "jokul_blog_post" => "/blog/" + slug.current
+            _type == "jokul_blog_post" => "/blog/" + slug.current,
+            _type == "jokul_monster" => "/monster/" + slug.current
         )
     }`,
 );

--- a/portal/src/sanity/queries/siteData.ts
+++ b/portal/src/sanity/queries/siteData.ts
@@ -20,6 +20,7 @@ export const siteDataQuery = defineQuery(
       url[0].internalReference->_type == "jokul_component" => "/komponenter/" + url[0].internalReference->slug.current,
       url[0].internalReference->_type == "jokul_fundamentals" => "/fundamenter/" + url[0].internalReference->slug.current,
       url[0].internalReference->_type == "jokul_blog_post" => "/blog/" + url[0].internalReference->slug.current,
+      url[0].internalReference->_type == "jokul_monster" => "/monster/" + url[0].internalReference->slug.current,
       url[0].internalReference->_type == "jokul_release_notes" => "/release-notes/" + url[0].internalReference->slug.current,
       "/" + url[0].internalReference->slug.current
     ),

--- a/portal/src/sanity/schemas/documents/blogPost.ts
+++ b/portal/src/sanity/schemas/documents/blogPost.ts
@@ -1,4 +1,5 @@
 import { commonBlock } from "@/sanity/schemas/commonBlock";
+import { ComposeIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 
 const MAX_LENGTH = 70;
@@ -6,6 +7,7 @@ const MAX_LENGTH = 70;
 export const blogPost = defineType({
     name: "jokul_blog_post",
     title: "Bloggartikkel",
+    icon: ComposeIcon,
     type: "document",
     fields: [
         defineField({

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -1,5 +1,6 @@
 import { commonBlock } from "@/sanity/schemas/commonBlock";
 import { COMPONENT_CATEGORIES } from "@/utils/user-preferences";
+import { ComponentIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 
 import "../lists/usageList.scss";
@@ -9,6 +10,7 @@ const MAX_LENGTH = 70;
 export const component = defineType({
     name: "jokul_component",
     title: "Komponent",
+    icon: ComponentIcon,
     type: "document",
     groups: [
         { name: "documentation", title: "Dokumentasjon" },
@@ -32,7 +34,10 @@ export const component = defineType({
                 source: "name",
                 maxLength: MAX_LENGTH,
                 slugify: (input) =>
-                    input.toLowerCase().replace(/\s+/g, "-").slice(0, 200),
+                    input
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")
+                        .slice(0, MAX_LENGTH),
             },
             validation: (Rule) => Rule.required(),
         }),

--- a/portal/src/sanity/schemas/documents/fundamentals.ts
+++ b/portal/src/sanity/schemas/documents/fundamentals.ts
@@ -1,4 +1,5 @@
 import { commonBlock } from "@/sanity/schemas/commonBlock";
+import { TokenIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 
 const MAX_LENGTH = 70;
@@ -6,6 +7,7 @@ const MAX_LENGTH = 70;
 export const fundamentals = defineType({
     name: "jokul_fundamentals",
     title: "Fundamenter",
+    icon: TokenIcon,
     type: "document",
     fields: [
         defineField({

--- a/portal/src/sanity/schemas/documents/index.ts
+++ b/portal/src/sanity/schemas/documents/index.ts
@@ -1,6 +1,7 @@
 import { blogPost } from "@/sanity/schemas/documents/blogPost";
 import { component } from "@/sanity/schemas/documents/component";
 import { fundamentals } from "@/sanity/schemas/documents/fundamentals";
+import { monster } from "@/sanity/schemas/documents/monster";
 import { releaseNotes } from "@/sanity/schemas/documents/releaseNotes";
 import { temaside } from "@/sanity/schemas/documents/temaside";
 
@@ -10,4 +11,5 @@ export const documents = [
     fundamentals,
     releaseNotes,
     temaside,
+    monster,
 ];

--- a/portal/src/sanity/schemas/documents/monster.ts
+++ b/portal/src/sanity/schemas/documents/monster.ts
@@ -1,0 +1,157 @@
+import { commonBlock } from "@/sanity/schemas/commonBlock";
+import { BulbOutlineIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+const MAX_LENGTH = 70;
+
+export const monster = defineType({
+    name: "jokul_monster",
+    title: "Mønster",
+    type: "document",
+    icon: BulbOutlineIcon,
+    groups: [
+        { name: "basics", title: "Grunnleggende info", default: true },
+        { name: "related", title: "Relatert innhold" },
+    ],
+    fields: [
+        defineField({
+            name: "name",
+            title: "Navn",
+            group: "basics",
+            type: "string",
+            description:
+                "Formuler gjerne som en oppgave, f.eks. «Hvordan vise datoer i ulike tilfeller»",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "slug",
+            title: "Slug",
+            group: "basics",
+            type: "slug",
+            options: {
+                source: "name",
+                maxLength: MAX_LENGTH,
+                slugify: (input) =>
+                    input
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")
+                        .slice(0, MAX_LENGTH),
+            },
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "short_description",
+            title: "Beskrivelse",
+            group: "basics",
+            type: "text",
+            rows: 2,
+            description:
+                "Vises på kort/oversiktssiden. Beskriv kort hvilken oppgave mønsteret løser.",
+            validation: (Rule) =>
+                Rule.required()
+                    .max(160)
+                    .warning(
+                        "Beskrivelsen vises på kortet i oversikten — hold den kort.",
+                    ),
+        }),
+        defineField({
+            name: "image",
+            title: "Bilde",
+            group: "basics",
+            type: "image",
+            description:
+                "Vises foreløpig kun som forhåndsvisning i oversikten.",
+            options: {
+                hotspot: true,
+            },
+        }),
+        defineField({
+            name: "article",
+            title: "Artikkel",
+            group: "basics",
+            type: "array",
+            description: "Selve innholdet i mønsteret.",
+            of: [
+                ...commonBlock,
+                { type: "jokul_code" },
+                { type: "jokul_examples" },
+                { type: "jokul_doAndDont" },
+                { type: "jokul_messageBox" },
+                { type: "jokul_table" },
+                { type: "jokul_qa" },
+            ],
+        }),
+        defineField({
+            name: "related_components",
+            title: "Relevante komponenter",
+            group: "related",
+            type: "array",
+            description: "Komponentene som er relevante for dette mønsteret.",
+            of: [
+                defineField({
+                    type: "reference",
+                    name: "component",
+                    to: [{ type: "jokul_component" }],
+                    options: {
+                        disableNew: true,
+                    },
+                }),
+            ],
+        }),
+        defineField({
+            name: "related_patterns",
+            title: "Relaterte mønstre",
+            group: "related",
+            type: "array",
+            of: [
+                defineField({
+                    type: "reference",
+                    name: "pattern",
+                    to: [{ type: "jokul_monster" }],
+                    options: {
+                        disableNew: true,
+                        filter: ({ document }) => {
+                            const id = document._id.replace(/^drafts\./, "");
+                            return {
+                                filter: "_id != $id && _id != $draftId",
+                                params: { id, draftId: `drafts.${id}` },
+                            };
+                        },
+                    },
+                }),
+            ],
+        }),
+    ],
+    orderings: [
+        {
+            title: "Navn A–Å",
+            name: "nameAsc",
+            by: [{ field: "name", direction: "asc" }],
+        },
+        {
+            title: "Sist endret",
+            name: "updatedDesc",
+            by: [{ field: "_updatedAt", direction: "desc" }],
+        },
+    ],
+    preview: {
+        select: {
+            title: "name",
+            subtitle: "short_description",
+            media: "image",
+            components: "related_components",
+        },
+        prepare({ title, subtitle, media, components }) {
+            const count = Array.isArray(components) ? components.length : 0;
+            return {
+                title: title || "Uten navn",
+                subtitle:
+                    subtitle ||
+                    (count
+                        ? `${count} relatert${count === 1 ? " komponent" : "e komponenter"}`
+                        : undefined),
+                media: media || BulbOutlineIcon,
+            };
+        },
+    },
+});

--- a/portal/src/sanity/schemas/documents/siteData.ts
+++ b/portal/src/sanity/schemas/documents/siteData.ts
@@ -85,16 +85,27 @@ export const siteData = defineType({
                                                                         {
                                                                             type: "jokul_release_notes",
                                                                         },
+                                                                        {
+                                                                            type: "jokul_monster",
+                                                                        },
                                                                     ],
                                                                 },
                                                             ],
                                                             preview: {
                                                                 select: {
                                                                     title: "internalReference.name",
-                                                                    version: "internalReference.version",
+                                                                    version:
+                                                                        "internalReference.version",
                                                                 },
-                                                                prepare({ title, version }) {
-                                                                    return { title: title ?? version };
+                                                                prepare({
+                                                                    title,
+                                                                    version,
+                                                                }) {
+                                                                    return {
+                                                                        title:
+                                                                            title ??
+                                                                            version,
+                                                                    };
                                                                 },
                                                             },
                                                         },
@@ -109,13 +120,33 @@ export const siteData = defineType({
                                                                     title: "Side",
                                                                     options: {
                                                                         list: [
-                                                                            { title: "Komponenter", value: "komponenter" },
-                                                                            { title: "Fundamenter", value: "fundamenter" },
-                                                                            { title: "Blogg", value: "blog" },
-                                                                            { title: "Release notes", value: "release-notes" },
+                                                                            {
+                                                                                title: "Komponenter",
+                                                                                value: "komponenter",
+                                                                            },
+                                                                            {
+                                                                                title: "Fundamenter",
+                                                                                value: "fundamenter",
+                                                                            },
+                                                                            {
+                                                                                title: "Mønster",
+                                                                                value: "monster",
+                                                                            },
+                                                                            {
+                                                                                title: "Blogg",
+                                                                                value: "blog",
+                                                                            },
+                                                                            {
+                                                                                title: "Release notes",
+                                                                                value: "release-notes",
+                                                                            },
                                                                         ],
                                                                     },
-                                                                    validation: (Rule) => Rule.required(),
+                                                                    validation:
+                                                                        (
+                                                                            Rule,
+                                                                        ) =>
+                                                                            Rule.required(),
                                                                 },
                                                             ],
                                                             preview: {

--- a/portal/src/sanity/schemas/documents/temaside.ts
+++ b/portal/src/sanity/schemas/documents/temaside.ts
@@ -6,6 +6,7 @@ const MAX_LENGTH = 70;
 export const temaside = defineType({
     name: "jokul_temaside",
     title: "Temaside",
+    hidden: true,
     type: "document",
     groups: [
         { name: "basics", title: "Grunnleggende info" },

--- a/portal/src/sanity/schemas/links/internalLink.tsx
+++ b/portal/src/sanity/schemas/links/internalLink.tsx
@@ -17,6 +17,7 @@ export const internalLink = defineField({
                 { type: "jokul_fundamentals" },
                 { type: "jokul_release_notes" },
                 { type: "jokul_temaside" },
+                { type: "jokul_monster" },
             ],
             validation: (Rule) => Rule.required(),
         },

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -40,6 +40,11 @@ export type Jokul_internal_link = {
     _type: "reference";
     _weak?: boolean;
     [internalGroqTypeReferenceTo]?: "jokul_temaside";
+  } | {
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    [internalGroqTypeReferenceTo]?: "jokul_monster";
   };
 };
 
@@ -121,11 +126,16 @@ export type Jokul_siteData = {
             _type: "reference";
             _weak?: boolean;
             [internalGroqTypeReferenceTo]?: "jokul_release_notes";
+          } | {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "jokul_monster";
           };
           _type: "internalLink";
           _key: string;
         } | {
-          route?: "komponenter" | "fundamenter" | "blog" | "release-notes";
+          route?: "komponenter" | "fundamenter" | "monster" | "blog" | "release-notes";
           _type: "mainPageLink";
           _key: string;
         } | {
@@ -388,6 +398,11 @@ export type Jokul_blog_post = {
         _type: "reference";
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
       };
       _type: "jokul_internal_link";
       _key: string;
@@ -493,6 +508,11 @@ export type Jokul_component = {
         _type: "reference";
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
       };
       _type: "jokul_internal_link";
       _key: string;
@@ -644,6 +664,11 @@ export type Jokul_fundamentals = {
         _type: "reference";
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
       };
       _type: "jokul_internal_link";
       _key: string;
@@ -730,6 +755,11 @@ export type Jokul_release_notes = {
         _type: "reference";
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
       };
       _type: "jokul_internal_link";
       _key: string;
@@ -817,6 +847,11 @@ export type Jokul_temaside = {
         _type: "reference";
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
       };
       _type: "jokul_internal_link";
       _key: string;
@@ -872,6 +907,120 @@ export type Jokul_temaside = {
     _key: string;
   }>;
   keywords?: Array<string>;
+};
+
+export type Jokul_monster = {
+  _id: string;
+  _type: "jokul_monster";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+  slug?: Slug;
+  short_description?: string;
+  image?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  article?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+    listItem?: "bullet" | "number" | "check" | "cross";
+    markDefs?: Array<{
+      href?: string;
+      blank?: boolean;
+      _type: "link";
+      _key: string;
+    } | {
+      article?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_component";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_blog_post";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_fundamentals";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_release_notes";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_temaside";
+      } | {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "jokul_monster";
+      };
+      _type: "jokul_internal_link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  } | {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+    _key: string;
+  } | {
+    _key: string;
+  } & Jokul_code | {
+    _key: string;
+  } & Jokul_examples | {
+    _key: string;
+  } & Jokul_doAndDont | {
+    _key: string;
+  } & Jokul_messageBox | {
+    _key: string;
+  } & Jokul_table | {
+    _key: string;
+  } & Jokul_qa>;
+  related_components?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "jokul_component";
+  }>;
+  related_patterns?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "jokul_monster";
+  }>;
 };
 
 export type Table = {
@@ -1021,7 +1170,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Table | Slug | Jokul_story | Code | Jokul_code | Jokul_componentProps | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Slug | Jokul_story | Code | Jokul_code | Jokul_componentProps | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
@@ -1119,6 +1268,24 @@ export type BlogPostBySlugQueryResult = {
           crop?: SanityImageCrop;
           _type: "image";
         } | null;
+      } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
       } | {
         _type: "jokul_release_notes";
         name: string | null;
@@ -1330,6 +1497,24 @@ export type KomIGangQueryResult = {
           _type: "image";
         } | null;
       } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
+      } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
@@ -1496,7 +1681,7 @@ export type ComponentsQueryResult = Array<{
   categories: Array<string> | null;
 }>;
 // Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "example_card": {            ...example_card,            "story": example_card.story->        },        documentation_article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  name,                  id,                  description,                  height,                  inert,                  code                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            ...,                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            },                            _type == "jokul_internal_link" => {                                ...,                                article->{                                    _type,                                    "name": coalesce(name, tema, version),                                    short_description,                                    "slug": slug.current,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            ...,                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            },                            _type == "jokul_internal_link" => {                                ...,                                article->{                                    _type,                                    "name": coalesce(name, tema, version),                                    short_description,                                    "slug": slug.current,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },                _type == "jokul_internal_link" => {                    article->{                        _type,                        "name": coalesce(name, tema, version),                        short_description,                        "slug": slug.current,                        image,                        imageDark                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        }    }
+// Query: *[_type == "jokul_component" && slug.current == $slug][0] {        ...,        "slug": slug.current,        "example_card": {            ...example_card,            "story": example_card.story->        },        documentation_article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language,          },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                  name,                  id,                  description,                  height,                  inert,                  code                },              },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[] {                        ...,                        markDefs[] {                            ...,                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            },                            _type == "jokul_internal_link" => {                                ...,                                article->{                                    _type,                                    "name": coalesce(name, tema, version),                                    short_description,                                    "slug": slug.current,                                    image,                                    imageDark                                }                            }                        }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[] {                        ...,                        markDefs[] {                            ...,                            _type == "componentPageLink" => {                                ...,                                component->{                                    name,                                    short_description,                                    "slug": slug.current,                                    figma_image,                                    image,                                    imageDark                                }                            },                            _type == "jokul_internal_link" => {                                ...,                                article->{                                    _type,                                    "name": coalesce(name, tema, version),                                    short_description,                                    "slug": slug.current,                                    image,                                    imageDark                                }                            }                        }                    }                }            },            markDefs[] {                ...,                _type == "componentPageLink" => {                    component-> {                        "slug": slug.current,                        name,                        short_description,                        image,                        imageDark,                    }                },                _type == "jokul_internal_link" => {                    article->{                        _type,                        "name": coalesce(name, tema, version),                        short_description,                        "slug": slug.current,                        image,                        imageDark                    }                },            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        },        "related_patterns": *[_type == "jokul_monster" && references(^._id)]{            name,            "slug": slug.current,            short_description,            image        } | order(name)    }
 export type ComponentBySlugQueryResult = {
   _id: string;
   _type: "jokul_component";
@@ -1608,6 +1793,24 @@ export type ComponentBySlugQueryResult = {
           crop?: SanityImageCrop;
           _type: "image";
         } | null;
+      } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
       } | {
         _type: "jokul_release_notes";
         name: string | null;
@@ -1903,6 +2106,23 @@ export type ComponentBySlugQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
   };
+  related_patterns: Array<{
+    name: string | null;
+    slug: string | null;
+    short_description: string | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  }>;
 } | null;
 
 // Source: ./src/sanity/queries/fundamentals.ts
@@ -2048,6 +2268,24 @@ export type FundamentalsBySlugQueryResult = {
           crop?: SanityImageCrop;
           _type: "image";
         } | null;
+      } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
       } | {
         _type: "jokul_release_notes";
         name: string | null;
@@ -2195,6 +2433,329 @@ export type FundamentalsBySlugQueryResult = {
   }> | null;
 } | null;
 
+// Source: ./src/sanity/queries/monster.ts
+// Variable: monstreQuery
+// Query: *[_type == "jokul_monster"]{    name,    "slug": slug.current,    short_description,    image,    related_components[]->{        name,        "slug": slug.current    }} | order(name)
+export type MonstreQueryResult = Array<{
+  name: string | null;
+  slug: string | null;
+  short_description: string | null;
+  image: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  related_components: Array<{
+    name: string | null;
+    slug: string | null;
+  }> | null;
+}>;
+// Variable: monsterBySlugQuery
+// Query: *[_type == "jokul_monster" && slug.current == $slug][0]{        ...,        "slug": slug.current,        related_components[]->{            name,            short_description,            "slug": slug.current,            image,            imageDark        },        "related_patterns": *[            _type == "jokul_monster"            && _id != ^._id            && (_id in ^.related_patterns[]._ref || references(^._id))        ]{            name,            short_description,            "slug": slug.current,            image        } | order(name),        article[]{            ...,            _type == "jokul_code" => {                ...,                title,                code,                language            },            _type == "jokul_examples" => {                ...,                title,                examples[]->{                    name,                    id,                    description,                    height,                    inert,                    code                }            },            markDefs[] {                ...,                _type == "jokul_internal_link" => {                    article->{                        _type,                        "name": coalesce(name, tema, version),                        short_description,                        "slug": slug.current,                        image,                        imageDark                    }                },                _type == "componentPageLink" => {                    component->{                        name,                        short_description,                        "slug": slug.current,                        image,                        imageDark                    }                }            }        }    }
+export type MonsterBySlugQueryResult = {
+  _id: string;
+  _type: "jokul_monster";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+  slug: string | null;
+  short_description?: string;
+  image?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  article: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+    listItem?: "bullet" | "check" | "cross" | "number";
+    markDefs: Array<{
+      article: {
+        _type: "jokul_blog_post";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: null;
+        imageDark: null;
+      } | {
+        _type: "jokul_component";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+      } | {
+        _type: "jokul_fundamentals";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+      } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
+      } | {
+        _type: "jokul_release_notes";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: null;
+        imageDark: null;
+      } | {
+        _type: "jokul_temaside";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: null;
+        imageDark: null;
+      } | null;
+      _type: "jokul_internal_link";
+      _key: string;
+    } | {
+      href?: string;
+      blank?: boolean;
+      _type: "link";
+      _key: string;
+    }> | null;
+    level?: number;
+    _type: "block";
+    _key: string;
+  } | {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+    _key: string;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_code";
+    title: string | null;
+    code: Code | null;
+    language: null;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_doAndDont";
+    do?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "image";
+    };
+    dont?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      alt?: string;
+      _type: "image";
+    };
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_examples";
+    title: string | null;
+    examples: Array<{
+      name: string | null;
+      id: string | null;
+      description: string | null;
+      height: 100 | 1000 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | null;
+      inert: boolean | null;
+      code: Code | null;
+    }> | null;
+    layout?: "carousel" | "gallery" | "list";
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_messageBox";
+    messageType?: "error" | "info" | "success" | "warning";
+    title?: string;
+    message?: string;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_qa";
+    title?: string;
+    faq?: Array<{
+      question?: string;
+      answer?: Array<{
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+        listItem?: "bullet" | "number";
+        markDefs?: Array<{
+          href?: string;
+          _type: "link";
+          _key: string;
+        }>;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }>;
+      _type: "faqitem";
+      _key: string;
+    }>;
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_table";
+    caption?: string;
+    table?: Table;
+    show_caption?: boolean;
+    sticky_header?: boolean;
+    copy_button?: boolean;
+    markDefs: null;
+  }> | null;
+  related_components: Array<{
+    name: string | null;
+    short_description: string | null;
+    slug: string | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    imageDark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  }> | null;
+  related_patterns: Array<{
+    name: string | null;
+    short_description: string | null;
+    slug: string | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  }>;
+} | null;
+
 // Source: ./src/sanity/queries/releaseNotes.ts
 // Variable: releaseNotesQuery
 // Query: *[_type == "jokul_release_notes"]{        _id,        version,        "slug": slug.current,        short_description,        releaseDate,    } | order(releaseDate desc)
@@ -2288,6 +2849,24 @@ export type ReleaseNoteBySlugQueryResult = {
           crop?: SanityImageCrop;
           _type: "image";
         } | null;
+      } | {
+        _type: "jokul_monster";
+        name: string | null;
+        short_description: string | null;
+        slug: string | null;
+        image: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        imageDark: null;
       } | {
         _type: "jokul_release_notes";
         name: string | null;
@@ -2414,7 +2993,7 @@ export type ReleaseNoteBySlugQueryResult = {
 
 // Source: ./src/sanity/queries/search.ts
 // Variable: searchQuery
-// Query: *[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post"] && defined(slug.current) && (        name match "*" + $searchString + "*" ||        short_description match "*" + $searchString + "*" ||        slug.current match "*" + $searchString + "*" ||        (_type == "jokul_component" && (            keywords[] match "*" + $searchString + "*" ||            documentation_article[].children[].text match "*" + $searchString + "*" ||            considerations[].title match "*" + $searchString + "*" ||            considerations[].description match "*" + $searchString + "*"        ))    )] | {        _id,        name,        slug,        short_description,        "image": select(            _type == "jokul_component" => image.asset->url,            null        ),        "type": select(            _type == "jokul_component" => "Komponent",            _type == "jokul_fundamentals" => "Fundament",            _type == "jokul_blog_post" => "Blogg"        ),        "href": select(            _type == "jokul_component" => "/komponenter/" + slug.current,            _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,            _type == "jokul_blog_post" => "/blog/" + slug.current        )    }
+// Query: *[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post", "jokul_monster"] && defined(slug.current) && (        name match "*" + $searchString + "*" ||        short_description match "*" + $searchString + "*" ||        slug.current match "*" + $searchString + "*" ||        (_type == "jokul_component" && (            keywords[] match "*" + $searchString + "*" ||            documentation_article[].children[].text match "*" + $searchString + "*" ||            considerations[].title match "*" + $searchString + "*" ||            considerations[].description match "*" + $searchString + "*"        )) ||        (_type == "jokul_monster" &&            article[].children[].text match "*" + $searchString + "*"        )    )] | {        _id,        name,        slug,        short_description,        "image": select(            _type == "jokul_component" => image.asset->url,            _type == "jokul_monster" => image.asset->url,            null        ),        "type": select(            _type == "jokul_component" => "Komponent",            _type == "jokul_fundamentals" => "Fundament",            _type == "jokul_blog_post" => "Blogg",            _type == "jokul_monster" => "Mønster"        ),        "href": select(            _type == "jokul_component" => "/komponenter/" + slug.current,            _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,            _type == "jokul_blog_post" => "/blog/" + slug.current,            _type == "jokul_monster" => "/monster/" + slug.current        )    }
 export type SearchQueryResult = Array<{
   _id: string;
   name: string | null;
@@ -2439,11 +3018,19 @@ export type SearchQueryResult = Array<{
   image: string | null;
   type: "Komponent";
   href: string | null;
+} | {
+  _id: string;
+  name: string | null;
+  slug: Slug | null;
+  short_description: string | null;
+  image: string | null;
+  type: "M\xF8nster";
+  href: string | null;
 }>;
 
 // Source: ./src/sanity/queries/siteData.ts
 // Variable: siteDataQuery
-// Query: *[_type == "jokul_siteData"]{        ...,        "seo": {            "title": coalesce(seo.title, title, ""),            "description": coalesce(seo.description,  ""),            "image": seo.image,            "noIndex": seo.noIndex == true          },        footer {            text,            linkGroups[]{                title,                linkList[]{                    text,                    "url": select(    url[0]._type == "internalLink" => select(      url[0].internalReference->_type == "jokul_component" => "/komponenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_fundamentals" => "/fundamenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_blog_post" => "/blog/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_release_notes" => "/release-notes/" + url[0].internalReference->slug.current,      "/" + url[0].internalReference->slug.current    ),    url[0]._type == "mainPageLink" => "/" + url[0].route,    url[0]._type == "externalLink" => url[0].url  )                }            }        },        "date": _createdAt,    } | order(_createdAt desc)[0]
+// Query: *[_type == "jokul_siteData"]{        ...,        "seo": {            "title": coalesce(seo.title, title, ""),            "description": coalesce(seo.description,  ""),            "image": seo.image,            "noIndex": seo.noIndex == true          },        footer {            text,            linkGroups[]{                title,                linkList[]{                    text,                    "url": select(    url[0]._type == "internalLink" => select(      url[0].internalReference->_type == "jokul_component" => "/komponenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_fundamentals" => "/fundamenter/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_blog_post" => "/blog/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_monster" => "/monster/" + url[0].internalReference->slug.current,      url[0].internalReference->_type == "jokul_release_notes" => "/release-notes/" + url[0].internalReference->slug.current,      "/" + url[0].internalReference->slug.current    ),    url[0]._type == "mainPageLink" => "/" + url[0].route,    url[0]._type == "externalLink" => url[0].url  )                }            }        },        "date": _createdAt,    } | order(_createdAt desc)[0]
 export type SiteDataQueryResult = {
   _id: string;
   _type: "jokul_siteData";
@@ -2476,7 +3063,7 @@ export type SiteDataQueryResult = {
       title: string | null;
       linkList: Array<{
         text: string | null;
-        url: null | string | "/blog" | "/fundamenter" | "/komponenter" | "/release-notes";
+        url: null | string | "/blog" | "/fundamenter" | "/komponenter" | "/monster" | "/release-notes";
       }> | null;
     }> | null;
   } | null;
@@ -2496,13 +3083,15 @@ declare module "@sanity/client" {
     "*[_type == \"jokul_blog_post\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n  },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n  },\n    }": BlogPostBySlugQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    stories[]->{\n      storyName,\n      storyId,\n      storyDescription,\n    },\n  },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n  },\n    }": KomIGangQueryResult;
     "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    categories\n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  name,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            ...,\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            },\n                            _type == \"jokul_internal_link\" => {\n                                ...,\n                                article->{\n                                    _type,\n                                    \"name\": coalesce(name, tema, version),\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            ...,\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            },\n                            _type == \"jokul_internal_link\" => {\n                                ...,\n                                article->{\n                                    _type,\n                                    \"name\": coalesce(name, tema, version),\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        }\n    }": ComponentBySlugQueryResult;
+    "*[_type == \"jokul_component\" && slug.current == $slug][0] {\n        ...,\n        \"slug\": slug.current,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  name,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n              },\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            ...,\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            },\n                            _type == \"jokul_internal_link\" => {\n                                ...,\n                                article->{\n                                    _type,\n                                    \"name\": coalesce(name, tema, version),\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[] {\n                        ...,\n                        markDefs[] {\n                            ...,\n                            _type == \"componentPageLink\" => {\n                                ...,\n                                component->{\n                                    name,\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    figma_image,\n                                    image,\n                                    imageDark\n                                }\n                            },\n                            _type == \"jokul_internal_link\" => {\n                                ...,\n                                article->{\n                                    _type,\n                                    \"name\": coalesce(name, tema, version),\n                                    short_description,\n                                    \"slug\": slug.current,\n                                    image,\n                                    imageDark\n                                }\n                            }\n                        }\n                    }\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"componentPageLink\" => {\n                    component-> {\n                        \"slug\": slug.current,\n                        name,\n                        short_description,\n                        image,\n                        imageDark,\n                    }\n                },\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        },\n        \"related_patterns\": *[_type == \"jokul_monster\" && references(^._id)]{\n            name,\n            \"slug\": slug.current,\n            short_description,\n            image\n        } | order(name)\n    }": ComponentBySlugQueryResult;
     "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        image,\n        imageDark,\n        \"date\": _createdAt,\n    } | order(_createdAt desc)": FundamentalsQueryResult;
     "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n            },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n        },\n    }": FundamentalsBySlugQueryResult;
+    "*[_type == \"jokul_monster\"]{\n    name,\n    \"slug\": slug.current,\n    short_description,\n    image,\n    related_components[]->{\n        name,\n        \"slug\": slug.current\n    }\n} | order(name)": MonstreQueryResult;
+    "*[_type == \"jokul_monster\" && slug.current == $slug][0]{\n        ...,\n        \"slug\": slug.current,\n        related_components[]->{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            image,\n            imageDark\n        },\n        \"related_patterns\": *[\n            _type == \"jokul_monster\"\n            && _id != ^._id\n            && (_id in ^.related_patterns[]._ref || references(^._id))\n        ]{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            image\n        } | order(name),\n        article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language\n            },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                    name,\n                    id,\n                    description,\n                    height,\n                    inert,\n                    code\n                }\n            },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n                _type == \"componentPageLink\" => {\n                    component->{\n                        name,\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                }\n            }\n        }\n    }": MonsterBySlugQueryResult;
     "*[_type == \"jokul_release_notes\"]{\n        _id,\n        version,\n        \"slug\": slug.current,\n        short_description,\n        releaseDate,\n    } | order(releaseDate desc)": ReleaseNotesQueryResult;
     "*[_type == \"jokul_release_notes\" && slug.current == $slug][0] {\n        version,\n        releaseDate,\n        short_description,\n        migrationUrl,\n        figmaUrl,\n        article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                \"language\": code.language,\n            },\n            _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                    name,\n                    id,\n                    description,\n                    height,\n                    inert,\n                    code\n                },\n            },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n        },\n    }": ReleaseNoteBySlugQueryResult;
-    "*[_type in [\"jokul_component\", \"jokul_fundamentals\", \"jokul_blog_post\"] && defined(slug.current) && (\n        name match \"*\" + $searchString + \"*\" ||\n        short_description match \"*\" + $searchString + \"*\" ||\n        slug.current match \"*\" + $searchString + \"*\" ||\n        (_type == \"jokul_component\" && (\n            keywords[] match \"*\" + $searchString + \"*\" ||\n            documentation_article[].children[].text match \"*\" + $searchString + \"*\" ||\n            considerations[].title match \"*\" + $searchString + \"*\" ||\n            considerations[].description match \"*\" + $searchString + \"*\"\n        ))\n    )] | {\n        _id,\n        name,\n        slug,\n        short_description,\n        \"image\": select(\n            _type == \"jokul_component\" => image.asset->url,\n            null\n        ),\n        \"type\": select(\n            _type == \"jokul_component\" => \"Komponent\",\n            _type == \"jokul_fundamentals\" => \"Fundament\",\n            _type == \"jokul_blog_post\" => \"Blogg\"\n        ),\n        \"href\": select(\n            _type == \"jokul_component\" => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\" => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_blog_post\" => \"/blog/\" + slug.current\n        )\n    }": SearchQueryResult;
-    "*[_type == \"jokul_siteData\"]{\n        ...,\n        \"seo\": {\n            \"title\": coalesce(seo.title, title, \"\"),\n            \"description\": coalesce(seo.description,  \"\"),\n            \"image\": seo.image,\n            \"noIndex\": seo.noIndex == true\n          },\n        footer {\n            text,\n            linkGroups[]{\n                title,\n                linkList[]{\n                    text,\n                    \"url\": select(\n    url[0]._type == \"internalLink\" => select(\n      url[0].internalReference->_type == \"jokul_component\" => \"/komponenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_fundamentals\" => \"/fundamenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_blog_post\" => \"/blog/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_release_notes\" => \"/release-notes/\" + url[0].internalReference->slug.current,\n      \"/\" + url[0].internalReference->slug.current\n    ),\n    url[0]._type == \"mainPageLink\" => \"/\" + url[0].route,\n    url[0]._type == \"externalLink\" => url[0].url\n  )\n                }\n            }\n        },\n        \"date\": _createdAt,\n    } | order(_createdAt desc)[0]": SiteDataQueryResult;
+    "*[_type in [\"jokul_component\", \"jokul_fundamentals\", \"jokul_blog_post\", \"jokul_monster\"] && defined(slug.current) && (\n        name match \"*\" + $searchString + \"*\" ||\n        short_description match \"*\" + $searchString + \"*\" ||\n        slug.current match \"*\" + $searchString + \"*\" ||\n        (_type == \"jokul_component\" && (\n            keywords[] match \"*\" + $searchString + \"*\" ||\n            documentation_article[].children[].text match \"*\" + $searchString + \"*\" ||\n            considerations[].title match \"*\" + $searchString + \"*\" ||\n            considerations[].description match \"*\" + $searchString + \"*\"\n        )) ||\n        (_type == \"jokul_monster\" &&\n            article[].children[].text match \"*\" + $searchString + \"*\"\n        )\n    )] | {\n        _id,\n        name,\n        slug,\n        short_description,\n        \"image\": select(\n            _type == \"jokul_component\" => image.asset->url,\n            _type == \"jokul_monster\" => image.asset->url,\n            null\n        ),\n        \"type\": select(\n            _type == \"jokul_component\" => \"Komponent\",\n            _type == \"jokul_fundamentals\" => \"Fundament\",\n            _type == \"jokul_blog_post\" => \"Blogg\",\n            _type == \"jokul_monster\" => \"M\xF8nster\"\n        ),\n        \"href\": select(\n            _type == \"jokul_component\" => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\" => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_blog_post\" => \"/blog/\" + slug.current,\n            _type == \"jokul_monster\" => \"/monster/\" + slug.current\n        )\n    }": SearchQueryResult;
+    "*[_type == \"jokul_siteData\"]{\n        ...,\n        \"seo\": {\n            \"title\": coalesce(seo.title, title, \"\"),\n            \"description\": coalesce(seo.description,  \"\"),\n            \"image\": seo.image,\n            \"noIndex\": seo.noIndex == true\n          },\n        footer {\n            text,\n            linkGroups[]{\n                title,\n                linkList[]{\n                    text,\n                    \"url\": select(\n    url[0]._type == \"internalLink\" => select(\n      url[0].internalReference->_type == \"jokul_component\" => \"/komponenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_fundamentals\" => \"/fundamenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_blog_post\" => \"/blog/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_monster\" => \"/monster/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_release_notes\" => \"/release-notes/\" + url[0].internalReference->slug.current,\n      \"/\" + url[0].internalReference->slug.current\n    ),\n    url[0]._type == \"mainPageLink\" => \"/\" + url[0].route,\n    url[0]._type == \"externalLink\" => url[0].url\n  )\n                }\n            }\n        },\n        \"date\": _createdAt,\n    } | order(_createdAt desc)[0]": SiteDataQueryResult;
     "*[_type == \"jokul_example\"]{\n    title,\n    id,\n    description,\n    height,\n    inert,\n} | order(name)": ExamplesQueryResult;
   }
 }


### PR DESCRIPTION
### Ny dokumenttype
- Ny Sanity-type `jokul_monster` med navn, slug, beskrivelse, bilde, artikkel
  og relaterte komponenter/mønstre.
- GROQ-spørringer for oversikt og detalj, inkludert toveis relaterte mønstre
  via `references()`.

### Sider og navigasjon
- Oversiktsside med kortgrid og søkbart komponentfilter.
- Detaljside med artikkel, relaterte komponenter og relaterte mønstre.
- Lagt til «Mønster» i hovednavigasjon, globalt søk, footer og interne lenker.

### Kobling til komponenter
- Komponentsider viser «Brukes i mønstre» via revers-referanse, så det ikke trenger å velges i komponentene også (tenker å lage en ny PR som lager et view som viser refererte steder nederst på komponenter og mønster?).

### Div
- Ikoner på dokumenttypene (mønster, komponent, fundament, temaside, blogg).
- Skjuler (men fjerner ikke i tilefelle vi vil ha det også en gang) temasider fra Sanity da jeg opplever at dette kanskje er et svar på samme problem som de skal løse?

### Bilder
<img width="4030" height="2320" alt="2026-07-31 14 58 52 localhost 80569aed3a80" src="https://github.com/user-attachments/assets/0b9d46f8-f3f8-43cd-9d2c-6c1dddab1056" />
<img width="4030" height="7363" alt="2026-07-31 14 59 21 localhost e5c5565cfe8e" src="https://github.com/user-attachments/assets/70010742-e583-42ff-9292-180f87faa899" />
<img width="4030" height="5774" alt="2026-07-31 14 59 41 localhost 5ff6fd0cbbcc" src="https://github.com/user-attachments/assets/6b430c1d-0fc7-4b43-be2e-a040a42a0588" />
<img width="4006" height="2352" alt="2026-07-31 15 00 20 localhost b1bff202cbb3" src="https://github.com/user-attachments/assets/07d9a44d-40c4-4d89-8f39-e13f6a81ae1f" />

