### PR TITLE
docs(changeset): search: søkefelt med knapp og label, fokus-linje

### DIFF
--- a/.changeset/full-ads-shine.md
+++ b/.changeset/full-ads-shine.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+search: fikser en feil som gjorde at Search ikke hadde fokus-outline

--- a/.changeset/full-tips-sing.md
+++ b/.changeset/full-tips-sing.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+search: Fikser en feil som gjorde at Search ikke ble vist riktig med label og/eller description

--- a/packages/jokul/src/components/search/styles/search-with-submit-button.scss
+++ b/packages/jokul/src/components/search/styles/search-with-submit-button.scss
@@ -6,6 +6,12 @@
     grid-template-columns: 1fr max-content;
     align-items: end;
 
+    .jkl-input-group-description,
+    .jkl-label,
+    .input-wrapper {
+        grid-column: 1 / 2;
+    }
+
     .input-wrapper {
         border-inline-end: 0;
         border-top-right-radius: 0;

--- a/packages/jokul/src/components/search/styles/search.scss
+++ b/packages/jokul/src/components/search/styles/search.scss
@@ -11,6 +11,10 @@
 
     @include jkl.text-style("text-medium");
 
+    .jkl-input-group {
+        display: contents;
+    }
+
     input[type="search"] {
         appearance: none;
         padding: 0;
@@ -52,6 +56,11 @@
 
         &:has(.clear-button) {
             grid-template-columns: 1.3em 1fr 1.3em;
+        }
+
+        &:has(input:focus-visible) {
+            @include jkl.focus-outline;
+            background-color: var(--jkl-color-background-container);
         }
     }
 


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Legger til fokus-linje på søkefeltet.
Fikser griddet så man kan vise label og description sammen med Search.Button uten at knappen tar opp hele høyden.

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6190
