### PR TITLE
Flere måter å hente feedback fra brukerne på

### DIFF
--- a/.changeset/five-doodles-sniff.md
+++ b/.changeset/five-doodles-sniff.md
@@ -1,0 +1,5 @@
+---
+"portal": minor
+---
+
+Legger til feedback block

--- a/.changeset/hvalen-hopper-hoyt.md
+++ b/.changeset/hvalen-hopper-hoyt.md
@@ -1,0 +1,5 @@
+---
+"portal": minor
+---
+
+Legg til tracking av ulike interaksjoner i portalen.

--- a/portal/src/app/(frontend)/layout.tsx
+++ b/portal/src/app/(frontend)/layout.tsx
@@ -36,7 +36,7 @@ export default async function PortalLayout({ children }: Props) {
             <body>
                 <TabListener />
                 <CookiesNextProvider>
-                    <MixpanelProvider>
+                    <MixpanelProvider disabled={(await draftMode()).isEnabled}>
                         <div className="jkl-portal-layout">
                             <Header />
                             <main>{children}</main>

--- a/portal/src/components/MixpanelProvider.tsx
+++ b/portal/src/components/MixpanelProvider.tsx
@@ -3,11 +3,13 @@
 import { initMixpanel } from "@/utils/tracking/mixpanel";
 import { type ReactNode, useEffect } from "react";
 
-type ProviderProps = { children?: ReactNode };
-export function MixpanelProvider({ children }: ProviderProps) {
+type ProviderProps = { children?: ReactNode; disabled?: boolean };
+export function MixpanelProvider({ children, disabled }: ProviderProps) {
     useEffect(() => {
-        initMixpanel();
-    }, []);
+        if (!disabled) {
+            initMixpanel();
+        }
+    }, [disabled]);
 
     return <>{children}</>;
 }

--- a/portal/src/components/PageFooter.tsx
+++ b/portal/src/components/PageFooter.tsx
@@ -1,7 +1,5 @@
-"use client";
-
+import { FooterLink } from "@/components/layout/footer/FooterLink";
 import { Flex } from "@fremtind/jokul/flex";
-import { Link } from "@fremtind/jokul/link";
 import styles from "../app/(frontend)/komponenter/[slug]/component.module.scss";
 
 type ComponentFooterProps = {
@@ -12,36 +10,24 @@ export const PageFooter = ({ name }: ComponentFooterProps) => {
     if (!name) {
         return (
             <Flex as="footer" gap="m" wrap="wrap" className={styles.footer}>
-                <Link
-                    external
+                <FooterLink
                     href="https://github.com/fremtind/jokul/issues/new?&template=dokumentasjon.yml&title=%5BInnspill+til+innhold%5D%3A"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    Innspill til innholdet
-                </Link>
+                    text="Innspill til innholdet"
+                />
             </Flex>
         );
     }
 
     return (
         <Flex as="footer" gap="m" wrap="wrap" className={styles.footer}>
-            <Link
-                external
+            <FooterLink
                 href={`https://github.com/fremtind/jokul/issues/new?&template=dokumentasjon.yml&title=%5BBidra+med+innhold%5D%3A+${name}`}
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                Bidra med innhold
-            </Link>
-            <Link
-                external
+                text="Bidra med innhold"
+            />
+            <FooterLink
                 href={`https://github.com/fremtind/jokul/issues/new?&template=innspill-komponent.yml&title=%5BInnspill+til+komponent%5D%3A+${name}`}
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                Innspill til <span lang="en">{name}</span>
-            </Link>
+                text={`Innspill til ${name}`}
+            />
         </Flex>
     );
 };

--- a/portal/src/components/layout/footer/Footer.tsx
+++ b/portal/src/components/layout/footer/Footer.tsx
@@ -1,11 +1,10 @@
+import { FooterLink } from "@/components/layout/footer/FooterLink";
+import { logger } from "@/logger";
 import { sanityFetch } from "@/sanity/lib/live";
 import { siteDataQuery } from "@/sanity/queries/siteData";
 import { Flex } from "@fremtind/jokul/flex";
-import { Link } from "@fremtind/jokul/link";
 import { List, ListItem } from "@fremtind/jokul/list";
 import jokul from "@fremtind/jokul/package.json";
-import { logger } from "@/logger";
-
 import styles from "../global-layout.module.scss";
 
 export const Footer = async () => {
@@ -38,16 +37,10 @@ export const Footer = async () => {
                         <List>
                             {linkGroup.linkList?.map((link) => (
                                 <ListItem key={link.text}>
-                                    <Link
+                                    <FooterLink
                                         href={link.url || ""}
-                                        target={
-                                            link.url?.includes("https")
-                                                ? "_blank"
-                                                : undefined
-                                        }
-                                    >
-                                        {link.text}
-                                    </Link>
+                                        text={link.text || ""}
+                                    />
                                 </ListItem>
                             ))}
                         </List>
@@ -55,12 +48,10 @@ export const Footer = async () => {
                 ))}
             </Flex>
             <p>
-                Jøkul{" "}
-                <Link
+                <FooterLink
                     href={`https://github.com/fremtind/jokul/releases/tag/@fremtind/jokul@${jokul.version}`}
-                >
-                    versjon {jokul.version}
-                </Link>
+                    text={`Jøkul versjon ${jokul.version}`}
+                />
                 .
             </p>
             <p>{footer.text}</p>

--- a/portal/src/components/layout/footer/FooterLink.tsx
+++ b/portal/src/components/layout/footer/FooterLink.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events } from "@/utils/tracking/types";
+import { Link } from "@fremtind/jokul/link";
+
+type FooterLinkProps = {
+    href: string;
+    text: string;
+};
+
+export const FooterLink = ({ href, text }: FooterLinkProps) => {
+    if (!text) {
+        return null;
+    }
+
+    return (
+        <Link
+            href={href}
+            onClick={() => {
+                trackEvent(Events.CLICK, {
+                    element: "footer",
+                    type: "footer link",
+                });
+            }}
+        >
+            {text}
+        </Link>
+    );
+};

--- a/portal/src/components/layout/header/navigation/menu/list/List.tsx
+++ b/portal/src/components/layout/header/navigation/menu/list/List.tsx
@@ -5,6 +5,8 @@ import { Button } from "@fremtind/jokul/button";
 import { Flex } from "@fremtind/jokul/flex";
 import Link from "next/link";
 
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events } from "@/utils/tracking/types";
 import styles from "../../navigation.module.scss";
 
 export const NavigationList = () => {
@@ -19,7 +21,18 @@ export const NavigationList = () => {
             className={styles.list}
         >
             {navigationLinks.map(({ href, label }) => (
-                <Button as={Link} href={href} variant="ghost" key={href}>
+                <Button
+                    as={Link}
+                    href={href}
+                    variant="ghost"
+                    key={href}
+                    onClick={() => {
+                        trackEvent(Events.CLICK, {
+                            element: label || "",
+                            type: "header link",
+                        });
+                    }}
+                >
                     {label}
                 </Button>
             ))}

--- a/portal/src/components/layout/header/navigation/search/Results.tsx
+++ b/portal/src/components/layout/header/navigation/search/Results.tsx
@@ -2,13 +2,14 @@
 
 import { client } from "@/sanity/lib/client";
 import { searchQuery } from "@/sanity/queries/search";
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events } from "@/utils/tracking/types";
 import { Card } from "@fremtind/jokul/card";
 import { Flex } from "@fremtind/jokul/flex";
 import { Icon } from "@fremtind/jokul/icon";
 import { Link as JklLink } from "@fremtind/jokul/link";
 import Link from "next/link";
 import { Fragment, useEffect, useRef, useState } from "react";
-
 import styles from "./search.module.scss";
 
 type SearchResult = {
@@ -100,6 +101,16 @@ export const Results = ({
                     });
 
                     setResults(ranked);
+
+                    trackEvent(Events.SEARCH, {
+                        query: trimmed,
+                        results: ranked.map(
+                            (rankedResult) => rankedResult.name || "",
+                        ),
+                    });
+                })
+                .catch((error) => {
+                    console.error("Error fetching search results:", error);
                 });
             setSelectedIndex(-1);
         } else {
@@ -196,7 +207,6 @@ export const Results = ({
                     alignItems="center"
                     justifyContent="center"
                     gap="s"
-                    textAlign="center"
                 >
                     <Icon>sentiment_very_dissatisfied</Icon>
                     <p>

--- a/portal/src/components/portable-text/PortableText.tsx
+++ b/portal/src/components/portable-text/PortableText.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExampleList } from "@/components/portable-text/examples/ExampleList";
+import { FeedbackBlock } from "@/components/portable-text/feedback-block/FeedbackBlock";
 import { InternalLink } from "@/components/portable-text/link/InternalLink";
 import { NewCodeBlock } from "@/components/portable-text/new-code-block/CodeBlock";
 import { QuestionsAndAnswers } from "@/components/portable-text/q-and-a/QuestionsAndAnswers";
@@ -43,6 +44,7 @@ const jokulBlockTypes = {
     jokul_table: Table,
     jokul_qa: QuestionsAndAnswers,
     jokul_messageBox: MessageBox,
+    jokul_feedbackBlock: FeedbackBlock,
     image: function ImageRenderer({
         value,
     }: {

--- a/portal/src/components/portable-text/feedback-block/FeedbackBlock.tsx
+++ b/portal/src/components/portable-text/feedback-block/FeedbackBlock.tsx
@@ -1,0 +1,32 @@
+import { FeedbackButton } from "@/components/portable-text/feedback-block/FeedbackButton";
+import type { Jokul_feedbackBlock } from "@/sanity/types";
+import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { Text } from "@fremtind/jokul/typography";
+import type { PortableTextTypeComponentProps } from "@portabletext/react";
+import type { FC } from "react";
+
+export const FeedbackBlock: FC<
+    PortableTextTypeComponentProps<Jokul_feedbackBlock>
+> = ({ value }) => {
+    const { question } = value;
+
+    if (!question) return null;
+
+    return (
+        <Card padding="m" outlined asChild style={{ maxWidth: "max-content" }}>
+            <Flex
+                justifyContent="space-between"
+                alignItems="center"
+                gap="s l"
+                wrap="wrap"
+            >
+                <Text>{question}</Text>
+                <Flex gap="xs" wrap="wrap">
+                    <FeedbackButton question={question} sentiment="positive" />
+                    <FeedbackButton question={question} sentiment="negative" />
+                </Flex>
+            </Flex>
+        </Card>
+    );
+};

--- a/portal/src/components/portable-text/feedback-block/FeedbackButton.tsx
+++ b/portal/src/components/portable-text/feedback-block/FeedbackButton.tsx
@@ -1,0 +1,78 @@
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events, type FeedbackEventProps } from "@/utils/tracking/types";
+import { Button } from "@fremtind/jokul/button";
+import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { ThumbDownIcon, ThumbUpIcon } from "@fremtind/jokul/icon";
+import { Popover } from "@fremtind/jokul/popover";
+import { TextArea } from "@fremtind/jokul/text-area";
+import { useState } from "react";
+import type { FC } from "react";
+
+interface FeedbackButtonProps {
+    question: string;
+    sentiment: FeedbackEventProps["sentiment"];
+}
+
+function sendFeedback(
+    question: string,
+    sentiment: "positive" | "negative",
+    feedback: string,
+) {
+    trackEvent(Events.FEEDBACK, {
+        question,
+        sentiment,
+        score: sentiment === "positive" ? 10 : 1,
+        comment: feedback,
+    });
+}
+
+export const FeedbackButton: FC<FeedbackButtonProps> = ({
+    question,
+    sentiment,
+}) => {
+    const positiv = sentiment === "positive";
+    const Icon = positiv ? ThumbUpIcon : ThumbDownIcon;
+    const [open, setOpen] = useState(false);
+    const [feedback, setFeedback] = useState("");
+
+    return (
+        <Popover placement="bottom-end" open={open} onOpenChange={setOpen}>
+            <Popover.Trigger asChild>
+                <Button
+                    onClick={() => setOpen(!open)}
+                    icon={<Icon />}
+                    aria-label={`${positiv ? "Gi positiv tilbakemelding" : "Gi negativ tilbakemelding"}: ${question}`}
+                    variant="ghost"
+                />
+            </Popover.Trigger>
+
+            <Popover.Content style={{ width: "35ch" }}>
+                <Card padding="l">
+                    <Flex
+                        direction="column"
+                        gap="s"
+                        as="form"
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            setOpen(false);
+                            sendFeedback(question, sentiment, feedback);
+                        }}
+                    >
+                        <TextArea
+                            label="Kommentar (valgfritt)"
+                            value={feedback}
+                            rows={3}
+                            autoExpand={false}
+                            onChange={(e) => setFeedback(e.target.value)}
+                            placeholder=""
+                        />
+                        <Button type="submit" variant="primary">
+                            Send
+                        </Button>
+                    </Flex>
+                </Card>
+            </Popover.Content>
+        </Popover>
+    );
+};

--- a/portal/src/components/portable-text/new-code-block/CodeBlock.tsx
+++ b/portal/src/components/portable-text/new-code-block/CodeBlock.tsx
@@ -1,6 +1,8 @@
 import fremtindTheme from "@/components/portable-text/code-block/fremtindTheme";
 import fremtindThemeDark from "@/components/portable-text/code-block/fremtindThemeDark";
 import type { Jokul_code } from "@/sanity/types";
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events } from "@/utils/tracking/types";
 import { Button } from "@fremtind/jokul/button";
 import { useBrowserPreferences } from "@fremtind/jokul/hooks";
 import { CheckIcon, CopyIcon } from "@fremtind/jokul/icon";
@@ -53,6 +55,10 @@ export const NewCodeBlock: React.FC<
                         try {
                             navigator.clipboard.writeText(code.code || "");
                             setCopied(true);
+                            trackEvent(Events.CLICK, {
+                                element: title || "",
+                                type: "copy button",
+                            });
                             setTimeout(() => {
                                 setCopied(false);
                             }, 2000);

--- a/portal/src/components/portable-text/q-and-a/QuestionsAndAnswers.tsx
+++ b/portal/src/components/portable-text/q-and-a/QuestionsAndAnswers.tsx
@@ -1,5 +1,7 @@
 import { PortableText } from "@/components/portable-text/PortableText";
 import type { Jokul_qa } from "@/sanity/types";
+import { trackEvent } from "@/utils/tracking/mixpanel";
+import { Events } from "@/utils/tracking/types";
 import { Accordion, ExpandablePanel } from "@fremtind/jokul/expander";
 import type { PortableTextTypeComponentProps } from "@portabletext/react";
 import React, { type FC } from "react";
@@ -17,7 +19,14 @@ export const QuestionsAndAnswers: FC<
                 (qa) =>
                     qa.answer && (
                         <ExpandablePanel key={qa._key}>
-                            <ExpandablePanel.Header>
+                            <ExpandablePanel.Header
+                                onClick={() =>
+                                    trackEvent(Events.CLICK, {
+                                        element: `Spørsmål: ${qa.question}`,
+                                        type: "q&a",
+                                    })
+                                }
+                            >
                                 {qa.question}
                             </ExpandablePanel.Header>
                             <ExpandablePanel.Content>

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -916,6 +916,29 @@
     }
   },
   {
+    "name": "jokul_feedbackBlock",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "jokul_feedbackBlock"
+          }
+        },
+        "question": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "jokul_qa",
     "type": "type",
     "value": {
@@ -3599,6 +3622,21 @@
                   "type": "inline",
                   "name": "jokul_doAndDont"
                 }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_feedbackBlock"
+                }
               }
             ]
           }
@@ -4381,6 +4419,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_doAndDont"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_feedbackBlock"
                 }
               },
               {
@@ -5446,6 +5499,21 @@
                 },
                 "rest": {
                   "type": "inline",
+                  "name": "jokul_feedbackBlock"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
                   "name": "jokul_codeBlock"
                 }
               }
@@ -6101,6 +6169,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_doAndDont"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_feedbackBlock"
                 }
               },
               {
@@ -6777,6 +6860,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_doAndDont"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_feedbackBlock"
                 }
               }
             ]
@@ -7635,6 +7733,21 @@
                 "rest": {
                   "type": "inline",
                   "name": "jokul_doAndDont"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "jokul_feedbackBlock"
                 }
               }
             ]

--- a/portal/src/sanity/schemas/blocks/commonBlock.ts
+++ b/portal/src/sanity/schemas/blocks/commonBlock.ts
@@ -12,4 +12,5 @@ export const commonBlock = [
     { type: "jokul_qa" },
     { type: "jokul_messageBox" },
     { type: "jokul_doAndDont" },
+    { type: "jokul_feedbackBlock" },
 ];

--- a/portal/src/sanity/schemas/blocks/feedbackBlock.ts
+++ b/portal/src/sanity/schemas/blocks/feedbackBlock.ts
@@ -1,0 +1,27 @@
+import { FeedbackIcon } from "@sanity/icons";
+import { defineType } from "sanity";
+
+export const feedbackBlock = defineType({
+    name: "jokul_feedbackBlock",
+    title: "Tilbakemelding",
+    type: "object",
+    icon: FeedbackIcon,
+    fields: [
+        {
+            title: "Spørsmål",
+            name: "question",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+    ],
+    preview: {
+        select: {
+            title: "question",
+        },
+        prepare({ title }) {
+            return {
+                title: title,
+            };
+        },
+    },
+});

--- a/portal/src/sanity/schemas/blocks/index.ts
+++ b/portal/src/sanity/schemas/blocks/index.ts
@@ -1,6 +1,7 @@
 import { code } from "./code";
 import { doAndDont } from "./doAndDont";
 import { examples } from "./examples";
+import { feedbackBlock } from "./feedbackBlock";
 import { linkCard } from "./linkCard";
 import { messageBox } from "./messageBox";
 import { questionsAndAnswers } from "./questionsAndAnswers";
@@ -14,4 +15,5 @@ export const blocks = [
     table,
     messageBox,
     questionsAndAnswers,
+    feedbackBlock,
 ];

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -169,6 +169,11 @@ export type SanityImageHotspot = {
   width?: number;
 };
 
+export type Jokul_feedbackBlock = {
+  _type: "jokul_feedbackBlock";
+  question?: string;
+};
+
 export type Jokul_qa = {
   _type: "jokul_qa";
   title?: string;
@@ -574,7 +579,9 @@ export type Jokul_blog_post = {
     _key: string;
   } & Jokul_messageBox | {
     _key: string;
-  } & Jokul_doAndDont>;
+  } & Jokul_doAndDont | {
+    _key: string;
+  } & Jokul_feedbackBlock>;
 };
 
 export type Jokul_component = {
@@ -687,6 +694,8 @@ export type Jokul_component = {
   } & Jokul_messageBox | {
     _key: string;
   } & Jokul_doAndDont | {
+    _key: string;
+  } & Jokul_feedbackBlock | {
     _key: string;
   } & Jokul_componentProps | {
     _key: string;
@@ -848,6 +857,8 @@ export type Jokul_fundamentals = {
     _key: string;
   } & Jokul_doAndDont | {
     _key: string;
+  } & Jokul_feedbackBlock | {
+    _key: string;
   } & Jokul_codeBlock>;
 };
 
@@ -943,6 +954,8 @@ export type Jokul_release_notes = {
     _key: string;
   } & Jokul_doAndDont | {
     _key: string;
+  } & Jokul_feedbackBlock | {
+    _key: string;
   } & Jokul_codeBlock>;
   migrationUrl?: string;
   figmaUrl?: string;
@@ -1037,7 +1050,9 @@ export type Jokul_temaside = {
     _key: string;
   } & Jokul_messageBox | {
     _key: string;
-  } & Jokul_doAndDont>;
+  } & Jokul_doAndDont | {
+    _key: string;
+  } & Jokul_feedbackBlock>;
   related_components?: Array<{
     _ref: string;
     _type: "reference";
@@ -1162,7 +1177,9 @@ export type Jokul_monster = {
     _key: string;
   } & Jokul_messageBox | {
     _key: string;
-  } & Jokul_doAndDont>;
+  } & Jokul_doAndDont | {
+    _key: string;
+  } & Jokul_feedbackBlock>;
   related_components?: Array<{
     _ref: string;
     _type: "reference";
@@ -1315,7 +1332,7 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_examples | Jokul_code | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | ComponentPageLink | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Code | Slug | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_feedbackBlock | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_examples | Jokul_code | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | ComponentPageLink | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Code | Slug | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/allPosts.ts
 // Variable: latestUpdatedArticlesQuery
@@ -1759,6 +1776,11 @@ export type BlogPostBySlugQueryResult = {
       code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_feedbackBlock";
+    question?: string;
     markDefs: null;
   } | {
     _key: string;
@@ -2475,6 +2497,11 @@ export type ComponentBySlugQueryResult = {
     markDefs: null;
   } | {
     _key: string;
+    _type: "jokul_feedbackBlock";
+    question?: string;
+    markDefs: null;
+  } | {
+    _key: string;
     _type: "jokul_linkCard";
     title?: string;
     description?: string;
@@ -3161,6 +3188,11 @@ export type FundamentalsBySlugQueryResult = {
     markDefs: null;
   } | {
     _key: string;
+    _type: "jokul_feedbackBlock";
+    question?: string;
+    markDefs: null;
+  } | {
+    _key: string;
     _type: "jokul_linkCard";
     title?: string;
     description?: string;
@@ -3724,6 +3756,11 @@ export type MonsterBySlugQueryResult = {
       code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_feedbackBlock";
+    question?: string;
     markDefs: null;
   } | {
     _key: string;
@@ -4313,6 +4350,11 @@ export type ReleaseNoteBySlugQueryResult = {
       code: Code | null;
     }> | null;
     layout?: "carousel" | "gallery" | "list";
+    markDefs: null;
+  } | {
+    _key: string;
+    _type: "jokul_feedbackBlock";
+    question?: string;
     markDefs: null;
   } | {
     _key: string;

--- a/portal/src/utils/tracking/mixpanel.ts
+++ b/portal/src/utils/tracking/mixpanel.ts
@@ -1,23 +1,86 @@
-import type { EventName } from "@/utils/tracking/types";
-import mixpanel, { type Dict } from "mixpanel-browser";
+import type { EventName, EventProps } from "@/utils/tracking/types";
+import mixpanel from "mixpanel-browser";
 
 const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN;
-const IS_ENABLED = typeof window !== "undefined" && !!MIXPANEL_TOKEN;
+const IS_DISABLED = typeof window === "undefined" || !MIXPANEL_TOKEN;
 
-export function initMixpanel() {
-    if (IS_ENABLED) {
-        mixpanel.init(MIXPANEL_TOKEN, {
-            api_host: "/mp",
-            debug: process.env.NODE_ENV === "development",
-            track_pageview: "url-with-path-and-query-string",
-            disable_persistence: true,
-        });
-        mixpanel.register({ environment: process.env.NODE_ENV || "unknown" });
+const STUDIO_AUTH_KEY_PREFIX = "__studio_auth_token_";
+
+/**
+ * Resultatet caches for økten, slik at vi slipper å skanne localStorage
+ * på hvert eneste sporingskall.
+ */
+let sanityEditorCache: boolean | undefined;
+
+/**
+ * Settes først når initMixpanel() faktisk har initialisert klienten.
+ * MixpanelProvider kan være disabled (f.eks. i draft mode), og da skal
+ * trackEvent() være en no-op i stedet for å kalle en uinitialisert klient.
+ */
+let isInitialized = false;
+
+function hasStudioAuthToken() {
+    try {
+        for (let i = 0; i < window.localStorage.length; i++) {
+            const key = window.localStorage.key(i);
+            if (key?.startsWith(STUDIO_AUTH_KEY_PREFIX)) {
+                return true;
+            }
+        }
+        return false;
+    } catch {
+        return false;
     }
 }
 
-export const trackEvent = (eventName: EventName, props?: Dict) => {
-    if (IS_ENABLED) {
-        mixpanel.track(eventName, props);
+/**
+ * Redaktører skal ikke telles med i statistikken.
+ */
+function isSanityEditor() {
+    if (typeof window === "undefined") {
+        return false;
     }
-};
+
+    if (sanityEditorCache) {
+        return true;
+    }
+
+    // Billig sjekk som også fanger opp redaktører som logger inn underveis
+    if (window.location.pathname.startsWith("/studio")) {
+        sanityEditorCache = true;
+        return true;
+    }
+
+    if (sanityEditorCache === undefined) {
+        sanityEditorCache = hasStudioAuthToken();
+    }
+
+    return sanityEditorCache;
+}
+
+export function initMixpanel() {
+    if (isInitialized || IS_DISABLED || isSanityEditor()) {
+        return;
+    }
+
+    mixpanel.init(MIXPANEL_TOKEN, {
+        api_host: "/mp",
+        debug: process.env.NODE_ENV === "development",
+        track_pageview: "url-with-path-and-query-string",
+        disable_persistence: true,
+    });
+    mixpanel.register({ environment: process.env.NODE_ENV || "unknown" });
+
+    isInitialized = true;
+}
+
+export function trackEvent<T extends EventName>(
+    eventName: T,
+    props: EventProps[T],
+) {
+    if (!isInitialized || isSanityEditor()) {
+        return;
+    }
+
+    mixpanel.track(eventName, props);
+}

--- a/portal/src/utils/tracking/types.ts
+++ b/portal/src/utils/tracking/types.ts
@@ -1,1 +1,37 @@
-export type EventName = "Klikk";
+export const Events = {
+    FEEDBACK: "Tilbakemelding",
+    CLICK: "Klikk",
+    SEARCH: "Søk",
+} as const;
+
+export type EventName = (typeof Events)[keyof typeof Events];
+
+export type FeedbackEventProps = {
+    question: string;
+    sentiment: "positive" | "negative";
+    score: number;
+    comment: string;
+};
+
+export type ClickEventProps = {
+    element: string;
+    type:
+        | "article link"
+        | "header link"
+        | "footer link"
+        | "component link"
+        | "button"
+        | "copy button"
+        | "q&a";
+};
+
+export type SearchEventProps = {
+    query: string;
+    results: string[];
+};
+
+export type EventProps = {
+    [Events.FEEDBACK]: FeedbackEventProps;
+    [Events.CLICK]: ClickEventProps;
+    [Events.SEARCH]: SearchEventProps;
+};


### PR DESCRIPTION
1. Lagt til feedback block i Sanity, hvor du kan stille spørsmål i en tekst og få en tommel opp eller ned.
2. Lagt til sporing av diverse lenker og knapper i løsningen: header, footer, code block, q&a.
3. Lagt til sporing av søk, med søketekst og resultater.
4. Fjernet redaktører fra sporing så langt det lar seg gjøre.