### PR TITLE
La data-brand overstyre font-variabler i tekststiler

### DIFF
--- a/.changeset/salty-planes-call.md
+++ b/.changeset/salty-planes-call.md
@@ -1,0 +1,5 @@
+---
+"@fremtind/jokul": patch
+---
+
+Fikser en feil der distributørtema ikke overstyrte fonter på riktig måte

--- a/packages/jokul/src/tokens/style-dictionary/formats/css-theme-variables.ts
+++ b/packages/jokul/src/tokens/style-dictionary/formats/css-theme-variables.ts
@@ -108,7 +108,8 @@ const cssThemeVariablesFormat: Format = {
 @layer jokul.theme {
     :root,
     [data-size],
-    [data-theme] {
+    [data-theme],
+    [data-brand] {
 ${allVariables}
     }
 }`;


### PR DESCRIPTION
## 💬 Endringer

Fikser en feil der distributørtema ikke overstyrte fonter på riktig måte
