### PR TITLE
Fjern data-theme fra innhold i message

### DIFF
--- a/.changeset/fresh-rice-fold.md
+++ b/.changeset/fresh-rice-fold.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Retter en feil som gjorde at innholdet i `Message` alltid ble vist med `data-theme="light"`.

--- a/packages/jokul/src/components/message/Message.tsx
+++ b/packages/jokul/src/components/message/Message.tsx
@@ -62,7 +62,7 @@ function messageFactory(messageType: MessageProps["variant"]) {
                 role={role}
             >
                 {getIcon(messageType)}
-                <div className="jkl-message__content" data-theme="light">
+                <div className="jkl-message__content">
                     {title && <p className="jkl-message__title">{title}</p>}
                     <div className="jkl-message__message">{newChildren}</div>
                 </div>
@@ -123,7 +123,7 @@ export const Message = forwardRef<HTMLDivElement, MessageProps>(
                 role={role}
             >
                 {getIcon(variant)}
-                <div className="jkl-message__content" data-theme="light">
+                <div className="jkl-message__content">
                     {title && <p className="jkl-message__title">{title}</p>}
                     <div className="jkl-message__message">{newChildren}</div>
                 </div>


### PR DESCRIPTION
## 💬 Endringer

Retter en feil som gjorde at innholdet i `Message` alltid ble vist med `data-theme="light"`.
