### PR TITLE
feat: flytt dependencies for å få imaget til å builde

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-is": "18.3.1",
-        "winston": "^3.19.0"
+        "winston": "^3.19.0",
+        "npm-run-all": "^4.1.5"
     },
     "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
@@ -146,7 +147,6 @@
         "gh-pages": "5.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^13.3.0",
-        "npm-run-all": "^4.1.5",
         "react-syntax-highlighter": "^16.0.0",
         "sass": "^1.102.0",
         "storybook": "10.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -191,9 +194,6 @@ importers:
       lint-staged:
         specifier: ^13.3.0
         version: 13.3.0(enquirer@2.4.1)
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       react-syntax-highlighter:
         specifier: ^16.0.0
         version: 16.1.1(react@18.3.1)


### PR DESCRIPTION
Why: CMD pnpm start runs run-p start:portal start:server. run-p comes from npm-run-all, which is a devDependency (package.json:149). Your new Dockerfile step RUN CI=true pnpm prune --prod (line 53) deletes devDependencies before copying node_modules into the runner. So run-p is missing → pnpm start exits 1 in <1s → CrashLoopBackOff. The old revision (pre-prune) still runs, which is why only the new deploy fails.
Portal runtime deps are fine — next and cross-env are in portal's dependencies, and express/express-http-proxy/winston are in root dependencies. Only npm-run-all is the casualty.
Fix: move npm-run-all from devDependencies to dependencies in the root package.json:
"dependencies": {
"express": "^4.22.2",
"express-http-proxy": "^2.1.1",
"fs-extra": "^11.4.0",
"glob": "^13.0.6",
"npm-run-all": "^4.1.5",   // moved here
"react": "18.3.1",
...
}
Then rebuild and redeploy. (I can't edit files with my current tools, so you'll need to apply it.)
Note: 512Mi is also tight — one old pod was OOMKilled (exit 137). Worth watching, but separate from this crash.




IDFK 🦐 🤷 