### PR TITLE
Bygg og publiser versjoner av Storybook for hver major

### DIFF
--- a/.github/workflows/storybook_branch_preview.yml
+++ b/.github/workflows/storybook_branch_preview.yml
@@ -3,17 +3,9 @@ name: Publiser Storybook branch preview
 on:
     push:
         branches:
-            - release/**
-        paths:
-            - ".storybook/**/*.(ts|tsx|scss|html)"
-            - "storybook-public/**/*"
-            - "packages/jokul/src/**/*.stories.tsx"
-            - "packages/jokul/src/**/*.scss"
-            - "packages/jokul/src/**/!(*.stories|*.test|*.d).ts"
-            - "packages/jokul/src/**/!(*.stories|*.test).tsx"
-            - "packages/jokul/src/**/*.json"
-            - "packages/jokul/src/fonts/**/*"
-            - "pnpm-lock.yaml"
+            - main
+            - next
+            - jokul-*.x
     workflow_dispatch:
 
 concurrency:
@@ -39,9 +31,31 @@ jobs:
                     node-version-file: ".nvmrc"
                     cache: "pnpm"
 
-            -   name: Set preview path
-                shell: bash
-                run: echo "PREVIEW_PATH=preview/branches/${GITHUB_REF_NAME//\//--}" >> "$GITHUB_ENV"
+            - name: Finn release-tag
+              id: release-tag
+              shell: bash
+              run: |
+                  if [[ "$GITHUB_REF_NAME" = "main" ]]; then
+                    exit 0
+                  elif [[ "$GITHUB_REF_NAME" =~ ^jokul-([0-9])\.x$ ]]; then
+                    echo "tag=version-${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  elif [[ -f .changeset/pre.json ]]; then
+                    node --input-type=module <<'NODE'
+                    import { appendFileSync, readFileSync } from "node:fs";
+
+                    const writeOutput = (key, value) => {
+                        appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+                    };
+
+                    const preSettings = JSON.parse(readFileSync(".changeset/pre.json", "utf8"));
+
+                    writeOutput("tag", preSettings.tag);
+                    process.exit(0);
+                  NODE
+                    exit 0
+                  fi
+                  exit 1
 
             -   name: Install dependencies
                 run: pnpm install
@@ -49,7 +63,7 @@ jobs:
             -   name: Build packages and site
                 run: pnpm build && pnpm build:storybook
                 env:
-                    STORYBOOK_FONTS_BASE_PATH: /jokul/${{ env.PREVIEW_PATH }}
+                    STORYBOOK_FONTS_BASE_PATH: /jokul/${{ steps.release-tag.outputs.tag || 'latest' }}
 
             -   name: Deploy preview
                 env:
@@ -58,9 +72,9 @@ jobs:
                     git config user.email "fremtind.designsystem@fremtind.no"
                     git config user.name "fremtind-bot"
                     git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/fremtind/jokul.git
-                    pnpm gh-pages --add --dist storybook-static --dest ${{ env.PREVIEW_PATH }} --message "docs: branch preview ${{ github.ref_name }}"
+                    pnpm gh-pages --add --dist storybook-static --dest ${{ steps.release-tag.outputs.tag || 'latest' }} --message "docs: branch preview ${{ github.ref_name }}"
 
             -   name: Add preview link to summary
                 run: |
-                    echo "Storybook preview: https://fremtind.github.io/jokul/${{ env.PREVIEW_PATH }}/" >> "$GITHUB_STEP_SUMMARY"
+                    echo "Storybook preview: https://fremtind.github.io/jokul/${{ steps.release-tag.outputs.tag || 'latest' }}/" >> "$GITHUB_STEP_SUMMARY"
                     echo "Commit: ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 💬 Endringer

Oppdaterer workflow for Storybook-preview til å bygge for hver major-versjon, `main` og `next`, og publisere en versjon av Storybook under `https://fremtind.github.io/jokul/<versjon>`.

## 🩹 Løser følgende issues

Closes #6408 
