### PR TITLE
Align bilder i kortene i komponentoversikten

### DIFF
--- a/.changeset/fancy-onions-worry.md
+++ b/.changeset/fancy-onions-worry.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Legger bildene i komponentoversikten lengst ned i kortene så de blir visuelt alignet.

--- a/portal/src/components/overview/card.tsx
+++ b/portal/src/components/overview/card.tsx
@@ -1,5 +1,7 @@
 import type { SanityImageLike } from "@/sanity/lib/image";
 import { Card } from "@fremtind/jokul/card";
+import { Flex } from "@fremtind/jokul/flex";
+import { Text } from "@fremtind/jokul/typography";
 import NextLink from "next/link";
 import { type ReactNode, useId } from "react";
 import { OverviewThumbnail } from "./thumbnail";
@@ -29,34 +31,43 @@ export const OverviewCard = (props: OverviewCardProps) => {
 
     return (
         <li>
-            <Card
-                as={NextLink}
-                href={link}
-                padding="l"
-                className={styles.card}
-                aria-labelledby={`${id}-title`}
-                aria-describedby={describedBy}
-            >
-                <p className={styles.name} id={`${id}-title`}>
-                    {title}
-                </p>
-                {description && (
-                    <p className={styles.description} id={descriptionId}>
-                        {description}
-                    </p>
-                )}
-                {image && (
-                    <OverviewThumbnail
-                        darkImage={image.dark}
-                        lightImage={image.light}
-                    />
-                )}
-                {footer && (
-                    <footer className={styles.footer} id={footerId}>
-                        {footer}
-                    </footer>
-                )}
-            </Card>
+            <Flex direction="column" asChild gap="16 0">
+                <Card
+                    as={NextLink}
+                    href={link}
+                    padding="l"
+                    className={styles.card}
+                    aria-labelledby={`${id}-title`}
+                    aria-describedby={describedBy}
+                >
+                    <Flex direction="column" gap="8 0">
+                        <p className={styles.name} id={`${id}-title`}>
+                            {title}
+                        </p>
+                        {description && (
+                            <Text
+                                subdued
+                                size="s"
+                                className={styles.description}
+                                id={descriptionId}
+                            >
+                                {description}
+                            </Text>
+                        )}
+                    </Flex>
+                    {image && (
+                        <OverviewThumbnail
+                            darkImage={image.dark}
+                            lightImage={image.light}
+                        />
+                    )}
+                    {footer && (
+                        <footer className={styles.footer} id={footerId}>
+                            {footer}
+                        </footer>
+                    )}
+                </Card>
+            </Flex>
         </li>
     );
 };

--- a/portal/src/components/overview/overview.module.scss
+++ b/portal/src/components/overview/overview.module.scss
@@ -50,37 +50,21 @@
 }
 
 .card {
-    --aspect-ratio: 1.5;
-
-    display: flex;
-    flex-direction: column;
-    color: var(--jkl-color-text-default);
-
-
     .name {
-        margin-bottom: var(--jkl-spacing-8);
-
-        &:last-child {
-            margin-bottom: 0;
-        }
-
         @include jkl.text-style("heading-5");
     }
 
     .description {
-        @include jkl.text-style("paragraph-small") {
-            color: var(--jkl-color-text-subdued);
-            word-wrap: break-word;
-        }
+        word-wrap: break-word;
     }
 
 
     .thumbnail {
         height: auto;
         width: 100%;
-        aspect-ratio: var(--aspect-ratio);
+        aspect-ratio: var(--aspect-ratio, 1.5);
         overflow: hidden;
-        margin-block-start: var(--jkl-unit-20);
+        margin-block-start: auto;
 
         img {
             width: 100%;
@@ -92,7 +76,6 @@
     }
 
     .footer {
-        padding-block-start: 2lh;
         margin-block-start: auto;
     }
 }


### PR DESCRIPTION
## 💬 Endringer

Legger bildene i komponentoversikten lengst ned i kortene så de blir visuelt alignet.

<img width="1036" height="747" alt="Skjermbilde 2026-09-09 kl  11 20 39" src="https://github.com/user-attachments/assets/25cd398d-c74d-4b0f-ac02-126a4bcb989e" />

## 🩹 Løser følgende issues

Closes #6407 
