### PR TITLE
Koble Expandable Panel til Figma Code Connect 

### DIFF
--- a/packages/jokul/src/components/expander/ExpandablePanel.figma.ts
+++ b/packages/jokul/src/components/expander/ExpandablePanel.figma.ts
@@ -1,0 +1,73 @@
+// url=https://www.figma.com/design/jnE6mPCHVfbjn7a0AiKGEK/Jokul?node-id=40014:1759
+// component=ExpandablePanel
+
+import figma from "figma";
+
+const multiple = figma.selectedInstance.getBoolean("Multiple");
+const outlined = figma.selectedInstance.getBoolean("Outlined");
+const panel = multiple
+    ? undefined
+    : figma.selectedInstance.findConnectedInstance("ExpandablePanelItem");
+const icon =
+    panel?.type === "INSTANCE"
+        ? panel.getBoolean("Icon left", {
+              true: figma.helpers.react.jsxElement("<GreenCheckIcon />"),
+              false: undefined,
+          })
+        : undefined;
+const imports = [
+    multiple
+        ? 'import { Accordion } from "@fremtind/jokul/expander";'
+        : 'import { ExpandablePanel } from "@fremtind/jokul/expander";',
+    ...(icon ? ['import { GreenCheckIcon } from "@fremtind/jokul/icon";'] : []),
+];
+
+const example = (() => {
+    if (multiple) {
+        // Sloten skal inneholde direkte, Code Connect-koblede paneler.
+        // connectedInstances utelater tekst, ukoblede og dypere nestede instanser.
+        const slot = figma.selectedInstance.getSlot("Expandables");
+        const panels = slot?.connectedInstances.map(
+            (panel) => panel.executeTemplate().example,
+        );
+
+        return figma.code`<Accordion
+    ${figma.helpers.react.renderProp("outlined", outlined)}
+>
+    ${panels?.length ? panels : slot}
+</Accordion>`;
+    }
+
+    if (!panel) {
+        throw new Error(
+            "Fant ikke Code Connect-koblingen ExpandablePanelItem. Publiser begge panelkoblingene under samme label, og kontroller at instansen inneholder et panel.",
+        );
+    }
+    if (panel.type === "ERROR") {
+        return figma.code`${panel.executeTemplate().example}`;
+    }
+
+    const title = panel.getString("Title");
+    const defaultOpen = panel.getBoolean("Open");
+
+    const slot = panel.getSlot("Content");
+
+    return figma.code`<ExpandablePanel
+    ${figma.helpers.react.renderProp("outlined", outlined)}
+    ${figma.helpers.react.renderProp("defaultOpen", defaultOpen)}
+>
+    <ExpandablePanel.Header ${figma.helpers.react.renderProp("icon", icon)}>
+        {${figma.helpers.react.stringifyObject(title)}}
+    </ExpandablePanel.Header>
+    <ExpandablePanel.Content>
+        ${slot ?? figma.code`{/* Innhold */}`}
+    </ExpandablePanel.Content>
+</ExpandablePanel>`;
+})();
+
+export default {
+    id: "ExpandablePanel",
+    imports,
+    example,
+    metadata: { nestable: true },
+};

--- a/packages/jokul/src/components/expander/ExpandablePanelItem.figma.ts
+++ b/packages/jokul/src/components/expander/ExpandablePanelItem.figma.ts
@@ -1,0 +1,35 @@
+// url=https://www.figma.com/design/jnE6mPCHVfbjn7a0AiKGEK/Jokul?node-id=40014:1769
+// component=ExpandablePanel
+
+import figma from "figma";
+
+const title = figma.selectedInstance.getString("Title");
+const defaultOpen = figma.selectedInstance.getBoolean("Open");
+const icon = figma.selectedInstance.getBoolean("Icon left", {
+    true: figma.helpers.react.jsxElement("<GreenCheckIcon />"),
+    false: undefined,
+});
+const slot = figma.selectedInstance.getSlot("Content");
+
+const example = figma.code`<ExpandablePanel
+    ${figma.helpers.react.renderProp("defaultOpen", defaultOpen)}
+>
+    <ExpandablePanel.Header ${figma.helpers.react.renderProp("icon", icon)}>
+        {${figma.helpers.react.stringifyObject(title)}}
+    </ExpandablePanel.Header>
+    <ExpandablePanel.Content>
+        ${slot ?? figma.code`{/* Innhold */}`}
+    </ExpandablePanel.Content>
+</ExpandablePanel>`;
+
+export default {
+    id: "ExpandablePanelItem",
+    imports: [
+        'import { ExpandablePanel } from "@fremtind/jokul/expander";',
+        ...(icon
+            ? ['import { GreenCheckIcon } from "@fremtind/jokul/icon";']
+            : []),
+    ],
+    example,
+    metadata: { nestable: true },
+};


### PR DESCRIPTION
Lagt til Code Connect for Expandable Panel, så kodeeksemplene i Figma følger valgene du gjør på panelene — både enkeltvis og i grupper.

Kan testes i [Figma](https://www.figma.com/design/jnE6mPCHVfbjn7a0AiKGEK/J%C3%B8kul-v5?node-id=40014-1695&component-browser=1&component-key=682b3edb5752749397c2d94c312020aa0f7d50f5&component-browser-scope=page_or_selection&m=dev).

Gjenstår å publisere under React.

Closes #6510
