### PR TITLE
Fjern warnings for ikonknapper i konsollen

### DIFF
--- a/.changeset/quiet-lanterns-drift.md
+++ b/.changeset/quiet-lanterns-drift.md
@@ -1,0 +1,5 @@
+---
+"portal": patch
+---
+
+Fjerner warnings i konsollen ved å gi ikonknapper tilgjengelige navn og riktig ekspandert tilstand.

--- a/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeaderLink.tsx
+++ b/portal/src/app/(frontend)/komponenter/[slug]/components/ComponentHeaderLink.tsx
@@ -29,6 +29,7 @@ export const ComponentHeaderLink = ({
                     rel="noopener noreferrer"
                     href={href}
                     icon={icon}
+                    aria-label={`${name} (åpnes i ny fane)`}
                 />
             </TooltipTrigger>
             <TooltipContent>{name}</TooltipContent>

--- a/portal/src/components/layout/header/navigation/menu/hamburger/HamburgerButton.tsx
+++ b/portal/src/components/layout/header/navigation/menu/hamburger/HamburgerButton.tsx
@@ -16,6 +16,8 @@ export const HamburgerButton = ({ expanded, ...props }: Props) => {
         <Button
             {...props}
             aria-controls={menuId}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Lukk meny" : "Åpne meny"}
             id={`${menuId}-button`}
             variant="ghost"
             icon={expanded ? <Icon>Close</Icon> : <Icon>Menu</Icon>}


### PR DESCRIPTION
Ikonknappene manglet navn. La til `aria-label`, og `aria-expanded` på menyknappen.