### PR TITLE
Flytt Sanity TypeGen-konfigurasjon til sanity config filen

### DIFF
--- a/portal/sanity-typegen.json
+++ b/portal/sanity-typegen.json
@@ -1,5 +1,0 @@
-{
-    "path": "./src/**/*.{ts,tsx,js,jsx}",
-    "schema": "./src/sanity/extract.json",
-    "generates": "./src/sanity/types.ts"
-}

--- a/portal/sanity.cli.ts
+++ b/portal/sanity.cli.ts
@@ -10,4 +10,9 @@ export default defineCliConfig({
         projectId,
         dataset,
     },
+    typegen: {
+        path: "./src/**/*.{ts,tsx,js,jsx}",
+        schema: "./src/sanity/extract.json",
+        generates: "./src/sanity/types.ts",
+    },
 });


### PR DESCRIPTION
Sanity støtter TypeGen-oppsettet direkte i `sanity.cli.ts`, så vi trenger ikke en egen konfigurasjonsfil.