### PR TITLE
Bedre innlasting av distributørenes fonter

### DIFF
--- a/.changeset/fonts-arver-webfonts-dir.md
+++ b/.changeset/fonts-arver-webfonts-dir.md
@@ -1,0 +1,6 @@
+---
+"@fremtind/jokul": patch
+---
+
+Gjør innlasting av distributørtilpassede fonter mer robust ved å arve samme
+variabel for plassering av fontfiler i prosjektet.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -272,8 +272,6 @@ jobs:
 
             -   name: Build packages and site
                 run: pnpm build && pnpm build:storybook
-                env:
-                    STORYBOOK_FONTS_BASE_PATH: /jokul/${{ env.PREVIEW_PATH }}
 
             -   name: Deploy preview
                 env:

--- a/.github/workflows/storybook_branch_preview.yml
+++ b/.github/workflows/storybook_branch_preview.yml
@@ -62,8 +62,6 @@ jobs:
 
             -   name: Build packages and site
                 run: pnpm build && pnpm build:storybook
-                env:
-                    STORYBOOK_FONTS_BASE_PATH: /jokul/${{ steps.release-tag.outputs.tag || 'latest' }}
 
             -   name: Deploy preview
                 env:

--- a/.storybook/global.scss
+++ b/.storybook/global.scss
@@ -1,2 +1,6 @@
+@use "../packages/jokul/src/styles/theme/fonts" with (
+    // La Vite håndtere innlasting og kopiering av fontfiler
+    $webfonts-dir: "../packages/jokul/src/fonts"
+);
 @use "../packages/jokul/src/styles/base";
 @use "../packages/jokul/src/styles/components";

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,19 +1,11 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 import react from "@vitejs/plugin-react";
 import { mergeConfig } from "vite";
-const fontsBasePath = process.env.STORYBOOK_FONTS_BASE_PATH;
 
 const config: StorybookConfig = {
     stories: [
         "../packages/jokul/**/*.stories.@(ts|tsx|md|mdx)",
         "./docs/*.mdx",
-    ],
-    staticDirs: [
-        "../storybook-public",
-        {
-            from: "../packages/jokul/src/fonts",
-            to: "/fonts",
-        },
     ],
     addons: ["@storybook/addon-docs"],
     framework: {
@@ -27,13 +19,6 @@ const config: StorybookConfig = {
                 preprocessorOptions: {
                     scss: {
                         api: "modern",
-                        additionalData: (source: string, filename: string) =>
-                            fontsBasePath &&
-                            filename
-                                .replace(/\\/g, "/")
-                                .endsWith("/.storybook/global.scss")
-                                ? `@use "../packages/jokul/src/styles/theme/fonts" with ($webfonts-dir: "${fontsBasePath}/fonts");\n${source}`
-                                : source,
                     },
                 },
             },

--- a/packages/jokul/README.md
+++ b/packages/jokul/README.md
@@ -112,8 +112,9 @@ eller i ts/js
 import "@fremtind/jokul/styles/components.scss";
 ```
 
-Vær obs på at du da kan få med en del mer stilark enn du trenger så vurder dette opp mot
-størrelsen på bundelen du sender ut. Bruker du SSR kan dette ende med veldig mye overhead.
+> [!CAUTION]
+> Vær obs på at du på denne måten kan få med en del mer stilark enn du trenger, så vurder dette opp mot
+> størrelsen på bundelen du sender ut. Bruker du SSR kan dette ende med veldig mye overhead.
 
 ## Fonter
 
@@ -132,6 +133,11 @@ Dette gjør du med
     $webfonts-dir: "relative/path/to/node_modules/@fremtind/jokul/src/fonts"
 );
 ```
+
+> [!IMPORTANT]
+> Merk at `@use ... with` må komme **før** du drar inn `styles/base` eller andre
+> stilark som laster fontene, ellers rekker Sass å laste modulen med standard-
+> verdien først.
 
 ### CSS
 

--- a/packages/jokul/src/components/card/stories/Card.stories.tsx
+++ b/packages/jokul/src/components/card/stories/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React from "react";
+import dog1200 from "../../../../../../storybook-public/images/dog-1200.jpg";
 import { CardImage } from "../../card/CardImage.js";
 import { Flex } from "../../flex/index.js";
 import { CheckIcon, CopyIcon } from "../../icon/index.js";
@@ -9,8 +10,6 @@ import { Card } from "../Card.js";
 import { CARD_PADDINGS } from "../types.js";
 
 import "../styles/_index.scss";
-
-const dog1200 = "/images/dog-1200.jpg";
 
 const meta = {
     title: "Komponenter/Card",

--- a/packages/jokul/src/components/image/stories/Image.stories.tsx
+++ b/packages/jokul/src/components/image/stories/Image.stories.tsx
@@ -1,15 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React from "react";
+import dog400 from "../../../../../../storybook-public/images/dog-400.jpg";
+import dog800 from "../../../../../../storybook-public/images/dog-800.jpg";
+import dog1200 from "../../../../../../storybook-public/images/dog-1200.jpg";
+import dog1920 from "../../../../../../storybook-public/images/dog-1920.jpg";
+import thumbnail from "../../../../../../storybook-public/images/thumbnail.jpg";
 import { Image } from "../Image.js";
 import type { ImageProps } from "../types.js";
 import "../styles/_index.scss";
 import "./styles.scss";
-
-const dog400 = "/images/dog-400.jpg";
-const dog800 = "/images/dog-800.jpg";
-const dog1200 = "/images/dog-1200.jpg";
-const dog1920 = "/images/dog-1920.jpg";
-const thumbnail = "/images/thumbnail.jpg";
 
 export default {
     title: "Komponenter/Image",

--- a/packages/jokul/src/tokens/style-dictionary/config.ts
+++ b/packages/jokul/src/tokens/style-dictionary/config.ts
@@ -106,7 +106,9 @@ export function createBrandConfig(brand: Brand): Config {
                         format: "css/brand-fonts",
                         options: {
                             selector: `[data-brand="${brand}"]`,
-                            webfontsDir: `/fonts/brands/${brand}`,
+                            // Relativt fra buildPath ovenfor til src/styles/theme/_fonts.scss
+                            baseFontsModule: "../../fonts",
+                            webfontsSubdir: `brands/${brand}`,
                             webfontsVarName: `webfonts-dir-${brand}`,
                         },
                     },

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-brand-fonts.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-brand-fonts.ts
@@ -9,7 +9,8 @@ import { PREFIX } from "../config.js";
 
 type BrandFontsOptions = {
     selector?: string;
-    webfontsDir?: string;
+    baseFontsModule?: string;
+    webfontsSubdir?: string;
     webfontsVarName?: string;
 };
 
@@ -49,12 +50,18 @@ const cssBrandFontsFormat: Format = {
         options?: BrandFontsOptions;
     }) => {
         const selector = options?.selector;
-        const webfontsDir = options?.webfontsDir;
+        const baseFontsModule = options?.baseFontsModule;
+        const webfontsSubdir = options?.webfontsSubdir;
         const webfontsVarName = options?.webfontsVarName;
 
-        if (!selector || !webfontsDir || !webfontsVarName) {
+        if (
+            !selector ||
+            !baseFontsModule ||
+            !webfontsSubdir ||
+            !webfontsVarName
+        ) {
             throw new Error(
-                'The "css/brand-fonts" format requires selector, webfontsDir and webfontsVarName options.',
+                'The "css/brand-fonts" format requires selector, baseFontsModule, webfontsSubdir and webfontsVarName options.',
             );
         }
 
@@ -84,7 +91,11 @@ const cssBrandFontsFormat: Format = {
             .join("\n");
 
         return `${await fileHeader({ file })}
-$${webfontsVarName}: "${webfontsDir}" !default;
+@use "${baseFontsModule}" as jokul-fonts;
+
+// Arver $webfonts-dir slik at konsumenter som flytter fontmappa bare trenger å
+// konfigurere den ene variabelen. Kan fortsatt overstyres alene ved behov.
+$${webfontsVarName}: "#{jokul-fonts.$webfonts-dir}/${webfontsSubdir}" !default;
 
 @layer jokul.theme {
 ${faceDeclarations}

--- a/packages/jokul/stories/patterns/Detaljside.stories.tsx
+++ b/packages/jokul/stories/patterns/Detaljside.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React, { type CSSProperties } from "react";
+import { assetUrl } from "../../../../storybook-public/assetUrl.js";
+import * as poolsideImage from "../../../../storybook-public/images/poolside.jpg";
 import { Button } from "../../src/components/button/Button.js";
 import { Card, CardImage } from "../../src/components/card/index.js";
 import {
@@ -32,7 +34,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const poolside = "/images/poolside.jpg";
+const poolside = assetUrl(poolsideImage);
 
 const Header = () => (
     <Flex

--- a/packages/jokul/stories/temabygger/Temabygger.overblikk.stories.tsx
+++ b/packages/jokul/stories/temabygger/Temabygger.overblikk.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import React, { type CSSProperties } from "react";
+import { assetUrl } from "../../../../storybook-public/assetUrl.js";
+import * as poolsideImage from "../../../../storybook-public/images/poolside.jpg";
 import { Button } from "../../src/components/button/index.js";
 import { Card, CardImage } from "../../src/components/card/index.js";
 import { Countdown } from "../../src/components/countdown/index.js";
@@ -84,7 +86,7 @@ function InsuranceSummaryCard() {
         <Card padding="l" outlined as="section">
             <Flex direction="column" gap="24">
                 <CardImage
-                    src="/images/poolside.jpg"
+                    src={assetUrl(poolsideImage)}
                     alt=""
                     style={
                         {

--- a/storybook-public/assetUrl.ts
+++ b/storybook-public/assetUrl.ts
@@ -1,0 +1,34 @@
+/**
+ * Normaliserer en bilde-import til en URL-streng.
+ *
+ * Storiene under `packages/jokul/stories/` bygges av to ulike bundlere:
+ * Storybook bruker Vite, mens portalen importerer noen av de samme storiene inn
+ * i Next.js (se `portal/src/app/(frontend)/temabygger/_preview/`). De to gir
+ * ulikt resultat for `import bilde from "…jpg"` — Vite gir en URL-streng, mens
+ * Next gir et `StaticImageData`-objekt med URLen i `src`.
+ *
+ * Stories som bare kjører i Storybook trenger ikke denne hjelperen og kan bruke
+ * importen direkte.
+ *
+ * Vi importerer bilder i stedet for å skrive absolutte stier som `/images/…`,
+ * fordi Storybook publiseres under en underbane (`/jokul/<versjon>/`) der slike
+ * stier ikke finnes. Bundleren gir oss relative URL-er som virker begge steder.
+ */
+export function assetUrl(asset: unknown): string {
+    const value =
+        typeof asset === "object" && asset !== null && "default" in asset
+            ? (asset as { default: unknown }).default
+            : asset;
+
+    if (typeof value === "string") {
+        return value;
+    }
+
+    if (typeof value === "object" && value !== null && "src" in value) {
+        return String((value as { src: unknown }).src);
+    }
+
+    throw new Error(
+        "assetUrl: forventet en URL-streng eller et StaticImageData-objekt fra bundleren.",
+    );
+}


### PR DESCRIPTION
## 💬 Endringer

- (Jøkul): Gjør innlasting av distributørtilpassede fonter mer robust ved å arve samme variabel for plassering av fontfiler i prosjektet.
- (Storybook): Sørger for at Vite håndterer innlasting og kopiering av fonter og andre assets ved bygg av Storybook, slik at vi ikke får feil med manglende innhold når vi publiserer Storybooks for forskjellige versjoner av Jøkul.
