### PR TITLE
Støtt kortbilder for lys og mørk modus

### DIFF
--- a/.changeset/quiet-images-shine.md
+++ b/.changeset/quiet-images-shine.md
@@ -1,0 +1,5 @@
+---
+"portal": minor
+---
+
+Legger til egne kortbilder for lys og mørk modus i portalen.

--- a/portal/migrations/move-card-images-to-color-scheme-object/index.ts
+++ b/portal/migrations/move-card-images-to-color-scheme-object/index.ts
@@ -1,0 +1,32 @@
+import { at, defineMigration, setIfMissing, unset } from "sanity/migrate";
+
+export default defineMigration({
+    title: "Move card images to color scheme object",
+    documentTypes: ["jokul_component", "jokul_fundamentals", "jokul_monster"],
+    filter: "defined(image) || defined(imageDark)",
+    migrate: {
+        document(document) {
+            const lightImage = document.image;
+            const darkImage = document.imageDark;
+
+            return [
+                at(
+                    "cardImages",
+                    setIfMissing({
+                        _type: "colorSchemeImages",
+                        ...(lightImage ? { light: lightImage } : {}),
+                        ...(darkImage ? { dark: darkImage } : {}),
+                    }),
+                ),
+                ...(lightImage
+                    ? [at("cardImages.light", setIfMissing(lightImage))]
+                    : []),
+                ...(darkImage
+                    ? [at("cardImages.dark", setIfMissing(darkImage))]
+                    : []),
+                at("image", unset()),
+                at("imageDark", unset()),
+            ];
+        },
+    },
+});

--- a/portal/public/component_placeholder_dark.svg
+++ b/portal/public/component_placeholder_dark.svg
@@ -1,5 +1,4 @@
 <svg width="1248" height="864" viewBox="0 0 1248 864" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="312" height="216" transform="scale(4)" fill="#313030"/>
 <rect x="434.121" y="432.333" width="125" height="125" transform="rotate(-45 434.121 432.333)" stroke="#F9F9F9" stroke-width="3"/>
 <rect width="32" height="32" transform="translate(533.823 330.51) scale(4) rotate(-45)" fill="#F9F9F9"/>
 <rect width="32" height="32" transform="translate(533.823 534.156) scale(4) rotate(-45)" fill="#F9F9F9"/>

--- a/portal/public/component_placeholder_light.svg
+++ b/portal/public/component_placeholder_light.svg
@@ -1,5 +1,4 @@
 <svg width="1248" height="864" viewBox="0 0 1248 864" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="312" height="216" transform="scale(4)" fill="white"/>
 <rect x="434.121" y="432.333" width="125" height="125" transform="rotate(-45 434.121 432.333)" stroke="#1B1917" stroke-width="3"/>
 <rect width="32" height="32" transform="translate(533.823 330.51) scale(4) rotate(-45)" fill="#1B1917"/>
 <rect width="32" height="32" transform="translate(533.823 534.156) scale(4) rotate(-45)" fill="#1B1917"/>

--- a/portal/src/app/(frontend)/fundamenter/page.tsx
+++ b/portal/src/app/(frontend)/fundamenter/page.tsx
@@ -1,11 +1,11 @@
 import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
 import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
 import { OverviewHeader } from "@/components/overview/header";
+import { logger } from "@/logger";
 import { sanityFetch } from "@/sanity/lib/live";
 import { fundamentalsQuery } from "@/sanity/queries/fundamentals";
 import { parseUserPreferences } from "@/utils/user-preferences";
 import { getCookie } from "cookies-next";
-import { logger } from "@/logger";
 import { cookies } from "next/headers";
 
 export default async function FundamentalsPage() {
@@ -35,10 +35,7 @@ export default async function FundamentalsPage() {
                         key={post.slug?.current}
                         title={post.name || ""}
                         description={post.short_description || ""}
-                        image={{
-                            light: post.image,
-                            dark: post.imageDark,
-                        }}
+                        image={post.images}
                         link={`/fundamenter/${post.slug?.current}`}
                         initialPreferences={userPreferences}
                     />

--- a/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { PageFooter } from "@/components/PageFooter";
 import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
 import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
 import { PortableText } from "@/components/portable-text/PortableText";
+import { logger } from "@/logger";
 import { sanityFetch } from "@/sanity/lib/live";
 import {
     componentBySlugQuery,
@@ -13,7 +14,6 @@ import { parseUserPreferences } from "@/utils/user-preferences";
 import { Flex } from "@fremtind/jokul/flex";
 import { NavLink } from "@fremtind/jokul/nav-link";
 import { getCookie } from "cookies-next";
-import { logger } from "@/logger";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import styles from "./component.module.scss";
@@ -186,10 +186,9 @@ export default async function Page({ params }: Props) {
                                                         relatedComponent.short_description ||
                                                         ""
                                                     }
-                                                    image={{
-                                                        light: relatedComponent.image,
-                                                        dark: relatedComponent.imageDark,
-                                                    }}
+                                                    image={
+                                                        relatedComponent.images
+                                                    }
                                                     link={`/komponenter/${relatedComponent.slug}`}
                                                     initialPreferences={
                                                         userPreferences
@@ -217,9 +216,7 @@ export default async function Page({ params }: Props) {
                                                         pattern.short_description ||
                                                         ""
                                                     }
-                                                    image={{
-                                                        light: pattern.image,
-                                                    }}
+                                                    image={pattern.images}
                                                     link={`/monster/${pattern.slug}`}
                                                     initialPreferences={
                                                         userPreferences

--- a/portal/src/app/(frontend)/komponenter/page.tsx
+++ b/portal/src/app/(frontend)/komponenter/page.tsx
@@ -1,6 +1,7 @@
 import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
 import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
 import { OverviewHeader } from "@/components/overview/header";
+import { logger } from "@/logger";
 import { sanityFetch } from "@/sanity/lib/live";
 import { componentsQuery } from "@/sanity/queries/component";
 import {
@@ -9,7 +10,6 @@ import {
 } from "@/utils/user-preferences";
 import { Flex } from "@fremtind/jokul/flex";
 import { getCookie } from "cookies-next";
-import { logger } from "@/logger";
 import { cookies } from "next/headers";
 import { FilterChip } from "./FilterChip";
 
@@ -72,10 +72,7 @@ export default async function Components({
                         key={component.slug}
                         title={component.name || ""}
                         description={component.short_description || ""}
-                        image={{
-                            light: component.image,
-                            dark: component.imageDark,
-                        }}
+                        image={component.images}
                         link={`/komponenter/${component.slug}`}
                         initialPreferences={userPreferences}
                     />

--- a/portal/src/app/(frontend)/monster/[slug]/page.tsx
+++ b/portal/src/app/(frontend)/monster/[slug]/page.tsx
@@ -3,12 +3,12 @@ import { ArticleHeader } from "@/components/article/header";
 import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
 import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
 import { PortableText } from "@/components/portable-text/PortableText";
+import { logger } from "@/logger";
 import { getSanityImageUrl } from "@/sanity/lib/image";
 import { sanityFetch } from "@/sanity/lib/live";
 import { monsterBySlugQuery } from "@/sanity/queries/monster";
 import { parseUserPreferences } from "@/utils/user-preferences";
 import { getCookie } from "cookies-next";
-import { logger } from "@/logger";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 
@@ -26,7 +26,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         tags: [`jokul_monster:${slug}`],
     });
 
-    const ogImage = getSanityImageUrl(monster?.image);
+    const ogImage = getSanityImageUrl(
+        monster?.images.light || monster?.images.dark,
+    );
 
     return {
         title: monster?.name || "Mønster",
@@ -79,10 +81,7 @@ export default async function MonsterPage({ params }: Props) {
                                 key={component.slug}
                                 title={component.name || ""}
                                 description={component.short_description || ""}
-                                image={{
-                                    light: component.image,
-                                    dark: component.imageDark,
-                                }}
+                                image={component.images}
                                 link={`/komponenter/${component.slug}`}
                                 initialPreferences={userPreferences}
                             />
@@ -102,7 +101,7 @@ export default async function MonsterPage({ params }: Props) {
                                 key={pattern.slug}
                                 title={pattern.name || ""}
                                 description={pattern.short_description || ""}
-                                image={{ light: pattern.image }}
+                                image={pattern.images}
                                 link={`/monster/${pattern.slug}`}
                                 initialPreferences={userPreferences}
                             />

--- a/portal/src/app/(frontend)/monster/page.tsx
+++ b/portal/src/app/(frontend)/monster/page.tsx
@@ -1,11 +1,11 @@
 import { OverviewCardWithPreferences } from "@/components/overview/OverviewCardWithPreferences";
 import { OverviewGridWithPreferences } from "@/components/overview/OverviewGridWithPreferences";
 import { OverviewHeader } from "@/components/overview/header";
+import { logger } from "@/logger";
 import { sanityFetch } from "@/sanity/lib/live";
 import { monstreQuery } from "@/sanity/queries/monster";
 import { parseUserPreferences } from "@/utils/user-preferences";
 import { getCookie } from "cookies-next";
-import { logger } from "@/logger";
 import { cookies } from "next/headers";
 import { MonsterFilter } from "./MonsterFilter";
 
@@ -71,7 +71,7 @@ export default async function MonstrePage({
                         key={monster.slug}
                         title={monster.name || ""}
                         description={monster.short_description || ""}
-                        image={{ light: monster.image }}
+                        image={monster.images}
                         link={`/monster/${monster.slug}`}
                         initialPreferences={userPreferences}
                     />

--- a/portal/src/app/(frontend)/nyheter/NewsPost.tsx
+++ b/portal/src/app/(frontend)/nyheter/NewsPost.tsx
@@ -5,16 +5,8 @@ import { Text } from "@fremtind/jokul/typography";
 export default function NewsPost({
     article,
 }: { article: NewsPageQueryResult["articles"][number] }) {
-    const {
-        name,
-        short_description,
-        updated,
-        created,
-        type,
-        href,
-        image,
-        imageDark,
-    } = article;
+    const { name, short_description, updated, created, type, href, images } =
+        article;
 
     if (!href) return null;
 
@@ -50,11 +42,7 @@ export default function NewsPost({
     return (
         <OverviewCardWithPreferences
             link={href || ""}
-            image={
-                image || imageDark
-                    ? { light: image, dark: imageDark }
-                    : undefined
-            }
+            image={images.light || images.dark ? images : undefined}
             title={name || ""}
             description={short_description || ""}
             footer={

--- a/portal/src/components/overview/resolveImageUrls.test.ts
+++ b/portal/src/components/overview/resolveImageUrls.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveImageUrls } from "./resolveImageUrls";
+
+const fallback = {
+    light: "/placeholder-light.svg",
+    dark: "/placeholder-dark.svg",
+};
+
+describe("resolveImageUrls", () => {
+    it("uses the matching image for each color mode", () => {
+        expect(resolveImageUrls("light.png", "dark.png", fallback)).toEqual({
+            light: "light.png",
+            dark: "dark.png",
+        });
+    });
+
+    it("uses the light image in both modes when no dark image exists", () => {
+        expect(resolveImageUrls("light.png", undefined, fallback)).toEqual({
+            light: "light.png",
+            dark: "light.png",
+        });
+    });
+
+    it("uses the dark image in both modes when no light image exists", () => {
+        expect(resolveImageUrls(undefined, "dark.png", fallback)).toEqual({
+            light: "dark.png",
+            dark: "dark.png",
+        });
+    });
+
+    it("uses mode-specific placeholders when no images exist", () => {
+        expect(resolveImageUrls(undefined, undefined, fallback)).toEqual(
+            fallback,
+        );
+    });
+});

--- a/portal/src/components/overview/resolveImageUrls.ts
+++ b/portal/src/components/overview/resolveImageUrls.ts
@@ -1,0 +1,15 @@
+type ImageUrls = {
+    light: string;
+    dark: string;
+};
+
+export function resolveImageUrls(
+    lightImageUrl: string | undefined,
+    darkImageUrl: string | undefined,
+    fallback: ImageUrls,
+): ImageUrls {
+    return {
+        light: lightImageUrl ?? darkImageUrl ?? fallback.light,
+        dark: darkImageUrl ?? lightImageUrl ?? fallback.dark,
+    };
+}

--- a/portal/src/components/overview/thumbnail.tsx
+++ b/portal/src/components/overview/thumbnail.tsx
@@ -2,6 +2,7 @@ import { getSanityImageUrl } from "@/sanity/lib/image";
 import type { SanityImageLike } from "@/sanity/lib/image";
 
 import styles from "./overview.module.scss";
+import { resolveImageUrls } from "./resolveImageUrls";
 
 // Bruk placeholderbilde midlertidig, mens vi finner ut av problemene
 // med å hente figma-bilder under bygging av applikasjonen.
@@ -20,16 +21,20 @@ export function OverviewThumbnail({
     darkImage,
     lightImage,
 }: OverviewThumbnailProps) {
-    const imageLightUrl = getSanityImageUrl(lightImage) || fallbackLight;
-    const imageDarkUrl = getSanityImageUrl(darkImage) || fallbackDark;
+    const lightImageUrl = getSanityImageUrl(lightImage);
+    const darkImageUrl = getSanityImageUrl(darkImage);
+    const imageUrls = resolveImageUrls(lightImageUrl, darkImageUrl, {
+        light: fallbackLight,
+        dark: fallbackDark,
+    });
 
     return (
         <picture className={styles.thumbnail}>
             <source
                 media="(prefers-color-scheme: dark)"
-                srcSet={imageDarkUrl}
+                srcSet={imageUrls.dark}
             />
-            <img src={imageLightUrl} alt="" />
+            <img src={imageUrls.light} alt="" />
         </picture>
     );
 }

--- a/portal/src/components/portable-text/link-card/LinkCard.tsx
+++ b/portal/src/components/portable-text/link-card/LinkCard.tsx
@@ -15,8 +15,10 @@ type LinkCardValue = {
     title?: string;
     description?: string;
     url?: string;
-    image?: SanityImageLike;
-    imageDark?: SanityImageLike;
+    images?: {
+        light?: SanityImageLike;
+        dark?: SanityImageLike;
+    };
 };
 
 export const LinkCard: FC<PortableTextTypeComponentProps<LinkCardValue>> = ({
@@ -27,7 +29,9 @@ export const LinkCard: FC<PortableTextTypeComponentProps<LinkCardValue>> = ({
     const { title, description, url } = value;
 
     const isExternalLink = url.startsWith("http");
-    const imageSrc = value.image ? getSanityImageUrl(value.image) : undefined;
+    const imageSrc = getSanityImageUrl(
+        value.images?.light ?? value.images?.dark,
+    );
 
     return (
         <Card

--- a/portal/src/components/portable-text/link/ComponentPageLink.tsx
+++ b/portal/src/components/portable-text/link/ComponentPageLink.tsx
@@ -46,7 +46,7 @@ export const ComponentPageLink = ({ value, children }: LinkProps) => {
     if (!value?.component) return null;
 
     const slug = value.component.slug || "#";
-    const { image, imageDark, name, short_description } = value.component;
+    const { images, name, short_description } = value.component;
 
     return (
         <>
@@ -90,8 +90,8 @@ export const ComponentPageLink = ({ value, children }: LinkProps) => {
                         </p>
                     )}
                     <OverviewThumbnail
-                        darkImage={imageDark}
-                        lightImage={image}
+                        darkImage={images.dark}
+                        lightImage={images.light}
                     />
                 </Card>,
                 // Vi rendrer popoveren rett i body for å unngå å legge

--- a/portal/src/components/portable-text/link/InternalLink.tsx
+++ b/portal/src/components/portable-text/link/InternalLink.tsx
@@ -24,8 +24,7 @@ type InternalLinkArticle = {
     name: string | null;
     short_description: string | null;
     slug: string | null;
-    image: NonNullable<ComponentBySlugQueryResult>["image"] | null;
-    imageDark: NonNullable<ComponentBySlugQueryResult>["imageDark"] | null;
+    images: NonNullable<ComponentBySlugQueryResult>["images"];
 };
 
 type LinkProps = PortableTextMarkComponentProps<{
@@ -68,8 +67,7 @@ export const InternalLink = ({ value, children }: LinkProps) => {
 
     if (!value?.article) return null;
 
-    const { _type, image, imageDark, name, short_description, slug } =
-        value.article;
+    const { _type, images, name, short_description, slug } = value.article;
     const href = `${ARTICLE_TYPE_TO_PATH[_type]}/${slug}`;
 
     return (
@@ -114,8 +112,8 @@ export const InternalLink = ({ value, children }: LinkProps) => {
                         </p>
                     )}
                     <OverviewThumbnail
-                        darkImage={imageDark}
-                        lightImage={image}
+                        darkImage={images.dark}
+                        lightImage={images.light}
                     />
                 </Card>,
                 // Vi rendrer popoveren rett i body for å unngå å legge

--- a/portal/src/sanity/extract.json
+++ b/portal/src/sanity/extract.json
@@ -273,6 +273,160 @@
     }
   },
   {
+    "name": "colorSchemeImages",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "colorSchemeImages"
+          }
+        },
+        "light": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "image"
+                }
+              }
+            }
+          },
+          "optional": true
+        },
+        "dark": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "object",
+                  "attributes": {
+                    "_ref": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "reference"
+                      }
+                    },
+                    "_weak": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "boolean"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "image"
+                }
+              }
+            }
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "jokul_siteData",
     "type": "document",
     "attributes": {
@@ -4569,6 +4723,14 @@
         },
         "optional": true
       },
+      "cardImages": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "colorSchemeImages"
+        },
+        "optional": true
+      },
       "image": {
         "type": "objectAttribute",
         "value": {
@@ -4763,6 +4925,14 @@
         "type": "objectAttribute",
         "value": {
           "type": "string"
+        },
+        "optional": true
+      },
+      "cardImages": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "colorSchemeImages"
         },
         "optional": true
       },
@@ -7080,6 +7250,14 @@
         "type": "objectAttribute",
         "value": {
           "type": "string"
+        },
+        "optional": true
+      },
+      "cardImages": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "colorSchemeImages"
         },
         "optional": true
       },

--- a/portal/src/sanity/queries/allPosts.ts
+++ b/portal/src/sanity/queries/allPosts.ts
@@ -1,4 +1,5 @@
 import { defineQuery } from "next-sanity";
+import { cardImagesProjection } from "./fragments";
 
 export const latestUpdatedArticlesQuery = defineQuery(
     `*[
@@ -22,8 +23,7 @@ export const latestUpdatedArticlesQuery = defineQuery(
         ),
         "name": coalesce(name, tema, version),
         short_description,
-        image,
-        imageDark,
+        ${cardImagesProjection},
         "slug": slug.current,
         "href": select(
             _type == "jokul_blog_post"     => "/blog/" + slug.current,
@@ -63,8 +63,7 @@ export const newsPageQuery = defineQuery(
             ),
             "name": coalesce(name, tema, version),
             short_description,
-            image,
-            imageDark,
+            ${cardImagesProjection},
             "slug": slug.current,
             "href": select(
                 _type == "jokul_blog_post"     => "/blog/" + slug.current,

--- a/portal/src/sanity/queries/component.ts
+++ b/portal/src/sanity/queries/component.ts
@@ -1,13 +1,16 @@
 import { defineQuery } from "next-sanity";
-import { commonBlockBody, markDefsFragment } from "./fragments";
+import {
+    cardImagesProjection,
+    commonBlockBody,
+    markDefsFragment,
+} from "./fragments";
 
 export const componentsQuery = defineQuery(`*[_type == "jokul_component"]{
     name,
     short_description,
     "slug": slug.current,
     figma_image,
-    image,
-    imageDark,
+    ${cardImagesProjection},
     related_components,
     categories
 } | order(name)`);
@@ -16,6 +19,7 @@ export const componentBySlugQuery = defineQuery(
     `*[_type == "jokul_component" && slug.current == $slug][0]{
         ...,
         "slug": slug.current,
+        ${cardImagesProjection},
         "example_card": {
             ...example_card,
             "story": example_card.story->
@@ -44,8 +48,7 @@ export const componentBySlugQuery = defineQuery(
                 short_description,
                 "slug": slug.current,
                 figma_image,
-                image,
-                imageDark,
+                ${cardImagesProjection},
                 related_components,
                 categories
             }
@@ -54,7 +57,7 @@ export const componentBySlugQuery = defineQuery(
             name,
             "slug": slug.current,
             short_description,
-            image
+            ${cardImagesProjection}
         } | order(name)
     }`,
 );

--- a/portal/src/sanity/queries/fragments.ts
+++ b/portal/src/sanity/queries/fragments.ts
@@ -1,3 +1,10 @@
+export const cardImagesProjection = /* groq */ `
+    "images": {
+        "light": coalesce(cardImages.light, image),
+        "dark": coalesce(cardImages.dark, imageDark)
+    }
+`;
+
 export const markDefsFragment = /* groq */ `
     markDefs[]{
         ...,
@@ -8,8 +15,7 @@ export const markDefsFragment = /* groq */ `
                 "name": coalesce(name, tema, version),
                 short_description,
                 "slug": slug.current,
-                image,
-                imageDark
+                ${cardImagesProjection}
             }
         },
         _type == "componentPageLink" => {
@@ -19,8 +25,7 @@ export const markDefsFragment = /* groq */ `
                 short_description,
                 "slug": slug.current,
                 figma_image,
-                image,
-                imageDark
+                ${cardImagesProjection}
             }
         }
     }
@@ -52,8 +57,10 @@ export const commonBlockBody = /* groq */ `
                 article->_type == "jokul_monster"       => "/monster/"       + article->slug.current
             )
         ),
-        "image": article->image,
-        "imageDark": article->imageDark
+        "images": {
+            "light": coalesce(article->cardImages.light, article->image),
+            "dark": coalesce(article->cardImages.dark, article->imageDark)
+        }
     },
     _type == "jokul_qa" => {
         ...,

--- a/portal/src/sanity/queries/fundamentals.ts
+++ b/portal/src/sanity/queries/fundamentals.ts
@@ -1,13 +1,12 @@
 import { defineQuery } from "next-sanity";
-import { commonBlockBody } from "./fragments";
+import { cardImagesProjection, commonBlockBody } from "./fragments";
 
 export const fundamentalsQuery = defineQuery(
     `*[_type == "jokul_fundamentals"]{
         name,
         slug,
         short_description,
-        image,
-        imageDark,
+        ${cardImagesProjection},
         "date": _createdAt
     } | order(_createdAt desc)`,
 );
@@ -15,6 +14,7 @@ export const fundamentalsQuery = defineQuery(
 export const fundamentalsBySlugQuery = defineQuery(
     `*[_type == "jokul_fundamentals" && slug.current == $slug][0]{
         ...,
+        ${cardImagesProjection},
         article[]{
             ${commonBlockBody}
         }

--- a/portal/src/sanity/queries/monster.ts
+++ b/portal/src/sanity/queries/monster.ts
@@ -1,11 +1,11 @@
 import { defineQuery } from "next-sanity";
-import { commonBlockBody } from "./fragments";
+import { cardImagesProjection, commonBlockBody } from "./fragments";
 
 export const monstreQuery = defineQuery(`*[_type == "jokul_monster"]{
     name,
     "slug": slug.current,
     short_description,
-    image,
+    ${cardImagesProjection},
     related_components[]->{
         name,
         "slug": slug.current
@@ -16,12 +16,12 @@ export const monsterBySlugQuery = defineQuery(
     `*[_type == "jokul_monster" && slug.current == $slug][0]{
         ...,
         "slug": slug.current,
+        ${cardImagesProjection},
         related_components[]->{
             name,
             short_description,
             "slug": slug.current,
-            image,
-            imageDark
+            ${cardImagesProjection}
         },
         "related_patterns": *[
             _type == "jokul_monster"
@@ -31,7 +31,7 @@ export const monsterBySlugQuery = defineQuery(
             name,
             short_description,
             "slug": slug.current,
-            image
+            ${cardImagesProjection}
         } | order(name),
         article[]{
             ${commonBlockBody}

--- a/portal/src/sanity/queries/search.ts
+++ b/portal/src/sanity/queries/search.ts
@@ -20,8 +20,18 @@ export const searchQuery = defineQuery(
         slug,
         short_description,
         "image": select(
-            _type == "jokul_component" => image.asset->url,
-            _type == "jokul_monster" => image.asset->url,
+            _type == "jokul_component" => coalesce(
+                cardImages.light.asset->url,
+                cardImages.dark.asset->url,
+                image.asset->url,
+                imageDark.asset->url
+            ),
+            _type == "jokul_monster" => coalesce(
+                cardImages.light.asset->url,
+                cardImages.dark.asset->url,
+                image.asset->url,
+                imageDark.asset->url
+            ),
             null
         ),
         "type": select(

--- a/portal/src/sanity/schemas/documents/component.ts
+++ b/portal/src/sanity/schemas/documents/component.ts
@@ -208,22 +208,36 @@ export const component = defineType({
             },
         }),
         defineField({
+            name: "cardImages",
+            title: "Kortbilder",
+            type: "colorSchemeImages",
+            group: "images",
+        }),
+        defineField({
             name: "image",
             type: "image",
             title: "Bilde til light mode",
+            group: "images",
+            hidden: ({ value }) => !value,
             options: {
                 hotspot: true,
             },
-            group: "images",
+            deprecated: {
+                reason: "Bruk feltet Kortbilder i stedet.",
+            },
         }),
         defineField({
             name: "imageDark",
             type: "image",
             title: "Bilde til dark mode",
+            group: "images",
+            hidden: ({ value }) => !value,
             options: {
                 hotspot: true,
             },
-            group: "images",
+            deprecated: {
+                reason: "Bruk feltet Kortbilder i stedet.",
+            },
         }),
     ],
 });

--- a/portal/src/sanity/schemas/documents/fundamentals.ts
+++ b/portal/src/sanity/schemas/documents/fundamentals.ts
@@ -38,19 +38,32 @@ export const fundamentals = defineType({
             rows: 2,
         }),
         defineField({
+            name: "cardImages",
+            title: "Kortbilder",
+            type: "colorSchemeImages",
+        }),
+        defineField({
             name: "image",
             type: "image",
             title: "Bilde til light mode",
+            hidden: ({ value }) => !value,
             options: {
                 hotspot: true,
+            },
+            deprecated: {
+                reason: "Bruk feltet Kortbilder i stedet.",
             },
         }),
         defineField({
             name: "imageDark",
             type: "image",
             title: "Bilde til dark mode",
+            hidden: ({ value }) => !value,
             options: {
                 hotspot: true,
+            },
+            deprecated: {
+                reason: "Bruk feltet Kortbilder i stedet.",
             },
         }),
         defineField({

--- a/portal/src/sanity/schemas/documents/monster.ts
+++ b/portal/src/sanity/schemas/documents/monster.ts
@@ -55,14 +55,24 @@ export const monster = defineType({
                     ),
         }),
         defineField({
+            name: "cardImages",
+            title: "Kortbilder",
+            type: "colorSchemeImages",
+            group: "basics",
+        }),
+        defineField({
             name: "image",
             title: "Bilde",
             group: "basics",
             type: "image",
+            hidden: ({ value }) => !value,
             description:
                 "Vises foreløpig kun som forhåndsvisning i oversikten.",
             options: {
                 hotspot: true,
+            },
+            deprecated: {
+                reason: "Bruk feltet Kortbilder i stedet.",
             },
         }),
         defineField({
@@ -130,10 +140,19 @@ export const monster = defineType({
         select: {
             title: "name",
             subtitle: "short_description",
-            media: "image",
+            lightImage: "cardImages.light",
+            darkImage: "cardImages.dark",
+            legacyLightImage: "image",
             components: "related_components",
         },
-        prepare({ title, subtitle, media, components }) {
+        prepare({
+            title,
+            subtitle,
+            lightImage,
+            darkImage,
+            legacyLightImage,
+            components,
+        }) {
             const count = Array.isArray(components) ? components.length : 0;
             return {
                 title: title || "Uten navn",
@@ -142,7 +161,11 @@ export const monster = defineType({
                     (count
                         ? `${count} relatert${count === 1 ? " komponent" : "e komponenter"}`
                         : undefined),
-                media: media || BulbOutlineIcon,
+                media:
+                    lightImage ||
+                    darkImage ||
+                    legacyLightImage ||
+                    BulbOutlineIcon,
             };
         },
     },

--- a/portal/src/sanity/schemas/index.ts
+++ b/portal/src/sanity/schemas/index.ts
@@ -1,6 +1,7 @@
 import { blocks } from "@/sanity/schemas/blocks";
 import { documents } from "@/sanity/schemas/documents";
 import { seoFields } from "@/sanity/schemas/fields";
+import { colorSchemeImages } from "@/sanity/schemas/objects";
 import { toBeDeleted } from "@/sanity/schemas/to-be-deleted";
 import { siteData } from "./documents/siteData";
 import { story } from "./documents/story";
@@ -12,6 +13,7 @@ export const schemaTypes = [
     ...blocks,
     story,
     siteData,
+    colorSchemeImages,
     seoFields,
     internalLink,
 ];

--- a/portal/src/sanity/schemas/objects/colorSchemeImages.ts
+++ b/portal/src/sanity/schemas/objects/colorSchemeImages.ts
@@ -1,0 +1,29 @@
+import { defineField, defineType } from "sanity";
+
+export const colorSchemeImages = defineType({
+    name: "colorSchemeImages",
+    title: "Bilder for lys og mørk modus",
+    type: "object",
+    fields: [
+        defineField({
+            name: "light",
+            type: "image",
+            title: "Lys modus",
+            description:
+                "Bruk samme motiv og utsnitt som for bildet i mørk modus.",
+            options: {
+                hotspot: true,
+            },
+        }),
+        defineField({
+            name: "dark",
+            type: "image",
+            title: "Mørk modus",
+            description:
+                "Bruk samme motiv og utsnitt som for bildet i lys modus.",
+            options: {
+                hotspot: true,
+            },
+        }),
+    ],
+});

--- a/portal/src/sanity/schemas/objects/index.ts
+++ b/portal/src/sanity/schemas/objects/index.ts
@@ -1,0 +1,1 @@
+export { colorSchemeImages } from "./colorSchemeImages";

--- a/portal/src/sanity/types.ts
+++ b/portal/src/sanity/types.ts
@@ -65,6 +65,34 @@ export type Seo = {
   noIndex?: boolean;
 };
 
+export type ColorSchemeImages = {
+  _type: "colorSchemeImages";
+  light?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  dark?: {
+    asset?: {
+      _ref: string;
+      _type: "reference";
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+    };
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+};
+
 export type Jokul_siteData = {
   _id: string;
   _type: "jokul_siteData";
@@ -716,6 +744,7 @@ export type Jokul_component = {
     figma_link?: string;
     storybook_link?: string;
   };
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -751,6 +780,7 @@ export type Jokul_fundamentals = {
   name?: string;
   slug?: Slug;
   short_description?: string;
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -1085,6 +1115,7 @@ export type Jokul_monster = {
   name?: string;
   slug?: Slug;
   short_description?: string;
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -1332,19 +1363,21 @@ export type Geopoint = {
   alt?: number;
 };
 
-export type AllSanitySchemaTypes = Jokul_internal_link | Seo | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_feedbackBlock | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_examples | Jokul_code | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | ComponentPageLink | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Code | Slug | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
+export type AllSanitySchemaTypes = Jokul_internal_link | Seo | ColorSchemeImages | Jokul_siteData | SanityImageCrop | SanityImageHotspot | Jokul_feedbackBlock | Jokul_qa | Jokul_messageBox | Jokul_table | Jokul_doAndDont | Jokul_linkCard | Jokul_examples | Jokul_code | Jokul_componentKortFortalt | Jokul_storybookStory | Jokul_storybook | Jokul_codeBlock | Jokul_codeExample | Jokul_componentProps | ComponentPageLink | Jokul_blog_post | Jokul_component | Jokul_fundamentals | Jokul_release_notes | Jokul_temaside | Jokul_monster | Table | Code | Slug | Jokul_story | TableRow | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageMetadata | SanityFileAsset | SanityAssetSourceData | SanityImageAsset | Geopoint;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ./src/sanity/queries/allPosts.ts
 // Variable: latestUpdatedArticlesQuery
-// Query: *[        _type in [            "jokul_blog_post",            "jokul_component",            "jokul_fundamentals",            "jokul_release_notes",            "jokul_monster"        ] && defined(slug.current)    ] | order(_updatedAt desc)[0...$limit]{        _id,        _type,        "type": select(            _type == "jokul_blog_post"     => "Blogg",            _type == "jokul_component"     => "Komponent",            _type == "jokul_fundamentals"  => "Fundament",            _type == "jokul_release_notes" => "Release notes",            _type == "jokul_monster"      => "Mønster",            "Artikkel"        ),        "name": coalesce(name, tema, version),        short_description,        image,        imageDark,        "slug": slug.current,        "href": select(            _type == "jokul_blog_post"     => "/blog/" + slug.current,            _type == "jokul_component"     => "/komponenter/" + slug.current,            _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,            _type == "jokul_release_notes" => "/release-notes/" + slug.current,            _type == "jokul_monster"      => "/monster/" + slug.current,            "/"        ),        "updated": _updatedAt,        "created": _createdAt,    }
+// Query: *[        _type in [            "jokul_blog_post",            "jokul_component",            "jokul_fundamentals",            "jokul_release_notes",            "jokul_monster"        ] && defined(slug.current)    ] | order(_updatedAt desc)[0...$limit]{        _id,        _type,        "type": select(            _type == "jokul_blog_post"     => "Blogg",            _type == "jokul_component"     => "Komponent",            _type == "jokul_fundamentals"  => "Fundament",            _type == "jokul_release_notes" => "Release notes",            _type == "jokul_monster"      => "Mønster",            "Artikkel"        ),        "name": coalesce(name, tema, version),        short_description,            "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },        "slug": slug.current,        "href": select(            _type == "jokul_blog_post"     => "/blog/" + slug.current,            _type == "jokul_component"     => "/komponenter/" + slug.current,            _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,            _type == "jokul_release_notes" => "/release-notes/" + slug.current,            _type == "jokul_monster"      => "/monster/" + slug.current,            "/"        ),        "updated": _updatedAt,        "created": _createdAt,    }
 export type LatestUpdatedArticlesQueryResult = Array<{
   _id: string;
   _type: "jokul_blog_post";
   type: "Blogg";
   name: string | null;
   short_description: string | null;
-  image: null;
-  imageDark: null;
+  images: {
+    light: null;
+    dark: null;
+  };
   slug: string | null;
   href: string | null;
   updated: string;
@@ -1355,30 +1388,32 @@ export type LatestUpdatedArticlesQueryResult = Array<{
   type: "Komponent";
   name: string | null;
   short_description: string | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   slug: string | null;
   href: string | null;
   updated: string;
@@ -1389,30 +1424,32 @@ export type LatestUpdatedArticlesQueryResult = Array<{
   type: "Fundament";
   name: string | null;
   short_description: string | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   slug: string | null;
   href: string | null;
   updated: string;
@@ -1423,19 +1460,32 @@ export type LatestUpdatedArticlesQueryResult = Array<{
   type: "M\xF8nster";
   name: string | null;
   short_description: string | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   slug: string | null;
   href: string | null;
   updated: string;
@@ -1446,15 +1496,17 @@ export type LatestUpdatedArticlesQueryResult = Array<{
   type: "Release notes";
   name: string | null;
   short_description: string | null;
-  image: null;
-  imageDark: null;
+  images: {
+    light: null;
+    dark: null;
+  };
   slug: string | null;
   href: string | null;
   updated: string;
   created: string;
 }>;
 // Variable: newsPageQuery
-// Query: {        "articles": *[            _type in [                "jokul_blog_post",                "jokul_component",                "jokul_fundamentals",                "jokul_release_notes",                "jokul_monster"            ] && defined(slug.current)            && (count($types) == 0 || _type in $types)            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60        ] | order(_updatedAt desc)[$start...$end]{            _id,            _type,            "type": select(                _type == "jokul_blog_post"     => "Blogg",                _type == "jokul_component"     => "Komponent",                _type == "jokul_fundamentals"  => "Fundament",                _type == "jokul_release_notes" => "Release notes",                _type == "jokul_monster"      => "Mønster",                "Artikkel"            ),            "name": coalesce(name, tema, version),            short_description,            image,            imageDark,            "slug": slug.current,            "href": select(                _type == "jokul_blog_post"     => "/blog/" + slug.current,                _type == "jokul_component"     => "/komponenter/" + slug.current,                _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,                _type == "jokul_release_notes" => "/release-notes/" + slug.current,                _type == "jokul_monster"      => "/monster/" + slug.current,                "/"            ),            "updated": _updatedAt,            "created": _createdAt,        },    }
+// Query: {        "articles": *[            _type in [                "jokul_blog_post",                "jokul_component",                "jokul_fundamentals",                "jokul_release_notes",                "jokul_monster"            ] && defined(slug.current)            && (count($types) == 0 || _type in $types)            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60        ] | order(_updatedAt desc)[$start...$end]{            _id,            _type,            "type": select(                _type == "jokul_blog_post"     => "Blogg",                _type == "jokul_component"     => "Komponent",                _type == "jokul_fundamentals"  => "Fundament",                _type == "jokul_release_notes" => "Release notes",                _type == "jokul_monster"      => "Mønster",                "Artikkel"            ),            "name": coalesce(name, tema, version),            short_description,                "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },            "slug": slug.current,            "href": select(                _type == "jokul_blog_post"     => "/blog/" + slug.current,                _type == "jokul_component"     => "/komponenter/" + slug.current,                _type == "jokul_fundamentals"  => "/fundamenter/" + slug.current,                _type == "jokul_release_notes" => "/release-notes/" + slug.current,                _type == "jokul_monster"      => "/monster/" + slug.current,                "/"            ),            "updated": _updatedAt,            "created": _createdAt,        },    }
 export type NewsPageQueryResult = {
   articles: Array<{
     _id: string;
@@ -1462,8 +1514,10 @@ export type NewsPageQueryResult = {
     type: "Blogg";
     name: string | null;
     short_description: string | null;
-    image: null;
-    imageDark: null;
+    images: {
+      light: null;
+      dark: null;
+    };
     slug: string | null;
     href: string | null;
     updated: string;
@@ -1474,30 +1528,32 @@ export type NewsPageQueryResult = {
     type: "Komponent";
     name: string | null;
     short_description: string | null;
-    image: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
-    imageDark: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
     slug: string | null;
     href: string | null;
     updated: string;
@@ -1508,30 +1564,32 @@ export type NewsPageQueryResult = {
     type: "Fundament";
     name: string | null;
     short_description: string | null;
-    image: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
-    imageDark: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
     slug: string | null;
     href: string | null;
     updated: string;
@@ -1542,19 +1600,32 @@ export type NewsPageQueryResult = {
     type: "M\xF8nster";
     name: string | null;
     short_description: string | null;
-    image: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
-    imageDark: null;
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
     slug: string | null;
     href: string | null;
     updated: string;
@@ -1565,8 +1636,10 @@ export type NewsPageQueryResult = {
     type: "Release notes";
     name: string | null;
     short_description: string | null;
-    image: null;
-    imageDark: null;
+    images: {
+      light: null;
+      dark: null;
+    };
     slug: string | null;
     href: string | null;
     updated: string;
@@ -1584,7 +1657,7 @@ export type BlogPostsQueryResult = Array<{
   date: string;
 }>;
 // Variable: blogPostBySlugQuery
-// Query: *[_type == "jokul_blog_post" && slug.current == $slug][0]{        ...,        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "image": article->image,        "imageDark": article->imageDark    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }        }    }        }    }
+// Query: *[_type == "jokul_blog_post" && slug.current == $slug][0]{        ...,        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "images": {            "light": coalesce(article->cardImages.light, article->image),            "dark": coalesce(article->cardImages.dark, article->imageDark)        }    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }        }    }        }    }
 export type BlogPostBySlugQueryResult = {
   _id: string;
   _type: "jokul_blog_post";
@@ -1610,98 +1683,121 @@ export type BlogPostBySlugQueryResult = {
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_component";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_fundamentals";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_monster";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_temaside";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | null;
       _type: "jokul_internal_link";
       _key: string;
@@ -1820,29 +1916,31 @@ export type BlogPostBySlugQueryResult = {
     };
     url: string | null;
     markDefs: null;
-    image: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-    imageDark: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
     };
   } | {
     _key: string;
@@ -1864,98 +1962,121 @@ export type BlogPostBySlugQueryResult = {
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_component";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_fundamentals";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_monster";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_release_notes";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_temaside";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | null;
         _type: "jokul_internal_link";
         _key: string;
@@ -1991,98 +2112,121 @@ export type BlogPostBySlugQueryResult = {
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_component";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_fundamentals";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_monster";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_release_notes";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_temaside";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | null;
           _type: "jokul_internal_link";
           _key: string;
@@ -2121,36 +2265,38 @@ export type BlogPostBySlugQueryResult = {
 
 // Source: ./src/sanity/queries/component.ts
 // Variable: componentsQuery
-// Query: *[_type == "jokul_component"]{    name,    short_description,    "slug": slug.current,    figma_image,    image,    imageDark,    related_components,    categories} | order(name)
+// Query: *[_type == "jokul_component"]{    name,    short_description,    "slug": slug.current,    figma_image,        "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },    related_components,    categories} | order(name)
 export type ComponentsQueryResult = Array<{
   name: string | null;
   short_description: string | null;
   slug: string | null;
   figma_image: null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   related_components: {
     components?: Array<{
       _ref: string;
@@ -2163,7 +2309,7 @@ export type ComponentsQueryResult = Array<{
   categories: Array<string> | null;
 }>;
 // Variable: componentBySlugQuery
-// Query: *[_type == "jokul_component" && slug.current == $slug][0]{        ...,        "slug": slug.current,        "example_card": {            ...example_card,            "story": example_card.story->        },        documentation_article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "image": article->image,        "imageDark": article->imageDark    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }        }    },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[]{                        ...,                            markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[]{                        ...,                            markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }                    }                }            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark,                related_components,                categories            }        },        "related_patterns": *[_type == "jokul_monster" && references(^._id)]{            name,            "slug": slug.current,            short_description,            image        } | order(name)    }
+// Query: *[_type == "jokul_component" && slug.current == $slug][0]{        ...,        "slug": slug.current,            "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },        "example_card": {            ...example_card,            "story": example_card.story->        },        documentation_article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "images": {            "light": coalesce(article->cardImages.light, article->image),            "dark": coalesce(article->cardImages.dark, article->imageDark)        }    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }        }    },            _type == "jokul_componentKortFortalt" => {                ...,                bruk[]{                    bruk_punkt[]{                        ...,                            markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }                    }                },                ikke_bruk[]{                    ikke_bruk_punkt[]{                        ...,                            markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }                    }                }            }        },        related_components {            components[]->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },                related_components,                categories            }        },        "related_patterns": *[_type == "jokul_monster" && references(^._id)]{            name,            "slug": slug.current,            short_description,                "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }        } | order(name)    }
 export type ComponentBySlugQueryResult = {
   _id: string;
   _type: "jokul_component";
@@ -2215,98 +2361,121 @@ export type ComponentBySlugQueryResult = {
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_component";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_fundamentals";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_monster";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_temaside";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | null;
       _type: "jokul_internal_link";
       _key: string;
@@ -2363,30 +2532,32 @@ export type ComponentBySlugQueryResult = {
             short_description: string | null;
             slug: string | null;
             figma_image: null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | null;
           _type: "componentPageLink";
           _key: string;
@@ -2412,30 +2583,32 @@ export type ComponentBySlugQueryResult = {
             short_description: string | null;
             slug: string | null;
             figma_image: null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | null;
           _type: "componentPageLink";
           _key: string;
@@ -2538,29 +2711,31 @@ export type ComponentBySlugQueryResult = {
     };
     url: string | null;
     markDefs: null;
-    image: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-    imageDark: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
     };
   } | {
     _key: string;
@@ -2582,98 +2757,121 @@ export type ComponentBySlugQueryResult = {
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_component";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_fundamentals";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_monster";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_release_notes";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_temaside";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | null;
         _type: "jokul_internal_link";
         _key: string;
@@ -2709,98 +2907,121 @@ export type ComponentBySlugQueryResult = {
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_component";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_fundamentals";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_monster";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_release_notes";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_temaside";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | null;
           _type: "jokul_internal_link";
           _key: string;
@@ -2841,30 +3062,32 @@ export type ComponentBySlugQueryResult = {
       short_description: string | null;
       slug: string | null;
       figma_image: null;
-      image: {
-        asset?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-        };
-        media?: unknown;
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: "image";
-      } | null;
-      imageDark: {
-        asset?: {
-          _ref: string;
-          _type: "reference";
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-        };
-        media?: unknown;
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: "image";
-      } | null;
+      images: {
+        light: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+        dark: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        } | null;
+      };
       related_components: {
         components?: Array<{
           _ref: string;
@@ -2882,6 +3105,7 @@ export type ComponentBySlugQueryResult = {
     figma_link?: string;
     storybook_link?: string;
   };
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -2906,11 +3130,8 @@ export type ComponentBySlugQueryResult = {
     crop?: SanityImageCrop;
     _type: "image";
   };
-  related_patterns: Array<{
-    name: string | null;
-    slug: string | null;
-    short_description: string | null;
-    image: {
+  images: {
+    light: {
       asset?: {
         _ref: string;
         _type: "reference";
@@ -2922,6 +3143,49 @@ export type ComponentBySlugQueryResult = {
       crop?: SanityImageCrop;
       _type: "image";
     } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
+  related_patterns: Array<{
+    name: string | null;
+    slug: string | null;
+    short_description: string | null;
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
   }>;
 } | null;
 // Variable: componentMetaBySlugQuery
@@ -2932,39 +3196,41 @@ export type ComponentMetaBySlugQueryResult = {
 
 // Source: ./src/sanity/queries/fundamentals.ts
 // Variable: fundamentalsQuery
-// Query: *[_type == "jokul_fundamentals"]{        name,        slug,        short_description,        image,        imageDark,        "date": _createdAt    } | order(_createdAt desc)
+// Query: *[_type == "jokul_fundamentals"]{        name,        slug,        short_description,            "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },        "date": _createdAt    } | order(_createdAt desc)
 export type FundamentalsQueryResult = Array<{
   name: string | null;
   slug: Slug | null;
   short_description: string | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
-  imageDark: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   date: string;
 }>;
 // Variable: fundamentalsBySlugQuery
-// Query: *[_type == "jokul_fundamentals" && slug.current == $slug][0]{        ...,        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "image": article->image,        "imageDark": article->imageDark    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }        }    }        }    }
+// Query: *[_type == "jokul_fundamentals" && slug.current == $slug][0]{        ...,            "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "images": {            "light": coalesce(article->cardImages.light, article->image),            "dark": coalesce(article->cardImages.dark, article->imageDark)        }    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }        }    }        }    }
 export type FundamentalsBySlugQueryResult = {
   _id: string;
   _type: "jokul_fundamentals";
@@ -2974,6 +3240,7 @@ export type FundamentalsBySlugQueryResult = {
   name?: string;
   slug?: Slug;
   short_description?: string;
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -3013,98 +3280,121 @@ export type FundamentalsBySlugQueryResult = {
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_component";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_fundamentals";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_monster";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_temaside";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | null;
       _type: "jokul_internal_link";
       _key: string;
@@ -3229,29 +3519,31 @@ export type FundamentalsBySlugQueryResult = {
     };
     url: string | null;
     markDefs: null;
-    image: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-    imageDark: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
     };
   } | {
     _key: string;
@@ -3273,98 +3565,121 @@ export type FundamentalsBySlugQueryResult = {
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_component";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_fundamentals";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_monster";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_release_notes";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_temaside";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | null;
         _type: "jokul_internal_link";
         _key: string;
@@ -3400,98 +3715,121 @@ export type FundamentalsBySlugQueryResult = {
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_component";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_fundamentals";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_monster";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_release_notes";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_temaside";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | null;
           _type: "jokul_internal_link";
           _key: string;
@@ -3526,34 +3864,74 @@ export type FundamentalsBySlugQueryResult = {
     copy_button?: boolean;
     markDefs: null;
   }> | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
 } | null;
 
 // Source: ./src/sanity/queries/monster.ts
 // Variable: monstreQuery
-// Query: *[_type == "jokul_monster"]{    name,    "slug": slug.current,    short_description,    image,    related_components[]->{        name,        "slug": slug.current    }} | order(name)
+// Query: *[_type == "jokul_monster"]{    name,    "slug": slug.current,    short_description,        "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },    related_components[]->{        name,        "slug": slug.current    }} | order(name)
 export type MonstreQueryResult = Array<{
   name: string | null;
   slug: string | null;
   short_description: string | null;
-  image: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    media?: unknown;
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  } | null;
+  images: {
+    light: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
   related_components: Array<{
     name: string | null;
     slug: string | null;
   }> | null;
 }>;
 // Variable: monsterBySlugQuery
-// Query: *[_type == "jokul_monster" && slug.current == $slug][0]{        ...,        "slug": slug.current,        related_components[]->{            name,            short_description,            "slug": slug.current,            image,            imageDark        },        "related_patterns": *[            _type == "jokul_monster"            && _id != ^._id            && (_id in ^.related_patterns[]._ref || references(^._id))        ]{            name,            short_description,            "slug": slug.current,            image        } | order(name),        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "image": article->image,        "imageDark": article->imageDark    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }        }    }        }    }
+// Query: *[_type == "jokul_monster" && slug.current == $slug][0]{        ...,        "slug": slug.current,            "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    },        related_components[]->{            name,            short_description,            "slug": slug.current,                "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }        },        "related_patterns": *[            _type == "jokul_monster"            && _id != ^._id            && (_id in ^.related_patterns[]._ref || references(^._id))        ]{            name,            short_description,            "slug": slug.current,                "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }        } | order(name),        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "images": {            "light": coalesce(article->cardImages.light, article->image),            "dark": coalesce(article->cardImages.dark, article->imageDark)        }    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }        }    }        }    }
 export type MonsterBySlugQueryResult = {
   _id: string;
   _type: "jokul_monster";
@@ -3563,6 +3941,7 @@ export type MonsterBySlugQueryResult = {
   name?: string;
   slug: string | null;
   short_description?: string;
+  cardImages?: ColorSchemeImages;
   image?: {
     asset?: {
       _ref: string;
@@ -3590,98 +3969,121 @@ export type MonsterBySlugQueryResult = {
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_component";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_fundamentals";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_monster";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_temaside";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | null;
       _type: "jokul_internal_link";
       _key: string;
@@ -3800,29 +4202,31 @@ export type MonsterBySlugQueryResult = {
     };
     url: string | null;
     markDefs: null;
-    image: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-    imageDark: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
     };
   } | {
     _key: string;
@@ -3844,98 +4248,121 @@ export type MonsterBySlugQueryResult = {
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_component";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_fundamentals";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_monster";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_release_notes";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_temaside";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | null;
         _type: "jokul_internal_link";
         _key: string;
@@ -3971,98 +4398,121 @@ export type MonsterBySlugQueryResult = {
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_component";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_fundamentals";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_monster";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_release_notes";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_temaside";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | null;
           _type: "jokul_internal_link";
           _key: string;
@@ -4101,36 +4551,66 @@ export type MonsterBySlugQueryResult = {
     name: string | null;
     short_description: string | null;
     slug: string | null;
-    image: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
-    imageDark: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    } | null;
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
   }> | null;
   related_patterns: Array<{
     name: string | null;
     short_description: string | null;
     slug: string | null;
-    image: {
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+    };
+  }>;
+  images: {
+    light: {
       asset?: {
         _ref: string;
         _type: "reference";
@@ -4142,7 +4622,19 @@ export type MonsterBySlugQueryResult = {
       crop?: SanityImageCrop;
       _type: "image";
     } | null;
-  }>;
+    dark: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    } | null;
+  };
 } | null;
 
 // Source: ./src/sanity/queries/releaseNotes.ts
@@ -4156,7 +4648,7 @@ export type ReleaseNotesQueryResult = Array<{
   releaseDate: string | null;
 }>;
 // Variable: releaseNoteBySlugQuery
-// Query: *[_type == "jokul_release_notes" && slug.current == $slug][0]{        version,        releaseDate,        short_description,        migrationUrl,        figmaUrl,        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "image": article->image,        "imageDark": article->imageDark    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                image,                imageDark            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                image,                imageDark            }        }    }        }    }        }    }
+// Query: *[_type == "jokul_release_notes" && slug.current == $slug][0]{        version,        releaseDate,        short_description,        migrationUrl,        figmaUrl,        article[]{                ...,        markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    },    _type == "jokul_examples" => {        ...,        examples[]->{            name,            id,            description,            height,            inert,            code        }    },        _type == "jokul_linkCard" => {        ...,        "url": coalesce(            url,            select(                article->_type == "jokul_component"     => "/komponenter/"   + article->slug.current,                article->_type == "jokul_blog_post"     => "/blog/"          + article->slug.current,                article->_type == "jokul_fundamentals"  => "/fundamenter/"   + article->slug.current,                article->_type == "jokul_release_notes" => "/release-notes/" + article->slug.current,                article->_type == "jokul_monster"       => "/monster/"       + article->slug.current            )        ),        "images": {            "light": coalesce(article->cardImages.light, article->image),            "dark": coalesce(article->cardImages.dark, article->imageDark)        }    },    _type == "jokul_qa" => {        ...,        faq[]{            ...,            answer[]{                ...,                    markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }            }        }    },    _type == "jokul_messageBox" => {        ...,        message[]{            ...,                markDefs[]{        ...,        _type == "jokul_internal_link" => {            ...,            article->{                _type,                "name": coalesce(name, tema, version),                short_description,                "slug": slug.current,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        },        _type == "componentPageLink" => {            ...,            component->{                name,                short_description,                "slug": slug.current,                figma_image,                    "images": {        "light": coalesce(cardImages.light, image),        "dark": coalesce(cardImages.dark, imageDark)    }            }        }    }        }    }        }    }
 export type ReleaseNoteBySlugQueryResult = {
   version: string | null;
   releaseDate: string | null;
@@ -4178,98 +4670,121 @@ export type ReleaseNoteBySlugQueryResult = {
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_component";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_fundamentals";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_monster";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: {
-          asset?: {
-            _ref: string;
-            _type: "reference";
-            _weak?: boolean;
-            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-          };
-          media?: unknown;
-          hotspot?: SanityImageHotspot;
-          crop?: SanityImageCrop;
-          _type: "image";
-        } | null;
-        imageDark: null;
+        images: {
+          light: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+          dark: {
+            asset?: {
+              _ref: string;
+              _type: "reference";
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+            };
+            media?: unknown;
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: "image";
+          } | null;
+        };
       } | {
         _type: "jokul_release_notes";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | {
         _type: "jokul_temaside";
         name: string | null;
         short_description: string | null;
         slug: string | null;
-        image: null;
-        imageDark: null;
+        images: {
+          light: null;
+          dark: null;
+        };
       } | null;
       _type: "jokul_internal_link";
       _key: string;
@@ -4394,29 +4909,31 @@ export type ReleaseNoteBySlugQueryResult = {
     };
     url: string | null;
     markDefs: null;
-    image: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-    imageDark: null | {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
+    images: {
+      light: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
+      dark: {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        media?: unknown;
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: "image";
+      } | null;
     };
   } | {
     _key: string;
@@ -4438,98 +4955,121 @@ export type ReleaseNoteBySlugQueryResult = {
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_component";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_fundamentals";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_monster";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: {
-            asset?: {
-              _ref: string;
-              _type: "reference";
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-            };
-            media?: unknown;
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: "image";
-          } | null;
-          imageDark: null;
+          images: {
+            light: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+            dark: {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              media?: unknown;
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              _type: "image";
+            } | null;
+          };
         } | {
           _type: "jokul_release_notes";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | {
           _type: "jokul_temaside";
           name: string | null;
           short_description: string | null;
           slug: string | null;
-          image: null;
-          imageDark: null;
+          images: {
+            light: null;
+            dark: null;
+          };
         } | null;
         _type: "jokul_internal_link";
         _key: string;
@@ -4565,98 +5105,121 @@ export type ReleaseNoteBySlugQueryResult = {
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_component";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_fundamentals";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_monster";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: {
-              asset?: {
-                _ref: string;
-                _type: "reference";
-                _weak?: boolean;
-                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-              };
-              media?: unknown;
-              hotspot?: SanityImageHotspot;
-              crop?: SanityImageCrop;
-              _type: "image";
-            } | null;
-            imageDark: null;
+            images: {
+              light: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+              dark: {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                media?: unknown;
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                _type: "image";
+              } | null;
+            };
           } | {
             _type: "jokul_release_notes";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | {
             _type: "jokul_temaside";
             name: string | null;
             short_description: string | null;
             slug: string | null;
-            image: null;
-            imageDark: null;
+            images: {
+              light: null;
+              dark: null;
+            };
           } | null;
           _type: "jokul_internal_link";
           _key: string;
@@ -4695,7 +5258,7 @@ export type ReleaseNoteBySlugQueryResult = {
 
 // Source: ./src/sanity/queries/search.ts
 // Variable: searchQuery
-// Query: *[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post", "jokul_monster"] && defined(slug.current) && (        name match "*" + $searchString + "*" ||        short_description match "*" + $searchString + "*" ||        slug.current match "*" + $searchString + "*" ||        (_type == "jokul_component" && (            keywords[] match "*" + $searchString + "*" ||            documentation_article[].children[].text match "*" + $searchString + "*" ||            considerations[].title match "*" + $searchString + "*" ||            considerations[].description match "*" + $searchString + "*"        )) ||        (_type == "jokul_monster" &&            article[].children[].text match "*" + $searchString + "*"        )    )] | {        _id,        name,        slug,        short_description,        "image": select(            _type == "jokul_component" => image.asset->url,            _type == "jokul_monster" => image.asset->url,            null        ),        "type": select(            _type == "jokul_component" => "Komponent",            _type == "jokul_fundamentals" => "Fundament",            _type == "jokul_blog_post" => "Blogg",            _type == "jokul_monster" => "Mønster"        ),        "href": select(            _type == "jokul_component" => "/komponenter/" + slug.current,            _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,            _type == "jokul_blog_post" => "/blog/" + slug.current,            _type == "jokul_monster" => "/monster/" + slug.current        )    }
+// Query: *[_type in ["jokul_component", "jokul_fundamentals", "jokul_blog_post", "jokul_monster"] && defined(slug.current) && (        name match "*" + $searchString + "*" ||        short_description match "*" + $searchString + "*" ||        slug.current match "*" + $searchString + "*" ||        (_type == "jokul_component" && (            keywords[] match "*" + $searchString + "*" ||            documentation_article[].children[].text match "*" + $searchString + "*" ||            considerations[].title match "*" + $searchString + "*" ||            considerations[].description match "*" + $searchString + "*"        )) ||        (_type == "jokul_monster" &&            article[].children[].text match "*" + $searchString + "*"        )    )] | {        _id,        name,        slug,        short_description,        "image": select(            _type == "jokul_component" => coalesce(                cardImages.light.asset->url,                cardImages.dark.asset->url,                image.asset->url,                imageDark.asset->url            ),            _type == "jokul_monster" => coalesce(                cardImages.light.asset->url,                cardImages.dark.asset->url,                image.asset->url,                imageDark.asset->url            ),            null        ),        "type": select(            _type == "jokul_component" => "Komponent",            _type == "jokul_fundamentals" => "Fundament",            _type == "jokul_blog_post" => "Blogg",            _type == "jokul_monster" => "Mønster"        ),        "href": select(            _type == "jokul_component" => "/komponenter/" + slug.current,            _type == "jokul_fundamentals" => "/fundamenter/" + slug.current,            _type == "jokul_blog_post" => "/blog/" + slug.current,            _type == "jokul_monster" => "/monster/" + slug.current        )    }
 export type SearchQueryResult = Array<{
   _id: string;
   name: string | null;
@@ -4718,7 +5281,7 @@ export type SearchQueryResult = Array<{
   slug: Slug | null;
   short_description: string | null;
   image: string | null;
-  type: "Komponent";
+  type: "M\xF8nster";
   href: string | null;
 } | {
   _id: string;
@@ -4726,7 +5289,7 @@ export type SearchQueryResult = Array<{
   slug: Slug | null;
   short_description: string | null;
   image: string | null;
-  type: "M\xF8nster";
+  type: "Komponent";
   href: string | null;
 }>;
 
@@ -4781,20 +5344,20 @@ export type ExamplesQueryResult = Array<never>;
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    "*[\n        _type in [\n            \"jokul_blog_post\",\n            \"jokul_component\",\n            \"jokul_fundamentals\",\n            \"jokul_release_notes\",\n            \"jokul_monster\"\n        ] && defined(slug.current)\n    ] | order(_updatedAt desc)[0...$limit]{\n        _id,\n        _type,\n        \"type\": select(\n            _type == \"jokul_blog_post\"     => \"Blogg\",\n            _type == \"jokul_component\"     => \"Komponent\",\n            _type == \"jokul_fundamentals\"  => \"Fundament\",\n            _type == \"jokul_release_notes\" => \"Release notes\",\n            _type == \"jokul_monster\"      => \"M\xF8nster\",\n            \"Artikkel\"\n        ),\n        \"name\": coalesce(name, tema, version),\n        short_description,\n        image,\n        imageDark,\n        \"slug\": slug.current,\n        \"href\": select(\n            _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n            _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n            _type == \"jokul_monster\"      => \"/monster/\" + slug.current,\n            \"/\"\n        ),\n        \"updated\": _updatedAt,\n        \"created\": _createdAt,\n    }": LatestUpdatedArticlesQueryResult;
-    "{\n        \"articles\": *[\n            _type in [\n                \"jokul_blog_post\",\n                \"jokul_component\",\n                \"jokul_fundamentals\",\n                \"jokul_release_notes\",\n                \"jokul_monster\"\n            ] && defined(slug.current)\n            && (count($types) == 0 || _type in $types)\n            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60\n        ] | order(_updatedAt desc)[$start...$end]{\n            _id,\n            _type,\n            \"type\": select(\n                _type == \"jokul_blog_post\"     => \"Blogg\",\n                _type == \"jokul_component\"     => \"Komponent\",\n                _type == \"jokul_fundamentals\"  => \"Fundament\",\n                _type == \"jokul_release_notes\" => \"Release notes\",\n                _type == \"jokul_monster\"      => \"M\xF8nster\",\n                \"Artikkel\"\n            ),\n            \"name\": coalesce(name, tema, version),\n            short_description,\n            image,\n            imageDark,\n            \"slug\": slug.current,\n            \"href\": select(\n                _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n                _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n                _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n                _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n                _type == \"jokul_monster\"      => \"/monster/\" + slug.current,\n                \"/\"\n            ),\n            \"updated\": _updatedAt,\n            \"created\": _createdAt,\n        },\n    }": NewsPageQueryResult;
+    "*[\n        _type in [\n            \"jokul_blog_post\",\n            \"jokul_component\",\n            \"jokul_fundamentals\",\n            \"jokul_release_notes\",\n            \"jokul_monster\"\n        ] && defined(slug.current)\n    ] | order(_updatedAt desc)[0...$limit]{\n        _id,\n        _type,\n        \"type\": select(\n            _type == \"jokul_blog_post\"     => \"Blogg\",\n            _type == \"jokul_component\"     => \"Komponent\",\n            _type == \"jokul_fundamentals\"  => \"Fundament\",\n            _type == \"jokul_release_notes\" => \"Release notes\",\n            _type == \"jokul_monster\"      => \"M\xF8nster\",\n            \"Artikkel\"\n        ),\n        \"name\": coalesce(name, tema, version),\n        short_description,\n        \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n        \"slug\": slug.current,\n        \"href\": select(\n            _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n            _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n            _type == \"jokul_monster\"      => \"/monster/\" + slug.current,\n            \"/\"\n        ),\n        \"updated\": _updatedAt,\n        \"created\": _createdAt,\n    }": LatestUpdatedArticlesQueryResult;
+    "{\n        \"articles\": *[\n            _type in [\n                \"jokul_blog_post\",\n                \"jokul_component\",\n                \"jokul_fundamentals\",\n                \"jokul_release_notes\",\n                \"jokul_monster\"\n            ] && defined(slug.current)\n            && (count($types) == 0 || _type in $types)\n            && dateTime(_updatedAt) > dateTime(now()) - 60*60*24*60\n        ] | order(_updatedAt desc)[$start...$end]{\n            _id,\n            _type,\n            \"type\": select(\n                _type == \"jokul_blog_post\"     => \"Blogg\",\n                _type == \"jokul_component\"     => \"Komponent\",\n                _type == \"jokul_fundamentals\"  => \"Fundament\",\n                _type == \"jokul_release_notes\" => \"Release notes\",\n                _type == \"jokul_monster\"      => \"M\xF8nster\",\n                \"Artikkel\"\n            ),\n            \"name\": coalesce(name, tema, version),\n            short_description,\n            \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n            \"slug\": slug.current,\n            \"href\": select(\n                _type == \"jokul_blog_post\"     => \"/blog/\" + slug.current,\n                _type == \"jokul_component\"     => \"/komponenter/\" + slug.current,\n                _type == \"jokul_fundamentals\"  => \"/fundamenter/\" + slug.current,\n                _type == \"jokul_release_notes\" => \"/release-notes/\" + slug.current,\n                _type == \"jokul_monster\"      => \"/monster/\" + slug.current,\n                \"/\"\n            ),\n            \"updated\": _updatedAt,\n            \"created\": _createdAt,\n        },\n    }": NewsPageQueryResult;
     "*[_type == \"jokul_blog_post\"]{\n        name,\n        slug,\n        short_description,\n        \"date\": _createdAt\n    } | order(_createdAt desc)": BlogPostsQueryResult;
-    "*[_type == \"jokul_blog_post\" && slug.current == $slug][0]{\n        ...,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"image\": article->image,\n        \"imageDark\": article->imageDark\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": BlogPostBySlugQueryResult;
-    "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    image,\n    imageDark,\n    related_components,\n    categories\n} | order(name)": ComponentsQueryResult;
-    "*[_type == \"jokul_component\" && slug.current == $slug][0]{\n        ...,\n        \"slug\": slug.current,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"image\": article->image,\n        \"imageDark\": article->imageDark\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n        }\n    }\n,\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[]{\n                        ...,\n                        \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[]{\n                        ...,\n                        \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n                    }\n                }\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark,\n                related_components,\n                categories\n            }\n        },\n        \"related_patterns\": *[_type == \"jokul_monster\" && references(^._id)]{\n            name,\n            \"slug\": slug.current,\n            short_description,\n            image\n        } | order(name)\n    }": ComponentBySlugQueryResult;
+    "*[_type == \"jokul_blog_post\" && slug.current == $slug][0]{\n        ...,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"images\": {\n            \"light\": coalesce(article->cardImages.light, article->image),\n            \"dark\": coalesce(article->cardImages.dark, article->imageDark)\n        }\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": BlogPostBySlugQueryResult;
+    "*[_type == \"jokul_component\"]{\n    name,\n    short_description,\n    \"slug\": slug.current,\n    figma_image,\n    \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n    related_components,\n    categories\n} | order(name)": ComponentsQueryResult;
+    "*[_type == \"jokul_component\" && slug.current == $slug][0]{\n        ...,\n        \"slug\": slug.current,\n        \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n        \"example_card\": {\n            ...example_card,\n            \"story\": example_card.story->\n        },\n        documentation_article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"images\": {\n            \"light\": coalesce(article->cardImages.light, article->image),\n            \"dark\": coalesce(article->cardImages.dark, article->imageDark)\n        }\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n        }\n    }\n,\n            _type == \"jokul_componentKortFortalt\" => {\n                ...,\n                bruk[]{\n                    bruk_punkt[]{\n                        ...,\n                        \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n                    }\n                },\n                ikke_bruk[]{\n                    ikke_bruk_punkt[]{\n                        ...,\n                        \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n                    }\n                }\n            }\n        },\n        related_components {\n            components[]->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n                related_components,\n                categories\n            }\n        },\n        \"related_patterns\": *[_type == \"jokul_monster\" && references(^._id)]{\n            name,\n            \"slug\": slug.current,\n            short_description,\n            \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n        } | order(name)\n    }": ComponentBySlugQueryResult;
     "*[_type == \"jokul_component\" && slug.current == $slug][0]{ name }": ComponentMetaBySlugQueryResult;
-    "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        image,\n        imageDark,\n        \"date\": _createdAt\n    } | order(_createdAt desc)": FundamentalsQueryResult;
-    "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0]{\n        ...,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"image\": article->image,\n        \"imageDark\": article->imageDark\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": FundamentalsBySlugQueryResult;
-    "*[_type == \"jokul_monster\"]{\n    name,\n    \"slug\": slug.current,\n    short_description,\n    image,\n    related_components[]->{\n        name,\n        \"slug\": slug.current\n    }\n} | order(name)": MonstreQueryResult;
-    "*[_type == \"jokul_monster\" && slug.current == $slug][0]{\n        ...,\n        \"slug\": slug.current,\n        related_components[]->{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            image,\n            imageDark\n        },\n        \"related_patterns\": *[\n            _type == \"jokul_monster\"\n            && _id != ^._id\n            && (_id in ^.related_patterns[]._ref || references(^._id))\n        ]{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            image\n        } | order(name),\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"image\": article->image,\n        \"imageDark\": article->imageDark\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": MonsterBySlugQueryResult;
+    "*[_type == \"jokul_fundamentals\"]{\n        name,\n        slug,\n        short_description,\n        \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n        \"date\": _createdAt\n    } | order(_createdAt desc)": FundamentalsQueryResult;
+    "*[_type == \"jokul_fundamentals\" && slug.current == $slug][0]{\n        ...,\n        \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"images\": {\n            \"light\": coalesce(article->cardImages.light, article->image),\n            \"dark\": coalesce(article->cardImages.dark, article->imageDark)\n        }\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": FundamentalsBySlugQueryResult;
+    "*[_type == \"jokul_monster\"]{\n    name,\n    \"slug\": slug.current,\n    short_description,\n    \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n    related_components[]->{\n        name,\n        \"slug\": slug.current\n    }\n} | order(name)": MonstreQueryResult;
+    "*[_type == \"jokul_monster\" && slug.current == $slug][0]{\n        ...,\n        \"slug\": slug.current,\n        \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n,\n        related_components[]->{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n        },\n        \"related_patterns\": *[\n            _type == \"jokul_monster\"\n            && _id != ^._id\n            && (_id in ^.related_patterns[]._ref || references(^._id))\n        ]{\n            name,\n            short_description,\n            \"slug\": slug.current,\n            \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n        } | order(name),\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"images\": {\n            \"light\": coalesce(article->cardImages.light, article->image),\n            \"dark\": coalesce(article->cardImages.dark, article->imageDark)\n        }\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": MonsterBySlugQueryResult;
     "*[_type == \"jokul_release_notes\"]{\n        _id,\n        version,\n        \"slug\": slug.current,\n        short_description,\n        releaseDate\n    } | order(releaseDate desc)": ReleaseNotesQueryResult;
-    "*[_type == \"jokul_release_notes\" && slug.current == $slug][0]{\n        version,\n        releaseDate,\n        short_description,\n        migrationUrl,\n        figmaUrl,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"image\": article->image,\n        \"imageDark\": article->imageDark\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                image,\n                imageDark\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                image,\n                imageDark\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": ReleaseNoteBySlugQueryResult;
-    "*[_type in [\"jokul_component\", \"jokul_fundamentals\", \"jokul_blog_post\", \"jokul_monster\"] && defined(slug.current) && (\n        name match \"*\" + $searchString + \"*\" ||\n        short_description match \"*\" + $searchString + \"*\" ||\n        slug.current match \"*\" + $searchString + \"*\" ||\n        (_type == \"jokul_component\" && (\n            keywords[] match \"*\" + $searchString + \"*\" ||\n            documentation_article[].children[].text match \"*\" + $searchString + \"*\" ||\n            considerations[].title match \"*\" + $searchString + \"*\" ||\n            considerations[].description match \"*\" + $searchString + \"*\"\n        )) ||\n        (_type == \"jokul_monster\" &&\n            article[].children[].text match \"*\" + $searchString + \"*\"\n        )\n    )] | {\n        _id,\n        name,\n        slug,\n        short_description,\n        \"image\": select(\n            _type == \"jokul_component\" => image.asset->url,\n            _type == \"jokul_monster\" => image.asset->url,\n            null\n        ),\n        \"type\": select(\n            _type == \"jokul_component\" => \"Komponent\",\n            _type == \"jokul_fundamentals\" => \"Fundament\",\n            _type == \"jokul_blog_post\" => \"Blogg\",\n            _type == \"jokul_monster\" => \"M\xF8nster\"\n        ),\n        \"href\": select(\n            _type == \"jokul_component\" => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\" => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_blog_post\" => \"/blog/\" + slug.current,\n            _type == \"jokul_monster\" => \"/monster/\" + slug.current\n        )\n    }": SearchQueryResult;
+    "*[_type == \"jokul_release_notes\" && slug.current == $slug][0]{\n        version,\n        releaseDate,\n        short_description,\n        migrationUrl,\n        figmaUrl,\n        article[]{\n            \n    ...,\n    \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n,\n    _type == \"jokul_examples\" => {\n        ...,\n        examples[]->{\n            name,\n            id,\n            description,\n            height,\n            inert,\n            code\n        }\n    },\n        _type == \"jokul_linkCard\" => {\n        ...,\n        \"url\": coalesce(\n            url,\n            select(\n                article->_type == \"jokul_component\"     => \"/komponenter/\"   + article->slug.current,\n                article->_type == \"jokul_blog_post\"     => \"/blog/\"          + article->slug.current,\n                article->_type == \"jokul_fundamentals\"  => \"/fundamenter/\"   + article->slug.current,\n                article->_type == \"jokul_release_notes\" => \"/release-notes/\" + article->slug.current,\n                article->_type == \"jokul_monster\"       => \"/monster/\"       + article->slug.current\n            )\n        ),\n        \"images\": {\n            \"light\": coalesce(article->cardImages.light, article->image),\n            \"dark\": coalesce(article->cardImages.dark, article->imageDark)\n        }\n    },\n    _type == \"jokul_qa\" => {\n        ...,\n        faq[]{\n            ...,\n            answer[]{\n                ...,\n                \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n            }\n        }\n    },\n    _type == \"jokul_messageBox\" => {\n        ...,\n        message[]{\n            ...,\n            \n    markDefs[]{\n        ...,\n        _type == \"jokul_internal_link\" => {\n            ...,\n            article->{\n                _type,\n                \"name\": coalesce(name, tema, version),\n                short_description,\n                \"slug\": slug.current,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        },\n        _type == \"componentPageLink\" => {\n            ...,\n            component->{\n                name,\n                short_description,\n                \"slug\": slug.current,\n                figma_image,\n                \n    \"images\": {\n        \"light\": coalesce(cardImages.light, image),\n        \"dark\": coalesce(cardImages.dark, imageDark)\n    }\n\n            }\n        }\n    }\n\n        }\n    }\n\n        }\n    }": ReleaseNoteBySlugQueryResult;
+    "*[_type in [\"jokul_component\", \"jokul_fundamentals\", \"jokul_blog_post\", \"jokul_monster\"] && defined(slug.current) && (\n        name match \"*\" + $searchString + \"*\" ||\n        short_description match \"*\" + $searchString + \"*\" ||\n        slug.current match \"*\" + $searchString + \"*\" ||\n        (_type == \"jokul_component\" && (\n            keywords[] match \"*\" + $searchString + \"*\" ||\n            documentation_article[].children[].text match \"*\" + $searchString + \"*\" ||\n            considerations[].title match \"*\" + $searchString + \"*\" ||\n            considerations[].description match \"*\" + $searchString + \"*\"\n        )) ||\n        (_type == \"jokul_monster\" &&\n            article[].children[].text match \"*\" + $searchString + \"*\"\n        )\n    )] | {\n        _id,\n        name,\n        slug,\n        short_description,\n        \"image\": select(\n            _type == \"jokul_component\" => coalesce(\n                cardImages.light.asset->url,\n                cardImages.dark.asset->url,\n                image.asset->url,\n                imageDark.asset->url\n            ),\n            _type == \"jokul_monster\" => coalesce(\n                cardImages.light.asset->url,\n                cardImages.dark.asset->url,\n                image.asset->url,\n                imageDark.asset->url\n            ),\n            null\n        ),\n        \"type\": select(\n            _type == \"jokul_component\" => \"Komponent\",\n            _type == \"jokul_fundamentals\" => \"Fundament\",\n            _type == \"jokul_blog_post\" => \"Blogg\",\n            _type == \"jokul_monster\" => \"M\xF8nster\"\n        ),\n        \"href\": select(\n            _type == \"jokul_component\" => \"/komponenter/\" + slug.current,\n            _type == \"jokul_fundamentals\" => \"/fundamenter/\" + slug.current,\n            _type == \"jokul_blog_post\" => \"/blog/\" + slug.current,\n            _type == \"jokul_monster\" => \"/monster/\" + slug.current\n        )\n    }": SearchQueryResult;
     "*[_type == \"jokul_siteData\"]{\n        ...,\n        \"seo\": {\n            \"title\": coalesce(seo.title, title, \"\"),\n            \"description\": coalesce(seo.description,  \"\"),\n            \"image\": seo.image,\n            \"noIndex\": seo.noIndex == true\n          },\n        footer {\n            text,\n            linkGroups[]{\n                title,\n                linkList[]{\n                    text,\n                    \"url\": select(\n    url[0]._type == \"internalLink\" => select(\n      url[0].internalReference->_type == \"jokul_component\" => \"/komponenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_fundamentals\" => \"/fundamenter/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_blog_post\" => \"/blog/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_monster\" => \"/monster/\" + url[0].internalReference->slug.current,\n      url[0].internalReference->_type == \"jokul_release_notes\" => \"/release-notes/\" + url[0].internalReference->slug.current,\n      \"/\" + url[0].internalReference->slug.current\n    ),\n    url[0]._type == \"mainPageLink\" => \"/\" + url[0].route,\n    url[0]._type == \"externalLink\" => url[0].url\n  )\n                }\n            }\n        },\n        \"date\": _createdAt,\n    } | order(_createdAt desc)[0]": SiteDataQueryResult;
     "*[_type == \"jokul_example\"]{\n    title,\n    id,\n    description,\n    height,\n    inert,\n} | order(name)": ExamplesQueryResult;
   }


### PR DESCRIPTION
Endrer hvordan bilder til oversiktskort lagres i Sanity. Bildene samles nå i ett felt med en variant for lys modus og en for mørk modus.

Fikser også fallbacken slik at vi bruker bildet som finnes dersom bare én variant er lagt inn, i stedet for å vise placeholder.

De gamle feltene beholdes midlertidig, slik at vi kan deploye før dataene i produksjon migreres. Migreringen er testet i datasettet `migration-test`.

Produksjonsmigrering og opprydding følges opp i #6451.