### PR TITLE
Fjern unødvendig installasjon av corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM 607705927749.dkr.ecr.eu-north-1.amazonaws.com/base/cicd-container-base-imag
 WORKDIR /app
 USER root
 COPY package.json .
-RUN npm install -g corepack
 RUN corepack enable
 RUN corepack prepare --activate
 RUN useradd -ms /bin/bash appuser


### PR DESCRIPTION
## 💬 Endringer

Fjerner unødvendig installasjon av corepack i Dockerfila. Dette er en mulig feilkilde i bygg av portalen etter bytte av runners for bygg.
