### PR TITLE
docs(changeset): Markerer helpLabel propen i input-komponenter som deprecated

### DIFF
--- a/.changeset/eleven-bats-nail.md
+++ b/.changeset/eleven-bats-nail.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Markerer `helpLabel` propen i input-komponenter som deprecated. Framover skal man heller bruke `description`.

--- a/packages/jokul/src/components/input-group/FieldGroup.tsx
+++ b/packages/jokul/src/components/input-group/FieldGroup.tsx
@@ -23,6 +23,7 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
 
     const uid = useId(id || "jkl-field-group", { generateSuffix: !id });
     const supportId = `${uid}_support-label`;
+    const descriptionId = `${uid}_description`;
 
     const supportText = errorLabel || helpLabel;
     const supportTextType = errorLabel
@@ -31,7 +32,13 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
           ? "help"
           : undefined;
 
-    const describedBy = supportText ? supportId : undefined;
+    const describedBy =
+        [
+            description ? descriptionId : undefined,
+            supportText ? supportId : undefined,
+        ]
+            .filter(Boolean)
+            .join(" ") || undefined;
 
     return (
         <fieldset
@@ -57,7 +64,9 @@ export const FieldGroup: FC<FieldGroupProps> = (props) => {
                 </Label>
             </legend>
             {description && (
-                <p className="jkl-input-group-description">{description}</p>
+                <p className="jkl-input-group-description" id={descriptionId}>
+                    {description}
+                </p>
             )}
             {children}
             {(helpLabel || errorLabel) && (

--- a/packages/jokul/src/components/input-group/types.ts
+++ b/packages/jokul/src/components/input-group/types.ts
@@ -17,6 +17,9 @@ export interface FieldGroupProps
     >;
     tooltip?: ReactNode;
     className?: string;
+    /**
+     * @deprecated Bruk heller `description`.
+     */
     helpLabel?: string;
     errorLabel?: string;
     description?: string;
@@ -35,6 +38,9 @@ export type InputGroupProps = WithOptionalChildren &
         "data-testid"?: string;
         "data-size"?: Size;
         errorLabel?: ReactNode;
+        /**
+         * @deprecated Bruk heller `description`.
+         */
         helpLabel?: ReactNode;
         inline?: boolean;
         label: ReactNode;


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6329
