### PR TITLE
feat(portal): legger til nylig oppdatert side og RSS-feed til portalen

### DIFF
--- a/portal/src/app/(frontend)/feed.xml/route.ts
+++ b/portal/src/app/(frontend)/feed.xml/route.ts
@@ -1,0 +1,35 @@
+import { client } from "@/sanity/lib/client";
+import { latestUpdatedArticlesQuery } from "@/sanity/queries/allPosts";
+const SITE = process.env.NEXT_PUBLIC_SITE_URL || "https://jokul.fremtind.no";
+export const revalidate = 3600;
+const esc = (v: string) =>
+    v.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+export async function GET() {
+    const arts = await client.fetch(
+        latestUpdatedArticlesQuery,
+        { limit: 50 },
+        { stega: false },
+    );
+    const items = arts
+        .map((a) => {
+            if (!a.href) return "";
+            const url = new URL(a.href, SITE).toString();
+            return [
+                "<item>",
+                `<title>${esc(a.name ?? "")}</title>`,
+                `<link>${url}</link>`,
+                `<guid>${url}</guid>`,
+                `<category>${esc(a.type)}</category>`,
+                `<pubDate>${new Date(a.updated).toUTCString()}</pubDate>`,
+                `<description>${esc(a.short_description ?? "")}</description>`,
+                "</item>",
+            ].join("");
+        })
+        .join("");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Jøkul – Nylig oppdatert</title><link>${SITE}/nyheter</link><atom:link href="${SITE}/feed.xml" rel="self" type="application/rss+xml" /><description>Nylig oppdaterte artikler i Jøkul.</description><language>nb-NO</language>${items}</channel></rss>`;
+    return new Response(xml, {
+        headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+    });
+}

--- a/portal/src/app/(frontend)/layout.tsx
+++ b/portal/src/app/(frontend)/layout.tsx
@@ -9,10 +9,21 @@ import { VisualEditing } from "next-sanity/visual-editing";
 import { draftMode } from "next/headers";
 import "./global.scss";
 
+const SITE_URL =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://jokul.fremtind.no";
+
 export const metadata: Metadata = {
+    metadataBase: new URL(SITE_URL),
     title: "Jøkul – Fremtinds designsystem",
     description:
         "Jøkul er Fremtinds designsystem for å bygge enkle og helhetlige brukeropplevelser.",
+    alternates: {
+        types: {
+            "application/rss+xml": [
+                { url: "/feed.xml", title: "Jøkul – Nylig oppdatert" },
+            ],
+        },
+    },
 };
 
 interface Props {

--- a/portal/src/app/(frontend)/nyheter/FilterChip.tsx
+++ b/portal/src/app/(frontend)/nyheter/FilterChip.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Chip } from "@fremtind/jokul/chip";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type FilterChipProps = {
+    value: string;
+    label: string;
+    selectedValues: string[];
+};
+
+const toggledValues = (value: string, selectedValues: string[]): string[] => {
+    if (selectedValues.includes(value)) {
+        return selectedValues.filter((v) => v !== value);
+    }
+    return [...selectedValues, value];
+};
+
+export function FilterChip({ value, label, selectedValues }: FilterChipProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    return (
+        <Chip
+            variant="filter"
+            selected={selectedValues.includes(value)}
+            onClick={() => {
+                const updated = toggledValues(value, selectedValues);
+                const params = new URLSearchParams(searchParams.toString());
+                if (updated.length > 0) {
+                    params.set("types", updated.join(","));
+                } else {
+                    params.delete("types");
+                }
+                params.delete("page");
+                const query = params.toString();
+                router.push(query ? `${pathname}?${query}` : pathname);
+            }}
+        >
+            {label}
+        </Chip>
+    );
+}

--- a/portal/src/app/(frontend)/nyheter/NewsPagination.tsx
+++ b/portal/src/app/(frontend)/nyheter/NewsPagination.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Pagination } from "@fremtind/jokul/pagination";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type Props = {
+    currentPage: number;
+    numberOfPages: number;
+};
+
+export function NewsPagination({ currentPage, numberOfPages }: Props) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    return (
+        <Pagination
+            aria-label="Sidenavigasjon for nyheter"
+            currentPage={currentPage}
+            numberOfPages={numberOfPages}
+            onPageChange={(toPage) => {
+                const params = new URLSearchParams(searchParams.toString());
+                params.set("page", String(toPage));
+                router.push(`${pathname}?${params.toString()}`, {
+                    scroll: false,
+                });
+            }}
+        />
+    );
+}

--- a/portal/src/app/(frontend)/nyheter/NewsPost.tsx
+++ b/portal/src/app/(frontend)/nyheter/NewsPost.tsx
@@ -1,0 +1,72 @@
+import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
+import type { NewsPageQueryResult } from "@/sanity/types";
+import { Text } from "@fremtind/jokul/typography";
+
+export default function NewsPost({
+    article,
+}: { article: NewsPageQueryResult["articles"][number] }) {
+    const {
+        name,
+        short_description,
+        updated,
+        created,
+        type,
+        href,
+        image,
+        imageDark,
+    } = article;
+
+    if (!href) return null;
+
+    const relativeDate = new Intl.RelativeTimeFormat("no", { numeric: "auto" });
+    const createdMs = new Date(created).getTime();
+    const updatedMs = new Date(updated).getTime();
+    const wasUpdated = updatedMs - createdMs > 600_000; // edited >10 min after creation
+    const referenceMs = wasUpdated ? updatedMs : createdMs;
+    const label = wasUpdated ? "Oppdatert" : "Postet";
+
+    const daysAgo = Math.max(
+        0,
+        Math.round((Date.now() - referenceMs) / 86_400_000),
+    );
+
+    let relative: string;
+    if (daysAgo > 60) {
+        relative = new Date(referenceMs).toLocaleDateString("no", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+        });
+    } else if (daysAgo >= 30) {
+        relative = relativeDate.format(-Math.round(daysAgo / 30), "month");
+    } else if (daysAgo >= 7) {
+        relative = relativeDate.format(-Math.round(daysAgo / 7), "week");
+    } else {
+        relative = relativeDate.format(-daysAgo, "day");
+    }
+
+    const dateText = `${label} ${relative}`;
+
+    return (
+        <OverviewCardWithPreferences
+            link={href || ""}
+            image={
+                image || imageDark
+                    ? { light: image, dark: imageDark }
+                    : undefined
+            }
+            title={name || ""}
+            description={short_description || ""}
+            footer={
+                <div>
+                    <Text size="xs" short>
+                        {type}
+                    </Text>
+                    <Text subdued size="xs">
+                        {dateText}
+                    </Text>
+                </div>
+            }
+        />
+    );
+}

--- a/portal/src/app/(frontend)/nyheter/article.types.ts
+++ b/portal/src/app/(frontend)/nyheter/article.types.ts
@@ -1,0 +1,38 @@
+export const ARTICLE_TYPES = [
+    {
+        value: "blogg",
+        sanityType: "jokul_blog_post",
+        label: "Blogg",
+    },
+    {
+        value: "komponent",
+        sanityType: "jokul_component",
+        label: "Komponenter",
+    },
+    {
+        value: "fundament",
+        sanityType: "jokul_fundamentals",
+        label: "Fundamenter",
+    },
+    {
+        value: "release-notes",
+        sanityType: "jokul_release_notes",
+        label: "Release notes",
+    },
+    {
+        value: "monster",
+        sanityType: "jokul_monster",
+        label: "Mønster",
+    },
+] as const;
+
+export type ArticleType = (typeof ARTICLE_TYPES)[number];
+export type ArticleTypeValue = ArticleType["value"];
+
+const articleTypeValues = new Set<string>(
+    ARTICLE_TYPES.map((type) => type.value),
+);
+
+export function isArticleTypeValue(value: string): value is ArticleTypeValue {
+    return articleTypeValues.has(value);
+}

--- a/portal/src/app/(frontend)/nyheter/page.tsx
+++ b/portal/src/app/(frontend)/nyheter/page.tsx
@@ -1,0 +1,156 @@
+import { FilterChip } from "@/app/(frontend)/nyheter/FilterChip";
+import { NewsPagination } from "@/app/(frontend)/nyheter/NewsPagination";
+import NewsPost from "@/app/(frontend)/nyheter/NewsPost";
+import {
+    ARTICLE_TYPES,
+    isArticleTypeValue,
+} from "@/app/(frontend)/nyheter/article.types";
+import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
+import { OverviewHeader } from "@/components/overview/header";
+import { sanityFetch } from "@/sanity/lib/live";
+import { newsPageQuery } from "@/sanity/queries/allPosts";
+import { parseUserPreferences } from "@/utils/user-preferences";
+import { Flex } from "@fremtind/jokul/flex";
+import { getCookie } from "cookies-next";
+import { logger } from "logger";
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+const SITE_URL =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://jokul.fremtind.no";
+const DESCRIPTION =
+    "Nylig oppdaterte artikler, komponenter, fundamenter og release notes i Jøkul – Fremtinds designsystem.";
+const PAGE_SIZE = 12;
+
+export const metadata: Metadata = {
+    metadataBase: new URL(SITE_URL),
+    title: "Nyheter",
+    description: DESCRIPTION,
+    openGraph: {
+        type: "website",
+        siteName: "Jøkul",
+        locale: "nb_NO",
+        url: "/nyheter",
+        title: "Nyheter – Jøkul",
+        description: DESCRIPTION,
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Nyheter – Jøkul",
+        description: DESCRIPTION,
+    },
+    robots: { index: true, follow: true },
+};
+
+export default async function NyheterPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | undefined }>;
+}) {
+    logger.info("Rendering nyheter page");
+
+    const userPreferences = parseUserPreferences(
+        await getCookie("userPreferences", { cookies }),
+    );
+
+    const { types: typesParam, page: pageParam } = await searchParams;
+
+    const selectedValues = (typesParam ?? "")
+        .split(",")
+        .filter(isArticleTypeValue);
+    const selectedTypes = ARTICLE_TYPES.filter((type) =>
+        selectedValues.includes(type.value),
+    );
+    const selectedSanityTypes = selectedTypes.map((type) => type.sanityType);
+
+    if (selectedValues.length > 0) {
+        logger.info(`Filtering articles by types: ${selectedValues.join(",")}`);
+    }
+
+    const requestedPage = Math.max(1, Number(pageParam) || 1);
+    const start = (requestedPage - 1) * PAGE_SIZE;
+
+    const { data } = await sanityFetch({
+        query: newsPageQuery,
+        params: {
+            types: selectedSanityTypes,
+            start,
+            end: start + PAGE_SIZE,
+        },
+        requestTag: "news-page",
+        tags: [
+            "jokul_blog_post",
+            "jokul_component",
+            "jokul_fundamentals",
+            "jokul_release_notes",
+            "jokul_temaside",
+        ],
+    });
+
+    const articles = data?.articles ?? [];
+    const total = data?.total ?? 0;
+    const availableTypes = data?.availableTypes ?? [];
+
+    if (articles.length === 0) {
+        logger.warn("No updated articles found");
+        return (
+            <>
+                <OverviewHeader title="Nylig oppdatert" />
+                <p>Fant ingen artikler :(</p>
+            </>
+        );
+    }
+
+    const numberOfPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+    if (requestedPage > numberOfPages) {
+        const params = new URLSearchParams();
+        if (selectedValues.length > 0) {
+            params.set("types", selectedValues.join(","));
+        }
+        if (numberOfPages > 1) {
+            params.set("page", String(numberOfPages));
+        }
+        const query = params.toString();
+        redirect(query ? `/nyheter?${query}` : "/nyheter");
+    }
+
+    const availableTypeSet = new Set(availableTypes);
+    const articleTypes = ARTICLE_TYPES.filter((type) =>
+        availableTypeSet.has(type.sanityType),
+    );
+
+    return (
+        <>
+            <OverviewHeader
+                title="Nylig oppdatert"
+                showToolbar
+                actions={
+                    numberOfPages > 1 ? (
+                        <NewsPagination
+                            currentPage={requestedPage}
+                            numberOfPages={numberOfPages}
+                        />
+                    ) : undefined
+                }
+            >
+                <Flex wrap="wrap" gap="xs">
+                    {articleTypes.map((type) => (
+                        <FilterChip
+                            key={type.value}
+                            value={type.value}
+                            label={type.label}
+                            selectedValues={selectedValues}
+                        />
+                    ))}
+                </Flex>
+            </OverviewHeader>
+            <OverviewGridWithPreferences initialPreferences={userPreferences}>
+                {articles.map((article) => (
+                    <NewsPost key={article._id} article={article} />
+                ))}
+            </OverviewGridWithPreferences>
+        </>
+    );
+}

--- a/portal/src/components/overview/card.tsx
+++ b/portal/src/components/overview/card.tsx
@@ -1,7 +1,7 @@
 import type { SanityImageLike } from "@/sanity/lib/image";
 import { Card } from "@fremtind/jokul/card";
 import NextLink from "next/link";
-import { useId } from "react";
+import { type ReactNode, useId } from "react";
 import { OverviewThumbnail } from "./thumbnail";
 
 import styles from "./overview.module.scss";
@@ -16,12 +16,16 @@ export type OverviewCardProps = {
     description?: string;
     image?: OverviewCardImage;
     link: string;
+    footer?: ReactNode;
 };
 
 export const OverviewCard = (props: OverviewCardProps) => {
     const id = useId();
-    const { link, title, description, image } = props;
+    const { link, title, description, image, footer } = props;
     const descriptionId = description ? `${id}-description` : undefined;
+    const footerId = footer ? `${id}-footer` : undefined;
+    const describedBy =
+        [footerId, descriptionId].filter(Boolean).join(" ") || undefined;
 
     return (
         <li>
@@ -31,7 +35,7 @@ export const OverviewCard = (props: OverviewCardProps) => {
                 padding="l"
                 className={styles.card}
                 aria-labelledby={`${id}-title`}
-                aria-describedby={descriptionId}
+                aria-describedby={describedBy}
             >
                 <p className={styles.name} id={`${id}-title`}>
                     {title}
@@ -46,6 +50,11 @@ export const OverviewCard = (props: OverviewCardProps) => {
                         darkImage={image.dark}
                         lightImage={image.light}
                     />
+                )}
+                {footer && (
+                    <footer className={styles.footer} id={footerId}>
+                        {footer}
+                    </footer>
                 )}
             </Card>
         </li>

--- a/portal/src/components/overview/header.tsx
+++ b/portal/src/components/overview/header.tsx
@@ -7,11 +7,12 @@ import styles from "./overview.module.scss";
 type OverviewHeaderProps = {
     title: string;
     children?: ReactNode;
+    actions?: ReactNode;
     showToolbar?: boolean;
 };
 
 export function OverviewHeader(props: OverviewHeaderProps) {
-    const { title, children, showToolbar = false } = props;
+    const { title, children, actions, showToolbar = false } = props;
 
     return (
         <Flex as="header" direction="column" gap="xl" className={styles.header}>
@@ -22,6 +23,7 @@ export function OverviewHeader(props: OverviewHeaderProps) {
                         <div className={styles.filters}>{children}</div>
                     )}
                     <div className={styles.views}>
+                        {actions}
                         <PreferencesMenu />
                     </div>
                 </search>

--- a/portal/src/components/overview/overview.module.scss
+++ b/portal/src/components/overview/overview.module.scss
@@ -14,6 +14,10 @@
 
         .views {
             grid-column: 2;
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: var(--jkl-spacing-16);
         }
     }
 }
@@ -64,8 +68,6 @@
     }
 
     .description {
-        margin-bottom: auto;
-
         @include jkl.text-style("paragraph-small") {
             color: var(--jkl-color-text-subdued);
             word-wrap: break-word;
@@ -87,5 +89,10 @@
             object-position: center;
             aspect-ratio: inherit;
         }
+    }
+
+    .footer {
+        padding-block-start: 2lh;
+        margin-block-start: auto;
     }
 }

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -704,6 +704,10 @@
                                               {
                                                 "type": "string",
                                                 "value": "release-notes"
+                                              },
+                                              {
+                                                "type": "string",
+                                                "value": "nyheter"
                                               }
                                             ]
                                           },

--- a/portal/src/sanity/queries/allPosts.ts
+++ b/portal/src/sanity/queries/allPosts.ts
@@ -1,0 +1,102 @@
+import { defineQuery } from "next-sanity";
+
+export const latestUpdatedArticlesQuery = defineQuery(
+    `*[
+        _type in [
+            "jokul_blog_post",
+            "jokul_component",
+            "jokul_fundamentals",
+            "jokul_release_notes",
+            "jokul_temaside"
+        ] && defined(slug.current)
+    ] | order(_updatedAt desc)[0...$limit]{
+        _id,
+        _type,
+        "type": select(
+            _type == "jokul_blog_post"     => "Blogg",
+            _type == "jokul_component"     => "Komponent",
+            _type == "jokul_fundamentals"  => "Fundament",
+            _type == "jokul_release_notes" => "Release notes",
+            _type == "jokul_temaside"      => "Temaside",
+            "Artikkel"
+        ),
+        "name": coalesce(name, tema, version),
+        short_description,
+        image,
+        imageDark,
+        "slug": slug.current,
+        "href": select(
+            _type == "jokul_blog_post"     => "/blog/" + slug.current,
+            _type == "jokul_component"     => "/komponenter/" + slug.current,
+            _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,
+            _type == "jokul_release_notes" => "/release-notes/" + slug.current,
+            _type == "jokul_temaside"      => "/temabygger/" + slug.current,
+            "/"
+        ),
+        "updated": _updatedAt,
+        "created": _createdAt,
+    }`,
+);
+
+export const newsPageQuery = defineQuery(
+    `{
+        "articles": *[
+            _type in [
+                "jokul_blog_post",
+                "jokul_component",
+                "jokul_fundamentals",
+                "jokul_release_notes",
+                "jokul_temaside"
+            ] && defined(slug.current)
+            && (count($types) == 0 || _type in $types)
+            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60
+        ] | order(_updatedAt desc)[$start...$end]{
+            _id,
+            _type,
+            "type": select(
+                _type == "jokul_blog_post"     => "Blogg",
+                _type == "jokul_component"     => "Komponent",
+                _type == "jokul_fundamentals"  => "Fundament",
+                _type == "jokul_release_notes" => "Release notes",
+                _type == "jokul_temaside"      => "Temaside",
+                "Artikkel"
+            ),
+            "name": coalesce(name, tema, version),
+            short_description,
+            image,
+            imageDark,
+            "slug": slug.current,
+            "href": select(
+                _type == "jokul_blog_post"     => "/blog/" + slug.current,
+                _type == "jokul_component"     => "/komponenter/" + slug.current,
+                _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,
+                _type == "jokul_release_notes" => "/release-notes/" + slug.current,
+                _type == "jokul_temaside"      => "/temabygger/" + slug.current,
+                "/"
+            ),
+            "updated": _updatedAt,
+            "created": _createdAt,
+        },
+        "total": count(*[
+            _type in [
+                "jokul_blog_post",
+                "jokul_component",
+                "jokul_fundamentals",
+                "jokul_release_notes",
+                "jokul_temaside"
+            ] && defined(slug.current)
+            && (count($types) == 0 || _type in $types)
+            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60
+        ]),
+        "availableTypes": array::unique(*[
+            _type in [
+                "jokul_blog_post",
+                "jokul_component",
+                "jokul_fundamentals",
+                "jokul_release_notes",
+                "jokul_temaside"
+            ] && defined(slug.current)
+            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60
+        ]._type)
+    }`,
+);

--- a/portal/src/sanity/schemas/documents/siteData.ts
+++ b/portal/src/sanity/schemas/documents/siteData.ts
@@ -140,6 +140,10 @@ export const siteData = defineType({
                                                                                 title: "Release notes",
                                                                                 value: "release-notes",
                                                                             },
+                                                                            {
+                                                                                title: "Nyheter",
+                                                                                value: "nyheter",
+                                                                            },
                                                                         ],
                                                                     },
                                                                     validation:

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -135,7 +135,7 @@ export type Jokul_siteData = {
           _type: "internalLink";
           _key: string;
         } | {
-          route?: "komponenter" | "fundamenter" | "monster" | "blog" | "release-notes";
+          route?: "komponenter" | "fundamenter" | "monster" | "blog" | "release-notes" | "nyheter";
           _type: "mainPageLink";
           _key: string;
         } | {
@@ -1172,6 +1172,226 @@ export type Geopoint = {
 
 export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_examples | Jokul_codeBlock | Jokul_codeExample | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Slug | Jokul_story | Code | Jokul_code | Jokul_componentProps | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
+// Source: ./src/sanity/queries/allPosts.ts
+// Variable: latestUpdatedArticlesQuery
+// Query: *[        _type in [            "jokul_blog_post",            "jokul_component",            "jokul_fundamentals",            "jokul_release_notes",            "jokul_temaside"        ] && defined(slug.current)    ] | order(_updatedAt desc)[0...$limit]{        _id,        _type,        "type": select(            _type == "jokul_blog_post"     => "Blogg",            _type == "jokul_component"     => "Komponent",            _type == "jokul_fundamentals"  => "Fundament",            _type == "jokul_release_notes" => "Release notes",            _type == "jokul_temaside"      => "Temaside",            "Artikkel"        ),        "name": coalesce(name, tema, version),        short_description,        image,        imageDark,        "slug": slug.current,        "href": select(            _type == "jokul_blog_post"     => "/blog/" + slug.current,            _type == "jokul_component"     => "/komponenter/" + slug.current,            _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,            _type == "jokul_release_notes" => "/release-notes/" + slug.current,            _type == "jokul_temaside"      => "/temabygger/" + slug.current,            "/"        ),        "updated": _updatedAt,        "created": _createdAt,    }
+export type LatestUpdatedArticlesQueryResult = Array<{
+  _id: string;
+  _type: "jokul_blog_post";
+  type: "Blogg";
+  name: string | null;
+  short_description: string | null;
+  image: null;
+  imageDark: null;
+  slug: string | null;
+  href: string | null;
+  updated: string;
+  created: string;
+} | {
+  _id: string;
+  _type: "jokul_component";
+  type: "Komponent";
+  name: string | null;
+  short_description: string | null;
+  image: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  imageDark: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  slug: string | null;
+  href: string | null;
+  updated: string;
+  created: string;
+} | {
+  _id: string;
+  _type: "jokul_fundamentals";
+  type: "Fundament";
+  name: string | null;
+  short_description: string | null;
+  image: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  imageDark: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  } | null;
+  slug: string | null;
+  href: string | null;
+  updated: string;
+  created: string;
+} | {
+  _id: string;
+  _type: "jokul_release_notes";
+  type: "Release notes";
+  name: string | null;
+  short_description: string | null;
+  image: null;
+  imageDark: null;
+  slug: string | null;
+  href: string | null;
+  updated: string;
+  created: string;
+} | {
+  _id: string;
+  _type: "jokul_temaside";
+  type: "Temaside";
+  name: string | null;
+  short_description: string | null;
+  image: null;
+  imageDark: null;
+  slug: string | null;
+  href: string | null;
+  updated: string;
+  created: string;
+}>;
+// Variable: newsPageQuery
+// Query: {        "articles": *[            _type in [                "jokul_blog_post",                "jokul_component",                "jokul_fundamentals",                "jokul_release_notes",                "jokul_temaside"            ] && defined(slug.current)            && (count($types) == 0 || _type in $types)            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60        ] | order(_updatedAt desc)[$start...$end]{            _id,            _type,            "type": select(                _type == "jokul_blog_post"     => "Blogg",                _type == "jokul_component"     => "Komponent",                _type == "jokul_fundamentals"  => "Fundament",                _type == "jokul_release_notes" => "Release notes",                _type == "jokul_temaside"      => "Temaside",                "Artikkel"            ),            "name": coalesce(name, tema, version),            short_description,            image,            imageDark,            "slug": slug.current,            "href": select(                _type == "jokul_blog_post"     => "/blog/" + slug.current,                _type == "jokul_component"     => "/komponenter/" + slug.current,                _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,                _type == "jokul_release_notes" => "/release-notes/" + slug.current,                _type == "jokul_temaside"      => "/temabygger/" + slug.current,                "/"            ),            "updated": _updatedAt,            "created": _createdAt,        },        "total": count(*[            _type in [                "jokul_blog_post",                "jokul_component",                "jokul_fundamentals",                "jokul_release_notes",                "jokul_temaside"            ] && defined(slug.current)            && (count($types) == 0 || _type in $types)            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60        ]),        "availableTypes": array::unique(*[            _type in [                "jokul_blog_post",                "jokul_component",                "jokul_fundamentals",                "jokul_release_notes",                "jokul_temaside"            ] && defined(slug.current)            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60        ]._type)    }
+export type NewsPageQueryResult = {
+  articles: Array<{
+    _id: string;
+    _type: "jokul_blog_post";
+    type: "Blogg";
+    name: string | null;
+    short_description: string | null;
+    image: null;
+    imageDark: null;
+    slug: string | null;
+    href: string | null;
+    updated: string;
+    created: string;
+  } | {
+    _id: string;
+    _type: "jokul_component";
+    type: "Komponent";
+    name: string | null;
+    short_description: string | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    imageDark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    slug: string | null;
+    href: string | null;
+    updated: string;
+    created: string;
+  } | {
+    _id: string;
+    _type: "jokul_fundamentals";
+    type: "Fundament";
+    name: string | null;
+    short_description: string | null;
+    image: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    imageDark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    slug: string | null;
+    href: string | null;
+    updated: string;
+    created: string;
+  } | {
+    _id: string;
+    _type: "jokul_release_notes";
+    type: "Release notes";
+    name: string | null;
+    short_description: string | null;
+    image: null;
+    imageDark: null;
+    slug: string | null;
+    href: string | null;
+    updated: string;
+    created: string;
+  } | {
+    _id: string;
+    _type: "jokul_temaside";
+    type: "Temaside";
+    name: string | null;
+    short_description: string | null;
+    image: null;
+    imageDark: null;
+    slug: string | null;
+    href: string | null;
+    updated: string;
+    created: string;
+  }>;
+  total: number;
+  availableTypes: Array<"jokul_blog_post" | "jokul_component" | "jokul_fundamentals" | "jokul_release_notes" | "jokul_temaside">;
+};
+
 // Source: ./src/sanity/queries/blog.ts
 // Variable: blogPostsQuery
 // Query: *[_type == "jokul_blog_post"]{        name,        slug,        short_description,        "date": _createdAt,        _type == "jokul_examples" => {                ...,                title,                examples[]->{                  title,                  id,                  description,                  height,                  inert                },          },    } | order(_createdAt desc)
@@ -3068,7 +3288,7 @@ export type SiteDataQueryResult = {
       title: string | null;
       linkList: Array<{
         text: string | null;
-        url: null | string | "/blog" | "/fundamenter" | "/komponenter" | "/monster" | "/release-notes";
+        url: null | string | "/blog" | "/fundamenter" | "/komponenter" | "/monster" | "/nyheter" | "/release-notes";
       }> | null;
     }> | null;
   } | null;
@@ -3084,6 +3304,8 @@ export type ExamplesQueryResult = Array<never>;
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
+    "*[\n        _type in [\n            \"jokul_blog_post\",\n            \"jokul_component\",\n            \"jokul_fundamentals\",\n            \"jokul_release_notes\",\n            \"jokul_temaside\"\n        ] && defined(slug.current)\n    ] | order(_updatedAt desc)[0...$limit]{\n        _id,\n        _type,\n        \"type\": select(\n            _type == \"jokul_blog_post\"     => \"Blogg\",\n            _type == \"jokul_component\"     => \"Komponent\",\n            _type == \"jokul_fundamentals\"  => \"Fundament\",\n            _type == \"jokul_release_notes\" => \"Release notes\",\n            _type == \"jokul_temaside\"      => \"Temaside\",\n            \"Artikkel\"\n        ),\n        \"name\": coalesce(name, tema, version),\n        short_description,\n        image,\n        imageDark,\n        \"slug\": slug.current,\n        \"href\": select(\n            _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n            _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n            _type == \"jokul_temaside\"      => \"/temabygger/\" + slug.current,\n            \"/\"\n        ),\n        \"updated\": _updatedAt,\n        \"created\": _createdAt,\n    }": LatestUpdatedArticlesQueryResult;
+    "{\n        \"articles\": *[\n            _type in [\n                \"jokul_blog_post\",\n                \"jokul_component\",\n                \"jokul_fundamentals\",\n                \"jokul_release_notes\",\n                \"jokul_temaside\"\n            ] && defined(slug.current)\n            && (count($types) == 0 || _type in $types)\n            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60\n        ] | order(_updatedAt desc)[$start...$end]{\n            _id,\n            _type,\n            \"type\": select(\n                _type == \"jokul_blog_post\"     => \"Blogg\",\n                _type == \"jokul_component\"     => \"Komponent\",\n                _type == \"jokul_fundamentals\"  => \"Fundament\",\n                _type == \"jokul_release_notes\" => \"Release notes\",\n                _type == \"jokul_temaside\"      => \"Temaside\",\n                \"Artikkel\"\n            ),\n            \"name\": coalesce(name, tema, version),\n            short_description,\n            image,\n            imageDark,\n            \"slug\": slug.current,\n            \"href\": select(\n                _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n                _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n                _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n                _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n                _type == \"jokul_temaside\"      => \"/temabygger/\" + slug.current,\n                \"/\"\n            ),\n            \"updated\": _updatedAt,\n            \"created\": _createdAt,\n        },\n        \"total\": count(*[\n            _type in [\n                \"jokul_blog_post\",\n                \"jokul_component\",\n                \"jokul_fundamentals\",\n                \"jokul_release_notes\",\n                \"jokul_temaside\"\n            ] && defined(slug.current)\n            && (count($types) == 0 || _type in $types)\n            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60\n        ]),\n        \"availableTypes\": array::unique(*[\n            _type in [\n                \"jokul_blog_post\",\n                \"jokul_component\",\n                \"jokul_fundamentals\",\n                \"jokul_release_notes\",\n                \"jokul_temaside\"\n            ] && defined(slug.current)\n            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60\n        ]._type)\n    }": NewsPageQueryResult;
     "*[_type == \"jokul_blog_post\"]{\n        name,\n        slug,\n        short_description,\n        \"date\": _createdAt,\n        _type == \"jokul_examples\" => {\n                ...,\n                title,\n                examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert\n                },\n          },\n    } | order(_createdAt desc)": BlogPostsQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == $slug][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_code\" => {\n                ...,\n                title,\n                code,\n                language,\n          },\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    examples[]->{\n                  title,\n                  id,\n                  description,\n                  height,\n                  inert,\n                  code\n                },\n  },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n  },\n    }": BlogPostBySlugQueryResult;
     "*[_type == \"jokul_blog_post\" && slug.current == \"kom-i-gang\"][0] {...,\n    article[]{\n            ...,\n            _type == \"jokul_examples\" => {\n    ...,\n    title,\n    stories[]->{\n      storyName,\n      storyId,\n      storyDescription,\n    },\n  },\n            markDefs[] {\n                ...,\n                _type == \"jokul_internal_link\" => {\n                    article->{\n                        _type,\n                        \"name\": coalesce(name, tema, version),\n                        short_description,\n                        \"slug\": slug.current,\n                        image,\n                        imageDark\n                    }\n                },\n            }\n  },\n    }": KomIGangQueryResult;


### PR DESCRIPTION
Legger til en Nyheter-side i portalen. Dette fungerer som ett sted som samler nylig publisert eller oppdatert innhold på tvers av alle innholdstyper.

I tillegg bruker den samme spørring for å lag en RSS-feed, som vi så kan bruke for å automatisk poste nyheter fra portalen i Teams/Slack.

Bilder:
<img width="2263" height="1633" alt="2026-08-03 09 04 24 localhost 908db07edcec" src="https://github.com/user-attachments/assets/53862fbe-8408-42b9-bd1e-f9392719418e" />
<img width="2263" height="1582" alt="2026-08-03 09 04 36 localhost 9f055f228b6e" src="https://github.com/user-attachments/assets/4bb4da4a-ecd5-4e82-ae4e-6913d10c83e3" />
