### PR TITLE
fix: gjenopprett .bin-symlinker etter pnpm prune i Docker-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,13 @@ RUN \
 # node_modules før de kopieres til runner. Kutter fil-antall og lagstørrelse
 # drastisk – det som gjør at "exporting layers" timer ut.
 RUN CI=true pnpm prune --prod
+# `pnpm prune --prod` skriver om den virtuelle store-en og etterlater
+# ødelagte/manglende `.bin`-symlinker for workspace-pakker – spesielt etter
+# tar-runden node_modules går gjennom mellom Docker-stegene. Det gjør at
+# runtime-kommandoer som `cross-env` og `run-p` feiler med «command not found».
+# Kjør en offline relink mot den allerede-prunede store-en for å gjenopprette
+# `.bin`-symlinkene uten å laste ned noe på nytt.
+RUN pnpm install --frozen-lockfile --prod --offline
 
 FROM base AS runner
 


### PR DESCRIPTION
## 💬 Endringer

🤖 Denne PRen er skrevet av Copilot

`pnpm prune --prod` skriver om den virtuelle store-en og etterlater ødelagte eller manglende `.bin`-symlinker for workspace-pakker, spesielt etter tar-runden `node_modules` går gjennom mellom Docker-stegene. Det førte til at runtime-kommandoer som `cross-env` og `run-p` feilet med "command not found" og krasjet containeren i en loop.

Kjør en offline relink mot den allerede-prunede store-en rett etter prune for å gjenopprette `.bin`-symlinkene uten å laste ned noe på nytt.
