### PR TITLE
Fiks feil redirect i api/draft-mode/disable

### DIFF
--- a/.changeset/fresh-boxes-do.md
+++ b/.changeset/fresh-boxes-do.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Fikser en feil der man kom til en tom side når man avsluttet draft mode for forhåndsvisning av Sanity-innhold.

--- a/portal/src/app/api/draft-mode/disable/route.ts
+++ b/portal/src/app/api/draft-mode/disable/route.ts
@@ -3,5 +3,21 @@ import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
     (await draftMode()).disable();
-    return NextResponse.redirect(new URL("/", request.url));
+
+    const origin = request.nextUrl.origin;
+    try {
+        const redirect = new URL(
+            request.headers.get("referer") ?? origin,
+            origin,
+        );
+        if (redirect.origin !== origin) {
+            throw new Error();
+        }
+
+        return NextResponse.redirect(redirect);
+    } catch {
+        // referer inneholder en feil eller peker på et annet nettsted
+        // faller tilbake til forsiden
+        return NextResponse.redirect(new URL("/", origin));
+    }
 }


### PR DESCRIPTION
## 💬 Endringer

Fikser en feil der man kom til en tom side når man avsluttet draft mode for forhåndsvisning av Sanity-innhold.
