### PR TITLE
Retter opp stiler for Card rendret som knapp

### DIFF
--- a/.changeset/gold-feet-move.md
+++ b/.changeset/gold-feet-move.md
@@ -1,0 +1,9 @@
+---
+"@fremtind/jokul": patch
+---
+
+Retter opp stiler for `Card` rendret som knapp
+
+- Fjerner standard `border` og `outline` så de ikke krasjer med stilene til `Card`
+- Setter automatisk `clickable`-stiler på `Card` rendret som knapper eller lenker
+- Markerer `clickable` som deprecated, siden stilene settes automatisk

--- a/packages/jokul/src/components/card/styles/card.scss
+++ b/packages/jokul/src/components/card/styles/card.scss
@@ -61,7 +61,16 @@
             --background-color: transparent;
         }
 
-        &[data-clickable="true"] {
+        &:where(button) {
+            border: none;
+            outline: none;
+            font: inherit;
+            line-height: inherit;
+            text-align: inherit;
+        }
+
+        &[data-clickable="true"],
+        &:is(a, button:not(disabled)) {
             cursor: pointer;
 
             &:hover {

--- a/packages/jokul/src/components/card/types.ts
+++ b/packages/jokul/src/components/card/types.ts
@@ -16,6 +16,7 @@ type Props = {
      */
     outlined?: boolean;
     /**
+     * @deprecated Kortet får automatisk riktige stiler dersom det rendres som `button` eller `a`
      * Angir om kortet visuelt skal fremstå som klikkbart. Du må selv rendre
      * kortet som et klikkbart element (f.eks. `<a>` eller en `<Link>` fra
      * et ruting-bibliotek) og gi det en `href` eller `onClick`-handler.


### PR DESCRIPTION
## 💬 Endringer

- Fjerner standard `border` og `outline` så de ikke krasjer med stilene til `Card`
- Setter automatisk `clickable`-stiler på `Card` rendret som knapper eller lenker

## 🩹 Løser følgende issues

Closes #6268
