### PR TITLE
fix: Fjern devDependencies (Storybook, Vite, Playwright, Biome, ...) fra node_modules før de kopieres til runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN \
 # Fjern devDependencies (Storybook, Vite, Playwright, Biome, ...) fra
 # node_modules før de kopieres til runner. Kutter fil-antall og lagstørrelse
 # drastisk – det som gjør at "exporting layers" timer ut.
-RUN pnpm prune --prod
+RUN CI=true pnpm prune --prod
 
 FROM base AS runner
 


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #NNNN
