### PR TITLE
docs(changeset): Fikser en feil der Tailwind v4-temaet manglet `color-scheme`, slik at `light-dark()` ikke byttet farger og CSS-minifisering med Lightning CSS brøt stilene.

### DIFF
--- a/.changeset/bold-worms-heal.md
+++ b/.changeset/bold-worms-heal.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der Tailwind v4-temaet manglet `color-scheme`, slik at `light-dark()` ikke byttet farger og CSS-minifisering med Lightning CSS brøt stilene.

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.test.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.test.ts
@@ -58,6 +58,33 @@ describe("css/tailwind4-format", () => {
         });
     });
 
+    describe("color-scheme-regler", () => {
+        it("setter color-scheme: light dark på :root", async () => {
+            const token = makeToken(
+                ["color", "neutral", "background", "page"],
+                { light: "#F4F2EF", dark: "#1B1917" },
+            );
+            const result = await runFormat([token]);
+            expect(result).toContain(
+                ":root {\n    color-scheme: light dark;\n}",
+            );
+        });
+
+        it("setter color-scheme via data-theme for manuell overstyring", async () => {
+            const token = makeToken(
+                ["color", "neutral", "background", "page"],
+                { light: "#F4F2EF", dark: "#1B1917" },
+            );
+            const result = await runFormat([token]);
+            expect(result).toContain(
+                '[data-theme="light"] {\n    color-scheme: light;\n}',
+            );
+            expect(result).toContain(
+                '[data-theme="dark"] {\n    color-scheme: dark;\n}',
+            );
+        });
+    });
+
     describe("spacingvariabler (formatSpacingVariables)", () => {
         it("genererer riktig variabelnavn for numeriske spacing-tokens", async () => {
             const tokens = [

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-tailwind4.ts
@@ -146,7 +146,10 @@ function formatBorderWidthVariables(
  * Formats text style tokens as Tailwind v4 @utility rules.
  * Uses the CSS font shorthand property pointing to the existing text style variables.
  */
-function formatTextUtilities(tokens: TransformedToken[], prefix: string): string {
+function formatTextUtilities(
+    tokens: TransformedToken[],
+    prefix: string,
+): string {
     return tokens
         .filter(isTextStyleToken)
         .map((token) => {
@@ -179,6 +182,18 @@ function formatTextUtilities(tokens: TransformedToken[], prefix: string): string
  *     --radius-m: 0.75rem;
  * }
  *
+ * :root {
+ *     color-scheme: light dark;
+ * }
+ *
+ * [data-theme="light"] {
+ *     color-scheme: light;
+ * }
+ *
+ * [data-theme="dark"] {
+ *     color-scheme: dark;
+ * }
+ *
  * @utility heading-1 {
  *     font: var(--jkl-text-style-heading-1);
  * }
@@ -190,7 +205,11 @@ const cssTailwind4Format: Format = {
         dictionary,
         file,
         options,
-    }: { dictionary: Dictionary; file: File; options: Config & LocalOptions }) => {
+    }: {
+        dictionary: Dictionary;
+        file: File;
+        options: Config & LocalOptions;
+    }) => {
         const allTokens = dictionary.allTokens;
         const indentation = "    ";
         const prefix = options.prefix as string;
@@ -226,12 +245,32 @@ const cssTailwind4Format: Format = {
             .filter(Boolean)
             .join("\n\n");
 
+        // light-dark() krever at color-scheme er satt for at riktig verdi skal
+        // velges. Uten dette resolver native light-dark() alltid til lys verdi,
+        // og Lightning CSS (Tailwind v4) sin polyfill får udefinerte toggle-
+        // variabler og produserer ugyldig CSS. Speiler css/color-scheme-formatet.
+        const colorSchemeRules = [
+            ":root {",
+            "    color-scheme: light dark;",
+            "}",
+            "",
+            '[data-theme="light"] {',
+            "    color-scheme: light;",
+            "}",
+            "",
+            '[data-theme="dark"] {',
+            "    color-scheme: dark;",
+            "}",
+        ].join("\n");
+
         return `${await fileHeader({ file })}
 @theme {
     --*: initial;
 
 ${themeContent}
 }
+
+${colorSchemeRules}
 
 ${textUtilities}
 `;


### PR DESCRIPTION
## 💬 Endringer

<!-- Skriv et kortfattet sammendrag av endringene som er gjort og hva de løser. -->

Takk copilot 🗣️ 

## 🩹 Løser følgende issues

<!-- Erstatt NNNN under med nummeret til issuet som lukkes, og legg evt flere punkter med flere issues -->
-   Closes #6158
