### PR TITLE
Fiks feil i responssive stiler i Flex

### DIFF
--- a/.changeset/whole-streets-swim.md
+++ b/.changeset/whole-streets-swim.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der `Flex` ikke fikk riktige klasser satt dersom man satte responsive verdier for `gap` eller `layout`

--- a/packages/jokul/src/components/flex/Flex.tsx
+++ b/packages/jokul/src/components/flex/Flex.tsx
@@ -76,7 +76,9 @@ export const Flex = forwardRef(function Flex<
  */
 function toObjectEntries<T>(value: T | Responsive<T>): [Breakpoint, T][] {
     if (isResponsive(value)) {
-        return Object.entries(value) as [Breakpoint, T][];
+        return (Object.entries(value) as [Breakpoint, T][]).filter(
+            ([, v]) => v !== undefined,
+        );
     }
 
     return [["small", value]];

--- a/packages/jokul/src/components/flex/types.ts
+++ b/packages/jokul/src/components/flex/types.ts
@@ -42,9 +42,11 @@ export type Breakpoint = (typeof BREAKPOINTS)[number];
 
 export type Responsive<T> = Partial<Record<Breakpoint, T>>;
 export function isResponsive<T>(value: unknown): value is Responsive<T> {
-    return BREAKPOINTS.includes(
-        Object.keys(value as Responsive<T>)[0] as Breakpoint,
-    );
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return false;
+    }
+    const keys = Object.keys(value);
+    return keys.length === 0 || BREAKPOINTS.includes(keys[0] as Breakpoint);
 }
 
 export const LAYOUTS = [


### PR DESCRIPTION
## 💬 Endringer

Fikser en feil der `Flex` ikke fikk riktige klasser satt dersom man satte responsive verdier for `gap` eller `layout`

## 🩹 Løser følgende issues

Closes #6330 
