### PR TITLE
Bruk innebygd glob fra node

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "express": "^4.22.2",
         "express-http-proxy": "^2.1.1",
         "fs-extra": "^11.4.0",
-        "glob": "^13.0.6",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-is": "18.3.1",
@@ -78,7 +77,6 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.3",
         "@types/express": "^4.17.23",
-        "@types/glob": "^9.0.0",
         "@types/node": "^24.13.3",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -98,7 +96,6 @@
         "sass": "^1.102.0",
         "storybook": "10.2.10",
         "stylelint": "^16.26.1",
-        "tiny-glob": "^0.2.9",
         "typescript": "^5.9.2",
         "vite": "^7.3.6",
         "yaml": "^2.8.3"

--- a/packages/jokul/build-styles.mjs
+++ b/packages/jokul/build-styles.mjs
@@ -1,11 +1,10 @@
 import { mkdirSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { glob, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import autoprefixer from "autoprefixer";
 import cssnano from "cssnano";
 import litePreset from "cssnano-preset-lite";
-import { glob } from "glob";
 import postcss from "postcss";
 import * as sass from "sass-embedded";
 
@@ -66,6 +65,7 @@ const rewriteImportsForBuiltFile = (content, sourceFilePath) =>
                 path.dirname(sourceFilePath),
                 importPath,
             );
+
             // Sass forventer POSIX-separatorer i import paths, også på andre OS.
             let rewrittenImportPath = path
                 .relative(
@@ -85,16 +85,26 @@ const rewriteImportsForBuiltFile = (content, sourceFilePath) =>
 
 (async function build() {
     try {
-        const sources = await glob("./src/**/[!_]*.scss", {
-            ignore: ["node_modules/**", "**/documentation/**", "**/stories/**"],
-        });
-        const unfilteredSources = await glob("./src/**/*.scss", {
-            ignore: ["node_modules/**", "**/documentation/**"],
-        });
+        const sources = await Array.fromAsync(
+            glob("./src/**/[!_]*.scss", {
+                exclude: [
+                    "node_modules/**",
+                    "**/documentation/**",
+                    "**/stories/**",
+                ],
+            }),
+        );
+
+        const unfilteredSources = await Array.fromAsync(
+            glob("./src/**/*.scss", {
+                exclude: ["node_modules/**", "**/documentation/**"],
+            }),
+        );
+
         await Promise.all(
             sources
                 .flatMap((source) => {
-                    const fileName = source.slice(source.lastIndexOf("/") + 1);
+                    const fileName = path.basename(source);
                     const sourcePath = fileURLToPath(
                         new URL(source, import.meta.url),
                     );
@@ -105,37 +115,30 @@ const rewriteImportsForBuiltFile = (content, sourceFilePath) =>
                     const content = sass.compile(sourcePath);
                     mkdirSync(outDirName, { recursive: true });
 
+                    const cssFilePath = path.join(
+                        outDirName,
+                        fileName.replace(".scss", ".css"),
+                    );
+
+                    const minifiedCssFilePath = path.join(
+                        outDirName,
+                        fileName.replace(".scss", ".min.css"),
+                    );
+
                     return [
-                        writeFile(
-                            `${outDirName}/${fileName.replace(
-                                ".scss",
-                                ".css",
-                            )}`,
-                            content.css,
-                        ).then(() =>
-                            console.log(
-                                `Wrote ${outDirName}/${fileName.replace(
-                                    ".scss",
-                                    ".css",
-                                )}`,
-                            ),
+                        writeFile(cssFilePath, content.css).then(() =>
+                            console.log(`Wrote ${cssFilePath}`),
                         ),
                         new Promise((resolve, reject) => {
                             postcss([autoprefixer(), cssnano(litePreset)])
                                 .process(content.css)
                                 .then((result) =>
                                     writeFile(
-                                        `${outDirName}/${fileName.replace(
-                                            ".scss",
-                                            ".min.css",
-                                        )}`,
+                                        minifiedCssFilePath,
                                         result.css,
                                     ).then(() => {
                                         console.log(
-                                            `Wrote ${outDirName}/${fileName.replace(
-                                                ".scss",
-                                                ".min.css",
-                                            )}`,
+                                            `Wrote ${minifiedCssFilePath}`,
                                         );
                                         resolve();
                                     }),
@@ -145,10 +148,8 @@ const rewriteImportsForBuiltFile = (content, sourceFilePath) =>
                     ];
                 })
                 .concat(
-                    unfilteredSources.map((source) => {
-                        const fileName = source.slice(
-                            source.lastIndexOf("/") + 1,
-                        );
+                    unfilteredSources.map(async (source) => {
+                        const fileName = path.basename(source);
                         const sourcePath = fileURLToPath(
                             new URL(source, import.meta.url),
                         );
@@ -158,17 +159,19 @@ const rewriteImportsForBuiltFile = (content, sourceFilePath) =>
 
                         mkdirSync(outDirName, { recursive: true });
 
-                        return readFile(sourcePath, "utf-8").then((content) => {
-                            const outputFilePath = `${outDirName}/${fileName}`;
-                            const modifiedContent = rewriteImportsForBuiltFile(
-                                content,
-                                sourcePath,
-                            );
-
-                            writeFile(outputFilePath, modifiedContent, {
+                        const content = await readFile(sourcePath, "utf-8");
+                        const outputFilePath = path.join(
+                            outDirName,
+                            fileName);
+                        const modifiedContent = rewriteImportsForBuiltFile(
+                            content,
+                            sourcePath);
+                        return await writeFile(
+                            outputFilePath,
+                            modifiedContent,
+                            {
                                 encoding: "utf-8",
                             });
-                        });
                     }),
                 ),
         );

--- a/packages/jokul/dev-server.mjs
+++ b/packages/jokul/dev-server.mjs
@@ -1,10 +1,10 @@
+import { glob } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react-swc";
 import { Box, Text, render, useApp, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import glob from "tiny-glob";
 import { createServer } from "vite";
 import { copyJklFonts, setupDev } from "../../utils/vite/index.mjs";
 
@@ -51,7 +51,7 @@ export default function App() {
     }, [log]);
 
     useEffect(() => {
-        glob("**/development/Example.tsx").then((result) => {
+        Array.fromAsync(glob("**/development/Example.tsx")).then((result) => {
             setComponents(
                 result.map((file) => {
                     return {

--- a/packages/jokul/package.json
+++ b/packages/jokul/package.json
@@ -107,7 +107,6 @@
         "cssnano": "^8.0.2",
         "cssnano-preset-lite": "^5.0.1",
         "dayjs": "^1.11.21",
-        "glob": "^13.0.6",
         "ink": "^5.1.0",
         "ink-select-input": "^6.0.0",
         "jsdom": "^30.0.1",

--- a/packages/jokul/vite.build.config.mjs
+++ b/packages/jokul/vite.build.config.mjs
@@ -1,8 +1,8 @@
+import { globSync } from "node:fs";
 import { extname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import terser from "@rollup/plugin-terser";
 import react from "@vitejs/plugin-react-swc";
-import { globSync } from "glob";
 import nodeExternals from "rollup-plugin-node-externals";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       fs-extra:
         specifier: ^11.4.0
         version: 11.4.0
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -145,9 +142,6 @@ importers:
       '@types/express':
         specifier: ^4.17.23
         version: 4.17.25
-      '@types/glob':
-        specifier: ^9.0.0
-        version: 9.0.0
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -205,9 +199,6 @@ importers:
       stylelint:
         specifier: ^16.26.1
         version: 16.26.1(typescript@5.9.3)
-      tiny-glob:
-        specifier: ^0.2.9
-        version: 0.2.9
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -310,9 +301,6 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
       ink:
         specifier: ^5.1.0
         version: 5.2.1(@types/react@18.3.1)(react@18.3.1)
@@ -4991,10 +4979,6 @@ packages:
   '@types/gensync@1.0.5':
     resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
 
-  '@types/glob@9.0.0':
-    resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
-    deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
-
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -7867,9 +7851,6 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
-
-  globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -11707,9 +11688,6 @@ packages:
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
-
-  tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -17908,10 +17886,6 @@ snapshots:
 
   '@types/gensync@1.0.5': {}
 
-  '@types/glob@9.0.0':
-    dependencies:
-      glob: 13.0.6
-
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 24.13.3
@@ -21478,8 +21452,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-
-  globalyzer@0.1.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -26221,11 +26193,6 @@ snapshots:
   timers-browserify@2.0.12:
     dependencies:
       setimmediate: 1.0.5
-
-  tiny-glob@0.2.9:
-    dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
 
   tiny-inflate@1.0.3: {}
 

--- a/portal/src/app/api/code-example-files/route.ts
+++ b/portal/src/app/api/code-example-files/route.ts
@@ -1,12 +1,15 @@
+import { glob } from "node:fs/promises";
 import nodePath, { resolve } from "node:path";
 import { NextResponse } from "next/server";
-import glob from "tiny-glob";
 
 export async function GET() {
     try {
-        const codeExamplePaths = await glob("**/documentation/*.tsx", {
+        const codeExamplePaths: string[] = [];
+        for await (const examplePath of glob("**/documentation/*.tsx", {
             cwd: resolve("..", "packages", "jokul", "src", "components"),
-        });
+        })) {
+            codeExamplePaths.push(examplePath);
+        }
 
         const optionGroups = Object.groupBy(
             codeExamplePaths.sort().map((examplePath) => ({

--- a/portal/src/app/api/component-folders/route.ts
+++ b/portal/src/app/api/component-folders/route.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs";
+import { glob } from "node:fs/promises";
 import path from "node:path";
 import { NextResponse } from "next/server";
-import glob from "tiny-glob";
 
 const packageRoot = path.resolve(
     process.cwd(),
@@ -14,12 +13,17 @@ const packageRoot = path.resolve(
 
 export async function GET() {
     try {
-        const paths = (await glob("*", { cwd: packageRoot })).filter(
-            (component) =>
-                fs.statSync(path.resolve(packageRoot, component)).isDirectory(),
-        );
+        const componentNames: string[] = [];
+        for await (const component of glob("*", {
+            cwd: packageRoot,
+            withFileTypes: true,
+        })) {
+            if (component.isDirectory()) {
+                componentNames.push(component.name);
+            }
+        }
 
-        const formattedOptions = paths.sort().map((component) => ({
+        const formattedOptions = componentNames.sort().map((component) => ({
             title: component,
             value: component,
         }));


### PR DESCRIPTION
Siden vi nå støtter Node 22 og nyere kan vi droppe `glob` og `tiny-glob` pakkene og heller bruke node's innebygde alternativ.

Copilot reagerte på håndteringen av "/", så jeg byttet heller til node sine innebygde funksjoner som skal ta seg av det på tvers av OS.